### PR TITLE
feat: add phase 8 task-line scoping and secret safety

### DIFF
--- a/src/compact/index-format.ts
+++ b/src/compact/index-format.ts
@@ -6,6 +6,7 @@
 
 import type { IndexEntry, TimelineContext } from '../types.js';
 import { sourceBadge, resolveSourceDetail, resolveEvidenceBasis, evidenceBasisLine } from '../memory/disclosure-policy.js';
+import { redactCredentials } from '../memory/secret-filter.js';
 
 /**
  * Format a list of IndexEntries as a compact markdown table.
@@ -66,7 +67,7 @@ export function formatIndexTable(entries: IndexEntry[], query?: string, forcePro
   lines.push(`|${divider.map((part) => ` ${part} `).join('|')}|`);
 
   for (const entry of entries) {
-    const row = [`#${entry.id}`, entry.time, entry.icon, entry.title, `~${entry.tokens}`];
+    const row = [`#${entry.id}`, entry.time, entry.icon, redactCredentials(entry.title), `~${entry.tokens}`];
     if (hasSrc) row.push(sourceBadge(entry.sourceDetail, entry.source) || '-');
     if (hasProject) row.push(entry.projectId ?? '-');
     if (hasExplanation) row.push(entry.matchedFields?.join(', ') ?? '-');
@@ -101,7 +102,7 @@ export function formatTimeline(timeline: TimelineContext): string {
   const tableDivider = hasSrc ? '|----|------|---|-------|--------|-----|' : '|----|------|---|-------|--------|';
 
   const entryRow = (e: IndexEntry): string => {
-    const base = `| #${e.id} | ${e.time} | ${e.icon} | ${e.title} | ~${e.tokens} |`;
+    const base = `| #${e.id} | ${e.time} | ${e.icon} | ${redactCredentials(e.title)} | ~${e.tokens} |`;
     return hasSrc ? `${base} ${sourceBadge(e.sourceDetail, e.source) || '-'} |` : base;
   };
 
@@ -190,9 +191,9 @@ export function formatObservationDetail(doc: {
   lines.push(`Entity: ${doc.entityName}`);
   lines.push(`Project: ${doc.projectId}`);
   lines.push('');
-  lines.push(`Narrative: ${doc.narrative}`);
+  lines.push(`Narrative: ${redactCredentials(doc.narrative)}`);
 
-  const facts = doc.facts ? doc.facts.split('\n').filter(Boolean) : [];
+  const facts = doc.facts ? doc.facts.split('\n').filter(Boolean).map(redactCredentials) : [];
   if (facts.length > 0) {
     lines.push('');
     lines.push('Facts:');

--- a/src/memory/observations.ts
+++ b/src/memory/observations.ts
@@ -24,6 +24,7 @@ import { withFileLock } from '../store/file-lock.js';
 import { countTextTokens } from '../compact/token-budget.js';
 import { extractEntities, enrichConcepts } from './entity-extractor.js';
 import { getEmbeddingProvider, isEmbeddingExplicitlyDisabled } from '../embedding/provider.js';
+import { sanitizeCredentials } from './secret-filter.js';
 
 /** In-memory observation list (loaded from persistence on init) */
 let observations: Observation[] = [];
