### PR TITLE
fix: silence console.log spam in static OpenCode plugin

### DIFF
--- a/.opencode/plugins/memorix.js
+++ b/.opencode/plugins/memorix.js
@@ -76,7 +76,7 @@ export const MemorixPlugin = async ({ project, client, $, directory, worktree })
       output.context.push(
         '## Memorix Cross-Agent Memory\n' +
         'Before compacting, use memorix_store to save important discoveries, decisions, and gotchas.\n' +
-        'After compacting, use memorix_session_start to reload session context, then memorix_search for specific topics.'
+        'After compacting, use memorix_search to reload relevant context.'
       );
     },
   };


### PR DESCRIPTION
## Summary

Silences the static `.opencode/plugins/memorix.js` file that was polluting the OpenCode TUI with log messages on every tool call.

## What changed

- Removed `console.log('[memorix] plugin loaded')` on startup
- Removed `console.log('[memorix] hook fired')` on every tool call (fires on **every** tool execution, spamming the TUI)
- Changed `console.log('[memorix] hook error')` to silent catch — hooks must never break the agent

## Why this matters

OpenCode's plugin runtime routes `console.log` directly to the TUI status area. The `logLevel` config only controls Go-level slog, not JS plugin output — there's no way for users to suppress these messages via configuration. The `tool.execute.after` hook fires on every single tool call, flooding the input area.

Fixes #16