### PR TITLE
fix: make formation timeout configurable via MEMORIX_FORMATION_TIMEOUT_MS

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -37,7 +37,9 @@ On the release development machine used for this check, the healthy HTTP control
 | Knob | Default | Use When |
 | --- | --- | --- |
 | `MEMORIX_SESSION_TIMEOUT_MS` | `1800000` (30 min) | Increase for HTTP MCP clients that do not recover from stale session IDs after idle time |
+| `MEMORIX_FORMATION_TIMEOUT_MS` | `12000` (12 s) | Raise when LLM-backed formation should outlive slow proxy/provider hops |
 | `MEMORIX_LLM_API_KEY` / `OPENAI_API_KEY` | unset | Enable LLM-backed enrichment, extraction, rerank, or skill generation |
+| `MEMORIX_LLM_TIMEOUT_MS` | `30000` (30 s) | Bound a single LLM-backed extraction/resolve call |
 | `MEMORIX_RERANK_TIMEOUT_MS` | provider default | Bound slow LLM rerank calls |
 | `memorix retention status` | report only | Inspect whether memory growth needs cleanup |
 | `memorix retention archive` | explicit | Archive expired memories when the project gets noisy |
@@ -47,6 +49,7 @@ On the release development machine used for this check, the healthy HTTP control
 
 - For memory-only use, prefer stdio MCP or a lightweight `memorix_session_start`; do not join the Agent Team by default.
 - For long-lived IDE sessions over HTTP, set `MEMORIX_SESSION_TIMEOUT_MS=86400000` before `memorix background start` if your client is stale-session-sensitive.
+- If LLM-backed formation is timing out against a slow proxy/provider, raise `MEMORIX_FORMATION_TIMEOUT_MS` and keep it higher than `MEMORIX_LLM_TIMEOUT_MS`, because the full pipeline can include multiple LLM-backed stages.
 - For Docker, use it when you want a managed HTTP control plane. Do not use image size alone as the runtime memory estimate.
 - For autonomous multi-agent work, expect CPU and disk activity proportional to the spawned agents and verification commands.
 - For release checks, measure build/test/pack separately from idle service cost.

--- a/src/memory/formation/index.ts
+++ b/src/memory/formation/index.ts
@@ -18,6 +18,7 @@ import type {
   FormationConfig,
   FormationMetrics,
   BeforeAfterMetrics,
+  FormationStage,
 } from './types.js';
 import { runExtract } from './extract.js';
 import { runResolve } from './resolve.js';