@@ -82,6 +83,10 @@ export async function storeObservation(input: {
   valueCategory?: 'core' | 'contextual' | 'ephemeral';
 }): Promise<{ observation: Observation; upserted: boolean }> {
   const now = new Date().toISOString();
+
+  // ── Central secret sanitization — strip credential values before any persistence ──
+  // Covers all write paths: hooks, git-ingest, CLI, reasoning, compact-on-write, etc.
+  input = { ...input, title: sanitizeCredentials(input.title), narrative: sanitizeCredentials(input.narrative), facts: input.facts?.map(sanitizeCredentials) };
 
   // Topic key upsert: fast-path check in-memory (optimistic, may be stale).
   // A second authoritative check happens inside the file lock to prevent TOCTOU races
@@ -301,6 +306,9 @@ async function upsertObservation(
   },
   now: string,
 ): Promise<Observation> {
+  // ── Central secret sanitization ──
+  input = { ...input, title: sanitizeCredentials(input.title), narrative: sanitizeCredentials(input.narrative), facts: input.facts?.map(sanitizeCredentials) };
+
   // Auto-extract and enrich (same as storeObservation)
   const contentForExtraction = [input.title, input.narrative, ...(input.facts ?? [])].join(' ');
   const extracted = extractEntities(contentForExtraction);

--- a/src/memory/secret-filter.ts
+++ b/src/memory/secret-filter.ts
@@ -1,0 +1,79 @@
+/**
+ * Secret Filter
+ *
+ * Conservative credential detection and redaction for Memorix memory content.
+ * Designed for low false-positive risk: only matches explicit credential
+ * assignments (key=value / key: value), not generic discussion of auth concepts.
+ *
+ *   sanitizeCredentials()  — store-time: called inside storeObservation() before write
+ *   redactCredentials()    — retrieval-time: called in format/output paths for legacy safety
+ *   containsCredential()   — predicate used for testing and optional logging
+ *
+ * Both sanitize and redact share the same pattern logic. They are kept as
+ * separate named exports so call-site semantics remain clear.
+ */
+
+/**
+ * Replaces the VALUE portion of matched credential patterns with [REDACTED].
+ * The credential key name is preserved so context is not lost.
+ *
+ * Pattern categories:
+ *   1. key=value / key: value forms — password, token, api_key, secret, etc.
+ *      Requires a real value (6+ non-whitespace chars) to avoid matching
+ *      discussion text like "password must be 8 chars".
+ *   2. Bearer authorization header tokens (20+ chars)
+ *   3. Structured token prefixes: GitHub (ghp_/ghs_/gho_), OpenAI (sk-), JWT (eyJ)
+ */
+function applyRedaction(text: string): string {
+  if (!text) return text;
+  let out = text;
+
+  // key=value / key: "value" / key='value' — preserve key, redact value
+  out = out.replace(
+    /((?:password|passwd|pwd|secret|token|api[_-]?key|auth[_-]?key|access[_-]?key|private[_-]?key|client[_-]?secret)\s*[:=]\s*["']?)([^\s"',;\n]{6,})/gi,
+    '$1[REDACTED]',
+  );
+
+  // Bearer <token> — preserve "Bearer ", redact token
+  out = out.replace(
+    /(Bearer\s+)([A-Za-z0-9._\-/+]{20,})/g,
+    '$1[REDACTED]',
+  );
+
+  // GitHub tokens (ghp_, ghs_, gho_, github_pat_)
+  out = out.replace(/\b(?:ghp|ghs|gho|github_pat)_[A-Za-z0-9]{36,}\b/g, '[REDACTED]');
+
+  // OpenAI / similar keys (sk-...)
+  out = out.replace(/\bsk-[A-Za-z0-9T-]{20,}\b/g, '[REDACTED]');
+
+  // JWT tokens (base64url header eyJ...)
+  out = out.replace(/\beyJ[A-Za-z0-9._-]{40,}\b/g, '[REDACTED]');
+
+  return out;
+}
+
+/**
+ * Store-time sanitization: strips credential values before any durable write.
+ * Called inside storeObservation() / upsertObservation() so that every write
+ * path (hooks, git-ingest, CLI, reasoning, compact-on-write) is covered.
+ */
+export function sanitizeCredentials(text: string): string {
+  return applyRedaction(text);
+}
+
+/**
+ * Retrieval-time redaction: masks credential values in display output.
+ * Applied in all output formatters (detail, index table, timeline, session context)
+ * as a safety net for legacy observations stored before sanitization was in place.
+ */
+export function redactCredentials(text: string): string {
+  return applyRedaction(text);
+}
+
+/**
+ * Returns true if the text contains an obvious credential pattern.
+ * Used for testing and optional diagnostic logging.
+ */
+export function containsCredential(text: string): boolean {
+  return applyRedaction(text) !== text;
+}

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -17,6 +17,7 @@ import { resolveAliases } from '../project/aliases.js';
 import { withFileLock } from '../store/file-lock.js';
 import { loadObservationsJson, loadSessionsJson, saveSessionsJson } from '../store/persistence.js';
 import { KnowledgeGraphManager } from './graph.js';
+import { redactCredentials, sanitizeCredentials } from './secret-filter.js';
 
 const PRIORITY_TYPES = new Set(['gotcha', 'decision', 'problem-solution', 'trade-off', 'discovery']);
 const TYPE_EMOJI: Record<string, string> = {
@@ -278,7 +279,7 @@ export async function endSession(
     session.status = 'completed';
     session.endedAt = new Date().toISOString();
     if (summary) {
-      session.summary = summary;
+      session.summary = sanitizeCredentials(summary);
     }
 
     endedSession = session;
@@ -332,15 +333,32 @@ export async function getSessionContext(
     .filter((obs) => !isNoiseObservation(obs) && !isSystemSelfObservation(obs));
 
   // L2: durable working context (explicit/undefined/core), priority types only
-  const l2Obs = projectObs
+  const l2Scored = projectObs
     .filter((obs) => PRIORITY_TYPES.has(obs.type) && classifyLayer(obs) === 'L2')
     .map((obs) => ({ obs, score: scoreObservationForSessionContext(obs, projectTokens) }))
     .sort((a, b) => {
       if (b.score !== a.score) return b.score - a.score;
       return new Date(b.obs.createdAt).getTime() - new Date(a.obs.createdAt).getTime();
-    })
-    .slice(0, 5)
-    .map(({ obs }) => obs);
+    });
+
+  // Per-entity cap: only when multiple distinct entities are present.
+  // Prevents one workstream from monopolizing session context.
+  // When all candidates belong to a single entity, skip the cap — no pollution risk.
+  const distinctL2Entities = new Set(l2Scored.map(({ obs }) => obs.entityName).filter(Boolean)).size;
+  const l2Obs = (distinctL2Entities > 1
+    ? (() => {
+        const entityCount = new Map<string, number>();
+        const ENTITY_CAP = 3;
+        return l2Scored.filter(({ obs }) => {
+          const key = obs.entityName ?? '';
+          const count = entityCount.get(key) ?? 0;
+          if (count >= ENTITY_CAP) return false;
+          entityCount.set(key, count + 1);
+          return true;
+        });
+      })()
+    : l2Scored
+  ).slice(0, 5).map(({ obs }) => obs);
 
   // L1: recent hook activity signals (titles only, most recent first)
   const l1HookObs = projectObs
@@ -392,7 +410,7 @@ export async function getSessionContext(
 
     if (l1HookObs.length > 0) {
       for (const obs of l1HookObs) {
-        lines.push(`🔗 ${obs.title}`);
+        lines.push(`🔗 ${redactCredentials(obs.title)}`);
       }
       lines.push('');
     }
@@ -433,7 +451,7 @@ export async function getSessionContext(
     }
     lines.push(`Ended: ${handoff.endedAt || handoff.startedAt}`);
     if (handoff.summary && handoff.summary !== '(session ended implicitly by new session start)') {
-      lines.push('', handoff.summary);
+      lines.push('', redactCredentials(handoff.summary));
     }
     lines.push('');
   }
@@ -444,8 +462,8 @@ export async function getSessionContext(
     lines.push('*Durable working context — explicit decisions, gotchas, and discoveries.*');
     for (const obs of l2Obs) {
       const emoji = TYPE_EMOJI[obs.type] ?? '📌';
-      const fact = obs.facts?.[0] ? ` — ${obs.facts[0]}` : '';
-      lines.push(`${emoji} ${obs.title}${fact}`);
+      const fact = obs.facts?.[0] ? ` — ${redactCredentials(obs.facts[0])}` : '';
+      lines.push(`${emoji} ${redactCredentials(obs.title)}${fact}`);
     }
     lines.push('');
   }
@@ -460,7 +478,7 @@ export async function getSessionContext(
       const rawSummary = session.summary && session.summary !== '(session ended implicitly by new session start)'
         ? session.summary : null;
       const summary = rawSummary
-        ? ` — ${rawSummary.split('\n')[0].replace(/^#+\s*/, '').slice(0, 80)}`
+        ? ` — ${redactCredentials(rawSummary.split('\n')[0].replace(/^#+\s*/, '')).slice(0, 80)}`
         : '';
       lines.push(`- ${date}${agent}${summary}`);
     }

--- a/src/store/orama-store.ts
+++ b/src/store/orama-store.ts
@@ -497,6 +497,7 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
         source: (doc.source || 'agent') as 'agent' | 'git' | 'manual',
         sourceDetail: (doc.sourceDetail || undefined) as 'explicit' | 'hook' | 'git-ingest' | undefined,
         valueCategory: (doc.valueCategory || undefined) as 'core' | 'contextual' | 'ephemeral' | undefined,
+        entityName: doc.entityName || undefined,
         _isCommandLog: isCommandLogEntry(doc.title),
       };
     });
@@ -644,6 +645,52 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
       }
     }
     if (changed) intermediate.sort((a, b) => b.score - a.score);
