### PR TITLE
feat: add phase 4c orchestrator loop

### DIFF
--- a/src/cli/commands/orchestrate.ts
+++ b/src/cli/commands/orchestrate.ts
@@ -98,6 +98,24 @@ export default defineCommand({
     const pollIntervalMs = parseInt(args.poll as string, 10);
     const dryRun = args['dry-run'] as boolean;
 
+    // Validate numeric CLI args — fail fast with clear messages
+    if (!Number.isFinite(parallel) || parallel < 1) {
+      console.error(`❌ --parallel must be a positive integer, got: ${args.parallel}`);
+      process.exit(1);
+    }
+    if (!Number.isFinite(taskTimeoutMs) || taskTimeoutMs <= 0) {
+      console.error(`❌ --timeout must be a positive integer (ms), got: ${args.timeout}`);
+      process.exit(1);
+    }
+    if (!Number.isFinite(pollIntervalMs) || pollIntervalMs < 0) {
+      console.error(`❌ --poll must be a non-negative integer (ms), got: ${args.poll}`);
+      process.exit(1);
+    }
+    if (!Number.isFinite(maxRetries) || maxRetries < 0) {
+      console.error(`❌ --max-retries must be a non-negative integer, got: ${args['max-retries']}`);
+      process.exit(1);
+    }
+
     // Check if there are tasks to work on
     const tasks = teamStore.listTasks(proj.id);
     const pendingTasks = tasks.filter(t => t.status === 'pending');

--- a/src/cli/commands/orchestrate.ts
+++ b/src/cli/commands/orchestrate.ts
@@ -1,0 +1,165 @@
+/**
+ * memorix orchestrate — Autonomous multi-agent coordination.
+ *
+ * Phase 4c: Runs a coordination loop that dispatches agents to tasks,
+ * monitors progress, handles failures, and exits when all work is done.
+ *
+ * Drive model: SQLite poll (rule D1). NOT EventBus.
+ */
+
+import { defineCommand } from 'citty';
+
+export default defineCommand({
+  meta: {
+    name: 'orchestrate',
+    description: 'Run autonomous multi-agent coordination loop',
+  },
+  args: {
+    project: {
+      type: 'string',
+      description: 'Project root path (default: cwd)',
+      required: false,
+    },
+    agents: {
+      type: 'string',
+      description: 'Comma-separated agent names: claude,codex,gemini (default: claude)',
+      default: 'claude',
+    },
+    'max-retries': {
+      type: 'string',
+      description: 'Max retries per task (default: 2)',
+      default: '2',
+    },
+    timeout: {
+      type: 'string',
+      description: 'Per-task timeout in ms (default: 600000)',
+      default: '600000',
+    },
+    parallel: {
+      type: 'string',
+      description: 'Max parallel agents (default: 1)',
+      default: '1',
+    },
+    'dry-run': {
+      type: 'boolean',
+      description: 'Show what would be executed without spawning agents',
+      default: false,
+    },
+    poll: {
+      type: 'string',
+      description: 'Poll interval in ms (default: 5000)',
+      default: '5000',
+    },
+  },
+  run: async ({ args }) => {
+    const { detectProject } = await import('../../project/detector.js');
+    const { initTeamStore } = await import('../../team/team-store.js');
+    const { getProjectDataDir } = await import('../../store/persistence.js');
+    const { resolveAdapters } = await import('../../orchestrate/adapters/index.js');
+    const { runCoordinationLoop } = await import('../../orchestrate/coordinator.js');
+    const path = await import('node:path');
+
+    const projectDir = args.project ? path.resolve(args.project) : process.cwd();
+    const proj = detectProject(projectDir);
+    if (!proj) {
+      console.error('❌ Not a git repository. Run `git init` first.');
+      process.exit(1);
+    }
+
+    const agentNames = (args.agents as string).split(',').map(s => s.trim()).filter(Boolean);
+    const adapters = resolveAdapters(agentNames);
+    if (adapters.length === 0) {
+      console.error('❌ No valid agent adapters found.');
+      process.exit(1);
+    }
+
+    // Check adapter availability
+    const available: typeof adapters = [];
+    for (const adapter of adapters) {
+      if (await adapter.available()) {
+        available.push(adapter);
+      } else {
+        console.error(`⚠️  ${adapter.name} CLI not found on PATH — skipping`);
+      }
+    }
+
+    if (available.length === 0 && !(args['dry-run'] as boolean)) {
+      console.error('❌ No agent CLIs available. Install at least one: claude, codex, gemini');
+      process.exit(1);
+    }
+
+    // Initialize TeamStore (own connection — rule D4)
+    const dataDir = await getProjectDataDir(proj.id);
+    const teamStore = await initTeamStore(dataDir);
+
+    const maxRetries = parseInt(args['max-retries'] as string, 10);
+    const taskTimeoutMs = parseInt(args.timeout as string, 10);
+    const parallel = parseInt(args.parallel as string, 10);
+    const pollIntervalMs = parseInt(args.poll as string, 10);
+    const dryRun = args['dry-run'] as boolean;
+
+    // Check if there are tasks to work on
+    const tasks = teamStore.listTasks(proj.id);
+    const pendingTasks = tasks.filter(t => t.status === 'pending');
+    if (tasks.length === 0) {
+      console.error('📋 No tasks found. Create tasks first with `team_task create`.');
+      process.exit(0);
+    }
+
+    console.error(`\n🚀 Orchestrator started for project ${proj.name}`);
+    console.error(`📋 ${pendingTasks.length} pending, ${tasks.filter(t => t.status === 'in_progress').length} in progress, ${tasks.filter(t => t.status === 'completed').length} completed`);
+    console.error(`🤖 Agents: ${(dryRun ? adapters : available).map(a => a.name).join(', ')}`);
+    console.error(`⚙️  Parallel: ${parallel}, Retries: ${maxRetries}, Timeout: ${taskTimeoutMs}ms`);
+    if (dryRun) console.error('🔍 DRY RUN — no agents will be spawned\n');
+    else console.error('');
+
+    const result = await runCoordinationLoop({
+      projectDir,
+      projectId: proj.id,
+      adapters: dryRun ? adapters : available,
+      teamStore,
+      maxRetries,
+      pollIntervalMs,
+      taskTimeoutMs,
+      parallel,
+      dryRun,
+      onProgress: (event) => {
+        const ts = new Date(event.timestamp).toLocaleTimeString();
+        const icons: Record<string, string> = {
+          'started': '🚀',
+          'task:dispatched': '🔵',
+          'task:completed': '✅',
+          'task:failed': '❌',
+          'task:retry': '🔄',
+          'task:timeout': '⏰',
+          'agent:stale': '💀',
+          'finished': '🎉',
+          'error': '⚠️',
+        };
+        console.error(`[${ts}] ${icons[event.type] ?? '•'} ${event.message}`);
+      },
+    });
+
+    console.error(`\n${'═'.repeat(60)}`);
+    if (result.aborted) {
+      console.error('⚠️  Orchestration aborted');
+    } else if (result.failed === 0) {
+      console.error(`🎉 All ${result.completed}/${result.totalTasks} tasks completed in ${formatDuration(result.elapsed)}`);
+    } else {
+      console.error(`📊 ${result.completed} completed, ${result.failed} failed out of ${result.totalTasks} tasks`);
+    }
+    if (result.retries > 0) console.error(`🔄 ${result.retries} retries`);
+    console.error(`⏱️  Total time: ${formatDuration(result.elapsed)}`);
+
+    process.exit(result.failed > 0 ? 1 : 0);
+  },
+});
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const secs = Math.floor(ms / 1000);
+  if (secs < 60) return `${secs}s`;
+  const mins = Math.floor(secs / 60);
+  const remainSecs = secs % 60;
+  return `${mins}m ${remainSecs}s`;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -855,6 +855,7 @@ const main = defineCommand({
     doctor: () => import('./commands/doctor.js').then(m => m.default),
     dashboard: () => import('./commands/dashboard.js').then(m => m.default),
     cleanup: () => import('./commands/cleanup.js').then(m => m.default),
+    orchestrate: () => import('./commands/orchestrate.js').then(m => m.default),
   },
   async run() {
     // Guard: if citty already resolved a subcommand, its run() was called before this.
@@ -863,7 +864,7 @@ const main = defineCommand({
     const knownSubs = ['search', 'remember', 'recent',
       'init', 'integrate', 'serve', 'serve-http', 'status', 'sync',
       'hook', 'hooks', 'ingest', 'git-hook', 'git-hook-uninstall',
-      'background', 'doctor', 'dashboard', 'cleanup'];
+      'background', 'doctor', 'dashboard', 'cleanup', 'orchestrate'];
     if (firstArg && knownSubs.includes(firstArg)) return;
 
     // No subcommand provided — show fullscreen workbench if in TTY, otherwise show help

--- a/src/orchestrate/adapters/claude.ts
+++ b/src/orchestrate/adapters/claude.ts
@@ -22,6 +22,7 @@ export class ClaudeAdapter implements AgentAdapter {
 
   spawn(prompt: string, opts: SpawnOptions): AgentProcess {
     // Use stdin to avoid shell escaping issues with long prompts
-    return spawnAgent('claude', ['-p', '-', '--output-format', 'json'], opts, prompt);
+    // --permission-mode bypassPermissions: auto-approve all tools (including MCP) in orchestrated headless mode
+    return spawnAgent('claude', ['-p', '-', '--output-format', 'json', '--permission-mode', 'bypassPermissions'], opts, prompt);
   }
 }

--- a/src/orchestrate/adapters/claude.ts
+++ b/src/orchestrate/adapters/claude.ts
@@ -1,0 +1,27 @@
+/**
+ * Claude Code CLI adapter.
+ *
+ * Invocation: claude -p "<prompt>" --output-format json
+ */
+
+import { execSync } from 'node:child_process';
+import { spawnAgent } from './spawn-helper.js';
+import type { AgentAdapter, AgentProcess, SpawnOptions } from './types.js';
+
+export class ClaudeAdapter implements AgentAdapter {
+  name = 'claude';
+
+  async available(): Promise<boolean> {
+    try {
+      execSync('claude --version', { stdio: 'ignore', timeout: 5_000 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  spawn(prompt: string, opts: SpawnOptions): AgentProcess {
+    // Use stdin to avoid shell escaping issues with long prompts
+    return spawnAgent('claude', ['-p', '-', '--output-format', 'json'], opts, prompt);
+  }
+}

--- a/src/orchestrate/adapters/codex.ts
+++ b/src/orchestrate/adapters/codex.ts
@@ -1,0 +1,27 @@
+/**
+ * Codex CLI adapter.
+ *
+ * Invocation: codex "<prompt>"
+ */
+
+import { execSync } from 'node:child_process';
+import { spawnAgent } from './spawn-helper.js';
+import type { AgentAdapter, AgentProcess, SpawnOptions } from './types.js';
+
+export class CodexAdapter implements AgentAdapter {
+  name = 'codex';
+
+  async available(): Promise<boolean> {
+    try {
+      execSync('codex --version', { stdio: 'ignore', timeout: 5_000 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  spawn(prompt: string, opts: SpawnOptions): AgentProcess {
+    // Use stdin ('-') to avoid shell escaping issues with long prompts
+    return spawnAgent('codex', ['exec', '-'], opts, prompt);
+  }
+}

--- a/src/orchestrate/adapters/codex.ts
+++ b/src/orchestrate/adapters/codex.ts
@@ -22,6 +22,8 @@ export class CodexAdapter implements AgentAdapter {
 
   spawn(prompt: string, opts: SpawnOptions): AgentProcess {
     // Use stdin ('-') to avoid shell escaping issues with long prompts
-    return spawnAgent('codex', ['exec', '-'], opts, prompt);
+    // --dangerously-bypass-approvals-and-sandbox: auto-approve + full write access for orchestrated headless mode
+    // (--full-auto forces read-only sandbox which blocks file creation)
+    return spawnAgent('codex', ['exec', '--dangerously-bypass-approvals-and-sandbox', '-'], opts, prompt);
   }
 }

--- a/src/orchestrate/adapters/gemini.ts
+++ b/src/orchestrate/adapters/gemini.ts
@@ -1,7 +1,8 @@
 /**
  * Gemini CLI adapter.
  *
- * Invocation: gemini "<prompt>"
+ * Invocation: echo "<prompt>" | gemini -p ""
+ * Gemini's -p flag enables headless mode and is "appended to input on stdin (if any)".
  */
 
 import { execSync } from 'node:child_process';
@@ -21,6 +22,9 @@ export class GeminiAdapter implements AgentAdapter {
   }
 
   spawn(prompt: string, opts: SpawnOptions): AgentProcess {
-    return spawnAgent('gemini', [prompt], opts);
+    // Use stdin to avoid shell escaping issues with long prompts
+    // -p "." activates headless mode (requires non-empty value); actual prompt piped via stdin
+    // --yolo auto-approves actions (orchestrated agent should not block on confirmations)
+    return spawnAgent('gemini', ['-p', '.', '--yolo'], opts, prompt);
   }
 }

--- a/src/orchestrate/adapters/gemini.ts
+++ b/src/orchestrate/adapters/gemini.ts
@@ -1,0 +1,26 @@
+/**
+ * Gemini CLI adapter.
+ *
+ * Invocation: gemini "<prompt>"
+ */
+
+import { execSync } from 'node:child_process';
+import { spawnAgent } from './spawn-helper.js';
+import type { AgentAdapter, AgentProcess, SpawnOptions } from './types.js';
+
+export class GeminiAdapter implements AgentAdapter {
+  name = 'gemini';
+
+  async available(): Promise<boolean> {
+    try {
+      execSync('gemini --version', { stdio: 'ignore', timeout: 5_000 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  spawn(prompt: string, opts: SpawnOptions): AgentProcess {
+    return spawnAgent('gemini', [prompt], opts);
+  }
+}

--- a/src/orchestrate/adapters/index.ts
+++ b/src/orchestrate/adapters/index.ts
@@ -1,0 +1,36 @@
+/**
+ * Agent adapter registry.
+ */
+
+export { ClaudeAdapter } from './claude.js';
+export { CodexAdapter } from './codex.js';
+export { GeminiAdapter } from './gemini.js';
+export { OpenCodeAdapter } from './opencode.js';
+export type { AgentAdapter, AgentProcess, AgentProcessResult, SpawnOptions } from './types.js';
+
+import { ClaudeAdapter } from './claude.js';
+import { CodexAdapter } from './codex.js';
+import { GeminiAdapter } from './gemini.js';
+import { OpenCodeAdapter } from './opencode.js';
+import type { AgentAdapter } from './types.js';
+
+const REGISTRY: Record<string, () => AgentAdapter> = {
+  claude: () => new ClaudeAdapter(),
+  codex: () => new CodexAdapter(),
+  gemini: () => new GeminiAdapter(),
+  opencode: () => new OpenCodeAdapter(),
+};
+
+/** Resolve adapter names to instances. Unknown names are skipped with a warning. */
+export function resolveAdapters(names: string[]): AgentAdapter[] {
+  const adapters: AgentAdapter[] = [];
+  for (const name of names) {
+    const factory = REGISTRY[name.toLowerCase()];
+    if (factory) {
+      adapters.push(factory());
+    } else {
+      console.error(`[orchestrate] Unknown agent adapter: ${name} (available: ${Object.keys(REGISTRY).join(', ')})`);
+    }
+  }
+  return adapters;
+}

--- a/src/orchestrate/adapters/opencode.ts
+++ b/src/orchestrate/adapters/opencode.ts
@@ -1,7 +1,9 @@
 /**
  * OpenCode CLI adapter.
  *
- * Invocation: opencode -p "<prompt>"
+ * Invocation: echo "<prompt>" | opencode -p "."
+ * OpenCode's -p flag enables non-interactive mode; prompt piped via stdin
+ * to avoid shell escaping and Windows command line length limits.
  */
 
 import { execSync } from 'node:child_process';
@@ -21,6 +23,7 @@ export class OpenCodeAdapter implements AgentAdapter {
   }
 
   spawn(prompt: string, opts: SpawnOptions): AgentProcess {
-    return spawnAgent('opencode', ['-p', prompt], opts);
+    // Pipe prompt via stdin; -p "." triggers non-interactive mode with minimal arg
+    return spawnAgent('opencode', ['-p', '.'], opts, prompt);
   }
 }

--- a/src/orchestrate/adapters/opencode.ts
+++ b/src/orchestrate/adapters/opencode.ts
@@ -1,0 +1,26 @@
+/**
+ * OpenCode CLI adapter.
+ *
+ * Invocation: opencode -p "<prompt>"
+ */
+
+import { execSync } from 'node:child_process';
+import { spawnAgent } from './spawn-helper.js';
+import type { AgentAdapter, AgentProcess, SpawnOptions } from './types.js';
+
+export class OpenCodeAdapter implements AgentAdapter {
+  name = 'opencode';
+
+  async available(): Promise<boolean> {
+    try {
+      execSync('opencode --version', { stdio: 'ignore', timeout: 5_000 });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  spawn(prompt: string, opts: SpawnOptions): AgentProcess {
+    return spawnAgent('opencode', ['-p', prompt], opts);
+  }
+}

--- a/src/orchestrate/adapters/spawn-helper.ts
+++ b/src/orchestrate/adapters/spawn-helper.ts
@@ -28,10 +28,20 @@ export function spawnAgent(
     shell: process.platform === 'win32',
   });
 
-  // Write prompt via stdin to avoid shell argument escaping issues
+  // Write prompt via stdin to avoid shell argument escaping issues.
+  // Must handle EPIPE / early-close — if the child exits before we finish
+  // writing (bad args, crash, etc.), write() would emit an unhandled error
+  // that kills the orchestrator process.
+  let stdinError: string | undefined;
   if (stdinData && child.stdin) {
-    child.stdin.write(stdinData);
-    child.stdin.end();
+    child.stdin.on('error', (err: NodeJS.ErrnoException) => {
+      // Swallow EPIPE and other write errors — they are expected when
+      // the child process closes stdin early. Record for diagnostics.
+      stdinError = `stdin write error: ${err.code ?? err.message}`;
+    });
+    child.stdin.write(stdinData, () => {
+      try { child.stdin!.end(); } catch { /* already destroyed */ }
+    });
   }
 
   const ring = new RingBuffer(opts.tailLines ?? DEFAULT_TAIL_LINES);
@@ -53,19 +63,21 @@ export function spawnAgent(
   const completion = new Promise<AgentProcessResult>((resolve) => {
     child.on('exit', (code, signal) => {
       if (timer) clearTimeout(timer);
+      const tail = stdinError ? `${stdinError}\n${ring.toString()}` : ring.toString();
       resolve({
         exitCode: code,
         signal: signal ?? null,
-        tailOutput: ring.toString(),
+        tailOutput: tail,
         killed,
       });
     });
     child.on('error', (err) => {
       if (timer) clearTimeout(timer);
+      const tail = stdinError ? `${stdinError}\n` : '';
       resolve({
         exitCode: null,
         signal: null,
-        tailOutput: `spawn error: ${err.message}\n${ring.toString()}`,
+        tailOutput: `${tail}spawn error: ${err.message}\n${ring.toString()}`,
         killed: false,
       });
     });

--- a/src/orchestrate/adapters/spawn-helper.ts
+++ b/src/orchestrate/adapters/spawn-helper.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared spawn logic for agent adapters.
+ *
+ * Encapsulates: child_process.spawn, ring buffer wiring,
+ * timeout handling, and abort/SIGKILL escalation.
+ */
+
+import { spawn as nodeSpawn } from 'node:child_process';
+import { RingBuffer } from '../ring-buffer.js';
+import type { AgentProcess, AgentProcessResult, SpawnOptions } from './types.js';
+
+const DEFAULT_TIMEOUT_MS = 600_000;  // 10 minutes
+const DEFAULT_TAIL_LINES = 50;
+const SIGKILL_GRACE_MS = 5_000;
+
+export function spawnAgent(
+  command: string,
+  args: string[],
+  opts: SpawnOptions,
+  /** If provided, write this to stdin then close it (avoids shell escaping issues) */
+  stdinData?: string,
+): AgentProcess {
+  const child = nodeSpawn(command, args, {
+    cwd: opts.cwd,
+    env: { ...process.env, ...opts.env },
+    stdio: [stdinData ? 'pipe' : 'ignore', 'pipe', 'pipe'],
+    // Windows: use shell to resolve CLI tools on PATH
+    shell: process.platform === 'win32',
+  });
+
+  // Write prompt via stdin to avoid shell argument escaping issues
+  if (stdinData && child.stdin) {
+    child.stdin.write(stdinData);
+    child.stdin.end();
+  }
+
+  const ring = new RingBuffer(opts.tailLines ?? DEFAULT_TAIL_LINES);
+  child.stdout?.on('data', (chunk: Buffer) => ring.push(chunk.toString()));
+  child.stderr?.on('data', (chunk: Buffer) => ring.push(chunk.toString()));
+
+  let killed = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  if (timeoutMs > 0) {
+    timer = setTimeout(() => {
+      killed = true;
+      try { child.kill('SIGTERM'); } catch { /* already dead */ }
+      setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* already dead */ } }, SIGKILL_GRACE_MS);
+    }, timeoutMs);
+  }
+
+  const completion = new Promise<AgentProcessResult>((resolve) => {
+    child.on('exit', (code, signal) => {
+      if (timer) clearTimeout(timer);
+      resolve({
+        exitCode: code,
+        signal: signal ?? null,
+        tailOutput: ring.toString(),
+        killed,
+      });
+    });
+    child.on('error', (err) => {
+      if (timer) clearTimeout(timer);
+      resolve({
+        exitCode: null,
+        signal: null,
+        tailOutput: `spawn error: ${err.message}\n${ring.toString()}`,
+        killed: false,
+      });
+    });
+  });
+
+  return {
+    pid: child.pid ?? -1,
+    completion,
+    abort() {
+      killed = true;
+      if (timer) clearTimeout(timer);
+      try { child.kill('SIGTERM'); } catch { /* already dead */ }
+      setTimeout(() => { try { child.kill('SIGKILL'); } catch { /* already dead */ } }, SIGKILL_GRACE_MS);
+    },
+  };
+}

--- a/src/orchestrate/adapters/types.ts
+++ b/src/orchestrate/adapters/types.ts
@@ -1,0 +1,47 @@
+/**
+ * Agent Adapter types — Phase 4c spawn + handle model.
+ *
+ * Each agent CLI adapter implements this interface.
+ * spawn() returns a process handle immediately (NOT exec + string).
+ * Bounded memory via RingBuffer. Cancellation via abort().
+ */
+
+export interface AgentProcess {
+  /** Underlying child process PID */
+  pid: number;
+
+  /** Resolves when process exits */
+  completion: Promise<AgentProcessResult>;
+
+  /** Abort the process (SIGTERM, then SIGKILL after grace period) */
+  abort(): void;
+}
+
+export interface AgentProcessResult {
+  exitCode: number | null;
+  signal: string | null;
+  /** Last N lines of combined stdout+stderr (ring buffer, not full capture) */
+  tailOutput: string;
+  /** Whether the process was killed by timeout or abort */
+  killed: boolean;
+}
+
+export interface SpawnOptions {
+  cwd: string;
+  env?: Record<string, string>;
+  /** Per-task timeout in ms (default: 600_000 = 10 min) */
+  timeoutMs?: number;
+  /** Ring buffer size in lines (default: 50) */
+  tailLines?: number;
+}
+
+export interface AgentAdapter {
+  /** Adapter display name (e.g. 'claude', 'codex', 'gemini') */
+  name: string;
+
+  /** Check if the CLI tool is installed and accessible */
+  available(): Promise<boolean>;
+
+  /** Spawn agent process — returns handle immediately, does NOT wait for completion */
+  spawn(prompt: string, opts: SpawnOptions): AgentProcess;
+}

--- a/src/orchestrate/coordinator.ts
+++ b/src/orchestrate/coordinator.ts
@@ -1,0 +1,335 @@
+/**
+ * Coordinator — Phase 4c autonomous coordination loop.
+ *
+ * Drives off SQLite poll (rule D1) — NOT EventBus.
+ * Reads TeamStore task board, claims available tasks, spawns agent CLIs,
+ * monitors exit, handles retry/rescue, and exits when all tasks are done.
+ *
+ * Architectural boundary: this is a leaf module under src/orchestrate/.
+ * It depends on 4a TeamStore + 4b primitives. Nothing depends on it.
+ * Deleting src/orchestrate/ has zero impact on the rest of Memorix.
+ */
+
+import type { TeamStore, TeamTaskRow } from '../team/team-store.js';
+import type { AgentAdapter, AgentProcess } from './adapters/types.js';
+import { buildAgentPrompt, type HandoffContext } from './prompt-builder.js';
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export interface CoordinatorConfig {
+  projectDir: string;
+  projectId: string;
+  adapters: AgentAdapter[];
+  teamStore: TeamStore;
+  /** Max retries per task (default: 2) */
+  maxRetries?: number;
+  /** SQLite poll interval in ms (default: 5_000) */
+  pollIntervalMs?: number;
+  /** Per-task timeout in ms (default: 600_000 = 10 min) */
+  taskTimeoutMs?: number;
+  /** Max parallel agent sessions (default: 1) */
+  parallel?: number;
+  /** Stale agent TTL in ms (default: 300_000 = 5 min) */
+  staleTtlMs?: number;
+  /** Dry run — show plan without spawning (default: false) */
+  dryRun?: boolean;
+  /** Progress callback */
+  onProgress?: (event: CoordinatorEvent) => void;
+  /** Optional: resolve handoff context for a task. Injected to avoid coupling to observation layer. */
+  resolveHandoffs?: (taskId: string) => Promise<HandoffContext[]>;
+}
+
+export type CoordinatorEventType =
+  | 'started' | 'task:dispatched' | 'task:completed' | 'task:failed'
+  | 'task:retry' | 'task:timeout' | 'agent:stale' | 'finished' | 'error';
+
+export interface CoordinatorEvent {
+  type: CoordinatorEventType;
+  timestamp: number;
+  taskId?: string;
+  agentName?: string;
+  message: string;
+}
+
+export interface CoordinatorResult {
+  totalTasks: number;
+  completed: number;
+  failed: number;
+  retries: number;
+  elapsed: number;
+  aborted: boolean;
+}
+
+// ── Internal tracking ──────────────────────────────────────────────
+
+interface ActiveDispatch {
+  taskId: string;
+  agentProcess: AgentProcess;
+  adapterName: string;
+  attempt: number;
+}
+
+// ── Main coordination loop ─────────────────────────────────────────
+
+export async function runCoordinationLoop(config: CoordinatorConfig): Promise<CoordinatorResult> {
+  const {
+    projectDir,
+    projectId,
+    adapters,
+    teamStore,
+    maxRetries = 2,
+    pollIntervalMs = 5_000,
+    taskTimeoutMs = 600_000,
+    parallel = 1,
+    staleTtlMs = 300_000,
+    dryRun = false,
+    onProgress,
+    resolveHandoffs,
+  } = config;
+
+  const startTime = Date.now();
+  let retryCount = 0;
+  let aborted = false;
+  const taskAttempts = new Map<string, number>(); // taskId → attempt count
+  const activeDispatches: ActiveDispatch[] = [];
+  let adapterRoundRobin = 0;
+
+  // Register orchestrator as an agent
+  const orchestratorAgent = teamStore.registerAgent({
+    projectId,
+    agentType: 'orchestrator',
+    instanceId: `orch-${Date.now()}`,
+    name: 'memorix-orchestrator',
+  });
+  const orchAgentId = orchestratorAgent.agent_id;
+
+  const emit = (type: CoordinatorEventType, message: string, extra?: Partial<CoordinatorEvent>) => {
+    onProgress?.({ type, timestamp: Date.now(), message, ...extra });
+  };
+
+  emit('started', `Orchestrator started for project ${projectId}`);
+
+  // Ctrl+C handler: abort all active processes, release tasks
+  const cleanup = () => {
+    aborted = true;
+    for (const d of activeDispatches) {
+      d.agentProcess.abort();
+      try { teamStore.releaseTask(d.taskId, orchAgentId); } catch { /* best-effort */ }
+    }
+    activeDispatches.length = 0;
+    try { teamStore.leaveAgent(orchAgentId); } catch { /* best-effort */ }
+  };
+
+  process.on('SIGINT', cleanup);
+  process.on('SIGTERM', cleanup);
+
+  try {
+    // ── Main loop (SQLite poll driven — rule D1) ─────────────────
+    while (!aborted) {
+      // Heartbeat orchestrator BEFORE stale detection — prevents self-stale
+      try { teamStore.heartbeat(orchAgentId); } catch { /* best-effort */ }
+
+      // Stale detection (runs after heartbeat, so orchestrator is never stale)
+      try {
+        const staleIds = teamStore.detectAndMarkStale(projectId, staleTtlMs);
+        if (staleIds.length > 0) {
+          emit('agent:stale', `Detected ${staleIds.length} stale agent(s), tasks released`);
+        }
+      } catch { /* best-effort */ }
+
+      // Remove completed dispatches
+      for (let i = activeDispatches.length - 1; i >= 0; i--) {
+        // Non-blocking check — we'll await in the parallel section
+      }
+
+      // ── Detect & fail stranded tasks (pending with failed deps) ──
+      // A task is stranded if it's pending and has at least one dep whose status is 'failed'.
+      // Without this, the coordinator would spin forever trying to claim unclaimable tasks.
+      try {
+        const stranded = teamStore.getDb().prepare(`
+          SELECT DISTINCT t.task_id, t.description FROM team_tasks t
+            JOIN team_task_deps d ON t.task_id = d.task_id
+            JOIN team_tasks dep ON d.dep_task_id = dep.task_id
+          WHERE t.project_id = ? AND t.status = 'pending' AND dep.status = 'failed'
+        `).all(projectId) as { task_id: string; description: string }[];
+
+        for (const s of stranded) {
+          teamStore.getDb().prepare(
+            'UPDATE team_tasks SET status = ?, result = ?, updated_at = ? WHERE task_id = ? AND status = ?',
+          ).run('failed', 'Blocked: upstream dependency failed', Date.now(), s.task_id, 'pending');
+          emit('task:failed', `Task "${s.description}" blocked by failed dependency`, { taskId: s.task_id });
+        }
+      } catch { /* best-effort */ }
+
+      // Get task board snapshot
+      const allTasks = teamStore.listTasks(projectId);
+      const available = teamStore.listTasks(projectId, { available: true });
+      const completed = allTasks.filter(t => t.status === 'completed');
+      const failed = allTasks.filter(t => t.status === 'failed');
+      const inProgress = allTasks.filter(t => t.status === 'in_progress');
+
+      // Exit condition: no available, no in_progress, no active dispatches
+      if (available.length === 0 && inProgress.length === 0 && activeDispatches.length === 0) {
+        const result: CoordinatorResult = {
+          totalTasks: allTasks.length,
+          completed: completed.length,
+          failed: failed.length,
+          retries: retryCount,
+          elapsed: Date.now() - startTime,
+          aborted: false,
+        };
+        emit('finished', `All tasks processed: ${completed.length} completed, ${failed.length} failed`);
+        return result;
+      }
+
+      // Dry run: just show what would happen
+      if (dryRun) {
+        emit('finished', `[dry-run] Would dispatch ${available.length} available task(s) across ${adapters.length} adapter(s)`);
+        return {
+          totalTasks: allTasks.length,
+          completed: completed.length,
+          failed: failed.length,
+          retries: 0,
+          elapsed: Date.now() - startTime,
+          aborted: false,
+        };
+      }
+
+      // Dispatch available tasks up to parallel limit
+      while (available.length > 0 && activeDispatches.length < parallel && !aborted) {
+        const task = available.shift()!;
+        const attempts = taskAttempts.get(task.task_id) ?? 0;
+
+        // Skip tasks that exceeded max retries
+        if (attempts >= maxRetries + 1) {
+          continue;
+        }
+
+        // Pick adapter (round-robin)
+        const adapter = adapters[adapterRoundRobin % adapters.length];
+        adapterRoundRobin++;
+
+        // Claim task
+        const claim = teamStore.claimTask(task.task_id, orchAgentId);
+        if (!claim.success) continue; // another process claimed it
+
+        // Build prompt with handoff context
+        const handoffs = resolveHandoffs ? await resolveHandoffs(task.task_id) : [];
+        const prompt = buildAgentPrompt({
+          task,
+          handoffs,
+          agentId: orchAgentId,
+          projectId,
+          projectDir,
+        });
+
+        // Spawn agent
+        const agentProcess = adapter.spawn(prompt, {
+          cwd: projectDir,
+          timeoutMs: taskTimeoutMs,
+        });
+
+        taskAttempts.set(task.task_id, attempts + 1);
+        activeDispatches.push({
+          taskId: task.task_id,
+          agentProcess,
+          adapterName: adapter.name,
+          attempt: attempts + 1,
+        });
+
+        emit('task:dispatched', `Task "${task.description}" → ${adapter.name} (attempt ${attempts + 1})`, {
+          taskId: task.task_id,
+          agentName: adapter.name,
+        });
+      }
+
+      // Wait for any active dispatch to complete (or poll timeout)
+      if (activeDispatches.length > 0) {
+        const settled = await Promise.race([
+          ...activeDispatches.map(async (d, idx) => {
+            const result = await d.agentProcess.completion;
+            return { idx, dispatch: d, result };
+          }),
+          sleep(pollIntervalMs).then(() => null), // poll timeout
+        ]);
+
+        if (settled) {
+          // Remove from active
+          activeDispatches.splice(settled.idx, 1);
+          const { dispatch, result } = settled;
+
+          // ── 方案 A: Orchestrator owns task lifecycle ──
+          // Agent does NOT call team_task. Orchestrator infers outcome from exit code.
+          const taskState = teamStore.getTask(dispatch.taskId);
+          const taskDesc = taskState?.description ?? dispatch.taskId;
+
+          if (!result.killed && result.exitCode === 0) {
+            // Agent exited 0 → orchestrator marks task completed
+            try {
+              teamStore.completeTask(dispatch.taskId, orchAgentId, result.tailOutput.slice(-500) || 'Completed');
+            } catch { /* best-effort */ }
+            emit('task:completed', `Task "${taskDesc}" completed by ${dispatch.adapterName}`, {
+              taskId: dispatch.taskId,
+              agentName: dispatch.adapterName,
+            });
+          } else {
+            // Agent failed or timed out → orchestrator marks task failed (may retry)
+            let reason: string;
+            if (result.killed) {
+              reason = `Timed out after ${taskTimeoutMs}ms`;
+              emit('task:timeout', reason, { taskId: dispatch.taskId, agentName: dispatch.adapterName });
+            } else {
+              reason = `Exit code ${result.exitCode}: ${result.tailOutput.slice(-200)}`;
+            }
+
+            // Fail the task (orchestrator is the assignee)
+            try {
+              teamStore.failTask(dispatch.taskId, orchAgentId, reason);
+            } catch { /* may already be in a different state */ }
+
+            const attempts = taskAttempts.get(dispatch.taskId) ?? 1;
+            if (attempts <= maxRetries) {
+              // Reset to pending for retry via direct DB update
+              const taskRow = teamStore.getTask(dispatch.taskId);
+              if (taskRow && taskRow.status === 'failed') {
+                teamStore.getDb().prepare(
+                  'UPDATE team_tasks SET status = ?, assignee_agent_id = NULL, updated_at = ? WHERE task_id = ?',
+                ).run('pending', Date.now(), dispatch.taskId);
+              }
+              retryCount++;
+              emit('task:retry', `Task "${taskDesc}" failed, retrying (${attempts}/${maxRetries})`, {
+                taskId: dispatch.taskId,
+              });
+            } else {
+              emit('task:failed', `Task "${taskDesc}" failed after ${attempts} attempt(s): ${reason}`, {
+                taskId: dispatch.taskId,
+                agentName: dispatch.adapterName,
+              });
+            }
+          }
+        }
+      } else {
+        // Nothing to dispatch, nothing active — wait for state change
+        await sleep(pollIntervalMs);
+      }
+    }
+
+    // Aborted
+    return {
+      totalTasks: teamStore.listTasks(projectId).length,
+      completed: teamStore.listTasks(projectId, { status: 'completed' }).length,
+      failed: teamStore.listTasks(projectId, { status: 'failed' }).length,
+      retries: retryCount,
+      elapsed: Date.now() - startTime,
+      aborted: true,
+    };
+  } finally {
+    process.off('SIGINT', cleanup);
+    process.off('SIGTERM', cleanup);
+    try { teamStore.leaveAgent(orchAgentId); } catch { /* best-effort */ }
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/src/orchestrate/coordinator.ts
+++ b/src/orchestrate/coordinator.ts
@@ -87,6 +87,23 @@ export async function runCoordinationLoop(config: CoordinatorConfig): Promise<Co
     resolveHandoffs,
   } = config;
 
+  // ── Defensive validation (guards npm import path too) ──────────
+  if (!adapters || adapters.length === 0) {
+    throw new Error('coordinator: adapters must be a non-empty array');
+  }
+  if (!Number.isFinite(parallel) || parallel < 1) {
+    throw new Error(`coordinator: parallel must be >= 1, got ${parallel}`);
+  }
+  if (!Number.isFinite(pollIntervalMs) || pollIntervalMs < 0) {
+    throw new Error(`coordinator: pollIntervalMs must be >= 0, got ${pollIntervalMs}`);
+  }
+  if (!Number.isFinite(taskTimeoutMs) || taskTimeoutMs <= 0) {
+    throw new Error(`coordinator: taskTimeoutMs must be > 0, got ${taskTimeoutMs}`);
+  }
+  if (!Number.isFinite(maxRetries) || maxRetries < 0) {
+    throw new Error(`coordinator: maxRetries must be >= 0, got ${maxRetries}`);
+  }
+
   const startTime = Date.now();
   let retryCount = 0;
   let aborted = false;
@@ -213,8 +230,11 @@ export async function runCoordinationLoop(config: CoordinatorConfig): Promise<Co
         const claim = teamStore.claimTask(task.task_id, orchAgentId);
         if (!claim.success) continue; // another process claimed it
 
-        // Build prompt with handoff context
-        const handoffs = resolveHandoffs ? await resolveHandoffs(task.task_id) : [];
+        // Build prompt with handoff context (best-effort — failure falls back to empty)
+        let handoffs: HandoffContext[] = [];
+        if (resolveHandoffs) {
+          try { handoffs = await resolveHandoffs(task.task_id); } catch { /* handoff is enhancement, not critical */ }
+        }
         const prompt = buildAgentPrompt({
           task,
           handoffs,
@@ -290,10 +310,11 @@ export async function runCoordinationLoop(config: CoordinatorConfig): Promise<Co
             const attempts = taskAttempts.get(dispatch.taskId) ?? 1;
             if (attempts <= maxRetries) {
               // Reset to pending for retry via direct DB update
+              // Clear result to avoid stale data from previous attempt leaking
               const taskRow = teamStore.getTask(dispatch.taskId);
               if (taskRow && taskRow.status === 'failed') {
                 teamStore.getDb().prepare(
-                  'UPDATE team_tasks SET status = ?, assignee_agent_id = NULL, updated_at = ? WHERE task_id = ?',
+                  'UPDATE team_tasks SET status = ?, assignee_agent_id = NULL, result = NULL, updated_at = ? WHERE task_id = ?',
                 ).run('pending', Date.now(), dispatch.taskId);
               }
               retryCount++;

--- a/src/orchestrate/prompt-builder.ts
+++ b/src/orchestrate/prompt-builder.ts
@@ -1,0 +1,91 @@
+/**
+ * Prompt Builder — Constructs agent prompts for orchestrated task execution.
+ *
+ * Builds a structured prompt that includes:
+ * 1. Role and task description
+ * 2. Handoff context from previous agents (if any)
+ * 3. Memorix tool usage instructions
+ * 4. Completion criteria
+ */
+
+import type { TeamTaskRow } from '../team/team-store.js';
+
+export interface HandoffContext {
+  fromAgent: string;
+  summary: string;
+  context: string;
+  filesModified?: string[];
+}
+
+export interface PromptInput {
+  task: TeamTaskRow;
+  handoffs: HandoffContext[];
+  agentId: string;
+  projectId: string;
+  projectDir: string;
+}
+
+export function buildAgentPrompt(input: PromptInput): string {
+  const sections: string[] = [];
+
+  // 1. Role assignment
+  sections.push([
+    `You are an autonomous coding agent working on project "${input.projectId}".`,
+    `Coordinator agent ID (for reference only, NOT your identity): ${input.agentId}`,
+    `Working directory: ${input.projectDir}`,
+  ].join('\n'));
+
+  // 2. Task description
+  sections.push([
+    '## Your Task',
+    '',
+    `Task ID: ${input.task.task_id}`,
+    `Description: ${input.task.description}`,
+    input.task.metadata ? `Metadata: ${input.task.metadata}` : '',
+  ].filter(Boolean).join('\n'));
+
+  // 3. Handoff context from previous agents
+  if (input.handoffs.length > 0) {
+    const handoffLines = input.handoffs.map((h, i) => [
+      `### Handoff ${i + 1} (from ${h.fromAgent})`,
+      `Summary: ${h.summary}`,
+      `Context: ${h.context}`,
+      h.filesModified?.length ? `Files modified: ${h.filesModified.join(', ')}` : '',
+    ].filter(Boolean).join('\n'));
+
+    sections.push([
+      '## Context from Previous Agents',
+      '',
+      'The following handoff artifacts were left by agents who worked on related tasks.',
+      'Use this context to avoid re-doing work and to understand the current state.',
+      '',
+      ...handoffLines,
+    ].join('\n'));
+  }
+
+  // 4. Memorix tool instructions
+  sections.push([
+    '## Instructions',
+    '',
+    '1. Start by calling `memorix_session_start` to bind to this project.',
+    '2. Use the agentId returned by `memorix_session_start` as YOUR identity for any identity-bearing calls (e.g. `memorix_handoff` fromAgentId). Do NOT use the coordinator agent ID above — that belongs to the orchestrator, not to you.',
+    '3. Call `memorix_poll` to check for any additional context or messages.',
+    `4. Work on the task described above. The task is already claimed and managed by the orchestrator.`,
+    '5. Focus on completing the work. Do NOT call `team_task` — the orchestrator manages task state.',
+    '6. If you want to leave context for the next agent, call `memorix_handoff` with a summary of what you did.',
+    '7. Use `memorix_store` to save any important discoveries, decisions, or gotchas.',
+    '8. Do NOT create new tasks unless the original task explicitly requires subtask decomposition.',
+  ].join('\n'));
+
+  // 5. Completion criteria
+  sections.push([
+    '## Completion Criteria',
+    '',
+    '- Exit with code 0 when the task is successfully completed.',
+    '- Exit with a non-zero code if you cannot complete the task.',
+    '- The orchestrator will determine task success/failure based on your exit code.',
+    '- You do NOT need to mark the task as completed or failed — that is handled automatically.',
+  ].join('\n'));
+
+  return sections.join('\n\n');
+}

--- a/src/orchestrate/ring-buffer.ts
+++ b/src/orchestrate/ring-buffer.ts
@@ -1,0 +1,37 @@
+/**
+ * RingBuffer — Bounded line buffer for agent process output.
+ *
+ * Captures the last N lines of stdout/stderr without unbounded memory growth.
+ * Used by agent adapters to provide tail output for diagnostics.
+ */
+
+export class RingBuffer {
+  private lines: string[] = [];
+
+  constructor(private maxLines: number = 50) {}
+
+  push(text: string): void {
+    for (const line of text.split('\n')) {
+      if (line.trim()) {
+        this.lines.push(line);
+        if (this.lines.length > this.maxLines) this.lines.shift();
+      }
+    }
+  }
+
+  getLines(): string[] {
+    return [...this.lines];
+  }
+
+  toString(): string {
+    return this.lines.join('\n');
+  }
+
+  get length(): number {
+    return this.lines.length;
+  }
+
+  clear(): void {
+    this.lines = [];
+  }
+}

--- a/tests/orchestrate/coordinator.test.ts
+++ b/tests/orchestrate/coordinator.test.ts
@@ -1,0 +1,416 @@
+/**
+ * Coordinator integration tests — Phase 4c.
+ *
+ * Uses a MockAdapter that simulates agent behavior by directly
+ * manipulating TeamStore (completing/failing tasks), then exiting.
+ * This tests the full coordination loop without real CLI processes.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TeamStore } from '../../src/team/team-store.js';
+import { closeDatabase } from '../../src/store/sqlite-db.js';
+import { runCoordinationLoop, type CoordinatorEvent } from '../../src/orchestrate/coordinator.js';
+import type { AgentAdapter, AgentProcess, SpawnOptions, AgentProcessResult } from '../../src/orchestrate/adapters/types.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'memorix-coord-test-'));
+}
+
+function cleanup(dir: string): void {
+  closeDatabase(dir);
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+/**
+ * Mock adapter — 方案 A: agent does NOT touch TeamStore.
+ * Returns exit code only. Orchestrator owns task lifecycle.
+ */
+function createMockAdapter(opts: {
+  name?: string;
+  /** 'complete' → exit 0, 'fail' → exit 1, 'timeout' → never resolve */
+  behavior?: 'complete' | 'fail' | 'timeout';
+  delayMs?: number;
+}): AgentAdapter {
+  const { name = 'mock', behavior = 'complete', delayMs = 10 } = opts;
+
+  return {
+    name,
+    async available() { return true; },
+    spawn(_prompt: string, _spawnOpts: SpawnOptions): AgentProcess {
+      let aborted = false;
+
+      const completion = new Promise<AgentProcessResult>(async (resolve) => {
+        await new Promise(r => setTimeout(r, delayMs));
+
+        if (aborted) {
+          resolve({ exitCode: null, signal: 'SIGTERM', tailOutput: 'aborted', killed: true });
+          return;
+        }
+
+        if (behavior === 'timeout') {
+          // Never resolve — let timeout kill us
+          return;
+        }
+
+        // Agent just exits — orchestrator determines task outcome from exit code
+        resolve({
+          exitCode: behavior === 'fail' ? 1 : 0,
+          signal: null,
+          tailOutput: `${name} output`,
+          killed: false,
+        });
+      });
+
+      return {
+        pid: 99999,
+        completion,
+        abort() { aborted = true; },
+      };
+    },
+  };
+}
+
+describe('Coordinator', () => {
+  let store: TeamStore;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = makeTmpDir();
+    store = new TeamStore();
+    await store.init(tmpDir);
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  it('should complete a single task with mock adapter', async () => {
+    // Create a task
+    store.createTask({ projectId: 'proj1', description: 'Task A' });
+
+    const events: CoordinatorEvent[] = [];
+    const result = await runCoordinationLoop({
+      projectDir: tmpDir,
+      projectId: 'proj1',
+      adapters: [createMockAdapter({})],
+      teamStore: store,
+      maxRetries: 0,
+      pollIntervalMs: 50,
+      taskTimeoutMs: 5_000,
+      onProgress: (e) => events.push(e),
+    });
+
+    expect(result.completed).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(result.aborted).toBe(false);
+    expect(events.some(e => e.type === 'task:completed')).toBe(true);
+    expect(events.some(e => e.type === 'finished')).toBe(true);
+  });
+
+  it('should complete a 3-task dependency chain in order', async () => {
+    const t1 = store.createTask({ projectId: 'proj1', description: 'Base layer' });
+    const t2 = store.createTask({ projectId: 'proj1', description: 'Middle layer', deps: [t1.task_id] });
+    const t3 = store.createTask({ projectId: 'proj1', description: 'Top layer', deps: [t2.task_id] });
+
+    const completionOrder: string[] = [];
+    const result = await runCoordinationLoop({
+      projectDir: tmpDir,
+      projectId: 'proj1',
+      adapters: [createMockAdapter({})],
+      teamStore: store,
+      pollIntervalMs: 50,
+      taskTimeoutMs: 5_000,
+      onProgress: (e) => {
+        if (e.type === 'task:completed' && e.taskId) completionOrder.push(e.taskId);
+      },
+    });
+
+    expect(result.completed).toBe(3);
+    expect(result.failed).toBe(0);
+    // Verify dependency order
+    expect(completionOrder[0]).toBe(t1.task_id);
+    expect(completionOrder[1]).toBe(t2.task_id);
+    expect(completionOrder[2]).toBe(t3.task_id);
+  });
+
+  it('should retry failed task (exit 1 then exit 0)', async () => {
+    store.createTask({ projectId: 'proj1', description: 'Flaky task' });
+
+    let callCount = 0;
+    const flakyAdapter: AgentAdapter = {
+      name: 'flaky',
+      async available() { return true; },
+      spawn(_prompt: string, _opts: SpawnOptions): AgentProcess {
+        callCount++;
+        const attempt = callCount;
+        const completion = new Promise<AgentProcessResult>(async (resolve) => {
+          await new Promise(r => setTimeout(r, 10));
+          // First attempt fails (exit 1), second succeeds (exit 0)
+          resolve({
+            exitCode: attempt === 1 ? 1 : 0,
+            signal: null,
+            tailOutput: `attempt ${attempt}`,
+            killed: false,
+          });
+        });
+        return { pid: 99999, completion, abort() {} };
+      },
+    };
+
+    const result = await runCoordinationLoop({
+      projectDir: tmpDir,
+      projectId: 'proj1',
+      adapters: [flakyAdapter],
+      teamStore: store,
+      maxRetries: 2,
+      pollIntervalMs: 50,
+      taskTimeoutMs: 5_000,
+    });
+
+    expect(result.completed).toBe(1);
+    expect(result.retries).toBe(1);
+  });
+
+  it('should run parallel agents on independent tasks', async () => {
+    store.createTask({ projectId: 'proj1', description: 'Task A' });
+    store.createTask({ projectId: 'proj1', description: 'Task B' });
+
+    const dispatched: string[] = [];
+    const result = await runCoordinationLoop({
+      projectDir: tmpDir,
+      projectId: 'proj1',
+      adapters: [createMockAdapter({ name: 'agent1' })],
+      teamStore: store,
+      parallel: 2,
+      pollIntervalMs: 50,
+      taskTimeoutMs: 5_000,
+      onProgress: (e) => {
+        if (e.type === 'task:dispatched') dispatched.push(e.message);
+      },
+    });
+
+    expect(result.completed).toBe(2);
+    expect(result.failed).toBe(0);
+  });
+
+  it('should show plan in dry-run mode without spawning', async () => {
+    store.createTask({ projectId: 'proj1', description: 'Task DryRun' });
+
+    const events: CoordinatorEvent[] = [];
+    const result = await runCoordinationLoop({
+      projectDir: tmpDir,
+      projectId: 'proj1',
+      adapters: [createMockAdapter({})],
+      teamStore: store,
+      dryRun: true,
+      onProgress: (e) => events.push(e),
+    });
+
+    // Should finish immediately without dispatching
+    expect(events.some(e => e.type === 'finished' && e.message.includes('dry-run'))).toBe(true);
+    expect(events.some(e => e.type === 'task:dispatched')).toBe(false);
+    expect(result.aborted).toBe(false);
+  });
+
+  it('should detect stale agents and release their tasks', async () => {
+    // Register a fake agent and claim a task
+    const fakeAgent = store.registerAgent({
+      projectId: 'proj1', agentType: 'stale-test', instanceId: 'stale-1',
+    });
+    const task = store.createTask({ projectId: 'proj1', description: 'Stale task' });
+    store.claimTask(task.task_id, fakeAgent.agent_id);
+
+    // Manually set heartbeat to the past to simulate staleness
+    store.getDb().prepare(
+      'UPDATE team_agents SET last_heartbeat = ? WHERE agent_id = ?',
+    ).run(Date.now() - 999_999, fakeAgent.agent_id);
+
+    const events: CoordinatorEvent[] = [];
+    const result = await runCoordinationLoop({
+      projectDir: tmpDir,
+      projectId: 'proj1',
+      adapters: [createMockAdapter({})],
+      teamStore: store,
+      staleTtlMs: 1_000, // 1 second — our fake is 999s old
+      pollIntervalMs: 50,
+      taskTimeoutMs: 5_000,
+      onProgress: (e) => events.push(e),
+    });
+
+    expect(events.some(e => e.type === 'agent:stale')).toBe(true);
+    expect(result.completed).toBe(1); // rescued and completed
+  });
+
+  it('should fail task when agent exits non-zero (方案 A)', async () => {
+    store.createTask({ projectId: 'proj1', description: 'Failing task' });
+
+    const result = await runCoordinationLoop({
+      projectDir: tmpDir,
+      projectId: 'proj1',
+      adapters: [createMockAdapter({ behavior: 'fail' })],
+      teamStore: store,
+      maxRetries: 0,
+      pollIntervalMs: 50,
+      taskTimeoutMs: 5_000,
+    });
+
+    expect(result.failed).toBe(1);
+    expect(result.completed).toBe(0);
+  });
+
+  it('should exit with all tasks done when no tasks exist initially', async () => {
+    // No tasks created
+    const result = await runCoordinationLoop({
+      projectDir: tmpDir,
+      projectId: 'proj1',
+      adapters: [createMockAdapter({})],
+      teamStore: store,
+      pollIntervalMs: 50,
+    });
+
+    expect(result.totalTasks).toBe(0);
+    expect(result.completed).toBe(0);
+    expect(result.aborted).toBe(false);
+  });
+
+  it('should use round-robin adapter selection', async () => {
+    store.createTask({ projectId: 'proj1', description: 'Task 1' });
+    store.createTask({ projectId: 'proj1', description: 'Task 2' });
+
+    const adapterCalls: string[] = [];
+    const makeTracked = (adapterName: string): AgentAdapter => ({
+      name: adapterName,
+      async available() { return true; },
+      spawn(_prompt: string, _opts: SpawnOptions): AgentProcess {
+        adapterCalls.push(adapterName);
+        // Agent just exits 0 — orchestrator handles completion
+        const completion = new Promise<AgentProcessResult>(async (resolve) => {
+          await new Promise(r => setTimeout(r, 10));
+          resolve({ exitCode: 0, signal: null, tailOutput: '', killed: false });
+        });
+        return { pid: 99999, completion, abort() {} };
+      },
+    });
+
+    await runCoordinationLoop({
+      projectDir: tmpDir,
+      projectId: 'proj1',
+      adapters: [makeTracked('alpha'), makeTracked('beta')],
+      teamStore: store,
+      parallel: 1, // sequential to test round-robin
+      pollIntervalMs: 50,
+      taskTimeoutMs: 5_000,
+    });
+
+    expect(adapterCalls).toEqual(['alpha', 'beta']);
+  });
+
+  // ═══════════════════════════════════════════════════════════════
+  // Blocker 1: Orchestrator self-heartbeat
+  // ═══════════════════════════════════════════════════════════════
+
+  it('should NOT self-stale when task runs longer than staleTtlMs', async () => {
+    store.createTask({ projectId: 'proj1', description: 'Long running task' });
+
+    // staleTtlMs = 50ms, but task takes 200ms to complete
+    // Without heartbeat fix, orchestrator would stale itself
+    const events: CoordinatorEvent[] = [];
+    const result = await runCoordinationLoop({
+      projectDir: tmpDir,
+      projectId: 'proj1',
+      adapters: [createMockAdapter({ delayMs: 200 })],
+      teamStore: store,
+      staleTtlMs: 50,
+      pollIntervalMs: 30,
+      taskTimeoutMs: 5_000,
+      maxRetries: 0,
+      onProgress: (e) => events.push(e),
+    });
+
+    // Task should complete, not be released by self-stale
+    expect(result.completed).toBe(1);
+    expect(result.failed).toBe(0);
+    // No stale event should fire for the orchestrator itself
+    // (stale events are only for external agents)
+    const staleEvents = events.filter(e => e.type === 'agent:stale');
+    expect(staleEvents.length).toBe(0);
+  });
+
+  // ═══════════════════════════════════════════════════════════════
+  // Blocker 2: Orchestrator owns task lifecycle (方案 A)
+  // ═══════════════════════════════════════════════════════════════
+
+  it('should complete task when agent exits 0 (方案 A: orchestrator writes state)', async () => {
+    const task = store.createTask({ projectId: 'proj1', description: 'Orchestrator-owned task' });
+
+    await runCoordinationLoop({
+      projectDir: tmpDir,
+      projectId: 'proj1',
+      adapters: [createMockAdapter({})], // exits 0
+      teamStore: store,
+      maxRetries: 0,
+      pollIntervalMs: 50,
+      taskTimeoutMs: 5_000,
+    });
+
+    // Verify orchestrator wrote the completion (not the agent)
+    const finalTask = store.getTask(task.task_id);
+    expect(finalTask?.status).toBe('completed');
+    expect(finalTask?.result).toBeTruthy();
+  });
+
+  it('should fail task when agent exits non-zero (方案 A: orchestrator writes state)', async () => {
+    const task = store.createTask({ projectId: 'proj1', description: 'Will fail task' });
+
+    await runCoordinationLoop({
+      projectDir: tmpDir,
+      projectId: 'proj1',
+      adapters: [createMockAdapter({ behavior: 'fail' })], // exits 1
+      teamStore: store,
+      maxRetries: 0,
+      pollIntervalMs: 50,
+      taskTimeoutMs: 5_000,
+    });
+
+    const finalTask = store.getTask(task.task_id);
+    expect(finalTask?.status).toBe('failed');
+    expect(finalTask?.result).toContain('Exit code 1');
+  });
+
+  // ═══════════════════════════════════════════════════════════════
+  // Blocker 3: Stranded pending tasks with failed deps
+  // ═══════════════════════════════════════════════════════════════
+
+  it('should fail stranded task B when dep task A fails (not report as success)', async () => {
+    // A → B dependency chain. A fails → B should be marked failed too.
+    const tA = store.createTask({ projectId: 'proj1', description: 'Task A (will fail)' });
+    const tB = store.createTask({ projectId: 'proj1', description: 'Task B (depends on A)', deps: [tA.task_id] });
+
+    const events: CoordinatorEvent[] = [];
+    const result = await runCoordinationLoop({
+      projectDir: tmpDir,
+      projectId: 'proj1',
+      adapters: [createMockAdapter({ behavior: 'fail' })], // A exits 1
+      teamStore: store,
+      maxRetries: 0,
+      pollIntervalMs: 50,
+      taskTimeoutMs: 5_000,
+      onProgress: (e) => events.push(e),
+    });
+
+    // Both tasks must be failed
+    expect(result.completed).toBe(0);
+    expect(result.failed).toBe(2);
+
+    // Verify task B was marked failed with dependency reason
+    const finalB = store.getTask(tB.task_id);
+    expect(finalB?.status).toBe('failed');
+    expect(finalB?.result).toContain('upstream dependency failed');
+
+    // Verify the event was emitted for the stranded task
+    expect(events.some(e => e.type === 'task:failed' && e.message.includes('blocked by failed dependency'))).toBe(true);
+  });
+});

--- a/tests/orchestrate/coordinator.test.ts
+++ b/tests/orchestrate/coordinator.test.ts
@@ -381,6 +381,105 @@ describe('Coordinator', () => {
   });
 
   // ═══════════════════════════════════════════════════════════════
+  // Fix 2: Coordinator config validation (PR #76 round 3)
+  // ═══════════════════════════════════════════════════════════════
+
+  it('should throw on empty adapters array', async () => {
+    store.createTask({ projectId: 'proj1', description: 'Task' });
+    await expect(runCoordinationLoop({
+      projectDir: tmpDir,
+      projectId: 'proj1',
+      adapters: [],
+      teamStore: store,
+    })).rejects.toThrow('adapters must be a non-empty array');
+  });
+
+  it('should throw on invalid numeric config values', async () => {
+    store.createTask({ projectId: 'proj1', description: 'Task' });
+    const base = {
+      projectDir: tmpDir,
+      projectId: 'proj1',
+      adapters: [createMockAdapter({})],
+      teamStore: store,
+    };
+
+    await expect(runCoordinationLoop({ ...base, parallel: 0 }))
+      .rejects.toThrow('parallel must be >= 1');
+    await expect(runCoordinationLoop({ ...base, parallel: NaN }))
+      .rejects.toThrow('parallel must be >= 1');
+    await expect(runCoordinationLoop({ ...base, taskTimeoutMs: -1 }))
+      .rejects.toThrow('taskTimeoutMs must be > 0');
+    await expect(runCoordinationLoop({ ...base, taskTimeoutMs: 0 }))
+      .rejects.toThrow('taskTimeoutMs must be > 0');
+    await expect(runCoordinationLoop({ ...base, maxRetries: -1 }))
+      .rejects.toThrow('maxRetries must be >= 0');
+    await expect(runCoordinationLoop({ ...base, pollIntervalMs: -5 }))
+      .rejects.toThrow('pollIntervalMs must be >= 0');
+  });
+
+  // ═══════════════════════════════════════════════════════════════
+  // Fix 4a: retry reset clears stale result (PR #76 round 3)
+  // ═══════════════════════════════════════════════════════════════
+
+  it('should clear stale result on retry reset', async () => {
+    let callCount = 0;
+    // First call fails, second call succeeds
+    const flakyAdapter: AgentAdapter = {
+      name: 'flaky',
+      async available() { return true; },
+      spawn(_prompt: string, _opts: SpawnOptions): AgentProcess {
+        callCount++;
+        const exitCode = callCount === 1 ? 1 : 0;
+        const completion = new Promise<AgentProcessResult>(r =>
+          setTimeout(() => r({ exitCode, signal: null, tailOutput: `attempt ${callCount}`, killed: false }), 10),
+        );
+        return { pid: 99999, completion, abort() {} };
+      },
+    };
+
+    const task = store.createTask({ projectId: 'proj1', description: 'Flaky task' });
+
+    await runCoordinationLoop({
+      projectDir: tmpDir,
+      projectId: 'proj1',
+      adapters: [flakyAdapter],
+      teamStore: store,
+      maxRetries: 1,
+      pollIntervalMs: 50,
+      taskTimeoutMs: 5_000,
+    });
+
+    // After retry+success, result should reflect the second attempt, not the first failure
+    const finalTask = store.getTask(task.task_id);
+    expect(finalTask?.status).toBe('completed');
+    // The result should NOT contain the first failure's error message
+    expect(finalTask?.result).not.toContain('Exit code 1');
+  });
+
+  // ═══════════════════════════════════════════════════════════════
+  // Fix 4b: resolveHandoffs failure fallback (PR #76 round 3)
+  // ═══════════════════════════════════════════════════════════════
+
+  it('should not crash when resolveHandoffs throws', async () => {
+    store.createTask({ projectId: 'proj1', description: 'Task A' });
+
+    const result = await runCoordinationLoop({
+      projectDir: tmpDir,
+      projectId: 'proj1',
+      adapters: [createMockAdapter({})],
+      teamStore: store,
+      maxRetries: 0,
+      pollIntervalMs: 50,
+      taskTimeoutMs: 5_000,
+      resolveHandoffs: async () => { throw new Error('handoff DB exploded'); },
+    });
+
+    // Should still complete successfully — handoff is enhancement, not critical
+    expect(result.completed).toBe(1);
+    expect(result.failed).toBe(0);
+  });
+
+  // ═══════════════════════════════════════════════════════════════
   // Blocker 3: Stranded pending tasks with failed deps
   // ═══════════════════════════════════════════════════════════════
 

--- a/tests/orchestrate/e2e-seed.ts
+++ b/tests/orchestrate/e2e-seed.ts
@@ -1,0 +1,35 @@
+/**
+ * E2E test seed — creates a trivial task for orchestrator to dispatch.
+ * Usage: npx tsx tests/orchestrate/e2e-seed.ts
+ */
+
+import { TeamStore } from '../../src/team/team-store.js';
+import { getProjectDataDir } from '../../src/store/persistence.js';
+import { detectProject } from '../../src/project/detector.js';
+
+async function main() {
+  const proj = detectProject(process.cwd());
+  if (!proj) {
+    console.error('Not a git repo');
+    process.exit(1);
+  }
+
+  const dataDir = await getProjectDataDir(proj.id);
+  const store = new TeamStore();
+  await store.init(dataDir);
+
+  // Create a trivial task
+  const task = store.createTask({
+    projectId: proj.id,
+    description: 'Create a file called e2e-test-output.txt in the project root containing "Hello from autonomous agent". Then mark this task as complete using team_task with action "complete".',
+  });
+
+  console.log(`✅ Task created: ${task.task_id}`);
+  console.log(`   Description: ${task.description}`);
+  console.log(`   Project: ${proj.id}`);
+  console.log(`   Data dir: ${dataDir}`);
+  console.log(`\nNow run:`);
+  console.log(`  npx tsx src/cli/index.ts orchestrate --agents claude --timeout 120000`);
+}
+
+main().catch(console.error);

--- a/tests/orchestrate/e2e-seed.ts
+++ b/tests/orchestrate/e2e-seed.ts
@@ -21,7 +21,7 @@ async function main() {
   // Create a trivial task
   const task = store.createTask({
     projectId: proj.id,
-    description: 'Create a file called e2e-test-output.txt in the project root containing "Hello from autonomous agent". Then mark this task as complete using team_task with action "complete".',
+    description: 'Create a file called e2e-test-output.txt in the project root containing "Hello from autonomous agent". Exit when done (the orchestrator manages task state).',
   });
 
   console.log(`✅ Task created: ${task.task_id}`);

--- a/tests/orchestrate/prompt-builder.test.ts
+++ b/tests/orchestrate/prompt-builder.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Prompt Builder tests — Phase 4c prompt construction.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildAgentPrompt } from '../../src/orchestrate/prompt-builder.js';
+import type { TeamTaskRow } from '../../src/team/team-store.js';
+
+function makeTask(overrides?: Partial<TeamTaskRow>): TeamTaskRow {
+  return {
+    task_id: 'task-001',
+    project_id: 'proj1',
+    description: 'Implement feature X',
+    status: 'pending',
+    assignee_agent_id: null,
+    result: null,
+    metadata: null,
+    created_by: null,
+    created_at: Date.now(),
+    updated_at: Date.now(),
+    ...overrides,
+  };
+}
+
+describe('buildAgentPrompt', () => {
+  it('should include task description and coordinator ID (not as worker identity)', () => {
+    const prompt = buildAgentPrompt({
+      task: makeTask(),
+      handoffs: [],
+      agentId: 'agent-abc',
+      projectId: 'proj1',
+      projectDir: '/home/user/project',
+    });
+
+    expect(prompt).toContain('task-001');
+    expect(prompt).toContain('Implement feature X');
+    expect(prompt).toContain('agent-abc');
+    expect(prompt).toContain('proj1');
+    expect(prompt).toContain('/home/user/project');
+    // Must NOT present orchestrator agentId as worker's own identity
+    expect(prompt).not.toContain('Your agent ID is');
+    expect(prompt).toContain('Coordinator agent ID');
+    expect(prompt).toContain('NOT your identity');
+  });
+
+  it('should include handoff context when provided', () => {
+    const prompt = buildAgentPrompt({
+      task: makeTask(),
+      handoffs: [
+        {
+          fromAgent: 'agent-prev',
+          summary: 'Built the API layer',
+          context: 'All endpoints passing tests',
+          filesModified: ['src/api.ts', 'tests/api.test.ts'],
+        },
+      ],
+      agentId: 'agent-abc',
+      projectId: 'proj1',
+      projectDir: '/tmp/proj',
+    });
+
+    expect(prompt).toContain('agent-prev');
+    expect(prompt).toContain('Built the API layer');
+    expect(prompt).toContain('All endpoints passing tests');
+    expect(prompt).toContain('src/api.ts');
+  });
+
+  it('should not include handoff section when no handoffs', () => {
+    const prompt = buildAgentPrompt({
+      task: makeTask(),
+      handoffs: [],
+      agentId: 'agent-abc',
+      projectId: 'proj1',
+      projectDir: '/tmp/proj',
+    });
+
+    expect(prompt).not.toContain('Context from Previous Agents');
+  });
+
+  it('should include memorix tool instructions (方案 A: no team_task)', () => {
+    const prompt = buildAgentPrompt({
+      task: makeTask(),
+      handoffs: [],
+      agentId: 'agent-abc',
+      projectId: 'proj1',
+      projectDir: '/tmp/proj',
+    });
+
+    expect(prompt).toContain('memorix_session_start');
+    expect(prompt).toContain('memorix_poll');
+    // 方案 A: agent must NOT call team_task — orchestrator manages lifecycle
+    expect(prompt).toContain('Do NOT call `team_task`');
+    expect(prompt).toContain('orchestrator manages task state');
+  });
+
+  it('should include exit-code-based completion criteria', () => {
+    const prompt = buildAgentPrompt({
+      task: makeTask(),
+      handoffs: [],
+      agentId: 'agent-abc',
+      projectId: 'proj1',
+      projectDir: '/tmp/proj',
+    });
+
+    expect(prompt).toContain('Completion Criteria');
+    expect(prompt).toContain('Exit with code 0');
+    expect(prompt).toContain('non-zero code');
+    expect(prompt).toContain('orchestrator will determine');
+  });
+
+  it('should instruct worker to use session_start agentId, not orchestrator ID (identity contract)', () => {
+    const prompt = buildAgentPrompt({
+      task: makeTask(),
+      handoffs: [],
+      agentId: 'orch-id-123',
+      projectId: 'proj1',
+      projectDir: '/tmp/proj',
+    });
+
+    // Worker must derive identity from session_start
+    expect(prompt).toContain('agentId returned by `memorix_session_start`');
+    expect(prompt).toContain('YOUR identity');
+    // Orchestrator ID is present but clearly labeled as NOT the worker's
+    expect(prompt).toContain('orch-id-123');
+    expect(prompt).toContain('belongs to the orchestrator, not to you');
+  });
+
+  it('should NOT instruct agent to call team_task complete or fail (方案 A contract)', () => {
+    const prompt = buildAgentPrompt({
+      task: makeTask(),
+      handoffs: [],
+      agentId: 'agent-abc',
+      projectId: 'proj1',
+      projectDir: '/tmp/proj',
+    });
+
+    // These are the old (broken) instructions — must not appear
+    expect(prompt).not.toContain('action "complete"');
+    expect(prompt).not.toContain('action "fail"');
+    expect(prompt).not.toMatch(/call.*team_task.*complete/);
+  });
+});

--- a/tests/orchestrate/ring-buffer.test.ts
+++ b/tests/orchestrate/ring-buffer.test.ts
@@ -1,0 +1,52 @@
+/**
+ * RingBuffer — bounded line buffer tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { RingBuffer } from '../../src/orchestrate/ring-buffer.js';
+
+describe('RingBuffer', () => {
+  it('should store lines up to maxLines', () => {
+    const buf = new RingBuffer(3);
+    buf.push('line1\nline2\nline3');
+    expect(buf.length).toBe(3);
+    expect(buf.toString()).toBe('line1\nline2\nline3');
+  });
+
+  it('should evict oldest lines when exceeding maxLines', () => {
+    const buf = new RingBuffer(2);
+    buf.push('a\nb\nc\nd');
+    expect(buf.length).toBe(2);
+    expect(buf.getLines()).toEqual(['c', 'd']);
+  });
+
+  it('should skip empty lines', () => {
+    const buf = new RingBuffer(10);
+    buf.push('hello\n\n\nworld\n  \n');
+    expect(buf.getLines()).toEqual(['hello', 'world']);
+  });
+
+  it('should handle multiple push calls', () => {
+    const buf = new RingBuffer(5);
+    buf.push('first');
+    buf.push('second');
+    buf.push('third');
+    expect(buf.getLines()).toEqual(['first', 'second', 'third']);
+  });
+
+  it('should clear all lines', () => {
+    const buf = new RingBuffer(5);
+    buf.push('data');
+    buf.clear();
+    expect(buf.length).toBe(0);
+    expect(buf.toString()).toBe('');
+  });
+
+  it('should return copy from getLines', () => {
+    const buf = new RingBuffer(5);
+    buf.push('a');
+    const lines = buf.getLines();
+    lines.push('mutated');
+    expect(buf.length).toBe(1); // original unaffected
+  });
+});

--- a/tests/orchestrate/spawn-helper.test.ts
+++ b/tests/orchestrate/spawn-helper.test.ts
@@ -1,0 +1,54 @@
+/**
+ * spawn-helper tests — PR #76 Fix 1: stdin EPIPE / early-exit handling.
+ *
+ * Proves that if the child process closes stdin early (bad args, crash, etc.),
+ * the orchestrator process does NOT crash from an unhandled EPIPE/stream error.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { spawnAgent } from '../../src/orchestrate/adapters/spawn-helper.js';
+
+describe('spawnAgent', () => {
+  it('should not crash when child exits before stdin is consumed (EPIPE)', async () => {
+    // Spawn a process that exits immediately without reading stdin.
+    // On Unix: /bin/false or /usr/bin/true. On Windows: cmd /c exit 1
+    const isWin = process.platform === 'win32';
+    const cmd = isWin ? 'cmd' : 'false';
+    const args = isWin ? ['/c', 'exit', '1'] : [];
+
+    const proc = spawnAgent(cmd, args, {
+      cwd: process.cwd(),
+      timeoutMs: 5_000,
+    }, 'This is a long prompt that will be written to stdin of a process that exits immediately before reading it');
+
+    // This must resolve without the process crashing from EPIPE
+    const result = await proc.completion;
+
+    // Process exited (non-zero or null for spawn error) — but no crash
+    expect(result.killed).toBe(false);
+    // The result should exist (completion contract intact)
+    expect(result).toBeDefined();
+    expect(typeof result.tailOutput).toBe('string');
+  });
+
+  it('should include stdin error in tailOutput when EPIPE occurs', async () => {
+    // Spawn a process that exits immediately
+    const isWin = process.platform === 'win32';
+    const cmd = isWin ? 'cmd' : 'false';
+    const args = isWin ? ['/c', 'exit', '0'] : [];
+
+    const proc = spawnAgent(cmd, args, {
+      cwd: process.cwd(),
+      timeoutMs: 5_000,
+    }, 'x'.repeat(100_000)); // Large payload increases chance of EPIPE on fast exit
+
+    const result = await proc.completion;
+
+    // Completion resolves without crash — that's the main assertion
+    expect(result).toBeDefined();
+    // If stdin error occurred, it should be in tailOutput (not throw)
+    // Note: EPIPE might not always trigger on all platforms, so we just
+    // verify the process completed without crashing.
+    expect(typeof result.tailOutput).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary
- add a leaf `src/orchestrate` module with a poll-driven coordinator loop, spawn-based CLI adapters, and bounded process output buffering
- add `memorix orchestrate` CLI wiring plus prompt building for task execution, handoff-aware context, and orchestrator-owned task lifecycle
- cover orchestrator behavior with ring buffer, prompt contract, dependency-blocking, retry, parallelism, and cancellation tests

## Test Plan
- [x] npx tsc --noEmit
- [x] npx tsup
- [x] npx vitest run tests/orchestrate/coordinator.test.ts tests/orchestrate/prompt-builder.test.ts tests/orchestrate/ring-buffer.test.ts
- [x] npx vitest run