### PR TITLE
feat: add phase 4b coordination primitives

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./types": {
+      "import": "./dist/types.js",
+      "types": "./dist/types.d.ts"
     }
   },
   "files": [

--- a/src/server.ts
+++ b/src/server.ts
@@ -2677,6 +2677,7 @@ export async function createMemorixServer(
       // Phase 4a: Auto-register agent in TeamStore for durable identity
       let registeredAgent: import('./team/team-store.js').TeamAgentRow | null = null;
       let watermarkInfo = '';
+      let rescueInfo = '';
       try {
         if (typeof teamStore !== 'undefined' && (agent || agentType)) {
           registeredAgent = teamStore.registerAgent({
@@ -2690,19 +2691,37 @@ export async function createMemorixServer(
           currentAgentId = registeredAgent.agent_id;
 
           // Watermark: project-scoped count of new observations since last seen
-          // Uses projectId + writeGeneration filter (not global storage_generation diff)
+          // Uses computeWatermark (extracted to team/poll.ts for reuse by memorix_poll)
           // withFreshIndex ensures cross-process writes are visible before counting
+          const { computeWatermark } = await import('./team/poll.js');
           const lastSeen = registeredAgent.last_seen_obs_generation;
+          const store = getObservationStore();
+          const currentGen = store.getGeneration();
           const projectObs = await withFreshIndex(() => getAllObservations().filter(
             o => o.projectId === project.id && (o.writeGeneration ?? 0) > lastSeen,
           ));
-          if (projectObs.length > 0) {
-            watermarkInfo = `📊 ${projectObs.length} new observation(s) in this project since your last session.`;
+          const wm = computeWatermark(lastSeen, currentGen, projectObs.length);
+          if (wm.newObservationCount > 0) {
+            watermarkInfo = `📊 ${wm.newObservationCount} new observation(s) in this project since your last session.`;
           }
 
           // Update watermark to current global generation (high-water mark for next session)
-          const store = getObservationStore();
-          teamStore.updateWatermark(registeredAgent.agent_id, store.getGeneration());
+          teamStore.updateWatermark(registeredAgent.agent_id, currentGen);
+
+          // Phase 4b: Rescue detection — detect stale agents and surface rescued tasks
+          // detectAndMarkStale releases tasks from agents with stale heartbeats
+          const STALE_TTL_MS = 5 * 60 * 1000; // 5 minutes without heartbeat = stale
+          const rescuedAgentIds = teamStore.detectAndMarkStale(project.id, STALE_TTL_MS);
+          if (rescuedAgentIds.length > 0) {
+            rescueInfo = `🚑 ${rescuedAgentIds.length} stale agent(s) detected and rescued.`;
+          }
+
+          // Check for available tasks (including any just-rescued ones)
+          const availableTasks = teamStore.listTasks(project.id, { available: true });
+          if (availableTasks.length > 0) {
+            rescueInfo += rescueInfo ? '\n' : '';
+            rescueInfo += `📋 ${availableTasks.length} task(s) available to claim. Use memorix_poll for details.`;
+          }
         }
       } catch { /* team auto-registration is best-effort */ }
 
@@ -2713,6 +2732,7 @@ export async function createMemorixServer(
         registeredAgent ? `Agent ID: ${registeredAgent.agent_id} (instance: ${registeredAgent.instance_id})` : '',
         llmStatus,
         watermarkInfo,
+        rescueInfo,
         '',
         '💡 Tips: Use `memorix_resolve` to mark completed tasks. Use `progress` param in `memorix_store` for task tracking. Use `topicKey` to prevent duplicate memories.',
         '',
@@ -3082,6 +3102,13 @@ export async function createMemorixServer(
     teamStore = await initTeamStore(projectDir);
   }
 
+  // Phase 4b: Wire EventBus for same-process lifecycle notifications.
+  // EventBus is process-local only — NOT a cross-process mechanism.
+  if (!teamStore.getEventBus()) {
+    const { TeamEventBus } = await import('./team/event-bus.js');
+    teamStore.setEventBus(new TeamEventBus());
+  }
+
   // ── team_manage (join / leave / status) ─────────────────────────
   server.registerTool(
     'team_manage',
@@ -3324,6 +3351,171 @@ export async function createMemorixServer(
         return `${m.read_at ? ' ' : '*'} [${m.type}] from ${sender?.name ?? m.sender_agent_id.slice(0, 8)}: ${m.content.slice(0, 100)}`;
       });
       return { content: [{ type: 'text' as const, text: `Inbox: ${unread} unread / ${inbox.length} total\n\n${lines.join('\n')}` }] };
+    },
+  );
+
+  // ── memorix_poll (Phase 4b: situational awareness) ────────────────
+  server.registerTool(
+    'memorix_poll',
+    {
+      title: 'Team Poll — Situational Awareness',
+      description:
+        'Get a full snapshot of your team coordination state in one call. ' +
+        'Returns: your agent info, watermark (new observations since last session), ' +
+        'inbox (unread messages), tasks (your in-progress, available to claim, completed, failed), ' +
+        'and team roster (active agents). Use this to decide what to work on next.',
+      inputSchema: {
+        agentId: z.string().optional().describe('Your agent ID (from team_manage join or session_start). If omitted, returns project-level overview only.'),
+        markInboxRead: z.boolean().optional().describe('If true, mark all inbox messages as read after returning them.'),
+      },
+    },
+    async ({ agentId, markInboxRead }) => {
+      const { computeWatermark, computePoll } = await import('./team/poll.js');
+
+      // Compute watermark — requires observation store access
+      let watermark = computeWatermark(0, 0, 0);
+      if (agentId) {
+        const agent = teamStore.getAgent(agentId);
+        if (agent) {
+          const lastSeen = agent.last_seen_obs_generation;
+          const store = getObservationStore();
+          const currentGen = store.getGeneration();
+          const projectObs = await withFreshIndex(() => getAllObservations().filter(
+            o => o.projectId === project.id && (o.writeGeneration ?? 0) > lastSeen,
+          ));
+          watermark = computeWatermark(lastSeen, currentGen, projectObs.length);
+
+          // Advance watermark so next poll sees only truly new observations
+          teamStore.updateWatermark(agentId, currentGen);
+          // Heartbeat — proves this agent is alive
+          teamStore.heartbeat(agentId);
+        }
+      }
+
+      const poll = computePoll(teamStore, project.id, agentId ?? null, watermark);
+
+      // Optionally mark inbox as read
+      if (markInboxRead && agentId) {
+        teamStore.markAllRead(project.id, agentId);
+      }
+
+      // Format as readable text
+      const lines: string[] = [];
+
+      // Agent
+      if (poll.agent) {
+        lines.push(`🤖 You: ${poll.agent.agentId.slice(0, 8)}… (${poll.agent.status})`);
+      }
+
+      // Watermark
+      if (poll.watermark.newObservationCount > 0) {
+        lines.push(`📊 ${poll.watermark.newObservationCount} new observation(s) since your last session`);
+      }
+
+      // Inbox
+      if (poll.inbox.unreadCount > 0) {
+        lines.push(`📬 ${poll.inbox.unreadCount} unread message(s)`);
+        for (const m of poll.inbox.messages.slice(-5)) {
+          const sender = teamStore.getAgent(m.sender_agent_id);
+          lines.push(`  ${m.read_at ? ' ' : '*'} [${m.type}] from ${sender?.name ?? m.sender_agent_id.slice(0, 8)}: ${m.content.slice(0, 80)}`);
+        }
+      }
+
+      // Tasks
+      if (poll.tasks.myInProgress.length > 0) {
+        lines.push(`\n🔧 Your in-progress tasks (${poll.tasks.myInProgress.length}):`);
+        for (const t of poll.tasks.myInProgress) {
+          lines.push(`  [~] ${t.task_id.slice(0, 8)}… "${t.description}"`);
+        }
+      }
+      if (poll.tasks.availableToClaim.length > 0) {
+        lines.push(`\n📋 Available to claim (${poll.tasks.availableToClaim.length}):`);
+        for (const t of poll.tasks.availableToClaim) {
+          lines.push(`  [ ] ${t.task_id.slice(0, 8)}… "${t.description}"`);
+        }
+      }
+      if (poll.tasks.recentlyCompleted.length > 0) {
+        lines.push(`\n✅ Completed (${poll.tasks.recentlyCompleted.length}):`);
+        for (const t of poll.tasks.recentlyCompleted.slice(-5)) {
+          const who = t.assignee_agent_id ? teamStore.getAgent(t.assignee_agent_id)?.name ?? t.assignee_agent_id.slice(0, 8) : '?';
+          lines.push(`  [x] ${t.task_id.slice(0, 8)}… "${t.description}" — by ${who}`);
+        }
+      }
+      if (poll.tasks.recentlyFailed.length > 0) {
+        lines.push(`\n❌ Failed (${poll.tasks.recentlyFailed.length}):`);
+        for (const t of poll.tasks.recentlyFailed.slice(-3)) {
+          lines.push(`  [!] ${t.task_id.slice(0, 8)}… "${t.description}" — ${t.result?.slice(0, 80) ?? 'no reason'}`);
+        }
+      }
+
+      // Team
+      lines.push(`\n👥 Team: ${poll.team.activeAgents.length} active / ${poll.team.totalAgents} total`);
+      for (const a of poll.team.activeAgents) {
+        lines.push(`  ● ${a.name} (${a.agent_type}) — ${a.role ?? 'no role'}`);
+      }
+
+      if (lines.length === 0) {
+        lines.push('No team activity yet. Use team_manage action="join" to register, then team_task to create tasks.');
+      }
+
+      return { content: [{ type: 'text' as const, text: lines.join('\n') }] };
+    },
+  );
+
+  // ── memorix_handoff (Phase 4b: structured agent-to-agent context transfer) ──
+  server.registerTool(
+    'memorix_handoff',
+    {
+      title: 'Team Handoff — Agent Context Transfer',
+      description:
+        'Create a structured handoff artifact when passing work to another agent. ' +
+        'The handoff is stored as a durable observation (searchable, immune to archival) ' +
+        'and a notification message is sent to the recipient. ' +
+        'Use this when completing a task and another agent should continue, ' +
+        'or when you want to leave context for whoever works on this next.',
+      inputSchema: {
+        fromAgentId: z.string().describe('Your agent ID (from team_manage join or session_start)'),
+        summary: z.string().describe('Human-readable summary of what you did and what needs to happen next'),
+        context: z.string().describe('Detailed context for the next agent: what was done, current state, known issues, next steps'),
+        toAgentId: z.string().optional().describe('Specific recipient agent ID. Omit to broadcast to all.'),
+        taskId: z.string().optional().describe('Link to a specific team_task ID'),
+        filesModified: z.array(z.string()).optional().describe('Files you modified during this work'),
+        concepts: z.array(z.string()).optional().describe('Key concepts for search discoverability'),
+      },
+    },
+    async ({ fromAgentId, summary, context, toAgentId, taskId, filesModified, concepts }) => {
+      const { createHandoffArtifact } = await import('./team/handoff.js');
+
+      const result = await createHandoffArtifact(
+        {
+          projectId: project.id,
+          fromAgentId,
+          toAgentId,
+          taskId,
+          summary,
+          context,
+          filesModified: filesModified ? coerceStringArray(filesModified) : undefined,
+          concepts: concepts ? coerceStringArray(concepts) : undefined,
+        },
+        storeObservation,
+        teamStore,
+      );
+
+      const lines = [
+        `✅ Handoff created`,
+        `Observation: #${result.observationId}`,
+        `From: ${result.fromAgentId.slice(0, 8)}…`,
+        result.toAgentId ? `To: ${result.toAgentId.slice(0, 8)}…` : 'To: broadcast (any agent)',
+        result.taskId ? `Task: ${result.taskId.slice(0, 8)}…` : '',
+        `Summary: ${result.summary}`,
+        '',
+        'The handoff context is now stored as a durable observation (searchable via memorix_search).',
+        result.toAgentId
+          ? 'A notification message has been sent to the recipient.'
+          : 'A broadcast notification has been sent to all agents.',
+      ];
+
+      return { content: [{ type: 'text' as const, text: lines.filter(Boolean).join('\n') }] };
     },
   );
 

--- a/src/team/event-bus.ts
+++ b/src/team/event-bus.ts
@@ -1,0 +1,76 @@
+/**
+ * TeamEventBus — Process-local typed event emitter for team coordination.
+ *
+ * Phase 4b: Provides push-based acceleration within a single process.
+ * NOT a cross-process mechanism — the orchestrator uses SQLite polling.
+ *
+ * Architectural boundary (B1): This is process-local fanout only.
+ * No persistence, no cross-process delivery, no durability guarantees.
+ * If no listeners are registered, events are silently dropped.
+ */
+
+import { EventEmitter } from 'node:events';
+
+// ── Event type map ─────────────────────────────────────────────────
+
+export interface TeamEventMap {
+  'task:created':   { taskId: string; projectId: string; description: string };
+  'task:claimed':   { taskId: string; projectId: string; agentId: string };
+  'task:completed': { taskId: string; projectId: string; agentId: string; result?: string };
+  'task:failed':    { taskId: string; projectId: string; agentId: string; result?: string };
+  'task:released':  { taskId: string; projectId: string; agentId: string };
+  'agent:joined':   { agentId: string; projectId: string; agentType: string };
+  'agent:left':     { agentId: string; projectId: string };
+  'agent:stale':    { agentId: string; projectId: string; releasedTasks: number };
+  'handoff:created':{ observationId: number; projectId: string; fromAgent: string; toAgent?: string; taskId?: string };
+}
+
+export type TeamEventName = keyof TeamEventMap;
+
+// ── TeamEventBus ───────────────────────────────────────────────────
+
+export class TeamEventBus {
+  private emitter = new EventEmitter();
+
+  constructor() {
+    // Prevent memory leak warnings for legitimate multi-listener scenarios
+    this.emitter.setMaxListeners(50);
+  }
+
+  /**
+   * Emit a typed event. Non-blocking, best-effort.
+   * If no listeners are registered, the event is silently dropped.
+   */
+  emit<K extends TeamEventName>(event: K, data: TeamEventMap[K]): void {
+    try {
+      this.emitter.emit(event, data);
+    } catch {
+      // Best-effort: listener errors never propagate to caller
+    }
+  }
+
+  /** Subscribe to a typed event. Returns unsubscribe function. */
+  on<K extends TeamEventName>(event: K, listener: (data: TeamEventMap[K]) => void): () => void {
+    this.emitter.on(event, listener);
+    return () => { this.emitter.off(event, listener); };
+  }
+
+  /** Subscribe to a typed event, fire only once. */
+  once<K extends TeamEventName>(event: K, listener: (data: TeamEventMap[K]) => void): void {
+    this.emitter.once(event, listener);
+  }
+
+  /** Remove all listeners for a specific event, or all events if none specified. */
+  removeAllListeners(event?: TeamEventName): void {
+    if (event) {
+      this.emitter.removeAllListeners(event);
+    } else {
+      this.emitter.removeAllListeners();
+    }
+  }
+
+  /** Current listener count for a specific event. */
+  listenerCount(event: TeamEventName): number {
+    return this.emitter.listenerCount(event);
+  }
+}

--- a/src/team/handoff.ts
+++ b/src/team/handoff.ts
@@ -1,0 +1,153 @@
+/**
+ * Team Handoff — Structured context transfer between agents.
+ *
+ * Phase 4b: Creates a handoff artifact as a standard observation
+ * (canonical path — no new JSON/file persistence).
+ *
+ * Architectural boundary (B4): The canonical record is an Observation
+ * stored via storeObservation(). TeamStore only holds a reference pointer.
+ * Handoff artifacts use valueCategory: 'core' so they are immune to
+ * retention archival (Phase 1 provenance: core = immune).
+ */
+
+import type { TeamStore } from './team-store.js';
+import type { ObservationType } from '../types.js';
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export interface HandoffInput {
+  projectId: string;
+  fromAgentId: string;
+  toAgentId?: string;       // null = anyone can pick up
+  taskId?: string;           // link to specific task
+  summary: string;           // human-readable summary of what was done
+  context: string;           // machine-readable context for the next agent
+  filesModified?: string[];  // files touched during the work
+  concepts?: string[];       // key concepts for search discoverability
+}
+
+export interface HandoffResult {
+  observationId: number;
+  taskId?: string;
+  fromAgentId: string;
+  toAgentId?: string;
+  summary: string;
+}
+
+// ── createHandoffArtifact ──────────────────────────────────────────
+
+/**
+ * Create a structured handoff artifact stored as an observation.
+ *
+ * @param input - Handoff details
+ * @param storeObservation - The canonical storeObservation function (injected to avoid circular deps)
+ * @param teamStore - For sending notification message to recipient
+ */
+export async function createHandoffArtifact(
+  input: HandoffInput,
+  storeObservation: (params: {
+    entityName: string;
+    type: ObservationType;
+    title: string;
+    narrative: string;
+    facts?: string[];
+    filesModified?: string[];
+    concepts?: string[];
+    projectId: string;
+    topicKey?: string;
+    sourceDetail?: 'explicit' | 'hook' | 'git-ingest';
+    valueCategory?: 'core' | 'contextual' | 'ephemeral';
+    createdByAgentId?: string;
+  }) => Promise<{ observation: { id: number }; upserted: boolean }>,
+  teamStore: TeamStore,
+): Promise<HandoffResult> {
+  // Build facts from handoff context
+  const facts: string[] = [
+    `Handoff from agent ${input.fromAgentId}`,
+  ];
+  if (input.toAgentId) facts.push(`Intended recipient: ${input.toAgentId}`);
+  if (input.taskId) facts.push(`Related task: ${input.taskId}`);
+  facts.push(`Context: ${input.context}`);
+
+  // Store as observation — this IS the canonical record
+  const { observation } = await storeObservation({
+    entityName: 'team-handoff',
+    type: 'what-changed',
+    title: `[Handoff] ${input.summary}`,
+    narrative: input.context,
+    facts,
+    filesModified: input.filesModified,
+    concepts: ['handoff', ...(input.concepts ?? [])],
+    projectId: input.projectId,
+    topicKey: input.taskId ? `handoff:${input.taskId}:${input.fromAgentId}` : undefined,
+    sourceDetail: 'explicit',
+    valueCategory: 'core',  // immune to retention archival
+    createdByAgentId: input.fromAgentId,
+  });
+
+  // Emit handoff:created event (best-effort, process-local only).
+  // Happens AFTER canonical write succeeds — listener errors never affect the handoff.
+  try {
+    teamStore.getEventBus()?.emit('handoff:created', {
+      observationId: observation.id,
+      projectId: input.projectId,
+      fromAgent: input.fromAgentId,
+      toAgent: input.toAgentId,
+      taskId: input.taskId,
+    });
+  } catch {
+    // Best-effort: event emission failure never affects canonical handoff
+  }
+
+  // Send notification message to recipient.
+  // Broadcast handoff uses fanout-on-write (方案 A): instead of one NULL-recipient
+  // shared message, each active agent (excluding sender) gets their own copy.
+  // This prevents Agent A's markRead from consuming Agent B's unread state.
+  try {
+    if (input.toAgentId) {
+      // Targeted handoff — single recipient-specific message
+      teamStore.sendMessage({
+        projectId: input.projectId,
+        senderAgentId: input.fromAgentId,
+        recipientAgentId: input.toAgentId,
+        type: 'handoff',
+        content: `Handoff: ${input.summary}`,
+        payload: {
+          observationId: observation.id,
+          taskId: input.taskId,
+          filesModified: input.filesModified,
+        },
+        taskId: input.taskId,
+      });
+    } else {
+      // Broadcast handoff — fanout to each active agent (excluding sender)
+      const agents = teamStore.listAgents(input.projectId, { status: 'active' });
+      for (const agent of agents) {
+        if (agent.agent_id === input.fromAgentId) continue;
+        teamStore.sendMessage({
+          projectId: input.projectId,
+          senderAgentId: input.fromAgentId,
+          recipientAgentId: agent.agent_id,
+          type: 'handoff',
+          content: `Handoff: ${input.summary}`,
+          payload: {
+            observationId: observation.id,
+            taskId: input.taskId,
+            filesModified: input.filesModified,
+          },
+          taskId: input.taskId,
+        });
+      }
+    }
+  } catch {
+    // Message sending is best-effort — handoff observation is the canonical record
+  }
+
+  return {
+    observationId: observation.id,
+    taskId: input.taskId,
+    fromAgentId: input.fromAgentId,
+    toAgentId: input.toAgentId,
+    summary: input.summary,
+  };
+}

--- a/src/team/poll.ts
+++ b/src/team/poll.ts
@@ -1,0 +1,132 @@
+/**
+ * Team Poll — Situational awareness for agents.
+ *
+ * Phase 4b: Provides `computeWatermark` (extracted from server.ts session_start)
+ * and `computePoll` (full situational awareness in one call).
+ *
+ * Architectural boundary (B3): These are cross-process consistency mechanisms.
+ * They read from SQLite (canonical truth), never from EventBus.
+ */
+
+import type { TeamStore, TeamAgentRow, TeamTaskRow, TeamMessageRow } from './team-store.js';
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export interface WatermarkResult {
+  lastSeenGeneration: number;
+  currentGeneration: number;
+  newObservationCount: number;
+}
+
+export interface PollResult {
+  agent: {
+    agentId: string;
+    status: string;
+    lastHeartbeat: number;
+  } | null;
+  watermark: WatermarkResult;
+  inbox: {
+    unreadCount: number;
+    messages: TeamMessageRow[];
+  };
+  tasks: {
+    myInProgress: TeamTaskRow[];
+    availableToClaim: TeamTaskRow[];
+    recentlyCompleted: TeamTaskRow[];
+    recentlyFailed: TeamTaskRow[];
+  };
+  team: {
+    activeAgents: TeamAgentRow[];
+    totalAgents: number;
+  };
+}
+
+// ── computeWatermark ───────────────────────────────────────────────
+
+/**
+ * Compute the watermark for an agent: how many new observations
+ * have appeared in this project since the agent's last session.
+ *
+ * Extracted from server.ts session_start to be shared by poll and session_start.
+ *
+ * @param lastSeenGeneration - Agent's last_seen_obs_generation from TeamStore
+ * @param currentGeneration  - Current global generation from observation store
+ * @param projectObservations - Pre-filtered observations for this project
+ *                              with writeGeneration > lastSeenGeneration
+ */
+export function computeWatermark(
+  lastSeenGeneration: number,
+  currentGeneration: number,
+  newObservationCount: number,
+): WatermarkResult {
+  return {
+    lastSeenGeneration,
+    currentGeneration,
+    newObservationCount,
+  };
+}
+
+// ── computePoll ────────────────────────────────────────────────────
+
+/**
+ * Compute full situational awareness for an agent in one call.
+ * Reads only from SQLite (TeamStore) — never from EventBus.
+ *
+ * @param teamStore - The TeamStore instance
+ * @param projectId - Current project ID
+ * @param agentId   - The requesting agent's ID (null if no agent registered)
+ * @param watermark - Pre-computed watermark result
+ */
+export function computePoll(
+  teamStore: TeamStore,
+  projectId: string,
+  agentId: string | null,
+  watermark: WatermarkResult,
+): PollResult {
+  // Agent info
+  let agent: PollResult['agent'] = null;
+  if (agentId) {
+    const row = teamStore.getAgent(agentId);
+    if (row) {
+      agent = {
+        agentId: row.agent_id,
+        status: row.status,
+        lastHeartbeat: row.last_heartbeat,
+      };
+    }
+  }
+
+  // Inbox
+  const unreadCount = agentId ? teamStore.getUnreadCount(projectId, agentId) : 0;
+  const messages = agentId ? teamStore.getInbox(projectId, agentId) : [];
+
+  // Tasks
+  const allTasks = teamStore.listTasks(projectId);
+  const myInProgress = agentId
+    ? allTasks.filter(t => t.assignee_agent_id === agentId && t.status === 'in_progress')
+    : [];
+
+  // Available to claim: pending, no assignee, all deps met
+  const pendingTasks = allTasks.filter(t => t.status === 'pending' && !t.assignee_agent_id);
+  const availableToClaim = pendingTasks.filter(t => {
+    const unmet = teamStore.getTaskDeps(t.task_id)
+      .map(depId => teamStore.getTask(depId))
+      .filter(dep => dep && dep.status !== 'completed');
+    return unmet.length === 0;
+  });
+
+  const recentlyCompleted = allTasks.filter(t => t.status === 'completed');
+  const recentlyFailed = allTasks.filter(t => t.status === 'failed');
+
+  // Team
+  const allAgents = teamStore.listAgents(projectId);
+  const activeAgents = allAgents.filter(a => a.status === 'active');
+
+  return {
+    agent,
+    watermark,
+    inbox: { unreadCount, messages },
+    tasks: { myInProgress, availableToClaim, recentlyCompleted, recentlyFailed },
+    team: { activeAgents, totalAgents: allAgents.length },
+  };
+}

--- a/src/team/team-store.ts
+++ b/src/team/team-store.ts
@@ -17,6 +17,7 @@ import { randomUUID } from 'node:crypto';
 import { getDatabase } from '../store/sqlite-db.js';
 import path from 'node:path';
 import fs from 'node:fs';
+import type { TeamEventBus } from './event-bus.js';
 
 // ── Types ───────────────────────────────────────────────────────────
 
@@ -74,6 +75,13 @@ export interface TeamLockRow {
 export class TeamStore {
   private db: any = null;
   private dataDir: string = '';
+
+  /** Optional event bus for same-process lifecycle notifications.
+   *  Set via setEventBus(). Emit failures never block TeamStore writes. */
+  private eventBus: TeamEventBus | null = null;
+
+  setEventBus(bus: TeamEventBus): void { this.eventBus = bus; }
+  getEventBus(): TeamEventBus | null { return this.eventBus; }
 
   // ── Agent prepared statements
   private stmtAgentUpsert: any = null;
@@ -376,7 +384,9 @@ export class TeamStore {
         left_at: null,
         last_seen_obs_generation: existing.last_seen_obs_generation,
       });
-      return this.stmtAgentFindById.get(existing.agent_id) as TeamAgentRow;
+      const row = this.stmtAgentFindById.get(existing.agent_id) as TeamAgentRow;
+      this.eventBus?.emit('agent:joined', { agentId: row.agent_id, projectId: input.projectId, agentType: input.agentType });
+      return row;
     }
 
     // New agent
@@ -395,7 +405,9 @@ export class TeamStore {
       left_at: null,
       last_seen_obs_generation: 0,
     });
-    return this.stmtAgentFindById.get(agentId) as TeamAgentRow;
+    const row = this.stmtAgentFindById.get(agentId) as TeamAgentRow;
+    this.eventBus?.emit('agent:joined', { agentId: row.agent_id, projectId: input.projectId, agentType: input.agentType });
+    return row;
   }
 
   getAgent(agentId: string): TeamAgentRow | undefined {
@@ -420,7 +432,11 @@ export class TeamStore {
   }
 
   leaveAgent(agentId: string): boolean {
+    const agent = this.stmtAgentFindById.get(agentId) as TeamAgentRow | undefined;
     const info = this.stmtAgentLeave.run(Date.now(), agentId);
+    if (info.changes > 0 && agent) {
+      this.eventBus?.emit('agent:left', { agentId, projectId: agent.project_id });
+    }
     return info.changes > 0;
   }
 
@@ -441,10 +457,12 @@ export class TeamStore {
     for (const agent of staleAgents) {
       this.stmtAgentLeave.run(now, agent.agent_id);
       // Release tasks
-      this.stmtTaskReleaseByAgent.run(now, agent.agent_id);
+      const released = this.stmtTaskReleaseByAgent.run(now, agent.agent_id);
       // Release locks
       this.stmtLockDeleteByAgent.run(agent.agent_id);
       staleIds.push(agent.agent_id);
+      // Lifecycle hook: stale agent detected (best-effort)
+      this.eventBus?.emit('agent:stale', { agentId: agent.agent_id, projectId, releasedTasks: released.changes });
     }
     return staleIds;
   }
@@ -551,6 +569,10 @@ export class TeamStore {
         this.stmtTaskDepInsert.run(taskId, depId);
       }
     }
+
+    // Lifecycle hook: task created (best-effort, after successful write)
+    this.eventBus?.emit('task:created', { taskId, projectId: input.projectId, description: input.description });
+
     return row;
   }
 
@@ -603,7 +625,14 @@ export class TeamStore {
     });
 
     // Use immediate to acquire write lock before reading
-    return claimTx.immediate();
+    const result = claimTx.immediate();
+
+    // Lifecycle hook: task claimed (best-effort, after successful write)
+    if (result.success && result.task) {
+      this.eventBus?.emit('task:claimed', { taskId, projectId: result.task.project_id, agentId });
+    }
+
+    return result;
   }
 
   completeTask(taskId: string, agentId: string, result?: string): { success: boolean; reason?: string } {
@@ -612,6 +641,13 @@ export class TeamStore {
     if (info.changes === 0) {
       return { success: false, reason: 'Not the assignee or task not in progress' };
     }
+
+    // Lifecycle hook: task completed (best-effort)
+    const task = this.stmtTaskById.get(taskId) as TeamTaskRow | undefined;
+    if (task) {
+      this.eventBus?.emit('task:completed', { taskId, projectId: task.project_id, agentId, result: result ?? undefined });
+    }
+
     return { success: true };
   }
 
@@ -621,15 +657,29 @@ export class TeamStore {
     if (info.changes === 0) {
       return { success: false, reason: 'Not the assignee or task not in progress' };
     }
+
+    // Lifecycle hook: task failed (best-effort)
+    const task = this.stmtTaskById.get(taskId) as TeamTaskRow | undefined;
+    if (task) {
+      this.eventBus?.emit('task:failed', { taskId, projectId: task.project_id, agentId, result: result ?? undefined });
+    }
+
     return { success: true };
   }
 
   releaseTask(taskId: string, agentId: string): { success: boolean; reason?: string } {
     const now = Date.now();
+    const task = this.stmtTaskById.get(taskId) as TeamTaskRow | undefined;
     const info = this.stmtTaskRelease.run(now, taskId, agentId);
     if (info.changes === 0) {
       return { success: false, reason: 'Not the assignee or task not in progress' };
     }
+
+    // Lifecycle hook: task released (best-effort)
+    if (task) {
+      this.eventBus?.emit('task:released', { taskId, projectId: task.project_id, agentId });
+    }
+
     return { success: true };
   }
 

--- a/tests/team/event-bus.test.ts
+++ b/tests/team/event-bus.test.ts
@@ -1,0 +1,110 @@
+/**
+ * TeamEventBus — Phase 4b event emission layer tests.
+ *
+ * Covers: typed events, listener lifecycle, error isolation, once semantics.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { TeamEventBus } from '../../src/team/event-bus.js';
+
+describe('TeamEventBus', () => {
+  it('should emit and receive typed events', () => {
+    const bus = new TeamEventBus();
+    const received: any[] = [];
+    bus.on('task:created', (data) => received.push(data));
+
+    bus.emit('task:created', { taskId: 't1', projectId: 'p1', description: 'test' });
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toEqual({ taskId: 't1', projectId: 'p1', description: 'test' });
+  });
+
+  it('should support multiple listeners on the same event', () => {
+    const bus = new TeamEventBus();
+    const a: string[] = [];
+    const b: string[] = [];
+    bus.on('task:completed', () => a.push('a'));
+    bus.on('task:completed', () => b.push('b'));
+
+    bus.emit('task:completed', { taskId: 't1', projectId: 'p1', agentId: 'a1' });
+
+    expect(a).toEqual(['a']);
+    expect(b).toEqual(['b']);
+  });
+
+  it('should silently drop events with no listeners', () => {
+    const bus = new TeamEventBus();
+    // No listeners — should not throw
+    expect(() => {
+      bus.emit('task:failed', { taskId: 't1', projectId: 'p1', agentId: 'a1' });
+    }).not.toThrow();
+  });
+
+  it('should isolate listener errors from the emitter', () => {
+    const bus = new TeamEventBus();
+    bus.on('agent:joined', () => { throw new Error('listener boom'); });
+
+    // emit wraps in try-catch — should not throw
+    expect(() => {
+      bus.emit('agent:joined', { agentId: 'a1', projectId: 'p1', agentType: 'test' });
+    }).not.toThrow();
+  });
+
+  it('should support unsubscribe via returned function', () => {
+    const bus = new TeamEventBus();
+    const received: string[] = [];
+    const unsub = bus.on('task:released', () => received.push('hit'));
+
+    bus.emit('task:released', { taskId: 't1', projectId: 'p1', agentId: 'a1' });
+    expect(received).toHaveLength(1);
+
+    unsub();
+    bus.emit('task:released', { taskId: 't2', projectId: 'p1', agentId: 'a1' });
+    expect(received).toHaveLength(1); // no new hit
+  });
+
+  it('should support once semantics', () => {
+    const bus = new TeamEventBus();
+    const received: string[] = [];
+    bus.once('task:claimed', () => received.push('once'));
+
+    bus.emit('task:claimed', { taskId: 't1', projectId: 'p1', agentId: 'a1' });
+    bus.emit('task:claimed', { taskId: 't2', projectId: 'p1', agentId: 'a1' });
+
+    expect(received).toEqual(['once']); // only fired once
+  });
+
+  it('should report correct listener count', () => {
+    const bus = new TeamEventBus();
+    expect(bus.listenerCount('task:created')).toBe(0);
+
+    const unsub = bus.on('task:created', () => {});
+    expect(bus.listenerCount('task:created')).toBe(1);
+
+    unsub();
+    expect(bus.listenerCount('task:created')).toBe(0);
+  });
+
+  it('should removeAllListeners for a specific event', () => {
+    const bus = new TeamEventBus();
+    bus.on('task:created', () => {});
+    bus.on('task:created', () => {});
+    bus.on('agent:joined', () => {});
+
+    bus.removeAllListeners('task:created');
+
+    expect(bus.listenerCount('task:created')).toBe(0);
+    expect(bus.listenerCount('agent:joined')).toBe(1);
+  });
+
+  it('should removeAllListeners for all events', () => {
+    const bus = new TeamEventBus();
+    bus.on('task:created', () => {});
+    bus.on('agent:joined', () => {});
+
+    bus.removeAllListeners();
+
+    expect(bus.listenerCount('task:created')).toBe(0);
+    expect(bus.listenerCount('agent:joined')).toBe(0);
+  });
+});

--- a/tests/team/handoff.test.ts
+++ b/tests/team/handoff.test.ts
@@ -1,0 +1,345 @@
+/**
+ * Team Handoff — Phase 4b structured context transfer tests.
+ *
+ * Covers: observation creation, notification message, topicKey dedup, core immunity.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createHandoffArtifact } from '../../src/team/handoff.js';
+import { TeamStore } from '../../src/team/team-store.js';
+import { TeamEventBus } from '../../src/team/event-bus.js';
+import { closeDatabase } from '../../src/store/sqlite-db.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'memorix-handoff-test-'));
+}
+
+function cleanup(dir: string): void {
+  closeDatabase(dir);
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+/** Mock storeObservation that captures arguments and returns a fake observation */
+function createMockStore() {
+  let nextId = 1;
+  const calls: any[] = [];
+  const fn = async (params: any) => {
+    calls.push(params);
+    return { observation: { id: nextId++ }, upserted: false };
+  };
+  return { fn, calls };
+}
+
+describe('createHandoffArtifact', () => {
+  let store: TeamStore;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = makeTmpDir();
+    store = new TeamStore();
+    await store.init(tmpDir);
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  it('should create observation with correct fields', async () => {
+    const mock = createMockStore();
+    const a1 = store.registerAgent({ projectId: 'proj1', agentType: 'test', instanceId: 'i1' });
+    const a2 = store.registerAgent({ projectId: 'proj1', agentType: 'test2', instanceId: 'i2' });
+
+    const result = await createHandoffArtifact(
+      {
+        projectId: 'proj1',
+        fromAgentId: a1.agent_id,
+        toAgentId: a2.agent_id,
+        summary: 'Finished auth module',
+        context: 'JWT implemented, need to add refresh tokens',
+        filesModified: ['src/auth.ts'],
+        concepts: ['authentication', 'jwt'],
+      },
+      mock.fn,
+      store,
+    );
+
+    expect(result.observationId).toBe(1);
+    expect(result.fromAgentId).toBe(a1.agent_id);
+    expect(result.toAgentId).toBe(a2.agent_id);
+    expect(result.summary).toBe('Finished auth module');
+
+    // Check storeObservation was called with correct params
+    expect(mock.calls).toHaveLength(1);
+    const call = mock.calls[0];
+    expect(call.entityName).toBe('team-handoff');
+    expect(call.type).toBe('what-changed');
+    expect(call.title).toContain('[Handoff]');
+    expect(call.narrative).toBe('JWT implemented, need to add refresh tokens');
+    expect(call.valueCategory).toBe('core'); // immune to archival
+    expect(call.sourceDetail).toBe('explicit');
+    expect(call.createdByAgentId).toBe(a1.agent_id);
+    expect(call.filesModified).toEqual(['src/auth.ts']);
+    expect(call.concepts).toContain('handoff');
+    expect(call.concepts).toContain('authentication');
+  });
+
+  it('should send notification message to recipient', async () => {
+    const mock = createMockStore();
+    const a1 = store.registerAgent({ projectId: 'proj1', agentType: 'test', instanceId: 'i1' });
+    const a2 = store.registerAgent({ projectId: 'proj1', agentType: 'test2', instanceId: 'i2' });
+
+    await createHandoffArtifact(
+      {
+        projectId: 'proj1',
+        fromAgentId: a1.agent_id,
+        toAgentId: a2.agent_id,
+        summary: 'Handoff test',
+        context: 'context data',
+      },
+      mock.fn,
+      store,
+    );
+
+    // Check inbox for recipient
+    const inbox = store.getInbox('proj1', a2.agent_id);
+    expect(inbox).toHaveLength(1);
+    expect(inbox[0].type).toBe('handoff');
+    expect(inbox[0].content).toContain('Handoff: Handoff test');
+    expect(inbox[0].sender_agent_id).toBe(a1.agent_id);
+  });
+
+  it('should fanout broadcast to each active agent (excluding sender)', async () => {
+    const mock = createMockStore();
+    const a1 = store.registerAgent({ projectId: 'proj1', agentType: 'test', instanceId: 'i1' });
+    const a2 = store.registerAgent({ projectId: 'proj1', agentType: 'test2', instanceId: 'i2' });
+    const a3 = store.registerAgent({ projectId: 'proj1', agentType: 'test3', instanceId: 'i3' });
+
+    const result = await createHandoffArtifact(
+      {
+        projectId: 'proj1',
+        fromAgentId: a1.agent_id,
+        // no toAgentId → broadcast fanout
+        summary: 'Available handoff',
+        context: 'anyone can pick up',
+      },
+      mock.fn,
+      store,
+    );
+
+    expect(result.toAgentId).toBeUndefined();
+
+    // Each non-sender agent gets their own recipient-specific message
+    const inbox2 = store.getInbox('proj1', a2.agent_id);
+    const inbox3 = store.getInbox('proj1', a3.agent_id);
+    expect(inbox2).toHaveLength(1);
+    expect(inbox3).toHaveLength(1);
+    // Messages are distinct (different IDs, different recipients)
+    expect(inbox2[0].recipient_agent_id).toBe(a2.agent_id);
+    expect(inbox3[0].recipient_agent_id).toBe(a3.agent_id);
+    expect(inbox2[0].id).not.toBe(inbox3[0].id);
+    // Sender does not get a message
+    const inbox1 = store.getInbox('proj1', a1.agent_id);
+    expect(inbox1.filter(m => m.type === 'handoff')).toHaveLength(0);
+  });
+
+  it('should set topicKey when taskId is provided', async () => {
+    const mock = createMockStore();
+    const a1 = store.registerAgent({ projectId: 'proj1', agentType: 'test', instanceId: 'i1' });
+
+    await createHandoffArtifact(
+      {
+        projectId: 'proj1',
+        fromAgentId: a1.agent_id,
+        taskId: 'task-123',
+        summary: 'Task handoff',
+        context: 'task context',
+      },
+      mock.fn,
+      store,
+    );
+
+    expect(mock.calls[0].topicKey).toBe(`handoff:task-123:${a1.agent_id}`);
+  });
+
+  it('should include task reference in facts', async () => {
+    const mock = createMockStore();
+    const a1 = store.registerAgent({ projectId: 'proj1', agentType: 'test', instanceId: 'i1' });
+
+    await createHandoffArtifact(
+      {
+        projectId: 'proj1',
+        fromAgentId: a1.agent_id,
+        taskId: 'task-456',
+        summary: 'test',
+        context: 'ctx',
+      },
+      mock.fn,
+      store,
+    );
+
+    const facts = mock.calls[0].facts as string[];
+    expect(facts.some((f: string) => f.includes('task-456'))).toBe(true);
+  });
+
+  it('should not throw if message sending fails', async () => {
+    const mock = createMockStore();
+    // Use a store with broken sendMessage
+    const brokenStore = Object.create(store);
+    brokenStore.sendMessage = () => { throw new Error('DB error'); };
+    brokenStore.listAgents = store.listAgents.bind(store);
+
+    const a1 = store.registerAgent({ projectId: 'proj1', agentType: 'test', instanceId: 'i1' });
+
+    // Should not throw — message is best-effort
+    const result = await createHandoffArtifact(
+      {
+        projectId: 'proj1',
+        fromAgentId: a1.agent_id,
+        summary: 'test',
+        context: 'ctx',
+      },
+      mock.fn,
+      brokenStore,
+    );
+
+    expect(result.observationId).toBe(1); // observation still created
+  });
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Codex review: required correctness tests
+  // ═══════════════════════════════════════════════════════════════════
+
+  it('should emit handoff:created event after canonical write', async () => {
+    const bus = new TeamEventBus();
+    store.setEventBus(bus);
+    const received: any[] = [];
+    bus.on('handoff:created', (data) => received.push(data));
+
+    const mock = createMockStore();
+    const a1 = store.registerAgent({ projectId: 'proj1', agentType: 'test', instanceId: 'i1' });
+
+    await createHandoffArtifact(
+      {
+        projectId: 'proj1',
+        fromAgentId: a1.agent_id,
+        taskId: 'task-99',
+        summary: 'test emit',
+        context: 'ctx',
+      },
+      mock.fn,
+      store,
+    );
+
+    expect(received).toHaveLength(1);
+    expect(received[0].observationId).toBe(1);
+    expect(received[0].projectId).toBe('proj1');
+    expect(received[0].fromAgent).toBe(a1.agent_id);
+    expect(received[0].taskId).toBe('task-99');
+  });
+
+  it('should not block canonical write when handoff:created listener throws', async () => {
+    const bus = new TeamEventBus();
+    store.setEventBus(bus);
+    bus.on('handoff:created', () => { throw new Error('listener crash'); });
+
+    const mock = createMockStore();
+    const a1 = store.registerAgent({ projectId: 'proj1', agentType: 'test', instanceId: 'i1' });
+
+    const result = await createHandoffArtifact(
+      {
+        projectId: 'proj1',
+        fromAgentId: a1.agent_id,
+        summary: 'survives crash',
+        context: 'ctx',
+      },
+      mock.fn,
+      store,
+    );
+
+    expect(result.observationId).toBe(1);
+    expect(mock.calls).toHaveLength(1); // observation was stored
+  });
+
+  it('broadcast handoff: agent A markRead does not affect agent B unread', async () => {
+    const mock = createMockStore();
+    const a1 = store.registerAgent({ projectId: 'proj1', agentType: 'sender', instanceId: 'i1' });
+    const a2 = store.registerAgent({ projectId: 'proj1', agentType: 'reader', instanceId: 'i2' });
+    const a3 = store.registerAgent({ projectId: 'proj1', agentType: 'other', instanceId: 'i3' });
+
+    await createHandoffArtifact(
+      {
+        projectId: 'proj1',
+        fromAgentId: a1.agent_id,
+        summary: 'broadcast isolation test',
+        context: 'ctx',
+      },
+      mock.fn,
+      store,
+    );
+
+    // Both agents see unread
+    expect(store.getUnreadCount('proj1', a2.agent_id)).toBe(1);
+    expect(store.getUnreadCount('proj1', a3.agent_id)).toBe(1);
+
+    // Agent A2 marks all read
+    store.markAllRead('proj1', a2.agent_id);
+
+    // Agent A2 now has 0 unread, but A3 still has 1
+    expect(store.getUnreadCount('proj1', a2.agent_id)).toBe(0);
+    expect(store.getUnreadCount('proj1', a3.agent_id)).toBe(1);
+  });
+
+  it('targeted handoff (with toAgentId) semantics unchanged', async () => {
+    const mock = createMockStore();
+    const a1 = store.registerAgent({ projectId: 'proj1', agentType: 'test', instanceId: 'i1' });
+    const a2 = store.registerAgent({ projectId: 'proj1', agentType: 'test2', instanceId: 'i2' });
+    const a3 = store.registerAgent({ projectId: 'proj1', agentType: 'test3', instanceId: 'i3' });
+
+    await createHandoffArtifact(
+      {
+        projectId: 'proj1',
+        fromAgentId: a1.agent_id,
+        toAgentId: a2.agent_id,
+        summary: 'targeted only',
+        context: 'ctx',
+      },
+      mock.fn,
+      store,
+    );
+
+    // Only a2 gets the message, not a3
+    const inbox2 = store.getInbox('proj1', a2.agent_id);
+    const inbox3 = store.getInbox('proj1', a3.agent_id);
+    expect(inbox2.filter(m => m.type === 'handoff')).toHaveLength(1);
+    expect(inbox3.filter(m => m.type === 'handoff')).toHaveLength(0);
+  });
+
+  it('existing direct message behavior not regressed', () => {
+    const a1 = store.registerAgent({ projectId: 'proj1', agentType: 'test', instanceId: 'i1' });
+    const a2 = store.registerAgent({ projectId: 'proj1', agentType: 'test2', instanceId: 'i2' });
+    const a3 = store.registerAgent({ projectId: 'proj1', agentType: 'test3', instanceId: 'i3' });
+
+    // Send a direct (non-handoff) message
+    store.sendMessage({
+      projectId: 'proj1',
+      senderAgentId: a1.agent_id,
+      recipientAgentId: a2.agent_id,
+      type: 'info',
+      content: 'direct message',
+    });
+
+    // Only a2 sees it
+    expect(store.getUnreadCount('proj1', a2.agent_id)).toBe(1);
+    expect(store.getInbox('proj1', a3.agent_id).filter(m => m.type === 'info')).toHaveLength(0);
+
+    // markRead only affects a2
+    store.markAllRead('proj1', a2.agent_id);
+    expect(store.getUnreadCount('proj1', a2.agent_id)).toBe(0);
+
+    // a3 is unaffected (had no messages)
+    expect(store.getUnreadCount('proj1', a3.agent_id)).toBe(0);
+  });
+});

--- a/tests/team/lifecycle-hook.test.ts
+++ b/tests/team/lifecycle-hook.test.ts
@@ -1,0 +1,245 @@
+/**
+ * TaskLifecycleHook — Phase 4b lifecycle event emission tests.
+ *
+ * Covers: events fire on task/agent state changes, events fire AFTER successful writes,
+ * listener errors do not affect TeamStore writes.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TeamStore } from '../../src/team/team-store.js';
+import { TeamEventBus } from '../../src/team/event-bus.js';
+import { closeDatabase } from '../../src/store/sqlite-db.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'memorix-lifecycle-test-'));
+}
+
+function cleanup(dir: string): void {
+  closeDatabase(dir);
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe('TaskLifecycleHook', () => {
+  let store: TeamStore;
+  let bus: TeamEventBus;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = makeTmpDir();
+    store = new TeamStore();
+    await store.init(tmpDir);
+    bus = new TeamEventBus();
+    store.setEventBus(bus);
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  // ── Task lifecycle events ──────────────────────────────────────
+
+  it('should emit task:created when a task is created', () => {
+    const received: any[] = [];
+    bus.on('task:created', (data) => received.push(data));
+
+    const task = store.createTask({ projectId: 'proj1', description: 'do something' });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].taskId).toBe(task.task_id);
+    expect(received[0].projectId).toBe('proj1');
+    expect(received[0].description).toBe('do something');
+  });
+
+  it('should emit task:claimed when a task is claimed', () => {
+    const received: any[] = [];
+    bus.on('task:claimed', (data) => received.push(data));
+
+    const agent = store.registerAgent({ projectId: 'proj1', agentType: 'test', instanceId: 'i1' });
+    const task = store.createTask({ projectId: 'proj1', description: 'claimable' });
+    store.claimTask(task.task_id, agent.agent_id);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].taskId).toBe(task.task_id);
+    expect(received[0].agentId).toBe(agent.agent_id);
+  });
+
+  it('should NOT emit task:claimed when claim fails', () => {
+    const received: any[] = [];
+    bus.on('task:claimed', (data) => received.push(data));
+
+    const a1 = store.registerAgent({ projectId: 'proj1', agentType: 'test', instanceId: 'i1' });
+    const a2 = store.registerAgent({ projectId: 'proj1', agentType: 'test2', instanceId: 'i2' });
+    const task = store.createTask({ projectId: 'proj1', description: 'contested' });
+
+    store.claimTask(task.task_id, a1.agent_id); // succeeds
+    store.claimTask(task.task_id, a2.agent_id); // fails — already claimed
+
+    expect(received).toHaveLength(1); // only the successful claim
+    expect(received[0].agentId).toBe(a1.agent_id);
+  });
+
+  it('should emit task:completed on successful completion', () => {
+    const received: any[] = [];
+    bus.on('task:completed', (data) => received.push(data));
+
+    const agent = store.registerAgent({ projectId: 'proj1', agentType: 'test', instanceId: 'i1' });
+    const task = store.createTask({ projectId: 'proj1', description: 'completable' });
+    store.claimTask(task.task_id, agent.agent_id);
+    store.completeTask(task.task_id, agent.agent_id, 'done!');
+
+    expect(received).toHaveLength(1);
+    expect(received[0].taskId).toBe(task.task_id);
+    expect(received[0].result).toBe('done!');
+  });
+
+  it('should emit task:failed on task failure', () => {
+    const received: any[] = [];
+    bus.on('task:failed', (data) => received.push(data));
+
+    const agent = store.registerAgent({ projectId: 'proj1', agentType: 'test', instanceId: 'i1' });
+    const task = store.createTask({ projectId: 'proj1', description: 'will fail' });
+    store.claimTask(task.task_id, agent.agent_id);
+    store.failTask(task.task_id, agent.agent_id, 'error occurred');
+
+    expect(received).toHaveLength(1);
+    expect(received[0].taskId).toBe(task.task_id);
+    expect(received[0].result).toBe('error occurred');
+  });
+
+  it('should emit task:released when a task is released', () => {
+    const received: any[] = [];
+    bus.on('task:released', (data) => received.push(data));
+
+    const agent = store.registerAgent({ projectId: 'proj1', agentType: 'test', instanceId: 'i1' });
+    const task = store.createTask({ projectId: 'proj1', description: 'releasable' });
+    store.claimTask(task.task_id, agent.agent_id);
+    store.releaseTask(task.task_id, agent.agent_id);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].taskId).toBe(task.task_id);
+    expect(received[0].agentId).toBe(agent.agent_id);
+  });
+
+  // ── Agent lifecycle events ─────────────────────────────────────
+
+  it('should emit agent:joined when an agent registers', () => {
+    const received: any[] = [];
+    bus.on('agent:joined', (data) => received.push(data));
+
+    const agent = store.registerAgent({
+      projectId: 'proj1',
+      agentType: 'windsurf',
+      instanceId: 'inst-1',
+      name: 'Cascade',
+    });
+
+    expect(received).toHaveLength(1);
+    expect(received[0].agentId).toBe(agent.agent_id);
+    expect(received[0].agentType).toBe('windsurf');
+  });
+
+  it('should emit agent:joined on reactivation', () => {
+    const received: any[] = [];
+    bus.on('agent:joined', (data) => received.push(data));
+
+    store.registerAgent({ projectId: 'proj1', agentType: 'windsurf', instanceId: 'inst-1' });
+    store.registerAgent({ projectId: 'proj1', agentType: 'windsurf', instanceId: 'inst-1' }); // reactivate
+
+    expect(received).toHaveLength(2); // joined twice
+  });
+
+  it('should emit agent:left when an agent leaves', () => {
+    const received: any[] = [];
+    bus.on('agent:left', (data) => received.push(data));
+
+    const agent = store.registerAgent({ projectId: 'proj1', agentType: 'test', instanceId: 'i1' });
+    store.leaveAgent(agent.agent_id);
+
+    expect(received).toHaveLength(1);
+    expect(received[0].agentId).toBe(agent.agent_id);
+    expect(received[0].projectId).toBe('proj1');
+  });
+
+  it('should emit agent:stale when stale agent is detected', () => {
+    const received: any[] = [];
+    bus.on('agent:stale', (data) => received.push(data));
+
+    const agent = store.registerAgent({ projectId: 'proj1', agentType: 'test', instanceId: 'i1' });
+    // Make the heartbeat very old
+    store.getDb().prepare('UPDATE team_agents SET last_heartbeat = ? WHERE agent_id = ?')
+      .run(Date.now() - 10 * 60 * 1000, agent.agent_id); // 10 min ago
+
+    store.detectAndMarkStale('proj1', 5 * 60 * 1000); // 5 min TTL
+
+    expect(received).toHaveLength(1);
+    expect(received[0].agentId).toBe(agent.agent_id);
+    expect(received[0].projectId).toBe('proj1');
+  });
+
+  // ── Error isolation (Codex constraint #3) ──────────────────────
+
+  it('should NOT prevent TeamStore writes when listener throws', () => {
+    bus.on('task:created', () => { throw new Error('listener crash'); });
+
+    // createTask should succeed despite listener error
+    const task = store.createTask({ projectId: 'proj1', description: 'survives crash' });
+    expect(task.task_id).toBeTruthy();
+
+    // Verify task is actually in the database
+    const retrieved = store.getTask(task.task_id);
+    expect(retrieved).toBeDefined();
+    expect(retrieved!.description).toBe('survives crash');
+  });
+
+  it('should NOT prevent claim when listener throws', () => {
+    bus.on('task:claimed', () => { throw new Error('listener crash'); });
+
+    const agent = store.registerAgent({ projectId: 'proj1', agentType: 'test', instanceId: 'i1' });
+    const task = store.createTask({ projectId: 'proj1', description: 'claim test' });
+
+    const result = store.claimTask(task.task_id, agent.agent_id);
+    expect(result.success).toBe(true);
+
+    const retrieved = store.getTask(task.task_id);
+    expect(retrieved!.status).toBe('in_progress');
+    expect(retrieved!.assignee_agent_id).toBe(agent.agent_id);
+  });
+
+  it('should NOT prevent completion when listener throws', () => {
+    bus.on('task:completed', () => { throw new Error('listener crash'); });
+
+    const agent = store.registerAgent({ projectId: 'proj1', agentType: 'test', instanceId: 'i1' });
+    const task = store.createTask({ projectId: 'proj1', description: 'complete test' });
+    store.claimTask(task.task_id, agent.agent_id);
+
+    const result = store.completeTask(task.task_id, agent.agent_id, 'done');
+    expect(result.success).toBe(true);
+
+    const retrieved = store.getTask(task.task_id);
+    expect(retrieved!.status).toBe('completed');
+  });
+
+  // ── No EventBus (graceful degradation) ────────────────────────
+
+  it('should work normally without an EventBus', async () => {
+    // Create a fresh store without EventBus
+    const tmpDir2 = makeTmpDir();
+    const store2 = new TeamStore();
+    await store2.init(tmpDir2);
+    // No setEventBus call
+
+    const agent = store2.registerAgent({ projectId: 'proj1', agentType: 'test', instanceId: 'i1' });
+    const task = store2.createTask({ projectId: 'proj1', description: 'no bus test' });
+    const claim = store2.claimTask(task.task_id, agent.agent_id);
+    expect(claim.success).toBe(true);
+
+    store2.completeTask(task.task_id, agent.agent_id, 'done');
+    const retrieved = store2.getTask(task.task_id);
+    expect(retrieved!.status).toBe('completed');
+
+    cleanup(tmpDir2);
+  });
+});

--- a/tests/team/poll.test.ts
+++ b/tests/team/poll.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Team Poll — Phase 4b computeWatermark + computePoll tests.
+ *
+ * Covers: watermark calculation, full poll snapshot assembly.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { computeWatermark, computePoll } from '../../src/team/poll.js';
+import { TeamStore } from '../../src/team/team-store.js';
+import { closeDatabase } from '../../src/store/sqlite-db.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'memorix-poll-test-'));
+}
+
+function cleanup(dir: string): void {
+  closeDatabase(dir);
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe('computeWatermark', () => {
+  it('should return zero watermark when no new observations', () => {
+    const wm = computeWatermark(10, 10, 0);
+    expect(wm.lastSeenGeneration).toBe(10);
+    expect(wm.currentGeneration).toBe(10);
+    expect(wm.newObservationCount).toBe(0);
+  });
+
+  it('should report new observations when generation advanced', () => {
+    const wm = computeWatermark(5, 12, 7);
+    expect(wm.lastSeenGeneration).toBe(5);
+    expect(wm.currentGeneration).toBe(12);
+    expect(wm.newObservationCount).toBe(7);
+  });
+
+  it('should handle first session (lastSeen = 0)', () => {
+    const wm = computeWatermark(0, 5, 5);
+    expect(wm.lastSeenGeneration).toBe(0);
+    expect(wm.newObservationCount).toBe(5);
+  });
+});
+
+describe('computePoll', () => {
+  let store: TeamStore;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = makeTmpDir();
+    store = new TeamStore();
+    await store.init(tmpDir);
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  it('should return empty poll for project with no activity', () => {
+    const wm = computeWatermark(0, 0, 0);
+    const poll = computePoll(store, 'proj1', null, wm);
+
+    expect(poll.agent).toBeNull();
+    expect(poll.watermark.newObservationCount).toBe(0);
+    expect(poll.inbox.unreadCount).toBe(0);
+    expect(poll.tasks.myInProgress).toHaveLength(0);
+    expect(poll.tasks.availableToClaim).toHaveLength(0);
+    expect(poll.team.activeAgents).toHaveLength(0);
+    expect(poll.team.totalAgents).toBe(0);
+  });
+
+  it('should return agent info when agentId is provided', () => {
+    const agent = store.registerAgent({
+      projectId: 'proj1',
+      agentType: 'windsurf',
+      instanceId: 'inst-1',
+      name: 'Cascade',
+    });
+
+    const wm = computeWatermark(0, 5, 3);
+    const poll = computePoll(store, 'proj1', agent.agent_id, wm);
+
+    expect(poll.agent).not.toBeNull();
+    expect(poll.agent!.agentId).toBe(agent.agent_id);
+    expect(poll.agent!.status).toBe('active');
+    expect(poll.watermark.newObservationCount).toBe(3);
+    expect(poll.team.activeAgents).toHaveLength(1);
+    expect(poll.team.totalAgents).toBe(1);
+  });
+
+  it('should show tasks categorized correctly', () => {
+    const agent = store.registerAgent({
+      projectId: 'proj1',
+      agentType: 'test',
+      instanceId: 'i1',
+    });
+
+    // Create tasks
+    const t1 = store.createTask({ projectId: 'proj1', description: 'available task' });
+    const t2 = store.createTask({ projectId: 'proj1', description: 'my task' });
+    const t3 = store.createTask({ projectId: 'proj1', description: 'done task' });
+    const t4 = store.createTask({ projectId: 'proj1', description: 'failed task' });
+
+    // Claim t2
+    store.claimTask(t2.task_id, agent.agent_id);
+    // Complete t3
+    const otherAgent = store.registerAgent({ projectId: 'proj1', agentType: 'other', instanceId: 'i2' });
+    store.claimTask(t3.task_id, otherAgent.agent_id);
+    store.completeTask(t3.task_id, otherAgent.agent_id, 'done');
+    // Fail t4
+    store.claimTask(t4.task_id, otherAgent.agent_id);
+    store.failTask(t4.task_id, otherAgent.agent_id, 'oops');
+
+    const wm = computeWatermark(0, 0, 0);
+    const poll = computePoll(store, 'proj1', agent.agent_id, wm);
+
+    expect(poll.tasks.myInProgress).toHaveLength(1);
+    expect(poll.tasks.myInProgress[0].task_id).toBe(t2.task_id);
+    expect(poll.tasks.availableToClaim).toHaveLength(1);
+    expect(poll.tasks.availableToClaim[0].task_id).toBe(t1.task_id);
+    expect(poll.tasks.recentlyCompleted).toHaveLength(1);
+    expect(poll.tasks.recentlyFailed).toHaveLength(1);
+  });
+
+  it('should show unread messages in inbox', () => {
+    const a1 = store.registerAgent({ projectId: 'proj1', agentType: 'a', instanceId: 'i1' });
+    const a2 = store.registerAgent({ projectId: 'proj1', agentType: 'b', instanceId: 'i2' });
+
+    store.sendMessage({
+      projectId: 'proj1',
+      senderAgentId: a2.agent_id,
+      recipientAgentId: a1.agent_id,
+      type: 'info',
+      content: 'hello',
+    });
+
+    const wm = computeWatermark(0, 0, 0);
+    const poll = computePoll(store, 'proj1', a1.agent_id, wm);
+
+    expect(poll.inbox.unreadCount).toBe(1);
+    expect(poll.inbox.messages).toHaveLength(1);
+    expect(poll.inbox.messages[0].content).toBe('hello');
+  });
+
+  it('should exclude tasks with unmet deps from availableToClaim', () => {
+    const dep = store.createTask({ projectId: 'proj1', description: 'dependency' });
+    const blocked = store.createTask({ projectId: 'proj1', description: 'blocked', deps: [dep.task_id] });
+
+    const wm = computeWatermark(0, 0, 0);
+    const poll = computePoll(store, 'proj1', null, wm);
+
+    // dep is available, blocked is not (unmet dep)
+    const availableIds = poll.tasks.availableToClaim.map(t => t.task_id);
+    expect(availableIds).toContain(dep.task_id);
+    expect(availableIds).not.toContain(blocked.task_id);
+  });
+});

--- a/tests/tui/interaction.test.tsx
+++ b/tests/tui/interaction.test.tsx
@@ -539,7 +539,7 @@ describe('ConfigureView', () => {
     // Navigate to "Show Current Config" (index 3)
     for (let i = 0; i < 3; i++) { stdin.write('\x1B[B'); await tick(); }
     stdin.write('\r');
-    await tick();
+    await waitForCondition(() => (lastFrame() ?? '').includes('Current Configuration'));
     const frame = lastFrame()!;
     expect(frame).toContain('Current Configuration');
     expect(frame).toContain('Config file');
@@ -553,10 +553,10 @@ describe('ConfigureView', () => {
     );
     for (let i = 0; i < 3; i++) { stdin.write('\x1B[B'); await tick(); }
     stdin.write('\r');
-    await tick();
+    await waitForCondition(() => (lastFrame() ?? '').includes('Current Configuration'));
     expect(lastFrame()).toContain('Current Configuration');
     stdin.write('\x1B');
-    await tick();
+    await waitForCondition(() => (lastFrame() ?? '').includes('LLM Enhanced Mode'));
     expect(lastFrame()).toContain('LLM Enhanced Mode');
     unmount();
   });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,11 +6,13 @@ const define = { __MEMORIX_VERSION__: JSON.stringify(pkg.version) };
 
 export default defineConfig([
   {
-    entry: { index: 'src/index.ts' },
+    // Phase 4b: types entry added for memorix/types SDK subpath export
+    entry: { index: 'src/index.ts', types: 'src/types.ts' },
     format: ['esm'],
     target: 'node20',
     dts: true,
     sourcemap: true,
+    clean: true,
     splitting: false,
     shims: true,
     define,
@@ -22,7 +24,6 @@ export default defineConfig([
     target: 'node20',
     dts: true,
     sourcemap: true,
-    clean: true,
     splitting: false,
     shims: true,
     define,


### PR DESCRIPTION
## Summary
- add the Phase 4b coordination primitives: `memorix_poll`, `memorix_handoff`, `TeamEventBus`, reusable watermark logic, and rescue-aware session start wiring
- keep the new logic in `src/team/*` modules so `server.ts` stays a thin registration layer, and add a small `memorix/types` subpath export for library consumers
- fix Codex review findings by emitting `handoff:created` and making broadcast handoffs fan out per recipient so unread state stays isolated

## Test Plan
- [x] `npx tsc --noEmit`
- [x] `npx tsup`
- [x] `npx vitest run tests/team/event-bus.test.ts tests/team/poll.test.ts tests/team/handoff.test.ts tests/team/lifecycle-hook.test.ts`
- [x] `npx vitest run`
