### PR TITLE
feat: add phase 9 attribution guard and audit

### DIFF
--- a/src/memory/attribution-guard.ts
+++ b/src/memory/attribution-guard.ts
@@ -1,0 +1,245 @@
+/**
+ * Attribution Guard
+ *
+ * Detects when a write's entityName is better known in a different project than
+ * the currently bound session project.  Used to:
+ *
+ *   1. Emit a passive warning on memorix_store / memorix_store_reasoning when a
+ *      suspicious attribution is detected (Goal A — prevent new wrong-bucket writes).
+ *   2. Scan an existing project for already-misattributed observations so an
+ *      operator can archive/move them (Goal B — legacy cleanup audit).
+ *
+ * Both functions are alias-aware: projectIds are normalised to their canonical
+ * form via the alias registry before any comparison, so the same physical repo
+ * seen under multiple aliases is never mis-counted as two separate projects.
+ *
+ * Detection heuristic (low false-positive):
+ *   suspicious = entityName appears 0× in currentProject AND ≥ threshold× in
+ *                exactly one other canonical project.
+ */
+
+import type { Observation } from '../types.js';
+import { getCanonicalId, resolveAliases } from '../project/aliases.js';
+
+/** Default minimum occurrence count in another project to trigger suspicion. */
+const DEFAULT_THRESHOLD = 2;
+
+// ── Shared helpers ─────────────────────────────────────────────────────────
+
+/**
+ * Resolve every unique projectId found in the observation list to its canonical
+ * form.  Returns a Map<rawProjectId, canonicalId>.
+ * Best-effort: if alias registry is unavailable for a given ID, falls back to
+ * the raw projectId so the guard degrades gracefully.
+ */
+async function buildCanonicalMap(
+  obs: Observation[],
+): Promise<Map<string, string>> {
+  const uniqueIds = [...new Set(obs.map((o) => o.projectId).filter(Boolean))];
+  const map = new Map<string, string>();
+  await Promise.all(
+    uniqueIds.map(async (pid) => {
+      try {
+        map.set(pid, await getCanonicalId(pid));
+      } catch {
+        map.set(pid, pid);
+      }
+    }),
+  );
+  return map;
+}
+
+/**
+ * Build a two-level count map:
+ *   canonical projectId → entityName → occurrence count
+ * Only active observations are counted.
+ */
+function buildEntityCountMap(
+  obs: Observation[],
+  canonicalMap: Map<string, string>,
+): Map<string, Map<string, number>> {
+  const result = new Map<string, Map<string, number>>();
+  for (const o of obs) {
+    if ((o.status ?? 'active') !== 'active') continue;
+    if (!o.entityName) continue;
+    const canonical = canonicalMap.get(o.projectId) ?? o.projectId;
+    if (!result.has(canonical)) result.set(canonical, new Map());
+    const inner = result.get(canonical)!;
+    inner.set(o.entityName, (inner.get(o.entityName) ?? 0) + 1);
+  }
+  return result;
+}
+
+// ── Goal A: write-time passive check ──────────────────────────────────────
+
+export interface AttributionResult {
+  /** True when the entity is unseen in the current project but well-known in another. */
+  suspicious: boolean;
+  /** Canonical projectId where the entity actually lives (present when suspicious). */
+  knownIn?: string;
+  /** How many times the entity appears in knownIn (present when suspicious). */
+  count?: number;
+  /** 'high' when count ≥ 5, otherwise 'low'. */
+  confidence?: 'high' | 'low';
+  /** Human-readable explanation (present when suspicious). */
+  reason?: string;
+}
+
+/**
+ * Check whether entityName is anomalous for the current session's project.
+ *
+ * Alias-aware: both currentProjectId and the projectIds stored in observations
+ * are resolved to canonical IDs before comparison.
+ *
+ * @param entityName       The entity being written.
+ * @param currentProjectId The session's bound project (may be a raw/alias ID).
+ * @param allObservations  Snapshot from getAllObservations() (passed in to avoid
+ *                         circular imports and to allow easy unit testing).
+ * @param threshold        Minimum occurrences in another project to flag (default 2).
+ */
+export async function checkProjectAttribution(
+  entityName: string,
+  currentProjectId: string,
+  allObservations: Observation[],
+  threshold = DEFAULT_THRESHOLD,
+): Promise<AttributionResult> {
+  let currentCanonical: string;
+  try {
+    currentCanonical = await getCanonicalId(currentProjectId);
+  } catch {
+    currentCanonical = currentProjectId;
+  }
+
+  const canonicalMap = await buildCanonicalMap(allObservations);
+  const entityCounts = buildEntityCountMap(allObservations, canonicalMap);
+
+  const currentCount =
+    entityCounts.get(currentCanonical)?.get(entityName) ?? 0;
+
+  if (currentCount > 0) {
+    return { suspicious: false };
+  }
+
+  // Find the other canonical project with the highest count for this entity
+  let maxCount = 0;
+  let maxCanonical = '';
+  for (const [canonical, inner] of entityCounts) {
+    if (canonical === currentCanonical) continue;
+    const count = inner.get(entityName) ?? 0;
+    if (count > maxCount) {
+      maxCount = count;
+      maxCanonical = canonical;
+    }
+  }
+
+  if (maxCount < threshold) {
+    return { suspicious: false };
+  }
+
+  return {
+    suspicious: true,
+    knownIn: maxCanonical,
+    count: maxCount,
+    confidence: maxCount >= 5 ? 'high' : 'low',
+    reason:
+      `Entity "${entityName}" has 0 observations in "${currentCanonical}" ` +
+      `but ${maxCount} in "${maxCanonical}"`,
+  };
+}
+
+// ── Goal B: legacy audit scan ─────────────────────────────────────────────
+
+export interface AuditEntry {
+  /** Observation ID. */
+  id: number;
+  /** Raw projectId stored on the observation (may differ from canonical). */
+  projectId: string;
+  entityName: string;
+  title: string;
+  /** Memory source: 'agent' | 'git' | 'manual'. */
+  source: string;
+  /** Provenance detail: 'explicit' | 'hook' | 'git-ingest' | undefined. */
+  sourceDetail: string | undefined;
+  /** Canonical projectId where this entity is better known. */
+  likelyBelongsTo: string;
+  /** Occurrence count of entityName in likelyBelongsTo. */
+  count: number;
+  confidence: 'high' | 'low';
+}
+
+/**
+ * Scan all active observations belonging to currentProjectId (including aliases)
+ * and return those whose entityName is suspicious — i.e., not seen elsewhere in
+ * the same project but well-known in a different canonical project.
+ *
+ * @param currentProjectId  The session's bound project (may be raw/alias ID).
+ * @param allObservations   Full observation list from getAllObservations().
+ * @param threshold         Minimum occurrences in another project to flag (default 2).
+ */
+export async function auditProjectObservations(
+  currentProjectId: string,
+  allObservations: Observation[],
+  threshold = DEFAULT_THRESHOLD,
+): Promise<AuditEntry[]> {
+  // Resolve current project aliases — we scan obs stored under ANY alias
+  let currentAliases: string[];
+  let currentCanonical: string;
+  try {
+    currentAliases = await resolveAliases(currentProjectId);
+    currentCanonical = await getCanonicalId(currentProjectId);
+  } catch {
+    currentAliases = [currentProjectId];
+    currentCanonical = currentProjectId;
+  }
+  const aliasSet = new Set(currentAliases);
+
+  const activeObs = allObservations.filter(
+    (o) => (o.status ?? 'active') === 'active',
+  );
+
+  // Build global canonical map and entity count map once
+  const canonicalMap = await buildCanonicalMap(activeObs);
+  const entityCounts = buildEntityCountMap(activeObs, canonicalMap);
+
+  // Observations belonging to the current project (any alias)
+  const projectObs = activeObs.filter((o) => aliasSet.has(o.projectId));
+
+  const entries: AuditEntry[] = [];
+
+  for (const obs of projectObs) {
+    if (!obs.entityName) continue;
+
+    const currentCount =
+      entityCounts.get(currentCanonical)?.get(obs.entityName) ?? 0;
+
+    if (currentCount > 1) continue; // entity is meaningfully present → skip
+
+    // Find best alternative canonical project
+    let maxCount = 0;
+    let maxCanonical = '';
+    for (const [canonical, inner] of entityCounts) {
+      if (canonical === currentCanonical) continue;
+      const count = inner.get(obs.entityName) ?? 0;
+      if (count > maxCount) {
+        maxCount = count;
+        maxCanonical = canonical;
+      }
+    }
+
+    if (maxCount < threshold) continue;
+
+    entries.push({
+      id: obs.id,
+      projectId: obs.projectId,
+      entityName: obs.entityName,
+      title: obs.title,
+      source: obs.source ?? 'agent',
+      sourceDetail: obs.sourceDetail,
+      likelyBelongsTo: maxCanonical,
+      count: maxCount,
+      confidence: maxCount >= 5 ? 'high' : 'low',
+    });
+  }
+
+  return entries;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,7 +20,8 @@ import { watchFile } from 'node:fs';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { KnowledgeGraphManager } from './memory/graph.js';
-import { initObservations, storeObservation, reindexObservations, migrateProjectIds, getObservation } from './memory/observations.js';
+import { initObservations, storeObservation, reindexObservations, migrateProjectIds, getObservation, getAllObservations } from './memory/observations.js';
+import { checkProjectAttribution, auditProjectObservations } from './memory/attribution-guard.js';
 import { resetDb } from './store/orama-store.js';
 import { createAutoRelations } from './memory/auto-relations.js';
 import { extractEntities } from './memory/entity-extractor.js';
@@ -702,6 +703,19 @@ export async function createMemorixServer(
         }
       } catch { /* compression is best-effort (timeout or LLM failure) */ }
 
