### PR TITLE
fix: harden opencode compaction integration

### DIFF
--- a/src/hooks/handler.ts
+++ b/src/hooks/handler.ts
@@ -392,6 +392,11 @@ export async function handleHookEvent(input: NormalizedHookInput): Promise<{
       output: defaultOutput,
     };
   }
+  if (input.event === 'post_compact') {
+    // Post-compaction: acknowledge the event, no observation needed.
+    // The real value is the side-effect (runHook pipe) already handled by the plugin.
+    return { observation: null, output: defaultOutput };
+  }
 
   // ─── Classify & extract ───
   const category = classifyTool(input);

--- a/src/hooks/installers/index.ts
+++ b/src/hooks/installers/index.ts
@@ -243,7 +243,7 @@ function generateKiroHookFiles(): Array<{ filename: string; content: string }> {
  * The plugin hooks into OpenCode events and pipes JSON to `memorix hook`
  * via Bun.spawn, matching the same stdin/stdout protocol used by all agents.
  */
-const OPENCODE_PLUGIN_VERSION = 2;
+const OPENCODE_PLUGIN_VERSION = 3;
 
 function generateOpenCodePlugin(): string {
   return `/**
@@ -306,6 +306,12 @@ export const MemorixPlugin = async ({ project, client, $, directory, worktree })
           command: event.properties?.command ?? '',
           cwd: directory,
         });
+      } else if (event.type === 'session.compacted') {
+        await runHook({
+          agent: 'opencode',
+          hook_event_name: 'session.compacted',
+          cwd: directory,
+        });
       }
     },
 
@@ -320,12 +326,18 @@ export const MemorixPlugin = async ({ project, client, $, directory, worktree })
       });
     },
 
-    /** Inject memorix context into compaction prompt */
+    /** Structured continuation prompt for compaction (prompt-guided, not tool-automated) */
     'experimental.session.compacting': async (input, output) => {
       output.context.push(
-        '## Memorix Cross-Agent Memory\\n' +
-        'Before compacting, use memorix_store to save important discoveries, decisions, and gotchas.\\n' +
-        'After compacting, use memorix_session_start to reload session context, then memorix_search for specific topics.'
+        '## Continuation Context (Memorix)\\n' +
+        'Include the following in the compaction summary so the next continuation can resume effectively:\\n' +
+        '- **Current task**: what was being worked on and its status\\n' +
+        '- **Key decisions**: architectural or design choices made this session\\n' +
+        '- **Active files**: files currently being modified or reviewed\\n' +
+        '- **Blockers**: any unresolved issues or errors\\n' +
+        '- **Next steps**: what should happen next\\n' +
+        '- **Active entities**: module names, config keys, or concepts in play\\n' +
+        '- **Memorix context**: if memorix tools were used, note relevant entity names and memory topics for later retrieval'
       );
     },
   };
@@ -549,7 +561,7 @@ export async function installHooks(
       return {
         agent,
         configPath: pluginPath,
-        events: ['session_start', 'session_end', 'post_tool', 'post_edit', 'pre_compact'],
+        events: ['session_start', 'session_end', 'post_tool', 'post_edit', 'post_compact', 'post_command'],
         generated: { note: 'OpenCode plugin installed at ' + pluginPath },
       };
     }

--- a/src/hooks/normalizer.ts
+++ b/src/hooks/normalizer.ts
@@ -73,7 +73,7 @@ const EVENT_MAP: Record<string, HookEvent> = {
   // OpenCode (plugin events piped via Bun.spawn → memorix hook)
   'session.created': 'session_start',
   'session.idle': 'session_end',
-  'session.compacted': 'pre_compact',
+  'session.compacted': 'post_compact',
   'tool.execute.after': 'post_tool',
   'file.edited': 'post_edit',
   'command.executed': 'post_command',

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -12,6 +12,7 @@ export type HookEvent =
   | 'post_command'
   | 'post_tool'
   | 'pre_compact'
+  | 'post_compact'
   | 'session_end'
   | 'post_response';
 

--- a/tests/hooks/opencode-compaction.test.ts
+++ b/tests/hooks/opencode-compaction.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Tests for Issue #45: OpenCode compaction — normalizer mapping,
+ * installer events list, and compaction prompt text.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { normalizeHookInput } from '../../src/hooks/normalizer.js';
+import { installHooks } from '../../src/hooks/installers/index.js';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+
+describe('Issue #45: OpenCode compaction', () => {
+  // ─── Normalizer ───
+
+  describe('normalizer: session.compacted → post_compact', () => {
+    it('should normalize OpenCode session.compacted → post_compact', () => {
+      const input = normalizeHookInput({
+        agent: 'opencode',
+        hook_event_name: 'session.compacted',
+        cwd: '/project',
+      });
+      expect(input.agent).toBe('opencode');
+      expect(input.event).toBe('post_compact');
+    });
+
+    it('should NOT map session.compacted to pre_compact', () => {
+      const input = normalizeHookInput({
+        agent: 'opencode',
+        hook_event_name: 'session.compacted',
+        cwd: '/project',
+      });
+      expect(input.event).not.toBe('pre_compact');
+    });
+  });
+
+  // ─── Installer ───
+
+  describe('installer: OpenCode events list and plugin content', () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+      tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-oc-test-'));
+      // installHooks needs a .git dir to detect project
+      await fs.mkdir(path.join(tmpDir, '.git'), { recursive: true });
+    });
+
+    afterEach(async () => {
+      await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('should include post_compact in returned events list', async () => {
+      const result = await installHooks('opencode', tmpDir);
+      expect(result.events).toContain('post_compact');
+    });
+
+    it('should NOT include pre_compact in returned events list', async () => {
+      const result = await installHooks('opencode', tmpDir);
+      expect(result.events).not.toContain('pre_compact');
+    });
+
+    it('should write plugin file that handles session.compacted event', async () => {
+      await installHooks('opencode', tmpDir);
+      const pluginPath = path.join(tmpDir, '.opencode', 'plugins', 'memorix.js');
+      const content = await fs.readFile(pluginPath, 'utf-8');
+      expect(content).toContain("event.type === 'session.compacted'");
+      expect(content).toContain("hook_event_name: 'session.compacted'");
+    });
+
+    it('compaction prompt should NOT promise memorix_store auto-invocation', async () => {
+      await installHooks('opencode', tmpDir);
+      const pluginPath = path.join(tmpDir, '.opencode', 'plugins', 'memorix.js');
+      const content = await fs.readFile(pluginPath, 'utf-8');
+      expect(content).not.toContain('memorix_store');
+      expect(content).not.toContain('memorix_session_start');
+    });
+
+    it('compaction prompt should use structured continuation format', async () => {
+      await installHooks('opencode', tmpDir);
+      const pluginPath = path.join(tmpDir, '.opencode', 'plugins', 'memorix.js');
+      const content = await fs.readFile(pluginPath, 'utf-8');
+      expect(content).toContain('Continuation Context (Memorix)');
+      expect(content).toContain('Current task');
+      expect(content).toContain('Key decisions');
+      expect(content).toContain('Next steps');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- replace misleading OpenCode compaction instructions with a structured continuation prompt
- forward the real session.compacted event through the Memorix OpenCode plugin
- add a distinct post_compact hook event so post-compaction events are no longer mislabeled as pre-compaction
- add regression tests covering the OpenCode plugin prompt and event mapping

## Verification
- npm run build
- npx vitest run
- npx vitest run tests/hooks/opencode-compaction.test.ts tests/hooks/normalizer.test.ts