+  }
+
+  // ── Entity-affinity hint (standard + heavy tier only) ──────────────
+  // When query tokens (4+ chars) match some entity names in results but not
+  // others, mildly boost the matching entities (×1.08). This helps queries
+  // like "blog VPS deployment" surface blog-vps observations over api-relay
+  // observations stored in the same project bucket.
+  // Gates:
+  //   - standard or heavy tier only (fast tier is single-word, too noisy)
+  //   - only fires when some but not all entity names match the query
+  //   - top-8 and within the 20% window of the top score
+  //   - cannot reverse a meaningful score gap (amplitude ×1.08)
+  if ((tier === 'standard' || tier === 'heavy') && intermediate.length > 1 && hasQuery) {
+    const affTokens = originalQuery!
+      .toLowerCase()
+      .split(/\s+/)
+      .map(t => t.replace(/[_-]/g, ''))
+      .filter(t => t.length >= 4);
+
+    if (affTokens.length > 0) {
+      const entityNames = [...new Set(intermediate.map(e => e.entityName).filter((n): n is string => !!n))];
+      const matchedEntities = new Set(
+        entityNames.filter(name => {
+          const norm = name.toLowerCase().replace(/[_-]/g, '');
+          return affTokens.some(t => norm.includes(t));
+        }),
+      );
+
+      if (matchedEntities.size > 0 && matchedEntities.size < entityNames.length) {
+        const AFF_TOP_K = 8;
+        const AFF_WINDOW = 0.20;
+        const AFF_BOOST = 1.08;
+        const topScore = intermediate[0]?.score ?? 0;
+        const threshold = topScore * (1 - AFF_WINDOW);
+        let affChanged = false;
+        for (let i = 0; i < Math.min(AFF_TOP_K, intermediate.length); i++) {
+          const entry = intermediate[i];
+          if (entry.score < threshold) break;
+          if (matchedEntities.has(entry.entityName ?? '')) {
+            intermediate[i] = { ...entry, score: entry.score * AFF_BOOST };
+            affChanged = true;
+          }
+        }
+        if (affChanged) intermediate.sort((a, b) => b.score - a.score);
+      }
+    }
   }
 
   // ── LLM Reranking (heavy-tier only) ────────────────────────────

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,6 +171,8 @@ export interface IndexEntry {
   valueCategory?: 'core' | 'contextual' | 'ephemeral';
   /** Explainable recall: why this result matched. */
   matchedFields?: string[];
+  /** Entity name — used for entity-affinity scoring and workstream deduplication. */
+  entityName?: string;
 }
 
 /** Explicit reference to an observation, optionally scoped to a project. */

