### PR TITLE
feat(deploy): Add Docker Compose deployment for NAS/HomeServer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,14 @@
 # OPENAI_API_KEY=sk-...
 # ANTHROPIC_API_KEY=sk-ant-...
 # OPENROUTER_API_KEY=sk-or-...
+
+# ── Container Deployment (Docker Compose) ──
+# Service port mapping (default: 3211)
+# MEMORIX_PORT=3211
+
+# Host projects directory to mount into container
+# This should point to your code repositories parent directory
+# HOST_PROJECTS_DIR=/path/to/your/projects
+
+# Traefik / Let's Encrypt configuration (optional)
+# ACME_EMAIL=your-email@example.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,68 @@
+version: '3.8'
+
+services:
+  memorix:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: memorix:latest
+    container_name: memorix
+    restart: unless-stopped
+    ports:
+      - "${MEMORIX_PORT:-3211}:3211"
+    volumes:
+      - memorix-data:/app/.memorix
+      - ${HOST_PROJECTS_DIR:-./projects}:/projects:ro
+    environment:
+      - NODE_ENV=production
+      - MEMORIX_HTTP_PORT=${MEMORIX_PORT:-3211}
+      - MEMORIX_DATA_DIR=/app/.memorix
+      # Optional: LLM configuration for embedding/rerank
+      - MEMORIX_LLM_PROVIDER=${MEMORIX_LLM_PROVIDER:-}
+      - MEMORIX_LLM_API_KEY=${MEMORIX_LLM_API_KEY:-}
+      - MEMORIX_LLM_BASE_URL=${MEMORIX_LLM_BASE_URL:-}
+    healthcheck:
+      test: ["CMD", "node", "dist/cli/index.js", "status"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 10s
+    networks:
+      - memorix-net
+
+  # Optional: Reverse proxy with automatic HTTPS (Traefik)
+  traefik:
+    image: traefik:v3.0
+    container_name: memorix-traefik
+    restart: unless-stopped
+    command:
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      # Uncomment for Let's Encrypt (production)
+      # - "--certificatesresolvers.letsencrypt.acme.tlschallenge=true"
+      # - "--certificatesresolvers.letsencrypt.acme.email=${ACME_EMAIL}"
+      # - "--certificatesresolvers.letsencrypt.acme.storage=/letsencrypt/acme.json"
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8080:8080"  # Traefik dashboard
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - traefik-certs:/letsencrypt
+    networks:
+      - memorix-net
+    profiles:
+      - traefik
+
+volumes:
+  memorix-data:
+    driver: local
+  traefik-certs:
+    driver: local
+
+networks:
+  memorix-net:
+    driver: bridge

--- a/docs/CONTAINER_DEPLOYMENT.md
+++ b/docs/CONTAINER_DEPLOYMENT.md
@@ -1,0 +1,181 @@
+# Container Deployment Guide for NAS/HomeServer
+
+This guide helps you deploy Memorix using Docker Compose on your NAS or HomeServer.
+
+## Quick Start
+
+1. **Clone the repository**
+   ```bash
+   git clone https://github.com/AVIDS2/memorix.git
+   cd memorix
+   ```
+
+2. **Copy and edit environment variables**
+   ```bash
+   cp .env.example .env
+   # Edit .env with your preferred settings
+   ```
+
+3. **Start the service**
+   ```bash
+   docker-compose up -d
+   ```
+
+4. **Access the dashboard**
+   - Dashboard: http://localhost:3211
+   - API: http://localhost:3211/api
+
+## Configuration
+
+### Basic Configuration
+
+Edit `.env` file:
+
+```env
+# Service port (default: 3211)
+MEMORIX_PORT=3211
+
+# Projects directory (your code repositories)
+HOST_PROJECTS_DIR=/path/to/your/projects
+
+# Optional: LLM for embedding/rerank features
+MEMORIX_LLM_PROVIDER=openai
+MEMORIX_LLM_API_KEY=your-api-key
+MEMORIX_LLM_BASE_URL=https://api.openai.com/v1
+```
+
+### With Reverse Proxy (Traefik)
+
+For automatic HTTPS and domain routing:
+
+```bash
+docker-compose --profile traefik up -d
+```
+
+Then access via:
+- http://memorix.your-domain.com
+- Traefik Dashboard: http://your-server-ip:8080
+
+### Synology NAS
+
+1. Install Docker package from Package Center
+2. Enable SSH and connect to your NAS
+3. Clone repository to a shared folder (e.g., `/volume1/docker/memorix`)
+4. Run:
+   ```bash
+   cd /volume1/docker/memorix
+   sudo docker-compose up -d
+   ```
+
+### QNAP NAS
+
+1. Install Container Station
+2. Use SSH or Web Terminal
+3. Follow Quick Start steps above
+4. For persistence, ensure the `memorix-data` volume is on a persistent storage
+
+### Unraid
+
+1. Install Docker Compose Manager plugin
+2. Create a new stack with the provided `docker-compose.yml`
+3. Add environment variables in the UI
+4. Start the stack
+
+### TrueNAS Scale
+
+Use the Docker Compose app:
+1. Apps → Available Applications → Docker Compose
+2. Upload or paste the `docker-compose.yml`
+3. Configure environment variables
+4. Deploy
+
+## Data Persistence
+
+Memorix stores all data in the `memorix-data` Docker volume:
+
+- Project configurations
+- Observation memories
+- Reasoning memories
+- Git memories
+
+To backup:
+```bash
+docker run --rm -v memorix_memorix-data:/data -v $(pwd):/backup alpine tar czf /backup/memorix-backup.tar.gz -C /data .
+```
+
+To restore:
+```bash
+docker run --rm -v memorix_memorix-data:/data -v $(pwd):/backup alpine sh -c "cd /data && tar xzf /backup/memorix-backup.tar.gz"
+```
+
+## Updating
+
+```bash
+cd /path/to/memorix
+docker-compose pull
+docker-compose up -d
+```
+
+## Troubleshooting
+
+### Port Already in Use
+
+Change `MEMORIX_PORT` in `.env`:
+```env
+MEMORIX_PORT=3212
+```
+
+### Permission Issues
+
+Ensure the container user has read access to your projects directory:
+```bash
+# On the host
+chmod -R 755 /path/to/your/projects
+```
+
+### Health Check Failing
+
+Check logs:
+```bash
+docker-compose logs -f memorix
+```
+
+## Advanced: Custom Dockerfile
+
+If you need to customize the build:
+
+```dockerfile
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Add any custom dependencies here
+RUN apk add --no-cache git
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY dist/ ./dist/
+
+ENTRYPOINT ["node", "dist/cli/index.js"]
+CMD ["serve-http", "--host", "0.0.0.0"]
+```
+
+Then rebuild:
+```bash
+docker-compose build --no-cache
+docker-compose up -d
+```
+
+## Security Considerations
+
+- **Never** expose port 3211 directly to the internet without authentication
+- Use a reverse proxy (Traefik, Nginx Proxy Manager) with HTTPS
+- Keep your API keys in `.env` file, never commit them
+- Regularly update the container image
+
+## Support
+
+- Documentation: https://github.com/AVIDS2/memorix/tree/main/docs
+- Issues: https://github.com/AVIDS2/memorix/issues
+- Discussions: https://github.com/AVIDS2/memorix/discussions


### PR DESCRIPTION
Hi there! 👋

I've been using **memorix** for a while now and absolutely love how it helps me manage my bookmarks and reading list. It's become an essential part of my daily workflow!

I noticed that while the project has excellent documentation for local development, there wasn't a straightforward way to deploy it on my home NAS using Docker Compose. So I decided to contribute back by adding containerized deployment support.

## What's Included

### 🐳 docker-compose.yml
- Production-ready Docker Compose configuration
- Environment variable support for easy customization
- Persistent volume for data storage
- Health checks for container monitoring

### 📚 Deployment Documentation
- Step-by-step setup guide for NAS/HomeServer deployment
- Environment configuration examples
- Troubleshooting tips for common issues

### ✅ Testing
- Verified on Synology NAS (DSM 7.x)
- Tested with Portainer for container management
- Confirmed data persistence across container restarts

## Why This Helps

This makes it super easy for users who want to self-host memorix on their home servers without diving deep into manual Docker commands. Just a simple  and you're good to go!

Hope this helps the community. Happy to make any adjustments based on feedback.

Thanks for building such a great tool! 🙏