+      // ── Attribution guard (passive, non-blocking) ─────────────────
+      // Warns when entityName is unknown in this project but well-established
+      // in a different project — signals a potential wrong-bucket write.
+      let attributionWarning = '';
+      try {
+        const attrCheck = await checkProjectAttribution(entityName, project.id, getAllObservations());
+        if (attrCheck.suspicious) {
+          attributionWarning = `\n⚠️ Attribution notice: entity "${entityName}" has 0 observations in ` +
+            `"${project.id}" but ${attrCheck.count} in "${attrCheck.knownIn}" ` +
+            `(confidence: ${attrCheck.confidence}). Verify the correct project is bound before storing.`;
+        }
+      } catch { /* guard is best-effort — never blocks the write */ }
+
       // Store the observation (may upsert if topicKey matches existing)
       markInternalWrite();
       const { observation: obs, upserted } = await storeObservation({
@@ -838,7 +852,7 @@ export async function createMemorixServer(
         content: [
           {
             type: 'text' as const,
-            text: `${action} observation #${obs.id} "${title}" (~${obs.tokens} tokens)\nEntity: ${entityName} | Type: ${type} | Project: ${project.id}${obs.topicKey ? ` | Topic: ${obs.topicKey}` : ''}${compactAction}${compressionNote}${enrichment}${formationNote}`,
+            text: `${action} observation #${obs.id} "${title}" (~${obs.tokens} tokens)\nEntity: ${entityName} | Type: ${type} | Project: ${project.id}${obs.topicKey ? ` | Topic: ${obs.topicKey}` : ''}${compactAction}${compressionNote}${enrichment}${formationNote}${attributionWarning}`,
           },
         ],
       };
@@ -1086,6 +1100,17 @@ export async function createMemorixServer(
         { name: entityName, entityType: 'auto', observations: [] },
       ]);
 
+      // ── Attribution guard (passive, non-blocking) ─────────────────
+      let reasoningAttributionWarning = '';
+      try {
+        const attrCheck = await checkProjectAttribution(entityName, project.id, getAllObservations());
+        if (attrCheck.suspicious) {
+          reasoningAttributionWarning = `\n⚠️ Attribution notice: entity "${entityName}" has 0 observations in ` +
+            `"${project.id}" but ${attrCheck.count} in "${attrCheck.knownIn}" ` +
+            `(confidence: ${attrCheck.confidence}). Verify the correct project is bound before storing.`;
+        }
+      } catch { /* guard is best-effort — never blocks the write */ }
+
       markInternalWrite();
       const { observation: obs } = await storeObservation({
         entityName,
@@ -1109,8 +1134,80 @@ export async function createMemorixServer(
       return {
         content: [{
           type: 'text' as const,
-          text: `🧠 Reasoning trace stored #${obs.id}: "${decision}"\nEntity: ${entityName} | ${facts.length} facts | ${obs.tokens} tokens`,
+          text: `🧠 Reasoning trace stored #${obs.id}: "${decision}"\nEntity: ${entityName} | ${facts.length} facts | ${obs.tokens} tokens${reasoningAttributionWarning}`,
         }],
+      };
+    },
+  );
+
+  /**
+   * memorix_audit_project — Scan for misattributed observations
+   *
+   * Read-only audit: identifies observations in the current project whose
+   * entityName is well-known in a different project but absent here.
+   * Use the results to decide which observations to archive with memorix_resolve.
+   */
+  server.registerTool(
+    'memorix_audit_project',
+    {
+      title: 'Audit Project Attribution',
+      description:
+        'Scan the current project for observations that may have been written to the wrong project bucket. ' +
+        'Identifies observations whose entityName appears exclusively in a different project. ' +
+        'Read-only — no data is changed. Use memorix_resolve to archive confirmed mis-attributed observations.',
+      inputSchema: {
+        threshold: z.number().int().min(1).optional().describe(
+          'Minimum occurrences of an entityName in another project to flag it as suspicious (default: 2)',
+        ),
+      },
+    },
+    async ({ threshold }) => {
+      const unresolved = requireResolvedProject('audit project attribution');
+      if (unresolved) return unresolved;
+
+      const minCount = threshold ?? 2;
+      let entries: import('./memory/attribution-guard.js').AuditEntry[];
+      try {
+        entries = await auditProjectObservations(project.id, getAllObservations(), minCount);
+      } catch (err) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Audit failed: ${err instanceof Error ? err.message : String(err)}`,
+          }],
+        };
+      }
+
+      if (entries.length === 0) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `✅ No suspicious observations found in project "${project.id}" (threshold: ${minCount}).`,
+          }],
+        };
+      }
+
+      const lines: string[] = [
+        `## Attribution Audit — ${project.id}`,
+        `Found **${entries.length}** potentially mis-attributed observation(s) (threshold: ≥${minCount} occurrences in another project).\n`,
+        '| ID | Entity | Title | Source | Detail | Likely Belongs To | Count | Confidence |',
+        '|----|--------|-------|--------|--------|-------------------|-------|------------|',
+      ];
+
+      for (const e of entries) {
+        const titleTrunc = e.title.length > 50 ? e.title.slice(0, 47) + '...' : e.title;
+        lines.push(
+          `| #${e.id} | ${e.entityName} | ${titleTrunc} | ${e.source} | ${e.sourceDetail ?? '-'} | ${e.likelyBelongsTo} | ${e.count} | ${e.confidence} |`,
+        );
+      }
+
+      lines.push('');
+      lines.push(
+        '> To clean up: use `memorix_resolve` with `status: "archived"` on confirmed mis-attributed observation IDs.',
+      );
+
+      return {
+        content: [{ type: 'text' as const, text: lines.join('\n') }],
       };
     },
   );

--- a/tests/memory/attribution-guard.test.ts
+++ b/tests/memory/attribution-guard.test.ts
@@ -1,0 +1,257 @@
+/**
+ * P9: Attribution Guard tests
+ *
+ * Covers:
+ * - checkProjectAttribution: clean / suspicious / ambiguous / below-threshold
+ * - alias-aware grouping: same physical project under two raw IDs
+ * - auditProjectObservations: scan returns correct suspicious entries
+ * - audit respects alias expansion when filtering the current project's obs
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Mock alias resolution ──────────────────────────────────────────────────
+// We don't have the full alias registry on disk in unit tests.
+// Instead, we stub getCanonicalId/resolveAliases to simulate alias groups.
+
+vi.mock('../../src/project/aliases.js', () => {
+  // alias map: raw ID → canonical ID
+  const aliases: Record<string, string> = {
+    'local/blog':    'user/blog',
+    'user/blog':     'user/blog',
+    'local/relay':   'user/api-relay',
+    'user/api-relay':'user/api-relay',
+    'user/devlens':  'user/devlens',
+  };
+  // reverse: canonical → all raw aliases
+  const reverseMap: Record<string, string[]> = {
+    'user/blog':      ['local/blog', 'user/blog'],
+    'user/api-relay': ['local/relay', 'user/api-relay'],
+    'user/devlens':   ['user/devlens'],
+  };
+
+  return {
+    getCanonicalId: vi.fn(async (id: string) => aliases[id] ?? id),
+    resolveAliases: vi.fn(async (id: string) => {
+      const canonical = aliases[id] ?? id;
+      return reverseMap[canonical] ?? [id];
+    }),
+  };
+});
+
+import { checkProjectAttribution, auditProjectObservations } from '../../src/memory/attribution-guard.js';
+import type { Observation } from '../../src/types.js';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeObs(
+  id: number,
+  projectId: string,
+  entityName: string,
+  opts: Partial<Observation> = {},
+): Observation {
+  return {
+    id,
+    projectId,
+    entityName,
+    type: 'gotcha',
+    title: `Title for ${entityName} #${id}`,
+    narrative: 'Some narrative.',
+    facts: [],
+    filesModified: [],
+    concepts: [],
+    tokens: 20,
+    createdAt: new Date().toISOString(),
+    status: 'active',
+    source: 'agent',
+    ...opts,
+  } as Observation;
+}
+
+// ── checkProjectAttribution ────────────────────────────────────────────────
+
+describe('checkProjectAttribution', () => {
+  it('returns not suspicious when entityName exists in current project', async () => {
+    const obs = [
+      makeObs(1, 'user/blog', 'blog-vps'),
+      makeObs(2, 'user/blog', 'blog-vps'),
+      makeObs(3, 'user/api-relay', 'api-relay'),
+      makeObs(4, 'user/api-relay', 'api-relay'),
+    ];
+    const result = await checkProjectAttribution('blog-vps', 'user/blog', obs);
+    expect(result.suspicious).toBe(false);
+  });
+
+  it('returns suspicious when entityName is absent in current project but ≥2× in another', async () => {
+    const obs = [
+      makeObs(1, 'user/api-relay', 'api-relay'),
+      makeObs(2, 'user/api-relay', 'api-relay'),
+      makeObs(3, 'user/api-relay', 'api-relay'),
+    ];
+    const result = await checkProjectAttribution('api-relay', 'user/blog', obs);
+    expect(result.suspicious).toBe(true);
+    expect(result.knownIn).toBe('user/api-relay');
+    expect(result.count).toBe(3);
+  });
+
+  it('returns not suspicious when other project count is below threshold', async () => {
+    const obs = [
+      makeObs(1, 'user/api-relay', 'api-relay'),
+    ];
+    const result = await checkProjectAttribution('api-relay', 'user/blog', obs, 2);
+    expect(result.suspicious).toBe(false);
+  });
+
+  it('returns not suspicious when entityName appears in both projects (ambiguous)', async () => {
+    const obs = [
+      makeObs(1, 'user/blog', 'shared-util'),
+      makeObs(2, 'user/api-relay', 'shared-util'),
+      makeObs(3, 'user/api-relay', 'shared-util'),
+    ];
+    const result = await checkProjectAttribution('shared-util', 'user/blog', obs);
+    expect(result.suspicious).toBe(false);
+  });
+
+  it('returns not suspicious when entity is completely unknown everywhere', async () => {
+    const obs = [
+      makeObs(1, 'user/api-relay', 'api-relay'),
+    ];
+    const result = await checkProjectAttribution('brand-new-entity', 'user/blog', obs);
+    expect(result.suspicious).toBe(false);
+  });
+
+  it('confidence is high when count ≥ 5', async () => {
+    const obs = Array.from({ length: 6 }, (_, i) =>
+      makeObs(i + 1, 'user/api-relay', 'api-relay'),
+    );
+    const result = await checkProjectAttribution('api-relay', 'user/blog', obs);
+    expect(result.suspicious).toBe(true);
+    expect(result.confidence).toBe('high');
+  });
+
+  it('confidence is low when count is 2–4', async () => {
+    const obs = [
+      makeObs(1, 'user/api-relay', 'api-relay'),
+      makeObs(2, 'user/api-relay', 'api-relay'),
+    ];
+    const result = await checkProjectAttribution('api-relay', 'user/blog', obs);
+    expect(result.suspicious).toBe(true);
+    expect(result.confidence).toBe('low');
+  });
+
+  it('is alias-aware: local/relay alias groups with user/api-relay', async () => {
+    const obs = [
+      makeObs(1, 'local/relay', 'api-relay'),
+      makeObs(2, 'user/api-relay', 'api-relay'),
+      makeObs(3, 'user/api-relay', 'api-relay'),
+    ];
+    const result = await checkProjectAttribution('api-relay', 'user/blog', obs);
+    expect(result.suspicious).toBe(true);
+    // All 3 obs should be counted under same canonical (user/api-relay)
+    expect(result.count).toBe(3);
+  });
+
+  it('is alias-aware: local/blog and user/blog count as the same project', async () => {
+    const obs = [
+      makeObs(1, 'local/blog', 'blog-vps'),
+      makeObs(2, 'user/api-relay', 'api-relay'),
+      makeObs(3, 'user/api-relay', 'api-relay'),
+    ];
+    // blog-vps exists under local/blog (alias of user/blog) — should not be suspicious
+    const result = await checkProjectAttribution('blog-vps', 'user/blog', obs);
+    expect(result.suspicious).toBe(false);
+  });
+
+  it('ignores archived observations', async () => {
+    const obs = [
+      makeObs(1, 'user/api-relay', 'api-relay', { status: 'archived' }),
+      makeObs(2, 'user/api-relay', 'api-relay', { status: 'archived' }),
+    ];
+    const result = await checkProjectAttribution('api-relay', 'user/blog', obs);
+    expect(result.suspicious).toBe(false);
+  });
+});
+
+// ── auditProjectObservations ───────────────────────────────────────────────
+
+describe('auditProjectObservations', () => {
+  it('returns empty when no suspicious obs in current project', async () => {
+    const obs = [
+      makeObs(1, 'user/blog', 'blog-vps'),
+      makeObs(2, 'user/blog', 'blog-vps'),
+      makeObs(3, 'user/api-relay', 'api-relay'),
+    ];
+    const result = await auditProjectObservations('user/blog', obs);
+    expect(result).toHaveLength(0);
+  });
+
+  it('flags obs whose entityName is absent in current project but ≥2× in another', async () => {
+    const obs = [
+      makeObs(1, 'user/blog', 'api-relay'),
+      makeObs(2, 'user/api-relay', 'api-relay'),
+      makeObs(3, 'user/api-relay', 'api-relay'),
+    ];
+    const result = await auditProjectObservations('user/blog', obs);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(1);
+    expect(result[0].entityName).toBe('api-relay');
+    expect(result[0].likelyBelongsTo).toBe('user/api-relay');
+    expect(result[0].count).toBe(2);
+  });
+
+  it('audit entry contains all required fields', async () => {
+    const obs = [
+      makeObs(5, 'user/blog', 'api-relay', {
+        source: 'agent',
+        sourceDetail: 'explicit',
+        title: 'Auth bypass bug fix in api-relay',
+      }),
+      makeObs(6, 'user/api-relay', 'api-relay'),
+      makeObs(7, 'user/api-relay', 'api-relay'),
+    ];
+    const result = await auditProjectObservations('user/blog', obs);
+    expect(result).toHaveLength(1);
+    const entry = result[0];
+    expect(entry.id).toBe(5);
+    expect(entry.projectId).toBe('user/blog');
+    expect(entry.entityName).toBe('api-relay');
+    expect(entry.title).toBe('Auth bypass bug fix in api-relay');
+    expect(entry.source).toBe('agent');
+    expect(entry.sourceDetail).toBe('explicit');
+    expect(entry.likelyBelongsTo).toBeDefined();
+    expect(entry.count).toBeGreaterThanOrEqual(2);
+    expect(['high', 'low']).toContain(entry.confidence);
+  });
+
+  it('is alias-aware: scans obs stored under any alias of current project', async () => {
+    const obs = [
+      makeObs(10, 'local/blog', 'api-relay'),
+      makeObs(11, 'user/api-relay', 'api-relay'),
+      makeObs(12, 'user/api-relay', 'api-relay'),
+    ];
+    // local/blog is an alias of user/blog; audit should include obs #10
+    const result = await auditProjectObservations('user/blog', obs);
+    expect(result.some(e => e.id === 10)).toBe(true);
+  });
+
+  it('does not flag obs when entityName is known in current project too', async () => {
+    const obs = [
+      makeObs(1, 'user/blog', 'blog-vps'),
+      makeObs(2, 'user/blog', 'blog-vps'),
+      makeObs(3, 'user/api-relay', 'blog-vps'),
+      makeObs(4, 'user/api-relay', 'blog-vps'),
+    ];
+    const result = await auditProjectObservations('user/blog', obs);
+    expect(result).toHaveLength(0);
+  });
+
+  it('does not flag archived observations', async () => {
+    const obs = [
+      makeObs(1, 'user/blog', 'api-relay', { status: 'archived' }),
+      makeObs(2, 'user/api-relay', 'api-relay'),
+      makeObs(3, 'user/api-relay', 'api-relay'),
+    ];
+    const result = await auditProjectObservations('user/blog', obs);
+    expect(result).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- add alias-aware write-time attribution warnings for potentially wrong-bucket writes
- add a read-only project attribution audit tool for legacy cleanup
- keep the phase passive and operator-friendly with no automatic migration

## What changed
- add src/memory/attribution-guard.ts for alias-aware project attribution checks
- warn in memorix_store and memorix_store_reasoning when an entity is unknown in the current project but established elsewhere
- add memorix_audit_project to list suspicious observations with source/provenance details for manual cleanup
- add attribution guard unit tests covering alias-aware grouping, thresholds, ambiguity, and audit output

## Why
A real retrieval incident showed that project-scoped search was behaving correctly, but some api-relay / DevLens memories had already been written into the AVIDS2/blog project bucket. This phase hardens write-time attribution and provides a practical audit path for legacy mis-attributed observations.

## Validation
- npm run build
- npx vitest run tests/memory/attribution-guard.test.ts