--- a/tests/memory/secret-filter.test.ts
+++ b/tests/memory/secret-filter.test.ts
@@ -1,0 +1,142 @@
+/**
+ * P8-B: Secret Filter tests
+ *
+ * Covers:
+ * - containsCredential detection
+ * - sanitizeCredentials / redactCredentials (same logic)
+ * - all 5 pattern categories
+ * - low-false-positive cases (discussion text, short values)
+ */
+
+import { describe, it, expect } from 'vitest';
+import { containsCredential, sanitizeCredentials, redactCredentials } from '../../src/memory/secret-filter.js';
+// sanitizeCredentials is also exported directly; alias used for the idempotency test
+const san = sanitizeCredentials;
+
+describe('containsCredential', () => {
+  it('detects password=value', () => {
+    expect(containsCredential('password=abc123xyz')).toBe(true);
+  });
+
+  it('detects token: "value"', () => {
+    expect(containsCredential('token: "supersecrettoken"')).toBe(true);
+  });
+
+  it('detects api_key = value', () => {
+    expect(containsCredential('api_key = myLongApiKey1234')).toBe(true);
+  });
+
+  it('detects Bearer token', () => {
+    expect(containsCredential('Authorization: Bearer eyAbc1234567890abcdefgh')).toBe(true);
+  });
+
+  it('detects GitHub token', () => {
+    expect(containsCredential('ghp_abcdefghijklmnopqrstuvwxyz123456789012')).toBe(true);
+  });
+
+  it('detects OpenAI key', () => {
+    expect(containsCredential('sk-abcdefghijklmnopqrstuv123456')).toBe(true);
+  });
+
+  it('detects JWT', () => {
+    expect(containsCredential('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjMifQ.abc')).toBe(true);
+  });
+
+  it('does NOT flag discussion text without assignment', () => {
+    expect(containsCredential('the password must be at least 8 characters long')).toBe(false);
+  });
+
+  it('does NOT flag short values (< 6 chars)', () => {
+    expect(containsCredential('pwd=abc')).toBe(false);
+  });
+
+  it('does NOT flag empty string', () => {
+    expect(containsCredential('')).toBe(false);
+  });
+
+  it('does NOT flag generic auth discussion', () => {
+    expect(containsCredential('token-based authentication is recommended over sessions')).toBe(false);
+  });
+
+  it('does NOT flag api_key concept without value', () => {
+    expect(containsCredential('store the api_key in an environment variable')).toBe(false);
+  });
+});
+
+describe('redactCredentials', () => {
+  it('redacts value in password=value, preserves key', () => {
+    const result = redactCredentials('password=supersecret99');
+    expect(result).toContain('password=');
+    expect(result).toContain('[REDACTED]');
+    expect(result).not.toContain('supersecret99');
+  });
+
+  it('redacts value in token: "value", preserves key', () => {
+    const result = redactCredentials('token: "myTokenValue123"');
+    expect(result).toContain('token:');
+    expect(result).toContain('[REDACTED]');
+    expect(result).not.toContain('myTokenValue123');
+  });
+
+  it('redacts Bearer token, preserves Bearer prefix', () => {
+    const result = redactCredentials('Authorization: Bearer eyAbc1234567890abcdefghijklmnop');
+    expect(result).toContain('Bearer [REDACTED]');
+  });
+
+  it('redacts GitHub token entirely', () => {
+    const token = 'ghp_abcdefghijklmnopqrstuvwxyz123456789012';
+    const result = redactCredentials(`my token is ${token} use it`);
+    expect(result).toContain('[REDACTED]');
+    expect(result).not.toContain(token);
+  });
+
+  it('redacts OpenAI key', () => {
+    const result = redactCredentials('key = sk-abcdefghijklmnopqrstuv123456');
+    expect(result).not.toContain('sk-abcdefghijklmnopqrstuv123456');
+  });
+
+  it('does not alter text with no credentials', () => {
+    const clean = 'the password must be at least 8 characters long';
+    expect(redactCredentials(clean)).toBe(clean);
+  });
+
+  it('handles empty string', () => {
+    expect(redactCredentials('')).toBe('');
+  });
+
+  it('is idempotent: redacting twice gives same result', () => {
+    const input = 'password=supersecret99';
+    expect(redactCredentials(redactCredentials(input))).toBe(redactCredentials(input));
+  });
+});
+
+describe('sanitizeCredentials', () => {
+  it('same behaviour as redactCredentials (same underlying logic)', () => {
+    const input = 'api_key=myLongApiKey1234';
+    expect(san(input)).toBe(redactCredentials(input));
+  });
+});
+
+describe('session summary redaction (P8 coverage)', () => {
+  it('redacts credential in session handoff summary', () => {
+    const summary = '## Goal\nDeployed blog-VPS. SSH password=hunter2xx used for login.';
+    const result = redactCredentials(summary);
+    expect(result).not.toContain('hunter2xx');
+    expect(result).toContain('[REDACTED]');
+    expect(result).toContain('password=');
+  });
+
+  it('redacts credential in session history snippet (first line)', () => {
+    const firstLine = 'Authorization: Bearer AbcDefGhiJklMnoPqrStuVwxYz12345678901';
+    const result = redactCredentials(firstLine);
+    expect(result).not.toContain('AbcDefGhiJklMnoPqrStuVwxYz12345678901');
+    expect(result).toContain('Bearer [REDACTED]');
+  });
+
+  it('sanitizeCredentials applied at endSession write-time prevents storing raw secret', () => {
+    const rawSummary = 'Connected to VPS. root password=P@ssw0rdSecret123';
+    const stored = sanitizeCredentials(rawSummary);
+    expect(stored).not.toContain('P@ssw0rdSecret123');
+    expect(stored).toContain('[REDACTED]');
+  });
+});