@@ -270,21 +271,46 @@ export async function runFormation(
 ): Promise<FormedMemory> {
   const startTime = Date.now();
   let stagesCompleted = 0;
+  const stageDurationsMs: Partial<Record<FormationStage, number>> = {};
+  const emitStageEvent = (
+    stage: FormationStage,
+    status: 'start' | 'success' | 'skipped',
+    stageDurationMs?: number,
+  ): void => {
+    try {
+      config.onStageEvent?.({
+        stage,
+        status,
+        stageDurationMs,
+        totalElapsedMs: Date.now() - startTime,
+      });
+    } catch {
+      // Diagnostics hooks must never break the formation pipeline.
+    }
+  };
 
   // ── Stage 1: Extract ──
   const existingEntities = config.getEntityNames();
+  const extractStartTime = Date.now();
+  emitStageEvent('extract', 'start');
   const extraction = await runExtract(input, existingEntities, config.useLLM);
+  stageDurationsMs.extract = Date.now() - extractStartTime;
+  emitStageEvent('extract', 'success', stageDurationsMs.extract);
   stagesCompleted = 1;
 
   // ── Stage 2: Resolve ──
   // Skip resolve for topicKey upserts (they have their own resolution via topicKey)
   let resolution;
   if (input.topicKey) {
+    stageDurationsMs.resolve = 0;
+    emitStageEvent('resolve', 'skipped', 0);
     resolution = {
       action: 'new' as const,
       reason: 'TopicKey upsert — bypasses resolve stage',
     };
   } else {
+    const resolveStartTime = Date.now();
+    emitStageEvent('resolve', 'start');
     resolution = await runResolve(
       extraction,
       input.projectId,
@@ -292,11 +318,17 @@ export async function runFormation(
       config.getObservation,
       config.useLLM,
     );
+    stageDurationsMs.resolve = Date.now() - resolveStartTime;
+    emitStageEvent('resolve', 'success', stageDurationsMs.resolve);
   }
   stagesCompleted = 2;
 
   // ── Stage 3: Evaluate ──
+  const evaluateStartTime = Date.now();
+  emitStageEvent('evaluate', 'start');
   const evaluation = runEvaluate(extraction);
+  stageDurationsMs.evaluate = Date.now() - evaluateStartTime;
+  emitStageEvent('evaluate', 'success', stageDurationsMs.evaluate);
   stagesCompleted = 3;
 
   const durationMs = Date.now() - startTime;
@@ -320,6 +352,7 @@ export async function runFormation(
       durationMs,
       stagesCompleted,
       shadow: config.mode === 'shadow',
+      stageDurationsMs,
     },
 
     // Governance fields

--- a/src/memory/formation/types.ts
+++ b/src/memory/formation/types.ts
@@ -101,6 +101,21 @@ export interface EvaluateResult {
   reason: string;
 }
 
+/** Named Formation pipeline stage. */
+export type FormationStage = 'extract' | 'resolve' | 'evaluate';
+
+/** Per-stage diagnostics emitted during pipeline execution. */
+export interface FormationStageEvent {
+  /** Stage that emitted the event */
+  stage: FormationStage;
+  /** Lifecycle status for the stage */
+  status: 'start' | 'success' | 'skipped';
+  /** Duration of the stage when available */
+  stageDurationMs?: number;
+  /** Total elapsed time for the pipeline at emission time */
+  totalElapsedMs: number;
+}
+
 // ============================================================
 // Pipeline Output: FormedMemory
 // ============================================================
@@ -129,6 +144,8 @@ export interface FormedMemory {
     stagesCompleted: number;
     /** Whether this was run in shadow mode (no side effects) */
     shadow: boolean;
+    /** Per-stage durations in ms for diagnostics */
+    stageDurationsMs: Partial<Record<FormationStage, number>>;
   };
 
   // ── Governance fields (enterprise-grade metadata) ──
@@ -194,6 +211,8 @@ export interface FormationConfig {
   getObservation: (id: number) => ExistingMemoryRef | null;
   /** Function to list existing entity names (injected dependency) */
   getEntityNames: () => string[];
+  /** Optional stage callback for diagnostics/logging */
+  onStageEvent?: (event: FormationStageEvent) => void;
 }
 
 /** A search hit from existing memories (used by Resolve stage) */

--- a/src/server.ts
+++ b/src/server.ts
@@ -47,10 +47,12 @@ import { initLLM, isLLMEnabled, getLLMConfig } from './llm/provider.js';
 import { compactOnWrite, deduplicateMemory } from './llm/memory-manager.js';
 import type { ExistingMemory } from './llm/memory-manager.js';
 import { runFormation, getMetricsSummary, getBeforeAfterMetrics } from './memory/formation/index.js';
-import type { FormationConfig, SearchHit, FormedMemory } from './memory/formation/types.js';
+import type { FormationConfig, SearchHit, FormedMemory, FormationStage, FormationStageEvent } from './memory/formation/types.js';
+import { parseFormationTimeoutMs } from './server/formation-timeout.js';
 
 // ── Timeout budgets for LLM-heavy paths ──────────────────────────
-const FORMATION_TIMEOUT_MS = 12_000;   // Formation pipeline (extract+resolve+evaluate)
+const FORMATION_TIMEOUT_MS = parseFormationTimeoutMs(process.env.MEMORIX_FORMATION_TIMEOUT_MS); // Formation pipeline (extract+resolve+evaluate)
+const COMPACT_ON_WRITE_TIMEOUT_MS = 12_000; // Legacy compact-on-write fallback path
 const COMPRESSION_TIMEOUT_MS = 5_000;  // Narrative compression
 const DEDUP_PER_PAIR_TIMEOUT_MS = 5_000; // Per-pair dedup LLM call
 
@@ -63,6 +65,14 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
       timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
     }),
   ]).finally(() => clearTimeout(timer!));
+}
+
+function formatFormationStageDurations(stageDurationsMs: Partial<Record<FormationStage, number>>): string {
+  const orderedStages: FormationStage[] = ['extract', 'resolve', 'evaluate'];
+  const parts = orderedStages
+    .filter(stage => stageDurationsMs[stage] !== undefined)
+    .map(stage => `${stage}=${stageDurationsMs[stage]}ms`);
+  return parts.join(', ');
 }
 
 /** Timestamp of last MCP-initiated write — hot-reload skips changes within 10s */
