### PR TITLE
feat: add phase 6 retrieval tuning

### DIFF
--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -351,7 +351,16 @@ export async function getSessionContext(
   const l3GitCount = projectObs.filter((obs) => classifyLayer(obs) === 'L3').length;
   const totalHookCount = projectObs.filter((obs) => classifyLayer(obs) === 'L1').length;
 
+  // Active entities: unique entity names from top-scored L2 memories.
+  // Surfaced in L1 Routing as next-hop search guidance — not working context.
+  // Capped at 5, derived from the same l2Obs already scored above.
+  const activeEntities = [
+    ...new Set(l2Obs.map((o) => o.entityName).filter((n): n is string => !!n && n.trim().length > 0)),
+  ].slice(0, 5);
+
   // ── L1 Routing ─────────────────────────────────────────────────────
+  // L1 Routing requires actual L1/L3 signals (hooks or git evidence).
+  // Active entities enrich the section when it is shown but do not open it alone.
   const hasL1Content = l1HookObs.length > 0 || l3GitCount > 0;
   if (hasL1Content) {
     lines.push('## L1 Routing');
@@ -365,6 +374,9 @@ export async function getSessionContext(
     }
 
     const hints: string[] = [];
+    if (activeEntities.length > 0) {
+      hints.push(`Active entities: ${activeEntities.join(', ')}`);
+    }
     if (l3GitCount > 0) {
       hints.push(`${l3GitCount} git-memory item(s) available — search \`what-changed\` or by entity/commit`);
     }

--- a/src/store/orama-store.ts
+++ b/src/store/orama-store.ts
@@ -54,6 +54,20 @@ function isCommandLikeQuery(query: string): boolean {
   return COMMAND_LIKE_QUERY.test(query);
 }
 
+/**
+ * Resolve the effective source label for intent-boost purposes.
+ * Phase 1 introduced sourceDetail='git-ingest' as a more precise signal than
+ * source='git'. Treat them as equivalent so intent-based source boosts
+ * (e.g. what_changed → git: 2.0) apply to both representations.
+ * Used in the source-aware retrieval path only — not stored or exported.
+ */
+function effectiveSource(
+  source: 'agent' | 'git' | 'manual',
+  sourceDetail?: 'explicit' | 'hook' | 'git-ingest',
+): 'agent' | 'git' | 'manual' {
+  return sourceDetail === 'git-ingest' ? 'git' : source;
+}
+
 /** True when the query IS a command (tool word leads), not just mentioning a tool. */
 function isCommandIntentQuery(query: string): boolean {
   if (!COMMAND_INTENT_QUERY.test(query)) return false;
@@ -503,7 +517,7 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
   if (intentResult && intentResult.confidence > 0.3 && intentResult.sourceBoosts) {
     const srcBoosts = intentResult.sourceBoosts;
     intermediate = intermediate.map(entry => {
-      const boost = srcBoosts[entry.source] ?? 1.0;
+      const boost = srcBoosts[effectiveSource(entry.source, entry.sourceDetail)] ?? 1.0;
       const effectiveBoost = 1 + (boost - 1) * intentResult.confidence;
       return { ...entry, score: entry.score * effectiveBoost };
     });
@@ -595,6 +609,41 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
   // Apply original limit after post-filtering (we intentionally over-requested when project filtering is active)
   if (projectIds) {
     intermediate = intermediate.slice(0, options.limit ?? 20);
+  }
+
+  // ── Provenance Tiebreaker (standard tier only) ──────────────────
+  // When Orama scores converge — a common outcome in standard-tier queries
+  // where both fulltext and embedding are used — this pass gives a tiny
+  // preference to repository-backed and core memories within the top-K
+  // results whose scores fall within a 20% window of the highest score.
+  // Amplitudes are intentionally small: the tiebreaker must never reverse
+  // a meaningful score gap, only resolve genuine ambiguity.
+  //   git-ingest / source=git  → ×1.06 (repository evidence)
+  //   valueCategory=core       → ×1.03 (explicitly classified durable memory)
+  // Constraints:
+  //   - Standard tier only (fast has no ambiguity; heavy has LLM rerank)
+  //   - Top-8 results only (doesn't affect long tail)
+  //   - 20% score window from top score (score ≥ topScore × 0.80)
+  if (tier === 'standard' && intermediate.length > 1) {
+    const TIEBREAK_TOP_K = 8;
+    const TIEBREAK_WINDOW = 0.20;
+    const topScore = intermediate[0]?.score ?? 0;
+    const threshold = topScore * (1 - TIEBREAK_WINDOW);
+    let changed = false;
+    for (let i = 0; i < Math.min(TIEBREAK_TOP_K, intermediate.length); i++) {
+      const entry = intermediate[i];
+      if (entry.score < threshold) break; // outside tiebreak window, stop
+      const isGitEvidence = effectiveSource(entry.source, entry.sourceDetail) === 'git';
+      const isCore = entry.valueCategory === 'core';
+      if (isGitEvidence) {
+        intermediate[i] = { ...entry, score: entry.score * 1.06 };
+        changed = true;
+      } else if (isCore) {
+        intermediate[i] = { ...entry, score: entry.score * 1.03 };
+        changed = true;
+      }
+    }
+    if (changed) intermediate.sort((a, b) => b.score - a.score);
   }
 
   // ── LLM Reranking (heavy-tier only) ────────────────────────────

--- a/tests/search/phase6-provenance.test.ts
+++ b/tests/search/phase6-provenance.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Phase 6: Provenance-aware retrieval tests
+ *
+ * Covers:
+ *   P6-A: effectiveSource() — sourceDetail='git-ingest' treated as source='git' in intent boost
+ *   P6-B: provenance tiebreaker — standard tier, top-8, 20% window, tiny amplitude
+ *   P6-C: session context active entities — in L1 Routing, max 5
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// ── P6-A: effectiveSource logic ───────────────────────────────────────
+// The helper is internal to orama-store.ts; we test its contract by
+// replicating the logic and verifying the expected mappings.
+
+/** Mirrors the effectiveSource() helper in orama-store.ts */
+function effectiveSource(
+  source: 'agent' | 'git' | 'manual',
+  sourceDetail?: 'explicit' | 'hook' | 'git-ingest',
+): 'agent' | 'git' | 'manual' {
+  return sourceDetail === 'git-ingest' ? 'git' : source;
+}
+
+describe('P6-A: effectiveSource()', () => {
+  it('sourceDetail=git-ingest → "git" regardless of source field', () => {
+    expect(effectiveSource('agent', 'git-ingest')).toBe('git');
+  });
+
+  it('source=git + no sourceDetail → "git" (unchanged legacy)', () => {
+    expect(effectiveSource('git', undefined)).toBe('git');
+  });
+
+  it('sourceDetail=explicit → keeps source as-is', () => {
+    expect(effectiveSource('agent', 'explicit')).toBe('agent');
+  });
+
+  it('sourceDetail=hook → keeps source as-is (hook is not git evidence)', () => {
+    expect(effectiveSource('agent', 'hook')).toBe('agent');
+  });
+
+  it('source=manual + no sourceDetail → "manual" (unchanged)', () => {
+    expect(effectiveSource('manual', undefined)).toBe('manual');
+  });
+
+  it('source=git + sourceDetail=explicit → "git" (source already set, explicit overrides nothing)', () => {
+    expect(effectiveSource('git', 'explicit')).toBe('git');
+  });
+});
+
+// ── P6-A: source-aware boost uses effectiveSource ─────────────────────
+// Verify that git-ingest obs would receive the 2.0× intent boost on
+// what_changed intent (same boost as legacy source='git'), and hook obs
+// does NOT receive git boost.
+
+describe('P6-A: source-aware boost correctness', () => {
+  const WHAT_CHANGED_SRC_BOOSTS: Partial<Record<'agent' | 'git' | 'manual', number>> = {
+    git: 2.0,
+    agent: 0.8,
+  };
+
+  function applyBoost(
+    score: number,
+    source: 'agent' | 'git' | 'manual',
+    sourceDetail: 'explicit' | 'hook' | 'git-ingest' | undefined,
+    confidence: number,
+  ): number {
+    const src = effectiveSource(source, sourceDetail);
+    const boost = WHAT_CHANGED_SRC_BOOSTS[src] ?? 1.0;
+    const effectiveBoost = 1 + (boost - 1) * confidence;
+    return score * effectiveBoost;
+  }
+
+  it('sourceDetail=git-ingest gets full 2.0× git boost on what_changed (was 1.0× before fix)', () => {
+    const baseScore = 1.0;
+    const boosted = applyBoost(baseScore, 'agent', 'git-ingest', 1.0);
+    expect(boosted).toBeCloseTo(2.0);
+  });
+
+  it('source=git (legacy) still gets 2.0× boost (backward-compat)', () => {
+    const baseScore = 1.0;
+    const boosted = applyBoost(baseScore, 'git', undefined, 1.0);
+    expect(boosted).toBeCloseTo(2.0);
+  });
+
+  it('sourceDetail=hook stays at 0.8× (agent) — no git boost', () => {
+    const baseScore = 1.0;
+    const boosted = applyBoost(baseScore, 'agent', 'hook', 1.0);
+    expect(boosted).toBeCloseTo(0.8);
+  });
+
+  it('sourceDetail=explicit (no git) stays at 0.8×', () => {
+    const boosted = applyBoost(1.0, 'agent', 'explicit', 1.0);
+    expect(boosted).toBeCloseTo(0.8);
+  });
+
+  it('low confidence (0.2) → boost attenuated — does not fully apply', () => {
+    // confidence < 0.3 threshold in searchObservations means boost ≈ 1.0
+    const boostedHighConf = applyBoost(1.0, 'agent', 'git-ingest', 1.0);
+    const boostedLowConf = applyBoost(1.0, 'agent', 'git-ingest', 0.1);
+    expect(boostedHighConf).toBeGreaterThan(boostedLowConf);
+    // Low confidence barely moves the score
+    expect(boostedLowConf).toBeCloseTo(1 + (2.0 - 1) * 0.1);
+  });
+});
+
+// ── P6-B: provenance tiebreaker logic ─────────────────────────────────
+// Test the tiebreaker as a pure function to verify its contract:
+//   - Only applies within 20% window of top score
+//   - git evidence → ×1.06, core → ×1.03
+//   - Does NOT reverse large score gaps
+
+type TiebreakerEntry = {
+  score: number;
+  source: 'agent' | 'git' | 'manual';
+  sourceDetail?: 'explicit' | 'hook' | 'git-ingest';
+  valueCategory?: 'core' | 'contextual' | 'ephemeral';
+  id: number;
+};
+
+function applyTiebreaker(entries: TiebreakerEntry[]): TiebreakerEntry[] {
+  if (entries.length <= 1) return entries;
+  const TIEBREAK_TOP_K = 8;
+  const TIEBREAK_WINDOW = 0.20;
+  const topScore = entries[0]?.score ?? 0;
+  const threshold = topScore * (1 - TIEBREAK_WINDOW);
+  const result = entries.map(e => ({ ...e }));
+  let changed = false;
+  for (let i = 0; i < Math.min(TIEBREAK_TOP_K, result.length); i++) {
+    const entry = result[i];
+    if (entry.score < threshold) break;
+    const isGitEvidence = effectiveSource(entry.source, entry.sourceDetail) === 'git';
+    const isCore = entry.valueCategory === 'core';
+    if (isGitEvidence) {
+      result[i] = { ...entry, score: entry.score * 1.06 };
+      changed = true;
+    } else if (isCore) {
+      result[i] = { ...entry, score: entry.score * 1.03 };
+      changed = true;
+    }
+  }
+  if (changed) result.sort((a, b) => b.score - a.score);
+  return result;
+}
+
+describe('P6-B: provenance tiebreaker', () => {
+  it('git-ingest obs gets ×1.06 boost within 20% window', () => {
+    const entries: TiebreakerEntry[] = [
+      { id: 1, score: 1.00, source: 'agent', sourceDetail: 'explicit' },
+      { id: 2, score: 0.95, source: 'agent', sourceDetail: 'git-ingest' },
+    ];
+    const result = applyTiebreaker(entries);
+    // id=2 was 0.95, after ×1.06 = 1.007 → should be ranked first
+    expect(result[0].id).toBe(2);
+    expect(result[0].score).toBeCloseTo(0.95 * 1.06);
+  });
+
+  it('core obs gets ×1.03 boost within 20% window', () => {
+    const entries: TiebreakerEntry[] = [
+      { id: 1, score: 1.00, source: 'agent', sourceDetail: 'explicit' },
+      { id: 2, score: 0.99, source: 'agent', valueCategory: 'core' },
+    ];
+    const result = applyTiebreaker(entries);
+    expect(result[0].id).toBe(2);
+    expect(result[0].score).toBeCloseTo(0.99 * 1.03);
+  });
+
+  it('git evidence priority over core (both in window)', () => {
+    const entries: TiebreakerEntry[] = [
+      { id: 1, score: 1.00, source: 'agent' },
+      { id: 2, score: 0.95, source: 'agent', valueCategory: 'core' },
+      { id: 3, score: 0.92, source: 'agent', sourceDetail: 'git-ingest' },
+    ];
+    const result = applyTiebreaker(entries);
+    // id=3 (0.92 × 1.06 = 0.9752) vs id=2 (0.95 × 1.03 = 0.9785)
+    // In this case core still beats git-ingest because gap+multiplier: 0.9785 > 0.9752
+    // The key assertion: neither reverses id=1 at 1.00
+    expect(result[0].id).toBe(1);
+  });
+
+  it('does NOT reverse a large score gap (40% gap > 20% window)', () => {
+    const entries: TiebreakerEntry[] = [
+      { id: 1, score: 1.00, source: 'agent', sourceDetail: 'explicit' },
+      { id: 2, score: 0.55, source: 'agent', sourceDetail: 'git-ingest' }, // outside 20% window
+    ];
+    const result = applyTiebreaker(entries);
+    // id=2 is below threshold (1.00 * 0.80 = 0.80), tiebreaker does not apply
+    expect(result[0].id).toBe(1);
+    // id=2 score unchanged
+    expect(result[1].score).toBeCloseTo(0.55);
+  });
+
+  it('only top-8 entries get tiebreaker (index 8 is not modified)', () => {
+    const entries: TiebreakerEntry[] = Array.from({ length: 10 }, (_, i) => ({
+      id: i + 1,
+      score: 1.00 - i * 0.01, // all within 10% window (well within 20%)
+      source: 'agent' as const,
+      sourceDetail: 'git-ingest' as const,
+    }));
+    const before9Score = entries[8].score; // index 8 = 9th item
+    const result = applyTiebreaker(entries);
+    // Find id=9 in result
+    const item9 = result.find(e => e.id === 9);
+    // Index 8 (TIEBREAK_TOP_K limit) should NOT be boosted
+    expect(item9?.score).toBeCloseTo(before9Score);
+  });
+
+  it('single entry → no change', () => {
+    const entries: TiebreakerEntry[] = [
+      { id: 1, score: 1.0, source: 'git' },
+    ];
+    expect(applyTiebreaker(entries)).toHaveLength(1);
+    expect(applyTiebreaker(entries)[0].score).toBe(1.0);
+  });
+
+  it('no provenance signal → no score change', () => {
+    const entries: TiebreakerEntry[] = [
+      { id: 1, score: 1.00, source: 'agent', sourceDetail: 'explicit', valueCategory: 'contextual' },
+      { id: 2, score: 0.98, source: 'agent', sourceDetail: 'explicit', valueCategory: 'contextual' },
+    ];
+    const result = applyTiebreaker(entries);
+    expect(result[0].id).toBe(1);
+    expect(result[0].score).toBeCloseTo(1.00); // no boost applied
+    expect(result[1].score).toBeCloseTo(0.98);
+  });
+
+  it('git-ingest amplitude cap: ×1.06 never exceeds top score by more than 6%', () => {
+    const entries: TiebreakerEntry[] = [
+      { id: 1, score: 1.00, source: 'agent' },
+      { id: 2, score: 0.99, source: 'agent', sourceDetail: 'git-ingest' },
+    ];
+    const result = applyTiebreaker(entries);
+    const boostedScore = result.find(e => e.id === 2)!.score;
+    expect(boostedScore).toBeLessThanOrEqual(0.99 * 1.06 + 0.001);
+    expect(boostedScore).toBeGreaterThan(0.99);
+  });
+});
+
+// ── P6-C: session context active entities ────────────────────────────
+
+type ObsStub = { entityName?: string; type: string };
+
+/** Mirrors the activeEntities derivation in session.ts */
+function deriveActiveEntities(l2Obs: ObsStub[], max = 5): string[] {
+  return [
+    ...new Set(l2Obs.map((o) => o.entityName).filter((n): n is string => !!n && n.trim().length > 0)),
+  ].slice(0, max);
+}
+
+describe('P6-C: session context active entities', () => {
+  it('extracts unique entityNames from l2Obs in order', () => {
+    const l2Obs = [
+      { entityName: 'auth', type: 'decision' },
+      { entityName: 'database', type: 'gotcha' },
+      { entityName: 'auth', type: 'problem-solution' }, // duplicate
+    ];
+    expect(deriveActiveEntities(l2Obs)).toEqual(['auth', 'database']);
+  });
+
+  it('caps at max 5 entities', () => {
+    const l2Obs = ['a', 'b', 'c', 'd', 'e', 'f'].map(n => ({ entityName: n, type: 'decision' }));
+    const result = deriveActiveEntities(l2Obs);
+    expect(result).toHaveLength(5);
+    expect(result).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+
+  it('empty l2Obs → empty array (L1 Routing section stays hidden)', () => {
+    expect(deriveActiveEntities([])).toEqual([]);
+  });
+
+  it('filters out blank/empty entityNames', () => {
+    const l2Obs = [
+      { entityName: '', type: 'decision' },
+      { entityName: '   ', type: 'gotcha' },
+      { entityName: 'search', type: 'decision' },
+    ];
+    expect(deriveActiveEntities(l2Obs)).toEqual(['search']);
+  });
+
+  it('undefined entityName entries are dropped', () => {
+    const l2Obs = [
+      { entityName: undefined, type: 'decision' },
+      { entityName: 'embeddings', type: 'decision' },
+    ];
+    expect(deriveActiveEntities(l2Obs)).toEqual(['embeddings']);
+  });
+
+  it('output is formatted as comma-separated hint line', () => {
+    const entities = ['auth', 'database', 'search'];
+    const hint = `Active entities: ${entities.join(', ')}`;
+    expect(hint).toBe('Active entities: auth, database, search');
+    expect(hint).toContain('Active entities:');
+  });
+
+  it('active entities appear inside L1 Routing when section is already open (hooks/git)', () => {
+    // L1 Routing opens only when hooks or git evidence exist.
+    // Active entities enrich the section but do not open it alone.
+    const hasL1Content = (l1HookCount: number, l3GitCount: number) =>
+      l1HookCount > 0 || l3GitCount > 0;
+
+    expect(hasL1Content(0, 0)).toBe(false);   // entities alone → L1 Routing NOT shown
+    expect(hasL1Content(1, 0)).toBe(true);    // hook → L1 Routing shown (entities added inside)
+    expect(hasL1Content(0, 3)).toBe(true);    // git evidence → L1 Routing shown
+  });
+});


### PR DESCRIPTION
## Summary
- treat sourceDetail=git-ingest as git in source-aware retrieval boosts
- add a tiny provenance-aware tiebreaker for ambiguous standard-tier search results
- surface active entities in L1 routing as next-hop search guidance

## Verification
- npm run build
- npx vitest run tests/search/phase6-provenance.test.ts tests/search/source-aware.test.ts tests/search/intent-detector.test.ts tests/memory/session-layered.test.ts tests/memory/session.test.ts