--- a/tests/memory/session-workstream.test.ts
+++ b/tests/memory/session-workstream.test.ts
@@ -1,0 +1,118 @@
+/**
+ * P8-A2: Session per-entity cap tests
+ *
+ * Mirrors the per-entity cap logic in getSessionContext() (session.ts).
+ * The cap (max 3/entity) only activates when multiple distinct entities are present.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// ── Pure logic helper mirroring session.ts per-entity cap ─────────────
+
+interface ScoredObs {
+  entityName?: string;
+  score: number;
+  id: number;
+}
+
+function applyEntityCap(
+  scored: ScoredObs[],
+  cap = 3,
+  limit = 5,
+): ScoredObs[] {
+  const distinctEntities = new Set(scored.map(o => o.entityName).filter(Boolean)).size;
+
+  if (distinctEntities <= 1) {
+    return scored.slice(0, limit);
+  }
+
+  const entityCount = new Map<string, number>();
+  return scored
+    .filter(o => {
+      const key = o.entityName ?? '';
+      const count = entityCount.get(key) ?? 0;
+      if (count >= cap) return false;
+      entityCount.set(key, count + 1);
+      return true;
+    })
+    .slice(0, limit);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe('P8-A2: per-entity cap logic', () => {
+  it('single entity: no cap applied, all results pass through', () => {
+    const scored: ScoredObs[] = [
+      { entityName: 'blog-vps', score: 5, id: 1 },
+      { entityName: 'blog-vps', score: 4, id: 2 },
+      { entityName: 'blog-vps', score: 3, id: 3 },
+      { entityName: 'blog-vps', score: 2, id: 4 },
+      { entityName: 'blog-vps', score: 1, id: 5 },
+    ];
+    const result = applyEntityCap(scored);
+    expect(result).toHaveLength(5);
+    expect(result.every(o => o.entityName === 'blog-vps')).toBe(true);
+  });
+
+  it('multiple entities: cap at 3 per entity', () => {
+    const scored: ScoredObs[] = [
+      { entityName: 'api-relay', score: 9, id: 1 },
+      { entityName: 'api-relay', score: 8, id: 2 },
+      { entityName: 'api-relay', score: 7, id: 3 },
+      { entityName: 'api-relay', score: 6, id: 4 },
+      { entityName: 'blog-vps', score: 5, id: 5 },
+      { entityName: 'blog-vps', score: 4, id: 6 },
+    ];
+    const result = applyEntityCap(scored);
+    const apiCount = result.filter(o => o.entityName === 'api-relay').length;
+    expect(apiCount).toBeLessThanOrEqual(3);
+    expect(result.some(o => o.entityName === 'blog-vps')).toBe(true);
+  });
+
+  it('multiple entities: cap prevents one workstream monopolizing all 5 slots', () => {
+    const scored: ScoredObs[] = Array.from({ length: 5 }, (_, i) => ({
+      entityName: 'api-relay',
+      score: 10 - i,
+      id: i + 1,
+    })).concat({ entityName: 'blog-vps', score: 1, id: 99 });
+
+    const result = applyEntityCap(scored, 3, 5);
+    const apiCount = result.filter(o => o.entityName === 'api-relay').length;
+    expect(apiCount).toBe(3);
+    expect(result.some(o => o.entityName === 'blog-vps')).toBe(true);
+  });
+
+  it('respects the overall limit after capping', () => {
+    const scored: ScoredObs[] = [
+      { entityName: 'a', score: 10, id: 1 },
+      { entityName: 'b', score: 9, id: 2 },
+      { entityName: 'a', score: 8, id: 3 },
+      { entityName: 'b', score: 7, id: 4 },
+      { entityName: 'a', score: 6, id: 5 },
+      { entityName: 'c', score: 5, id: 6 },
+    ];
+    const result = applyEntityCap(scored, 3, 5);
+    expect(result.length).toBeLessThanOrEqual(5);
+  });
+
+  it('handles entries without entityName', () => {
+    const scored: ScoredObs[] = [
+      { entityName: 'api-relay', score: 9, id: 1 },
+      { score: 8, id: 2 },
+      { entityName: 'blog-vps', score: 7, id: 3 },
+    ];
+    expect(() => applyEntityCap(scored)).not.toThrow();
+  });
+
+  it('single distinct entity even with undefined names: no cap applied', () => {
+    const scored: ScoredObs[] = [
+      { score: 9, id: 1 },
+      { score: 8, id: 2 },
+      { score: 7, id: 3 },
+      { score: 6, id: 4 },
+      { score: 5, id: 5 },
+    ];
+    const result = applyEntityCap(scored);
+    expect(result).toHaveLength(5);
+  });
+});

--- a/tests/search/phase8-entity-affinity.test.ts
+++ b/tests/search/phase8-entity-affinity.test.ts
@@ -1,0 +1,145 @@
+/**
+ * P8-A1: Entity-affinity scoring logic tests
+ *
+ * Mirrors the entity-affinity pass in orama-store.ts.
+ * Tests the pure logic: token extraction, entity matching, boost application.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// ── Pure logic helpers mirroring the orama-store.ts implementation ──
+
+interface EntryStub {
+  entityName?: string;
+  score: number;
+}
+
+function extractAffTokens(query: string): string[] {
+  return query
+    .toLowerCase()
+    .split(/\s+/)
+    .map(t => t.replace(/[_-]/g, ''))
+    .filter(t => t.length >= 4);
+}
+
+function applyEntityAffinity(
+  entries: EntryStub[],
+  query: string,
+  opts = { topK: 8, window: 0.20, boost: 1.08 },
+): EntryStub[] {
+  const affTokens = extractAffTokens(query);
+  if (affTokens.length === 0) return entries;
+
+  const entityNames = [...new Set(entries.map(e => e.entityName).filter((n): n is string => !!n))];
+  const matchedEntities = new Set(
+    entityNames.filter(name => {
+      const norm = name.toLowerCase().replace(/[_-]/g, '');
+      return affTokens.some(t => norm.includes(t));
+    }),
+  );
+
+  if (matchedEntities.size === 0 || matchedEntities.size >= entityNames.length) return entries;
+
+  const topScore = entries[0]?.score ?? 0;
+  const threshold = topScore * (1 - opts.window);
+  const result = entries.map((e, i) => {
+    if (i >= opts.topK) return e;
+    if (e.score < threshold) return e;
+    if (matchedEntities.has(e.entityName ?? '')) {
+      return { ...e, score: e.score * opts.boost };
+    }
+    return e;
+  });
+  return result.sort((a, b) => b.score - a.score);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe('P8-A1: entity-affinity scoring logic', () => {
+  it('boosts matching entity results', () => {
+    const entries: EntryStub[] = [
+      { entityName: 'blog-vps', score: 1.0 },
+      { entityName: 'api-relay', score: 0.95 },
+    ];
+    const result = applyEntityAffinity(entries, 'blog VPS deployment');
+    const blogEntry = result.find(e => e.entityName === 'blog-vps');
+    const apiEntry = result.find(e => e.entityName === 'api-relay');
+    expect(blogEntry!.score).toBeGreaterThan(apiEntry!.score);
+    expect(blogEntry!.score).toBeCloseTo(1.0 * 1.08);
+    expect(apiEntry!.score).toBe(0.95);
+  });
+
+  it('does NOT fire when all entities match the query', () => {
+    const entries: EntryStub[] = [
+      { entityName: 'blog-vps', score: 1.0 },
+      { entityName: 'blog-config', score: 0.95 },
+    ];
+    const result = applyEntityAffinity(entries, 'blog setup');
+    expect(result[0].score).toBe(1.0);
+    expect(result[1].score).toBe(0.95);
+  });
+
+  it('does NOT fire when no entities match the query', () => {
+    const entries: EntryStub[] = [
+      { entityName: 'api-relay', score: 1.0 },
+      { entityName: 'devlens', score: 0.95 },
+    ];
+    const result = applyEntityAffinity(entries, 'deploy infrastructure');
+    expect(result[0].score).toBe(1.0);
+    expect(result[1].score).toBe(0.95);
+  });
+
+  it('does NOT boost entries outside the 20% window', () => {
+    const entries: EntryStub[] = [
+      { entityName: 'api-relay', score: 1.0 },
+      { entityName: 'blog-vps', score: 0.7 },
+    ];
+    const result = applyEntityAffinity(entries, 'blog VPS');
+    const blogEntry = result.find(e => e.entityName === 'blog-vps');
+    expect(blogEntry!.score).toBe(0.7);
+  });
+
+  it('does NOT fire for short query tokens (< 4 chars)', () => {
+    const entries: EntryStub[] = [
+      { entityName: 'vps', score: 1.0 },
+      { entityName: 'api-relay', score: 0.95 },
+    ];
+    const result = applyEntityAffinity(entries, 'vps up');
+    expect(result[0].score).toBe(1.0);
+    expect(result[1].score).toBe(0.95);
+  });
+
+  it('boost amplitude is ×1.08 — cannot reverse a 15%+ gap', () => {
+    const entries: EntryStub[] = [
+      { entityName: 'api-relay', score: 1.0 },
+      { entityName: 'blog-vps', score: 0.9 },
+    ];
+    const result = applyEntityAffinity(entries, 'blog VPS deployment');
+    const blogEntry = result.find(e => e.entityName === 'blog-vps')!;
+    const apiEntry = result.find(e => e.entityName === 'api-relay')!;
+    expect(blogEntry.score).toBeCloseTo(0.9 * 1.08);
+    expect(blogEntry.score).toBeLessThan(apiEntry.score);
+  });
+
+  it('handles entries without entityName gracefully', () => {
+    const entries: EntryStub[] = [
+      { entityName: 'blog-vps', score: 1.0 },
+      { score: 0.95 },
+    ];
+    expect(() => applyEntityAffinity(entries, 'blog VPS deployment')).not.toThrow();
+  });
+});
+
+describe('P8-A1: affinity token extraction', () => {
+  it('extracts tokens of 4+ chars', () => {
+    expect(extractAffTokens('blog VPS deployment')).toEqual(['blog', 'deployment']);
+  });
+
+  it('strips hyphens/underscores from tokens', () => {
+    expect(extractAffTokens('api-relay setup')).toEqual(['apirelay', 'setup']);
+  });
+
+  it('returns empty for all-short tokens', () => {
+    expect(extractAffTokens('vps up on db')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- add task-line/workstream scoping to reduce same-repo retrieval contamination
- add centralized secret sanitization on durable memory writes
- add retrieval-time redaction across detail, index, timeline, and session outputs

## What changed
- add src/memory/secret-filter.ts for conservative credential detection and redaction
- sanitize memory text in central write paths (storeObservation / upsertObservation)
- redact secrets in detail/search/timeline/session rendering paths
- add entity-affinity scoring in search for same-repo subdomain/task-line narrowing
- add per-entity cap in session L2 context when multiple entities compete
- redact session handoff summaries and history snippets, and sanitize session end summaries on write

## Why
A real retrieval incident showed that project-scoped search was working correctly, but unrelated api-relay / DevLens memories had already been written into the AVIDS2/blog bucket. This phase improves same-repo workstream narrowing and hardens secret safety so bad stored data is less likely to surface again.

## Validation
- npm run build
- npx vitest run tests/memory/secret-filter.test.ts tests/search/phase8-entity-affinity.test.ts tests/memory/session-workstream.test.ts