@@ -482,6 +492,19 @@ export async function createMemorixServer(
       let formationResult: FormedMemory | null = null;
       let formationNote = '';
       if (useFormation && !topicKey && !progress) {
+        let currentFormationStage: FormationStage | 'setup' = 'setup';
+        const completedFormationStages: Partial<Record<FormationStage, number>> = {};
+        const formationStartTime = Date.now();
+        const onFormationStageEvent = (event: FormationStageEvent): void => {
+          if (event.status === 'start') {
+            currentFormationStage = event.stage;
+            return;
+          }
+          currentFormationStage = event.stage;
+          if (event.stageDurationMs !== undefined) {
+            completedFormationStages[event.stage] = event.stageDurationMs;
+          }
+        };
         try {
           const formationConfig: FormationConfig = {
             mode: 'active',
@@ -516,6 +539,7 @@ export async function createMemorixServer(
               };
             },
             getEntityNames: () => graphManager.getEntityNames(),
+            onStageEvent: onFormationStageEvent,
           };
 
           formationResult = await withTimeout(
@@ -543,6 +567,14 @@ export async function createMemorixServer(
         } catch (formationErr) {
           // Formation timeout or failure → fall through to store without enrichment
           const isTimeout = formationErr instanceof Error && formationErr.message.includes('timed out');
+          const elapsedMs = Date.now() - formationStartTime;
+          const stageSummary = formatFormationStageDurations(completedFormationStages);
+          console.error(
+            `[memorix] Formation ${isTimeout ? 'timed out' : 'failed'} in memorix_store after ${elapsedMs}ms/${FORMATION_TIMEOUT_MS}ms at stage ${currentFormationStage}${stageSummary ? ` | completed: ${stageSummary}` : ''}`,
+          );
+          if (!isTimeout && formationErr instanceof Error) {
+            console.error(`[memorix] Formation error: ${formationErr.message}`);
+          }
           formationNote = `\n[WARN] Formation ${isTimeout ? 'timed out' : 'failed'} — storing base observation without enrichment`;
         }
       }
@@ -646,7 +678,7 @@ export async function createMemorixServer(
                 { title, narrative, facts: safeFacts ?? [] },
                 existingMemories,
               ),
-              FORMATION_TIMEOUT_MS,
+              COMPACT_ON_WRITE_TIMEOUT_MS,
               'Compact-on-write',
             );
 

--- a/src/server/formation-timeout.ts
+++ b/src/server/formation-timeout.ts
@@ -1,0 +1,27 @@
+export const DEFAULT_FORMATION_TIMEOUT_MS = 12_000;
+export const FORMATION_TIMEOUT_MIN_MS = 1_000;
+export const FORMATION_TIMEOUT_MAX_MS = 300_000;
+
+/**
+ * Parse and validate MEMORIX_FORMATION_TIMEOUT_MS.
+ * - Must be a valid integer in the range 1000-300000ms.
+ * - Invalid values fall back to the default and log a warning.
+ * - Out-of-range values are clamped to the nearest bound.
+ * Default: 12000ms (12s).
+ */
+export function parseFormationTimeoutMs(raw: string | undefined): number {
+  const value = raw?.trim();
+  if (!value) return DEFAULT_FORMATION_TIMEOUT_MS;
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || Number.isNaN(parsed)) {
+    console.warn(
+      `[memorix] MEMORIX_FORMATION_TIMEOUT_MS="${raw}" is invalid (must be a positive integer between ${FORMATION_TIMEOUT_MIN_MS}-${FORMATION_TIMEOUT_MAX_MS}ms). Using default ${DEFAULT_FORMATION_TIMEOUT_MS}ms.`,
+    );
+    return DEFAULT_FORMATION_TIMEOUT_MS;
+  }
+
+  if (parsed < FORMATION_TIMEOUT_MIN_MS) return FORMATION_TIMEOUT_MIN_MS;
+  if (parsed > FORMATION_TIMEOUT_MAX_MS) return FORMATION_TIMEOUT_MAX_MS;
+  return parsed;
+}

--- a/tests/memory/formation/pipeline.test.ts
+++ b/tests/memory/formation/pipeline.test.ts
@@ -74,6 +74,59 @@ describe('Formation Pipeline', () => {
     expect(result.resolution.reason).toContain('TopicKey');
   });
 
