### PR TITLE
feat: add phase 5 autonomous planner agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ test-*.mjs
 run-*.mjs
 e2e-*.mts
 e2e-*.mjs
+e2e-test/
+scripts/e2e-*.ts
+scripts/tsconfig.json
 
 # Reference / cloned repos
 temple/

--- a/src/cli/commands/orchestrate.ts
+++ b/src/cli/commands/orchestrate.ts
@@ -50,6 +50,21 @@ export default defineCommand({
       description: 'Poll interval in ms (default: 5000)',
       default: '5000',
     },
+    goal: {
+      type: 'string',
+      description: 'High-level goal for autonomous planning. Agents will decompose, execute, review, and iterate.',
+      required: false,
+    },
+    'max-iterations': {
+      type: 'string',
+      description: 'Max review→fix cycles for autonomous mode (default: 3)',
+      default: '3',
+    },
+    'task-budget': {
+      type: 'string',
+      description: 'Max total tasks for autonomous mode (default: 15)',
+      default: '15',
+    },
   },
   run: async ({ args }) => {
     const { detectProject } = await import('../../project/detector.js');
@@ -116,11 +131,43 @@ export default defineCommand({
       process.exit(1);
     }
 
+    // ── Autonomous mode: seed planning task from --goal ──────────
+    const goal = args.goal as string | undefined;
+    if (goal) {
+      const maxIterations = parseInt(args['max-iterations'] as string, 10);
+      const taskBudget = parseInt(args['task-budget'] as string, 10);
+
+      if (!Number.isFinite(maxIterations) || maxIterations < 1) {
+        console.error(`❌ --max-iterations must be a positive integer, got: ${args['max-iterations']}`);
+        process.exit(1);
+      }
+      if (!Number.isFinite(taskBudget) || taskBudget < 2) {
+        console.error(`❌ --task-budget must be >= 2, got: ${args['task-budget']}`);
+        process.exit(1);
+      }
+
+      if (dryRun) {
+        console.error(`\n🧠 Autonomous mode (DRY RUN): goal → "${goal}"`);
+        console.error(`📝 Would seed planning task (not written to task board)`);
+        console.error(`🔄 Max iterations: ${maxIterations}, Task budget: ${taskBudget}`);
+      } else {
+        const { seedAutonomousPipeline } = await import('../../orchestrate/planner.js');
+        const { planningTaskId, pipelineId } = seedAutonomousPipeline(teamStore, proj.id, {
+          goal,
+          maxIterations,
+          taskBudget,
+        });
+        console.error(`\n🧠 Autonomous mode: goal → "${goal}"`);
+        console.error(`📝 Planning task seeded: ${planningTaskId.slice(0, 8)}… (pipeline ${pipelineId.slice(0, 8)}…)`);
+        console.error(`🔄 Max iterations: ${maxIterations}, Task budget: ${taskBudget}`);
+      }
+    }
+
     // Check if there are tasks to work on
     const tasks = teamStore.listTasks(proj.id);
     const pendingTasks = tasks.filter(t => t.status === 'pending');
     if (tasks.length === 0) {
-      console.error('📋 No tasks found. Create tasks first with `team_task create`.');
+      console.error('📋 No tasks found. Use --goal or create tasks with `team_task create`.');
       process.exit(0);
     }
 

--- a/src/orchestrate/planner.ts
+++ b/src/orchestrate/planner.ts
@@ -1,0 +1,251 @@
+/**
+ * Planner — Phase 5: Autonomous goal→tasks decomposition.
+ *
+ * Seeds a "planning" meta-task that instructs an agent to break a high-level
+ * goal into concrete team tasks (via team_task MCP tool).  The existing
+ * coordinator loop then executes those tasks naturally.
+ *
+ * Review tasks include a quality-gate: the reviewer checks completed work
+ * and may spawn fix tasks + a follow-up review, up to maxIterations.
+ *
+ * Key insight: NO changes to the coordinator loop are needed.  Planning and
+ * review tasks are regular tasks whose descriptions instruct the agent to
+ * call team_task create.  Dependencies handle ordering.  The coordinator's
+ * SQLite poll picks up newly-created tasks automatically.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { TeamStore } from '../team/team-store.js';
+
+// ── Types ──────────────────────────────────────────────────────────
+
+export interface PlannerConfig {
+  goal: string;
+  /** Max review→fix cycles (default 3) */
+  maxIterations?: number;
+  /** Max total tasks the pipeline may create (default 15) */
+  taskBudget?: number;
+}
+
+export interface PlannerMeta {
+  plannerType: 'plan' | 'review';
+  pipelineId: string;
+  goal: string;
+  iteration: number;
+  maxIterations: number;
+  taskBudget: number;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────
+
+/**
+ * Parse task metadata to determine if a task is a planner/review task.
+ * Returns null for regular worker tasks.
+ */
+export function isPlannerTask(metadata?: string | null): PlannerMeta | null {
+  if (!metadata) return null;
+  try {
+    const parsed = JSON.parse(metadata);
+    if (parsed?.plannerType === 'plan' || parsed?.plannerType === 'review') {
+      return parsed as PlannerMeta;
+    }
+  } catch { /* not planner metadata */ }
+  return null;
+}
+
+/**
+ * Extract pipelineId from any task's metadata (planner, review, or worker).
+ * Returns null if the task is not part of an autonomous pipeline.
+ */
+export function extractPipelineId(metadata?: string | null): string | null {
+  if (!metadata) return null;
+  try {
+    const parsed = JSON.parse(metadata);
+    return typeof parsed?.pipelineId === 'string' ? parsed.pipelineId : null;
+  } catch { return null; }
+}
+
+// ── Guards (server-enforced hard limits) ───────────────────────────
+
+export interface GuardInput {
+  /** All existing tasks in the project */
+  existingTasks: Array<{ metadata?: string | null }>;
+  /** Metadata of the task being created (parsed), if any */
+  newTaskMeta?: Record<string, unknown> | null;
+}
+
+export type GuardResult =
+  | { allowed: true }
+  | { allowed: false; reason: string };
+
+/**
+ * Enforce autonomous-pipeline limits at the system level.
+ *
+ * Pipeline-scoped: only counts tasks belonging to the SAME pipelineId.
+ * Called by the team_task create handler in server.ts.
+ * Tasks without a pipelineId (manual tasks, other pipelines) are never affected.
+ */
+export function checkPipelineGuards(input: GuardInput): GuardResult {
+  // Extract pipelineId from the task being created
+  const newPipelineId = typeof input.newTaskMeta?.pipelineId === 'string'
+    ? input.newTaskMeta.pipelineId : null;
+
+  // No pipelineId on new task → not part of any autonomous pipeline → allow
+  if (!newPipelineId) return { allowed: true };
+
+  // Scan existing tasks: find plan meta + count pipeline members
+  let planMeta: PlannerMeta | null = null;
+  let pipelineTaskCount = 0;
+
+  for (const t of input.existingTasks) {
+    const pid = extractPipelineId(t.metadata);
+    if (pid === newPipelineId) {
+      pipelineTaskCount++;
+      if (!planMeta) {
+        const parsed = isPlannerTask(t.metadata);
+        if (parsed?.plannerType === 'plan') planMeta = parsed;
+      }
+    }
+  }
+
+  // No planning task found for this pipeline → allow (orphan pipelineId)
+  if (!planMeta) return { allowed: true };
+
+  // Guard 1: task budget (pipeline-scoped)
+  if (pipelineTaskCount + 1 > planMeta.taskBudget) {
+    return {
+      allowed: false,
+      reason: `Task budget exhausted (${pipelineTaskCount}/${planMeta.taskBudget}). Cannot create more tasks.`,
+    };
+  }
+
+  // Guard 2: review iteration limit (pipeline-scoped)
+  if (input.newTaskMeta?.plannerType === 'review') {
+    const iter = typeof input.newTaskMeta.iteration === 'number'
+      ? input.newTaskMeta.iteration : 0;
+    if (iter > planMeta.maxIterations) {
+      return {
+        allowed: false,
+        reason: `Max review iterations exceeded (${iter}/${planMeta.maxIterations}). Cannot create more review tasks.`,
+      };
+    }
+  }
+
+  return { allowed: true };
+}
+
+// ── Seed ───────────────────────────────────────────────────────────
+
+/**
+ * Create the initial planning task.  The agent that executes it will
+ * decompose the goal into concrete worker + review tasks via team_task.
+ */
+export function seedAutonomousPipeline(
+  teamStore: TeamStore,
+  projectId: string,
+  config: PlannerConfig,
+): { planningTaskId: string; pipelineId: string } {
+  const maxIterations = config.maxIterations ?? 3;
+  const taskBudget = config.taskBudget ?? 15;
+
+  const pipelineId = randomUUID();
+
+  const meta: PlannerMeta = {
+    plannerType: 'plan',
+    pipelineId,
+    goal: config.goal,
+    iteration: 0,
+    maxIterations,
+    taskBudget,
+  };
+
+  const task = teamStore.createTask({
+    projectId,
+    description: buildPlanningPrompt(config.goal, maxIterations, taskBudget, pipelineId),
+    metadata: meta as unknown as Record<string, unknown>,
+  });
+
+  return { planningTaskId: task.task_id, pipelineId };
+}
+
+// ── Prompts ────────────────────────────────────────────────────────
+
+function buildPlanningPrompt(
+  goal: string,
+  maxIterations: number,
+  taskBudget: number,
+  pipelineId: string,
+): string {
+  const reviewMetaExample = JSON.stringify({
+    plannerType: 'review',
+    pipelineId,
+    goal,
+    iteration: 1,
+    maxIterations,
+    taskBudget,
+  });
+  const workerMetaExample = JSON.stringify({ pipelineId });
+
+  return `[Role: Project Planner — Autonomous Task Decomposition]
+
+You are the technical lead and project planner for a team of AI agents.
+Analyze the goal below and create a concrete, executable task plan.
+
+## Goal
+${goal}
+
+## Instructions
+
+1. **Analyze** the goal.  Think about what roles are needed (PM, Engineer, QA, Reviewer) and what order tasks should run in.
+
+2. **Create tasks** using \`team_task action="create"\`.  For each task:
+   - Write a clear, self-contained \`description\` starting with \`[Role: <role>]\`.
+   - Include ALL context the executing agent will need — file paths, tech choices, acceptance criteria.
+   - Set \`deps\` to task IDs of prerequisite tasks (returned by previous create calls).
+   - **MANDATORY**: include \`metadata\` with at least: \`'${workerMetaExample}'\`
+     (This \`pipelineId\` links every task to this pipeline for budget tracking.)
+
+3. **Suggested structure** (adapt to the goal):
+   - 1–2 research / planning tasks (PM writes spec, explores approach)
+   - 1–3 implementation tasks (Engineer builds deliverables)
+   - 0–1 testing / QA tasks (validate output works)
+   - 1 review task (**MANDATORY** — depends on ALL other tasks)
+
+4. **Review task** — create it LAST, depending on every other task.  Its description MUST include:
+   \`\`\`
+   [Role: Reviewer — Quality Gate (iteration 1/${maxIterations})]
+   Review all completed work for this goal: "${goal}"
+   Read every output file and check correctness, completeness, and polish.
+   • If quality is satisfactory → call memorix_handoff with an approval summary, then exit.
+   • If issues found → create fix tasks via team_task action="create" (no deps),
+     then create ONE follow-up review task with deps on those fix tasks
+     and metadata: '${reviewMetaExample}'
+     (increment "iteration" for the follow-up review).
+   Task budget remaining: ~${taskBudget - 1}. Do NOT exceed it.
+   \`\`\`
+
+5. **Call memorix_handoff** to share your planning rationale with the team.
+
+## Rules
+- Task budget: **${taskBudget}** max total tasks (including this planning task).  Create only what's needed.
+- Maximum **${maxIterations}** review iterations.
+- Each description must be **self-contained** — no assumptions about shared state beyond file paths.
+- Prefer fewer, focused tasks over many trivial ones.
+
+Exit when all tasks are created.`;
+}
+
+/**
+ * Build a hint string for review-iteration context.
+ * Can be appended to review task descriptions by agents.
+ */
+export function buildReviewIterationHint(
+  iteration: number,
+  maxIterations: number,
+  budgetRemaining: number,
+): string {
+  if (iteration >= maxIterations) {
+    return `\n\n⚠️ This is the FINAL review iteration (${iteration}/${maxIterations}). Do NOT create more tasks. Summarize remaining issues and exit.`;
+  }
+  return `\n\nReview iteration: ${iteration}/${maxIterations}. Budget remaining: ~${budgetRemaining} tasks. You may create fix tasks if needed.`;
+}

--- a/src/orchestrate/prompt-builder.ts
+++ b/src/orchestrate/prompt-builder.ts
@@ -9,6 +9,7 @@
  */
 
 import type { TeamTaskRow } from '../team/team-store.js';
+import { isPlannerTask } from './planner.js';
 
 export interface HandoffContext {
   fromAgent: string;
@@ -64,6 +65,17 @@ export function buildAgentPrompt(input: PromptInput): string {
   }
 
   // 4. Memorix tool instructions
+  const plannerMeta = isPlannerTask(input.task.metadata);
+  const isAutonomous = !!plannerMeta;
+
+  const taskInstruction = isAutonomous
+    ? '5. You have FULL ACCESS to `team_task action="create"` for creating subtasks. Follow the instructions in your task description.'
+    : '5. Focus on completing the work. Do NOT call `team_task` — the orchestrator manages task state.';
+
+  const creationRule = isAutonomous
+    ? '8. Create tasks as instructed in your task description. Respect the task budget and include proper dependencies.'
+    : '8. Do NOT create new tasks unless the original task explicitly requires subtask decomposition.';
+
   sections.push([
     '## Instructions',
     '',
@@ -71,10 +83,10 @@ export function buildAgentPrompt(input: PromptInput): string {
     '2. Use the agentId returned by `memorix_session_start` as YOUR identity for any identity-bearing calls (e.g. `memorix_handoff` fromAgentId). Do NOT use the coordinator agent ID above — that belongs to the orchestrator, not to you.',
     '3. Call `memorix_poll` to check for any additional context or messages.',
     `4. Work on the task described above. The task is already claimed and managed by the orchestrator.`,
-    '5. Focus on completing the work. Do NOT call `team_task` — the orchestrator manages task state.',
+    taskInstruction,
     '6. If you want to leave context for the next agent, call `memorix_handoff` with a summary of what you did.',
     '7. Use `memorix_store` to save any important discoveries, decisions, or gotchas.',
-    '8. Do NOT create new tasks unless the original task explicitly requires subtask decomposition.',
+    creationRule,
   ].join('\n'));
 
   // 5. Completion criteria

--- a/src/server.ts
+++ b/src/server.ts
@@ -3247,16 +3247,31 @@ export async function createMemorixServer(
         result: z.string().optional().describe('Result summary (for complete)'),
         status: z.enum(['pending', 'in_progress', 'completed', 'failed']).optional().describe('Filter by status (for list)'),
         available: z.boolean().optional().describe('Show only claimable tasks (for list)'),
+        metadata: z.string().optional().describe('JSON metadata for the task (for create). Used by planner/review tasks for autonomous mode.'),
       },
     },
-    async ({ action, description: desc, deps, taskId, agentId, result, status, available }) => {
+    async ({ action, description: desc, deps, taskId, agentId, result, status, available, metadata }) => {
       try {
         if (action === 'create') {
           if (!desc) return { content: [{ type: 'text' as const, text: '❌ description is required for create' }], isError: true };
+          let parsedMeta: Record<string, unknown> | undefined;
+          if (metadata) {
+            try { parsedMeta = JSON.parse(metadata); } catch { /* ignore invalid JSON */ }
+          }
+
+          // Phase 5: enforce autonomous-pipeline hard guards
+          const { checkPipelineGuards } = await import('./orchestrate/planner.js');
+          const existingTasks = teamStore.listTasks(project.id);
+          const guard = checkPipelineGuards({ existingTasks, newTaskMeta: parsedMeta });
+          if (!guard.allowed) {
+            return { content: [{ type: 'text' as const, text: `❌ ${guard.reason}` }], isError: true };
+          }
+
           const task = teamStore.createTask({
             projectId: project.id,
             description: desc,
             deps: deps ? coerceStringArray(deps) : undefined,
+            metadata: parsedMeta,
             createdBy: agentId || undefined,
           });
           const taskDeps = teamStore.getTaskDeps(task.task_id);

--- a/tests/orchestrate/planner.test.ts
+++ b/tests/orchestrate/planner.test.ts
@@ -1,0 +1,296 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { isPlannerTask, seedAutonomousPipeline, buildReviewIterationHint, extractPipelineId } from '../../src/orchestrate/planner.js';
+import { initTeamStore, type TeamStore } from '../../src/team/team-store.js';
+
+describe('Planner — Phase 5', () => {
+  // ── isPlannerTask ──────────────────────────────────────────────
+
+  describe('isPlannerTask', () => {
+    it('returns null for undefined/null metadata', () => {
+      expect(isPlannerTask(undefined)).toBeNull();
+      expect(isPlannerTask(null)).toBeNull();
+    });
+
+    it('returns null for non-planner metadata', () => {
+      expect(isPlannerTask('{"foo":"bar"}')).toBeNull();
+      expect(isPlannerTask('not json')).toBeNull();
+      expect(isPlannerTask('{}')).toBeNull();
+    });
+
+    it('parses valid plan metadata', () => {
+      const meta = JSON.stringify({
+        plannerType: 'plan',
+        pipelineId: 'pipe-1',
+        goal: 'Build a web app',
+        iteration: 0,
+        maxIterations: 3,
+        taskBudget: 15,
+      });
+      const result = isPlannerTask(meta);
+      expect(result).not.toBeNull();
+      expect(result!.plannerType).toBe('plan');
+      expect(result!.pipelineId).toBe('pipe-1');
+      expect(result!.goal).toBe('Build a web app');
+      expect(result!.iteration).toBe(0);
+      expect(result!.maxIterations).toBe(3);
+      expect(result!.taskBudget).toBe(15);
+    });
+
+    it('parses valid review metadata', () => {
+      const meta = JSON.stringify({
+        plannerType: 'review',
+        pipelineId: 'pipe-1',
+        goal: 'Build a web app',
+        iteration: 2,
+        maxIterations: 3,
+        taskBudget: 10,
+      });
+      const result = isPlannerTask(meta);
+      expect(result).not.toBeNull();
+      expect(result!.plannerType).toBe('review');
+      expect(result!.iteration).toBe(2);
+    });
+  });
+
+  // ── seedAutonomousPipeline ─────────────────────────────────────
+
+  describe('seedAutonomousPipeline', () => {
+    let tmpDir: string;
+    let teamStore: TeamStore;
+
+    beforeEach(async () => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'planner-test-'));
+      teamStore = await initTeamStore(tmpDir);
+    });
+
+    afterEach(() => {
+      try { rmSync(tmpDir, { recursive: true }); } catch { /* ignore */ }
+    });
+
+    it('creates a planning task with correct metadata and pipelineId', () => {
+      const { planningTaskId, pipelineId } = seedAutonomousPipeline(teamStore, 'test/proj', {
+        goal: 'Build a PNG to SVG converter',
+      });
+
+      expect(planningTaskId).toBeTruthy();
+      expect(pipelineId).toBeTruthy();
+
+      const task = teamStore.getTask(planningTaskId);
+      expect(task).not.toBeNull();
+      expect(task!.status).toBe('pending');
+      expect(task!.description).toContain('Build a PNG to SVG converter');
+      expect(task!.description).toContain('[Role: Project Planner');
+      expect(task!.description).toContain(pipelineId);
+
+      const meta = isPlannerTask(task!.metadata);
+      expect(meta).not.toBeNull();
+      expect(meta!.plannerType).toBe('plan');
+      expect(meta!.pipelineId).toBe(pipelineId);
+      expect(meta!.goal).toBe('Build a PNG to SVG converter');
+      expect(meta!.maxIterations).toBe(3);  // default
+      expect(meta!.taskBudget).toBe(15);    // default
+    });
+
+    it('each call generates a unique pipelineId', () => {
+      const r1 = seedAutonomousPipeline(teamStore, 'test/proj', { goal: 'A' });
+      const r2 = seedAutonomousPipeline(teamStore, 'test/proj', { goal: 'B' });
+      expect(r1.pipelineId).not.toBe(r2.pipelineId);
+    });
+
+    it('respects custom config values', () => {
+      const { planningTaskId } = seedAutonomousPipeline(teamStore, 'test/proj', {
+        goal: 'Refactor auth module',
+        maxIterations: 5,
+        taskBudget: 25,
+      });
+
+      const task = teamStore.getTask(planningTaskId);
+      const meta = isPlannerTask(task!.metadata);
+      expect(meta!.maxIterations).toBe(5);
+      expect(meta!.taskBudget).toBe(25);
+    });
+
+    it('planning prompt includes goal, budget, and review instructions', () => {
+      const { planningTaskId } = seedAutonomousPipeline(teamStore, 'test/proj', {
+        goal: 'Create a REST API',
+        maxIterations: 2,
+        taskBudget: 10,
+      });
+
+      const task = teamStore.getTask(planningTaskId);
+      expect(task!.description).toContain('Create a REST API');
+      expect(task!.description).toContain('10');       // budget
+      expect(task!.description).toContain('2');         // maxIterations
+      expect(task!.description).toContain('Quality Gate');
+      expect(task!.description).toContain('team_task');
+    });
+  });
+
+  // ── checkPipelineGuards (system-enforced hard limits) ──────────
+
+  describe('checkPipelineGuards (pipeline-scoped)', () => {
+    const PID_A = 'pipeline-aaa';
+    const PID_B = 'pipeline-bbb';
+
+    // Helpers
+    const planTask = (pid: string, budget: number, maxIter: number) => ({
+      metadata: JSON.stringify({ plannerType: 'plan', pipelineId: pid, goal: 'X', iteration: 0, maxIterations: maxIter, taskBudget: budget }),
+    });
+    const pipelineWorker = (pid: string) => ({
+      metadata: JSON.stringify({ pipelineId: pid }),
+    });
+    const manualTask = () => ({ metadata: null });
+    const newWorkerMeta = (pid: string) => ({ pipelineId: pid });
+    const newReviewMeta = (pid: string, iter: number) => ({ plannerType: 'review', pipelineId: pid, iteration: iter });
+
+    it('rejects task creation when pipeline budget is exhausted', async () => {
+      const { checkPipelineGuards } = await import('../../src/orchestrate/planner.js');
+      // Pipeline A: budget=3, already 3 tasks
+      const existing = [planTask(PID_A, 3, 5), pipelineWorker(PID_A), pipelineWorker(PID_A)];
+      const result = checkPipelineGuards({ existingTasks: existing, newTaskMeta: newWorkerMeta(PID_A) });
+      expect(result.allowed).toBe(false);
+      expect((result as { reason: string }).reason).toContain('budget exhausted');
+    });
+
+    it('allows task creation when within pipeline budget', async () => {
+      const { checkPipelineGuards } = await import('../../src/orchestrate/planner.js');
+      const existing = [planTask(PID_A, 5, 3), pipelineWorker(PID_A)];
+      const result = checkPipelineGuards({ existingTasks: existing, newTaskMeta: newWorkerMeta(PID_A) });
+      expect(result.allowed).toBe(true);
+    });
+
+    it('rejects review task when iteration exceeds maxIterations', async () => {
+      const { checkPipelineGuards } = await import('../../src/orchestrate/planner.js');
+      const existing = [planTask(PID_A, 20, 2), pipelineWorker(PID_A)];
+      const result = checkPipelineGuards({ existingTasks: existing, newTaskMeta: newReviewMeta(PID_A, 3) });
+      expect(result.allowed).toBe(false);
+      expect((result as { reason: string }).reason).toContain('review iterations exceeded');
+    });
+
+    it('allows review task within iteration limit', async () => {
+      const { checkPipelineGuards } = await import('../../src/orchestrate/planner.js');
+      const existing = [planTask(PID_A, 20, 3), pipelineWorker(PID_A)];
+      const result = checkPipelineGuards({ existingTasks: existing, newTaskMeta: newReviewMeta(PID_A, 2) });
+      expect(result.allowed).toBe(true);
+    });
+
+    it('does NOT restrict tasks without pipelineId (manual tasks)', async () => {
+      const { checkPipelineGuards } = await import('../../src/orchestrate/planner.js');
+      const existing = [planTask(PID_A, 3, 3), pipelineWorker(PID_A), pipelineWorker(PID_A)];
+      // New task has no pipelineId → not part of pipeline → always allowed
+      const result = checkPipelineGuards({ existingTasks: existing, newTaskMeta: null });
+      expect(result.allowed).toBe(true);
+    });
+
+    // ── Pipeline isolation tests (Codex review requirement) ──────
+
+    it('old pipeline does NOT pollute new pipeline budget', async () => {
+      const { checkPipelineGuards } = await import('../../src/orchestrate/planner.js');
+      // Old pipeline A: budget=3, fully used (3 tasks)
+      // New pipeline B: budget=5, only 1 task (the plan)
+      const existing = [
+        planTask(PID_A, 3, 2), pipelineWorker(PID_A), pipelineWorker(PID_A),  // A: 3/3
+        planTask(PID_B, 5, 3),                                                 // B: 1/5
+      ];
+      // Creating for pipeline B should succeed (1+1=2 ≤ 5)
+      const result = checkPipelineGuards({ existingTasks: existing, newTaskMeta: newWorkerMeta(PID_B) });
+      expect(result.allowed).toBe(true);
+    });
+
+    it('manual tasks do NOT consume planner taskBudget', async () => {
+      const { checkPipelineGuards } = await import('../../src/orchestrate/planner.js');
+      // Pipeline A: budget=3, 1 plan task + 50 manual tasks (no pipelineId)
+      const existing = [
+        planTask(PID_A, 3, 2),
+        ...Array.from({ length: 50 }, () => manualTask()),
+      ];
+      // Pipeline A only has 1 task counted → 1+1=2 ≤ 3 → allowed
+      const result = checkPipelineGuards({ existingTasks: existing, newTaskMeta: newWorkerMeta(PID_A) });
+      expect(result.allowed).toBe(true);
+    });
+
+    it('review iteration limit is scoped to same pipeline', async () => {
+      const { checkPipelineGuards } = await import('../../src/orchestrate/planner.js');
+      // Pipeline A: maxIterations=1 (exhausted)
+      // Pipeline B: maxIterations=5 (plenty left)
+      const existing = [
+        planTask(PID_A, 20, 1),
+        planTask(PID_B, 20, 5),
+      ];
+      // Review iter=3 for pipeline B → allowed (3 ≤ 5)
+      const resultB = checkPipelineGuards({ existingTasks: existing, newTaskMeta: newReviewMeta(PID_B, 3) });
+      expect(resultB.allowed).toBe(true);
+      // Review iter=2 for pipeline A → rejected (2 > 1)
+      const resultA = checkPipelineGuards({ existingTasks: existing, newTaskMeta: newReviewMeta(PID_A, 2) });
+      expect(resultA.allowed).toBe(false);
+    });
+
+    it('two different goals with separate pipelines have independent guards', async () => {
+      const { checkPipelineGuards } = await import('../../src/orchestrate/planner.js');
+      // Pipeline A: budget=2, already full (2 tasks)
+      // Pipeline B: budget=10, only 1 task
+      const existing = [
+        planTask(PID_A, 2, 3), pipelineWorker(PID_A),  // A: 2/2 (full)
+        planTask(PID_B, 10, 3),                          // B: 1/10
+      ];
+      // A: budget exhausted
+      const rA = checkPipelineGuards({ existingTasks: existing, newTaskMeta: newWorkerMeta(PID_A) });
+      expect(rA.allowed).toBe(false);
+      // B: plenty of room
+      const rB = checkPipelineGuards({ existingTasks: existing, newTaskMeta: newWorkerMeta(PID_B) });
+      expect(rB.allowed).toBe(true);
+    });
+  });
+
+  // ── dry-run: seedAutonomousPipeline must NOT be called ──────────
+
+  describe('dry-run guard', () => {
+    let tmpDir: string;
+    let teamStore: TeamStore;
+
+    beforeEach(async () => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'planner-dryrun-'));
+      teamStore = await initTeamStore(tmpDir);
+    });
+
+    afterEach(() => {
+      try { rmSync(tmpDir, { recursive: true }); } catch { /* ignore */ }
+    });
+
+    it('seedAutonomousPipeline writes to DB (non-dry-run baseline)', () => {
+      seedAutonomousPipeline(teamStore, 'test/proj', { goal: 'Build X' });
+      const tasks = teamStore.listTasks('test/proj');
+      expect(tasks.length).toBe(1);
+    });
+
+    it('NOT calling seedAutonomousPipeline leaves task board empty (dry-run simulation)', () => {
+      // This mirrors the CLI dry-run path: we skip seedAutonomousPipeline entirely
+      const dryRun = true;
+      if (!dryRun) {
+        seedAutonomousPipeline(teamStore, 'test/proj', { goal: 'Build X' });
+      }
+      const tasks = teamStore.listTasks('test/proj');
+      expect(tasks.length).toBe(0);
+    });
+  });
+
+  // ── buildReviewIterationHint ───────────────────────────────────
+
+  describe('buildReviewIterationHint', () => {
+    it('returns FINAL warning on last iteration', () => {
+      const hint = buildReviewIterationHint(3, 3, 2);
+      expect(hint).toContain('FINAL review iteration');
+      expect(hint).toContain('Do NOT create more tasks');
+    });
+
+    it('shows iteration count and budget for non-final iterations', () => {
+      const hint = buildReviewIterationHint(1, 3, 8);
+      expect(hint).toContain('1/3');
+      expect(hint).toContain('8 tasks');
+      expect(hint).toContain('may create fix tasks');
+    });
+  });
+});

--- a/tests/orchestrate/prompt-builder.test.ts
+++ b/tests/orchestrate/prompt-builder.test.ts
@@ -125,6 +125,38 @@ describe('buildAgentPrompt', () => {
     expect(prompt).toContain('belongs to the orchestrator, not to you');
   });
 
+  it('should grant FULL ACCESS to team_task for planner tasks (Phase 5)', () => {
+    const prompt = buildAgentPrompt({
+      task: makeTask({
+        metadata: JSON.stringify({ plannerType: 'plan', pipelineId: 'pipe-1', goal: 'Build X', iteration: 0, maxIterations: 3, taskBudget: 15 }),
+      }),
+      handoffs: [],
+      agentId: 'agent-abc',
+      projectId: 'proj1',
+      projectDir: '/tmp/proj',
+    });
+
+    expect(prompt).toContain('FULL ACCESS');
+    expect(prompt).toContain('team_task action="create"');
+    expect(prompt).not.toContain('Do NOT call `team_task`');
+    expect(prompt).toContain('Respect the task budget');
+  });
+
+  it('should grant FULL ACCESS to team_task for review tasks (Phase 5)', () => {
+    const prompt = buildAgentPrompt({
+      task: makeTask({
+        metadata: JSON.stringify({ plannerType: 'review', pipelineId: 'pipe-1', goal: 'Build X', iteration: 1, maxIterations: 3, taskBudget: 10 }),
+      }),
+      handoffs: [],
+      agentId: 'agent-abc',
+      projectId: 'proj1',
+      projectDir: '/tmp/proj',
+    });
+
+    expect(prompt).toContain('FULL ACCESS');
+    expect(prompt).not.toContain('Do NOT call `team_task`');
+  });
+
   it('should NOT instruct agent to call team_task complete or fail (方案 A contract)', () => {
     const prompt = buildAgentPrompt({
       task: makeTask(),


### PR DESCRIPTION
## Summary
- add a planner task seeding flow for memorix orchestrate --goal
- enforce pipeline-scoped task budget and max-iteration guards server-side
- ignore informal E2E demo artifacts and seed scripts from git

## Verification
- npx tsc --noEmit
- npx vitest run tests/orchestrate/planner.test.ts tests/orchestrate/prompt-builder.test.ts tests/orchestrate/coordinator.test.ts
- npx vitest run
