### PR TITLE
feat(serve-http): make SESSION_TIMEOUT_MS configurable via MEMORIX_SESSION_TIMEOUT_MS

### DIFF
--- a/src/cli/commands/serve-http.ts
+++ b/src/cli/commands/serve-http.ts
@@ -1329,8 +1329,13 @@ export default defineCommand({
       import('../update-checker.js').then(m => m.checkForUpdates()).catch(() => {});
     });
 
-    // Session timeout GC — close sessions idle for 30 minutes
-    const SESSION_TIMEOUT_MS = 30 * 60 * 1000;
+    // Session timeout GC — close idle sessions. Configurable via
+    // MEMORIX_SESSION_TIMEOUT_MS (ms) for clients that do not transparently
+    // re-initialize after a server-side 404 on a stale Mcp-Session-Id
+    // (e.g. Codex/rmcp — see openai/codex#12869, #13969). Default 30 minutes.
+    const envTimeout = Number(process.env.MEMORIX_SESSION_TIMEOUT_MS);
+    const SESSION_TIMEOUT_MS =
+      Number.isFinite(envTimeout) && envTimeout > 0 ? envTimeout : 30 * 60 * 1000;
     const gcInterval = setInterval(() => {
       maybeProbeSummary(); // Flush suppressed probe count periodically
       const now = Date.now();


### PR DESCRIPTION
## Summary

Exposes the previously hardcoded 30-minute idle-session GC timeout in `serve-http` as an env variable `MEMORIX_SESSION_TIMEOUT_MS`. Default behavior preserved.

Closes #82.

## Why

Current hardcoded 30-min idle timeout combined with clients that do **not** transparently re-initialize after a server-side 404 on a stale `Mcp-Session-Id` (notably **Codex (rmcp)**, see openai/codex#12869 and openai/codex#13969) causes a persistent failure mode: after ~30 min of idle, subsequent MCP tool calls fail with `Transport send error: error decoding response body` until the entire Codex session is recreated, destroying in-progress context.

See #82 for forensic evidence (~34m57s between last success and first failure in a real session).

The upstream Codex bug is tracked but not yet fixed. A server-side knob unblocks affected users today without requiring any client-side change.

## Change

- `src/cli/commands/serve-http.ts`: read `process.env.MEMORIX_SESSION_TIMEOUT_MS`, fall back to `30 * 60 * 1000` when unset or invalid.
- Validation: `Number.isFinite` + `> 0` rejects `NaN`/negative/zero.
- Mirrors the pattern accepted in #56 / `MEMORIX_RERANK_TIMEOUT_MS`.

## Test plan

- [ ] unit: env parsing (finite positive → respected; unset / NaN / negative / zero → default)
- [ ] manual: `MEMORIX_SESSION_TIMEOUT_MS=5000 memorix serve-http --port 3211` — log line fires at 5 s idle
- [ ] regression: unset env → current 30-min behavior preserved