+  it('should emit stage events and record per-stage durations', async () => {
+    const events: string[] = [];
+    const result = await runFormation(
+      makeInput(),
+      makeConfig({
+        onStageEvent: (event) => {
+          events.push(`${event.stage}:${event.status}`);
+        },
+      }),
+    );
+
+    expect(events).toEqual([
+      'extract:start',
+      'extract:success',
+      'resolve:start',
+      'resolve:success',
+      'evaluate:start',
+      'evaluate:success',
+    ]);
+    expect(result.pipeline.stageDurationsMs.extract).toBeGreaterThanOrEqual(0);
+    expect(result.pipeline.stageDurationsMs.resolve).toBeGreaterThanOrEqual(0);
+    expect(result.pipeline.stageDurationsMs.evaluate).toBeGreaterThanOrEqual(0);
+  });
+
+  it('should emit a skipped resolve event for topicKey inputs', async () => {
+    const events: string[] = [];
+    const result = await runFormation(
+      makeInput({ topicKey: 'architecture/database' }),
+      makeConfig({
+        onStageEvent: (event) => {
+          events.push(`${event.stage}:${event.status}`);
+        },
+      }),
+    );
+
+    expect(events).toContain('resolve:skipped');
+    expect(result.pipeline.stageDurationsMs.resolve).toBe(0);
+  });
+
+  it('should ignore errors thrown by stage observers', async () => {
+    const result = await runFormation(
+      makeInput(),
+      makeConfig({
+        onStageEvent: () => {
+          throw new Error('observer failed');
+        },
+      }),
+    );
+
+    expect(result.pipeline.stagesCompleted).toBe(3);
+    expect(result.pipeline.stageDurationsMs.extract).toBeGreaterThanOrEqual(0);
+  });
+
   it('should return "discard" resolution for near-duplicates', async () => {
     const result = await runFormation(
       makeInput({ narrative: 'Short note.' }),

--- a/tests/server/formation-timeout.test.ts
+++ b/tests/server/formation-timeout.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_FORMATION_TIMEOUT_MS,
+  FORMATION_TIMEOUT_MAX_MS,
+  FORMATION_TIMEOUT_MIN_MS,
+  parseFormationTimeoutMs,
+} from '../../src/server/formation-timeout.js';
+
+describe('parseFormationTimeoutMs', () => {
+  it('returns default when env var is undefined', () => {
+    expect(parseFormationTimeoutMs(undefined)).toBe(DEFAULT_FORMATION_TIMEOUT_MS);
+  });
+
+  it('returns default when env var is empty', () => {
+    expect(parseFormationTimeoutMs('')).toBe(DEFAULT_FORMATION_TIMEOUT_MS);
+    expect(parseFormationTimeoutMs('   ')).toBe(DEFAULT_FORMATION_TIMEOUT_MS);
+  });
+
+  it('parses a valid positive integer', () => {
+    expect(parseFormationTimeoutMs('45000')).toBe(45_000);
+  });
+
+  it('falls back to default and warns on invalid values', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(parseFormationTimeoutMs('not-a-number')).toBe(DEFAULT_FORMATION_TIMEOUT_MS);
+    expect(parseFormationTimeoutMs('1500.5')).toBe(DEFAULT_FORMATION_TIMEOUT_MS);
+
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('clamps too-small values to the minimum', () => {
+    expect(parseFormationTimeoutMs('0')).toBe(FORMATION_TIMEOUT_MIN_MS);
+    expect(parseFormationTimeoutMs('-10')).toBe(FORMATION_TIMEOUT_MIN_MS);
+    expect(parseFormationTimeoutMs('999')).toBe(FORMATION_TIMEOUT_MIN_MS);
+  });
+
+  it('clamps too-large values to the maximum', () => {
+    expect(parseFormationTimeoutMs('999999')).toBe(FORMATION_TIMEOUT_MAX_MS);
+  });
+});


### PR DESCRIPTION
## Summary

This makes the Formation pipeline timeout configurable via `MEMORIX_FORMATION_TIMEOUT_MS` while keeping the existing default `12_000ms` behavior when the env is unset.

It also adds lightweight stage diagnostics so timeout/failure logs can report which Formation stage was active and which stages already completed.

Closes #84.

## What changed

- add `src/server/formation-timeout.ts` with `parseFormationTimeoutMs`
- use `MEMORIX_FORMATION_TIMEOUT_MS` for Formation paths only
- keep legacy `compact-on-write` fallback on its own fixed `12_000ms` budget
- add best-effort stage events and `stageDurationsMs` to `runFormation`
- make observer callbacks non-fatal
- add unit coverage for parser bounds, stage events, skipped resolve, and throwing observers
- document the new operator knob in `docs/PERFORMANCE.md`

## Checks

- `npm test -- tests/server/formation-timeout.test.ts tests/memory/formation/pipeline.test.ts`
- `npm run lint`
- `npm run build`
