### PR TITLE
test: fix provenance float precision flake

### DIFF
--- a/tests/memory/provenance.test.ts
+++ b/tests/memory/provenance.test.ts
@@ -289,7 +289,8 @@ describe('Session injection source-aware scoring', () => {
     const scoreHook = scoreObservationForSessionContext(hook, []);
 
     expect(scoreHook).toBeLessThan(scoreExplicit);
-    expect(scoreExplicit - scoreHook).toBeGreaterThanOrEqual(3); // exact delta from session.ts
+    // Floating point math can land infinitesimally below 3 on some runtimes.
+    expect(scoreExplicit - scoreHook).toBeGreaterThan(2.999); // nominal delta from session.ts
   });
 
   it('hook+ephemeral scores lower than hook alone (compound penalty)', () => {


### PR DESCRIPTION
## Summary
- relax the provenance scoring delta assertion to tolerate floating point precision drift
- keep the expected session scoring behavior unchanged
- restore green CI after merge commit 17984ac failed on ubuntu due to 2.9999999994 vs 3.0

## Verification
- npm run build
- npx vitest run tests/memory/provenance.test.ts