### PR TITLE
fix: correct event property names in opencode hook installer

### DIFF
--- a/src/hooks/installers/index.ts
+++ b/src/hooks/installers/index.ts
@@ -296,14 +296,14 @@ export const MemorixPlugin = async ({ project, client, $, directory, worktree })
         await runHook({
           agent: 'opencode',
           hook_event_name: 'file.edited',
-          file_path: event.properties?.path ?? '',
+          file_path: event.properties?.file ?? '',
           cwd: directory,
         });
       } else if (event.type === 'command.executed') {
         await runHook({
           agent: 'opencode',
           hook_event_name: 'command.executed',
-          command: event.properties?.command ?? '',
+          command: event.properties?.name ?? '',
           cwd: directory,
         });
       } else if (event.type === 'session.compacted') {


### PR DESCRIPTION
# [Bug] OpenCode hook installer uses incorrect event property names

## Description

The OpenCode hook installer was using incorrect property names when processing `file.edited` and `command.executed` events, causing the hook data to receive empty or undefined values.

### Incorrect Code

```typescript
} else if (event.type === 'file.edited') {
  await runHook({
    agent: 'opencode',
    hook_event_name: 'file.edited',
    file_path: event.properties?.path ?? '',  // ❌ Wrong property name
    cwd: directory,
  });
} else if (event.type === 'command.executed') {
  await runHook({
    agent: 'opencode',
    hook_event_name: 'command.executed',
    command: event.properties?.command ?? '',  // ❌ Wrong property name
    cwd: directory,
  });
}
```

## Expected Behavior

The hook should receive the correct file path and command name from OpenCode events.

## Actual Behavior

The `file_path` and `command` fields in the hook payload were always empty strings because `event.properties?.path` and `event.properties?.command` did not match OpenCode's actual event schema.

## Root Cause

OpenCode events use different property names in their schema:
- `file.edited` → `event.properties?.file` (not `path`)
- `command.executed` → `event.properties?.name` (not `command`)

## Fix

Changed the property accessors to match OpenCode's event schema:

```typescript
file_path: event.properties?.file ?? '',      // ✅ Correct
command: event.properties?.name ?? '',        // ✅ Correct
```

## Impact

- Hook payloads for `file.edited` events had empty `file_path`
- Hook payloads for `command.executed` events had empty `command`
- This affected memory formation and context tracking for OpenCode users

## Evidence

### OpenCode SDK Type Definitions

**Source**: [OpenCode SDK types.gen.ts](https://github.com/anomalyco/opencode/blob/dev/packages/sdk/js/src/gen/types.gen.ts)

#### `file.edited` event properties

```typescript
"file.edited" properties: { file: string }
```

#### `command.executed` event properties

```typescript
"command.executed" properties: { name: string, sessionID: string, arguments: string, messageID: string }
```

### Verification Summary

| Event | Old Property (Wrong) | New Property (Correct) | Verified |
|-------|----------------------|----------------------|----------|
| `file.edited` | `event.properties?.path` | `event.properties?.file` | ✅ |
| `command.executed` | `event.properties?.command` | `event.properties?.name` | ✅ |

## Files Modified

- `src/hooks/installers/index.ts`

## Additional Notes

This bug would have affected any user relying on OpenCode integration hooks for memory formation.
