### PR TITLE
fix: add version marker to OpenCode plugin for stale installation detection

### DIFF
--- a/src/cli/commands/hooks-status.ts
+++ b/src/cli/commands/hooks-status.ts
@@ -22,12 +22,18 @@ export default defineCommand({
     console.log('\nMemorix Hooks Status');
     console.log('═'.repeat(50));
 
-    for (const { agent, installed, configPath } of statuses) {
-      const icon = installed ? '[OK]' : '[ ]';
+    let hasOutdated = false;
+    for (const { agent, installed, outdated, configPath } of statuses) {
+      const icon = installed ? (outdated ? '[!!]' : '[OK]') : '[ ]';
       const label = agent.charAt(0).toUpperCase() + agent.slice(1);
-      console.log(`${icon} ${label.padEnd(12)} ${installed ? configPath : '(not installed)'}`);
+      const suffix = outdated ? ' (outdated — re-run `memorix hooks install`)' : '';
+      console.log(`${icon} ${label.padEnd(12)} ${installed ? configPath + suffix : '(not installed)'}`);
+      if (outdated) hasOutdated = true;
     }
 
+    if (hasOutdated) {
+      console.log('\n⚠ Outdated hooks detected. Run `memorix hooks install` to update.');
+    }
     console.log('\nRun `memorix hooks install` to set up hooks for detected agents.');
   },
 });

--- a/src/hooks/installers/index.ts
+++ b/src/hooks/installers/index.ts
@@ -218,9 +218,14 @@ function generateKiroHookFiles(): Array<{ filename: string; content: string }> {
  * The plugin hooks into OpenCode events and pipes JSON to `memorix hook`
  * via Bun.spawn, matching the same stdin/stdout protocol used by all agents.
  */
+// Version of the generated OpenCode plugin template.
+// Bump this when the template changes so hooks-status can detect stale installations.
+const OPENCODE_PLUGIN_VERSION = 2;
+
 function generateOpenCodePlugin(): string {
   return `/**
  * Memorix — Cross-Agent Memory Bridge Plugin for OpenCode
+ * @generated-version ${OPENCODE_PLUGIN_VERSION}
  *
  * Automatically captures session context and tool usage,
  * piping events to \`memorix hook\` for cross-agent memory persistence.
@@ -874,8 +879,8 @@ export async function uninstallHooks(
  */
 export async function getHookStatus(
   projectRoot: string,
-): Promise<Array<{ agent: AgentName; installed: boolean; configPath: string }>> {
-  const results: Array<{ agent: AgentName; installed: boolean; configPath: string }> = [];
+): Promise<Array<{ agent: AgentName; installed: boolean; outdated: boolean; configPath: string }>> {
+  const results: Array<{ agent: AgentName; installed: boolean; outdated: boolean; configPath: string }> = [];
   const agents: AgentName[] = ['claude', 'copilot', 'windsurf', 'cursor', 'kiro', 'codex', 'antigravity', 'opencode', 'trae'];
 
   for (const agent of agents) {
@@ -883,6 +888,7 @@ export async function getHookStatus(
     const globalPath = getGlobalConfigPath(agent);
 
     let installed = false;
+    let outdated = false;
     let usedPath = projectPath;
 
     try {
@@ -896,7 +902,19 @@ export async function getHookStatus(
       } catch { /* not installed */ }
     }
 
-    results.push({ agent, installed, configPath: usedPath });
+    // Check if installed OpenCode plugin is outdated by reading version marker
+    if (installed && agent === 'opencode') {
+      try {
+        const content = await fs.readFile(usedPath, 'utf-8');
+        const match = content.match(/@generated-version\s+(\d+)/);
+        const installedVersion = match ? parseInt(match[1], 10) : 0;
+        if (installedVersion < OPENCODE_PLUGIN_VERSION) {
+          outdated = true;
+        }
+      } catch { /* can't read — treat as not outdated */ }
+    }
+
+    results.push({ agent, installed, outdated, configPath: usedPath });
   }
 
   return results;


### PR DESCRIPTION
## Summary

- Adds `@generated-version` marker to the generated OpenCode plugin template
- `memorix hooks status` now detects outdated OpenCode plugin installations
- Shows `[!!]` warning for stale hooks, prompting users to re-run `memorix hooks install`

## Problem

The OpenCode plugin template was fixed in a recent version (silent hooks, `.quiet()`, no `console.log`), but users who installed hooks earlier still have the old version with `console.log` spam that corrupts the TUI. There was no way to detect this — `memorix hooks status` only checked if the file exists, not whether it's up-to-date.

Old installations show this spam on every tool call and session event:
```
[memorix] hook fired: tool.execute.after
[memorix] hook fired: session.idle
[memorix] hook error: expected a command or assignment but got: "Redirect"
```

The `"Redirect"` error is because old versions used `> /dev/null 2>&1` which doesn't work in Bun's `$` shell template (needs `.quiet()` instead).

## Changes

`src/hooks/installers/index.ts`:
- Added `OPENCODE_PLUGIN_VERSION = 2` constant
- Added `@generated-version` comment to the template output
- `getHookStatus()` now reads the version marker and flags outdated installs
- Return type includes `outdated: boolean`

`src/cli/commands/hooks-status.ts`:
- Shows `[!!]` for outdated hooks instead of `[OK]`
- Prints warning message when outdated hooks are detected

## How it works

Old installations without the `@generated-version` marker are detected as version 0 (outdated). When the template changes in the future, bump `OPENCODE_PLUGIN_VERSION` and all older installations will be flagged.

Fixes #22