### PR TITLE
[codex] Start Memorix 1.0.9 knowledge layer mainline

### DIFF
--- a/src/cli/commands/init-shared.ts
+++ b/src/cli/commands/init-shared.ts
@@ -38,3 +38,17 @@ export function getInitScopeDescription(scope: InitScope): string {
 export function shouldOfferDotenv(scope: InitScope): boolean {
   return scope === 'global' || scope === 'project';
 }
+
+export interface EnvTemplateTargetOptions {
+  hasDotenvExample: boolean;
+}
+
+export function getEnvTemplateTarget(
+  targetDir: string,
+  options: EnvTemplateTargetOptions,
+): string {
+  const filename = options.hasDotenvExample
+    ? '.env.memorix-example'
+    : '.env.example';
+  return path.join(targetDir, filename);
+}

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -11,6 +11,7 @@ import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import path from 'node:path';
 import {
+  getEnvTemplateTarget,
   getInitScopeDescription,
   getInitTargetDir,
   resolveInitScope,
@@ -74,7 +75,6 @@ export default defineCommand({
     const isGlobal = scope === 'global';
     const targetDir = getInitTargetDir(scope, process.cwd(), homedir());
     const targetPath = path.join(targetDir, 'memorix.yml');
-    const envExamplePath = path.join(targetDir, '.env.example');
     const envPath = path.join(targetDir, '.env');
 
     p.log.info(getInitScopeDescription(scope));
@@ -237,13 +237,26 @@ export default defineCommand({
     p.log.success(`Created ${targetPath}`);
 
     if (shouldOfferDotenv(scope)) {
+      const envExamplePath = getEnvTemplateTarget(targetDir, {
+        hasDotenvExample: existsSync(path.join(targetDir, '.env.example')),
+      });
       const envContent = envLines.join('\n');
+      if (existsSync(envExamplePath)) {
+        const overwriteEnvTemplate = await p.confirm({
+          message: `${envExamplePath} already exists. Overwrite it?`,
+          initialValue: false,
+        });
+        if (p.isCancel(overwriteEnvTemplate) || !overwriteEnvTemplate) {
+          p.outro('Cancelled.');
+          return;
+        }
+      }
       writeFileSync(envExamplePath, envContent, 'utf-8');
       p.log.success(`Created ${envExamplePath}`);
 
       const createEnv = !existsSync(envPath)
         ? await p.confirm({
-          message: 'Create .env from .env.example now? (you can fill in keys later)',
+          message: `Create .env from ${path.basename(envExamplePath)} now? (you can fill in keys later)`,
           initialValue: true,
         })
         : false;

--- a/src/cli/commands/operator-shared.ts
+++ b/src/cli/commands/operator-shared.ts
@@ -84,6 +84,7 @@ const OBSERVATION_TYPES: ObservationType[] = [
   'decision',
   'trade-off',
   'reasoning',
+  'probe',
 ];
 
 const OBSERVATION_STATUSES: ObservationStatus[] = ['active', 'resolved', 'archived'];

--- a/src/cli/commands/serve-http.ts
+++ b/src/cli/commands/serve-http.ts
@@ -750,6 +750,7 @@ export default defineCommand({
           const typeCounts: Record<string, number> = {};
           for (const obs of observations) {
             const t = obs.type || 'unknown';
+            if (t === 'probe') continue; // Exclude operational heartbeats from dashboard type distribution
             typeCounts[t] = (typeCounts[t] || 0) + 1;
           }
 
@@ -796,7 +797,7 @@ export default defineCommand({
             else retentionSummary.archive++;
           }
 
-          const sorted = [...observations].sort((a, b) => (b.id || 0) - (a.id || 0)).slice(0, 10);
+          const sorted = [...observations].filter(o => o.type !== 'probe').sort((a, b) => (b.id || 0) - (a.id || 0)).slice(0, 10);
 
           let embeddingStatus = { enabled: false, provider: '', dimensions: 0 };
           try {

--- a/src/cli/commands/serve-http.ts
+++ b/src/cli/commands/serve-http.ts
@@ -578,13 +578,20 @@ export default defineCommand({
         const ext = pathModule.default.extname(filePath);
         res.writeHead(200, {
           'Content-Type': MIME_TYPES[ext] || 'application/octet-stream',
-          'Cache-Control': 'no-cache',
+          'Cache-Control': 'no-store, no-cache, must-revalidate, max-age=0',
+          'Pragma': 'no-cache',
+          'Expires': '0',
         });
         res.end(data);
       } catch {
         try {
           const idx = await fsPromises.readFile(pathModule.default.join(dashStaticDir, 'index.html'));
-          res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+          res.writeHead(200, {
+            'Content-Type': 'text/html; charset=utf-8',
+            'Cache-Control': 'no-store, no-cache, must-revalidate, max-age=0',
+            'Pragma': 'no-cache',
+            'Expires': '0',
+          });
           res.end(idx);
         } catch {
           res.writeHead(404); res.end('Not found');
@@ -949,6 +956,44 @@ export default defineCommand({
           });
 
           sendJson(overview);
+          return;
+        }
+
+        if (apiPath === '/knowledge-graph') {
+          const { projectId: kgProjectId, dataDir: kgDataDir } = await resolveRequestProject(url);
+          const { generateKnowledgeGraph } = await import('../../wiki/knowledge-graph.js');
+          const { initObservations, getAllObservations } = await import('../../memory/observations.js');
+          const { initMiniSkillStore, getMiniSkillStore } = await import('../../store/mini-skill-store.js');
+          const { initGraphStore, getGraphStore } = await import('../../store/graph-store.js');
+
+          await initObservations(kgDataDir);
+          await initMiniSkillStore(kgDataDir);
+          await initGraphStore(kgDataDir);
+
+          const allObs = getAllObservations();
+          const skills = await getMiniSkillStore().loadByProject(kgProjectId);
+
+          // Project-scope graph store (same logic as /api/graph)
+          const fullGraph = { entities: getGraphStore().loadEntities(), relations: getGraphStore().loadRelations() };
+          const graphObs = await loadDashboardObservations(kgDataDir) as Array<{ projectId?: string; entityName?: string; status?: string }>;
+          const projectEntityNames = new Set(
+            graphObs
+              .filter(o => o.projectId === kgProjectId && (o.status ?? 'active') === 'active' && o.entityName)
+              .map(o => o.entityName!)
+          );
+          const scopedEntities = fullGraph.entities.filter(e => projectEntityNames.has(e.name));
+          const scopedEntityNameSet = new Set(scopedEntities.map(e => e.name));
+          const scopedRelations = fullGraph.relations.filter(r => scopedEntityNameSet.has(r.from) && scopedEntityNameSet.has(r.to));
+
+          const graph = generateKnowledgeGraph({
+            projectId: kgProjectId,
+            observations: allObs,
+            miniSkills: skills,
+            graphEntities: scopedEntities,
+            graphRelations: scopedRelations,
+          });
+
+          sendJson(graph);
           return;
         }
 

--- a/src/cli/commands/serve-http.ts
+++ b/src/cli/commands/serve-http.ts
@@ -930,6 +930,28 @@ export default defineCommand({
           return;
         }
 
+        if (apiPath === '/knowledge') {
+          const { projectId: kbProjectId, dataDir: kbDataDir } = await resolveRequestProject(url);
+          const { generateKnowledgeBase } = await import('../../wiki/generator.js');
+          const { initObservations, getAllObservations } = await import('../../memory/observations.js');
+          const { initMiniSkillStore, getMiniSkillStore } = await import('../../store/mini-skill-store.js');
+
+          await initObservations(kbDataDir);
+          await initMiniSkillStore(kbDataDir);
+
+          const allObs = getAllObservations();
+          const skills = await getMiniSkillStore().loadByProject(kbProjectId);
+
+          const overview = generateKnowledgeBase({
+            projectId: kbProjectId,
+            observations: allObs,
+            miniSkills: skills,
+          });
+
+          sendJson(overview);
+          return;
+        }
+
         if (apiPath === '/config') {
           const { projectId: configProjectId } = await resolveRequestProject(url);
           const os = await import('node:os');

--- a/src/cli/tui/App.tsx
+++ b/src/cli/tui/App.tsx
@@ -22,6 +22,7 @@ import {
   CleanupView,
   IngestView,
   IntegrateView,
+  WikiView,
   StatusMessage,
 } from './Panels.js';
 import { ConfigureView } from './ConfigureView.js';
@@ -42,6 +43,7 @@ import {
   searchMemories,
   storeQuickMemory,
   getDoctorSummary,
+  getKnowledgeBase,
   detectMode,
 } from './data.js';
 import { ChatView } from './ChatView.js';
@@ -95,6 +97,7 @@ export function WorkbenchApp({ version, onExitForInteractive }: AppProps): React
   const [searchResults, setSearchResults] = useState<SearchResult[]>([]);
   const [searchQuery, setSearchQuery] = useState('');
   const [doctor, setDoctor] = useState<DoctorResult | null>(null);
+  const [knowledge, setKnowledge] = useState<import('../../wiki/types.js').ProjectKnowledgeOverview | null>(null);
   const [statusMsg, setStatusMsg] = useState<{ text: string; type: 'success' | 'error' | 'info' } | null>(null);
   const [mode, setMode] = useState('CLI');
   const [actionStatus, setActionStatus] = useState('');
@@ -635,6 +638,17 @@ export function WorkbenchApp({ version, onExitForInteractive }: AppProps): React
           break;
         }
 
+        case 'wiki':
+        case 'knowledge': {
+          setView('wiki');
+          setLoading(true);
+          const kb = await getKnowledgeBase(project?.id);
+          setKnowledge(kb);
+          setLoading(false);
+          setStatusMsg({ text: kb ? `Knowledge Base: ${kb.stats.observationsUsed} obs, ${kb.stats.miniSkillsUsed} skills` : 'No knowledge available', type: 'info' });
+          break;
+        }
+
         case 'help':
         case '?': {
           setView('commands');
@@ -1052,6 +1066,8 @@ fi
         return <IntegrateView statusText={actionStatus} />;
       case 'configure':
         return <ConfigureView onBack={() => handleCommand('/home')} />;
+      case 'wiki':
+        return <WikiView knowledge={knowledge} loading={loading} />;
       case 'commands':
         return (
           <Box flexDirection="column" paddingX={2} paddingY={1}>

--- a/src/cli/tui/Panels.tsx
+++ b/src/cli/tui/Panels.tsx
@@ -17,6 +17,7 @@ import type {
   BackgroundInfo,
   HealthInfo,
 } from './data.js';
+import type { ProjectKnowledgeOverview } from '../../wiki/types.js';
 
 function separator(width = 50): string {
   return SEP.thin.repeat(width);
@@ -539,6 +540,73 @@ export function IntegrateView({ statusText }: IntegrateViewProps): React.ReactEl
       {statusText && (
         <Box marginTop={1}><Text color={COLORS.muted}>{statusText}</Text></Box>
       )}
+    </Box>
+  );
+}
+
+interface WikiViewProps {
+  knowledge: ProjectKnowledgeOverview | null;
+  loading: boolean;
+}
+
+export function WikiView({ knowledge, loading }: WikiViewProps): React.ReactElement {
+  if (loading) {
+    return (
+      <Box flexDirection="column" paddingX={1}>
+        <Text color={COLORS.brand} bold>Knowledge Base</Text>
+        <Text color={COLORS.muted}>  LLM Wiki</Text>
+        <Text color={COLORS.border}>{separator()}</Text>
+        <Text color={COLORS.muted}>Loading...</Text>
+      </Box>
+    );
+  }
+
+  if (!knowledge) {
+    return (
+      <Box flexDirection="column" paddingX={1}>
+        <Text color={COLORS.brand} bold>Knowledge Base</Text>
+        <Text color={COLORS.muted}>  LLM Wiki</Text>
+        <Text color={COLORS.border}>{separator()}</Text>
+        <Text color={COLORS.warning}>No knowledge available for this project.</Text>
+        <Text color={COLORS.textDim}>Store memories with /remember or /chat to build your Knowledge Base.</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" paddingX={1}>
+      <Text color={COLORS.brand} bold>Knowledge Base</Text>
+      <Text color={COLORS.muted}>  LLM Wiki</Text>
+      <Box>
+        <Text color={COLORS.textDim}>  Project: {knowledge.projectId}</Text>
+        <Text color={COLORS.muted}> │ {knowledge.stats.observationsUsed} obs, {knowledge.stats.miniSkillsUsed} skills</Text>
+      </Box>
+      <Text color={COLORS.border}>{separator()}</Text>
+
+      {knowledge.sections.map((section) => (
+        <Box key={section.id} flexDirection="column" marginBottom={1}>
+          <Text color={COLORS.brandDim} bold>{section.title}</Text>
+          {section.empty ? (
+            <Text color={COLORS.textDim}>  (empty)</Text>
+          ) : (
+            section.items.map((item, idx) => (
+              <Box key={idx} flexDirection="column">
+                <Box>
+                  <Text color={COLORS.muted}>{SYMBOLS.bullet} </Text>
+                  <Text color={COLORS.text}>{truncate(item.title)}</Text>
+                  {item.entityName && <Text color={COLORS.textDim}> [{item.entityName}]</Text>}
+                </Box>
+                <Text color={COLORS.textDim}>  {truncate(item.summary, 80)}</Text>
+                <Text color={COLORS.muted}>  refs: {item.refs.map((r) => r.id).join(', ')}</Text>
+              </Box>
+            ))
+          )}
+        </Box>
+      ))}
+
+      <Box marginTop={1}>
+        <Text color={COLORS.muted}>{SYMBOLS.arrow} Esc to return home</Text>
+      </Box>
     </Box>
   );
 }

--- a/src/cli/tui/chat-service.ts
+++ b/src/cli/tui/chat-service.ts
@@ -74,7 +74,7 @@ const MEMORY_TOOLS: ToolDefinition[] = [
       type: 'object',
       properties: {
         entityName: { type: 'string', description: 'The entity this observation belongs to (e.g. "auth-module", "database-schema")' },
-        type: { type: 'string', description: 'Observation type: gotcha, decision, problem-solution, how-it-works, what-changed, discovery, why-it-exists, trade-off, reasoning', enum: ['gotcha', 'decision', 'problem-solution', 'how-it-works', 'what-changed', 'discovery', 'why-it-exists', 'trade-off', 'reasoning'] },
+        type: { type: 'string', description: 'Observation type: gotcha, decision, problem-solution, how-it-works, what-changed, discovery, why-it-exists, trade-off, reasoning, probe', enum: ['gotcha', 'decision', 'problem-solution', 'how-it-works', 'what-changed', 'discovery', 'why-it-exists', 'trade-off', 'reasoning', 'probe'] },
         title: { type: 'string', description: 'Short descriptive title (5-10 words)' },
         narrative: { type: 'string', description: 'Full description of the observation' },
         facts: { type: 'array', items: { type: 'string' }, description: 'Key facts as structured strings (e.g. "Default timeout: 60s")' },

--- a/src/cli/tui/data.ts
+++ b/src/cli/tui/data.ts
@@ -465,3 +465,34 @@ export function detectMode(): { mode: string; detail: string } {
   }
   return { mode: 'CLI', detail: 'Quick mode' };
 }
+
+export async function getKnowledgeBase(projectId?: string): Promise<import('../../wiki/types.js').ProjectKnowledgeOverview | null> {
+  try {
+    const { detectProject } = await import('../../project/detector.js');
+    const { getProjectDataDir } = await import('../../store/persistence.js');
+    const { initObservationStore } = await import('../../store/obs-store.js');
+    const { initObservations, getAllObservations } = await import('../../memory/observations.js');
+    const { initMiniSkillStore, getMiniSkillStore } = await import('../../store/mini-skill-store.js');
+    const { generateKnowledgeBase } = await import('../../wiki/generator.js');
+
+    const proj = detectProject(process.cwd());
+    if (!proj) return null;
+
+    const effectiveProjectId = projectId || proj.id;
+    const dataDir = await getProjectDataDir(effectiveProjectId);
+    await initObservationStore(dataDir);
+    await initObservations(dataDir);
+    await initMiniSkillStore(dataDir);
+
+    const observations = getAllObservations();
+    const skills = await getMiniSkillStore().loadByProject(effectiveProjectId);
+
+    return generateKnowledgeBase({
+      projectId: effectiveProjectId,
+      observations,
+      miniSkills: skills,
+    });
+  } catch {
+    return null;
+  }
+}

--- a/src/cli/tui/theme.ts
+++ b/src/cli/tui/theme.ts
@@ -26,11 +26,12 @@ export const SLASH_COMMANDS: SlashCommand[] = [
   { name: '/background', description: 'Control plane service',  alias: '/bg' },
   { name: '/dashboard',  description: 'Open web dashboard',     alias: '/dash' },
   { name: '/home',       description: 'Back to home',           alias: '/h' },
+  { name: '/help',       description: 'Show commands',          alias: '/?' },
   { name: '/configure',  description: 'Settings',               alias: '/config' },
   { name: '/integrate',  description: 'Set up an IDE',          alias: '/setup' },
   { name: '/cleanup',    description: 'Cleanup and purge' },
   { name: '/ingest',     description: 'Git to Memory' },
-  { name: '/help',       description: 'Show commands',          alias: '/?' },
+  { name: '/wiki',       description: 'Knowledge Base',         alias: '/knowledge' },
   { name: '/exit',       description: 'Exit workbench',         alias: '/q' },
 ];
 
@@ -151,7 +152,8 @@ export type ViewType =
   | 'cleanup'
   | 'ingest'
   | 'integrate'
-  | 'configure';
+  | 'configure'
+  | 'wiki';
 
 /** Compute responsive sidebar and content widths from terminal width.
  *  Shared between App.tsx and ChatView.tsx to avoid DRY drift. */

--- a/src/cli/tui/useNavigation.ts
+++ b/src/cli/tui/useNavigation.ts
@@ -31,7 +31,7 @@ export const ACTION_VIEWS: Set<ViewType> = new Set([
 /** Views where Esc returns to home */
 export const ESC_RETURNABLE_VIEWS: Set<ViewType> = new Set([
   'chat', 'recent', 'doctor', 'project', 'cleanup', 'ingest',
-  'background', 'dashboard', 'integrate', 'configure', 'search',
+  'background', 'dashboard', 'integrate', 'configure', 'search', 'wiki',
 ]);
 
 /**

--- a/src/compact/index-format.ts
+++ b/src/compact/index-format.ts
@@ -285,6 +285,7 @@ function getTypeIcon(type: string): string {
     'decision': '[DECISION]',
     'trade-off': '[TRADEOFF]',
     'reasoning': '[REASONING]',
+    'probe': '[PROBE]',
   };
   return icons[type] ?? '[UNKNOWN]';
 }

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -222,10 +222,11 @@ async function handleApi(
                 // Project-scoped graph counts (must match /api/graph and /api/export)
                 const projectGraphCounts = computeProjectGraphCounts(graph.entities, graph.relations, observations as Array<{ entityName?: string; status?: string }>);
 
-                // Type counts
+                // Type counts (exclude probe -- operational heartbeats, not durable knowledge)
                 const typeCounts: Record<string, number> = {};
                 for (const obs of observations) {
                     const t = obs.type || 'unknown';
+                    if (t === 'probe') continue;
                     typeCounts[t] = (typeCounts[t] || 0) + 1;
                 }
 
@@ -272,8 +273,8 @@ async function handleApi(
                     else retentionSummary.archive++;
                 }
 
-                // Recent observations (last 10)
-                const sorted = [...observations]
+                // Recent observations (last 10, exclude probe)
+                const sorted = [...observations].filter(o => o.type !== 'probe')
                     .sort((a, b) => (b.id || 0) - (a.id || 0))
                     .slice(0, 10);
 
@@ -332,7 +333,8 @@ async function handleApi(
                 const observations = filterActiveByProject(allObs, effectiveProjectId);
 
                 const now = Date.now();
-                const scored = observations.map((obs) => {
+                // Exclude probe from retention display -- not durable knowledge
+                const scored = observations.filter(obs => obs.type !== 'probe').map((obs) => {
                     const age = now - new Date(obs.createdAt || now).getTime();
                     const ageHours = age / (1000 * 60 * 60);
                     const importance = obs.importance ?? 5;

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -376,6 +376,27 @@ async function handleApi(
                 break;
             }
 
+            case '/knowledge': {
+                const { generateKnowledgeBase } = await import('../wiki/generator.js');
+                const { initObservations, getAllObservations } = await import('../memory/observations.js');
+                const { initMiniSkillStore, getMiniSkillStore } = await import('../store/mini-skill-store.js');
+
+                await initObservations(effectiveDataDir);
+                await initMiniSkillStore(effectiveDataDir);
+
+                const allObs = getAllObservations();
+                const skills = await getMiniSkillStore().loadByProject(effectiveProjectId);
+
+                const overview = generateKnowledgeBase({
+                    projectId: effectiveProjectId,
+                    observations: allObs,
+                    miniSkills: skills,
+                });
+
+                sendJson(res, overview);
+                break;
+            }
+
             case '/config': {
                 // Config provenance — shows where each config value comes from
                 const os = await import('node:os');

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -397,6 +397,43 @@ async function handleApi(
                 break;
             }
 
+            case '/knowledge-graph': {
+                const { generateKnowledgeGraph } = await import('../wiki/knowledge-graph.js');
+                const { initObservations, getAllObservations } = await import('../memory/observations.js');
+                const { initMiniSkillStore, getMiniSkillStore } = await import('../store/mini-skill-store.js');
+                const { initGraphStore, getGraphStore } = await import('../store/graph-store.js');
+
+                await initObservations(effectiveDataDir);
+                await initMiniSkillStore(effectiveDataDir);
+                await initGraphStore(effectiveDataDir);
+
+                const allObs = getAllObservations();
+                const skills = await getMiniSkillStore().loadByProject(effectiveProjectId);
+
+                // Project-scope graph store (same logic as /api/graph)
+                const fullGraph = { entities: getGraphStore().loadEntities(), relations: getGraphStore().loadRelations() };
+                const graphObs = await getObservationStore().loadAll() as Array<{ projectId?: string; entityName?: string; status?: string }>;
+                const projectEntityNames = new Set(
+                    graphObs
+                        .filter(o => o.projectId === effectiveProjectId && (o.status ?? 'active') === 'active' && o.entityName)
+                        .map(o => o.entityName!),
+                );
+                const scopedEntities = fullGraph.entities.filter((e: any) => projectEntityNames.has(e.name));
+                const scopedEntityNameSet = new Set(scopedEntities.map((e: any) => e.name));
+                const scopedRelations = fullGraph.relations.filter((r: any) => scopedEntityNameSet.has(r.from) && scopedEntityNameSet.has(r.to));
+
+                const graph = generateKnowledgeGraph({
+                    projectId: effectiveProjectId,
+                    observations: allObs,
+                    miniSkills: skills,
+                    graphEntities: scopedEntities,
+                    graphRelations: scopedRelations,
+                });
+
+                sendJson(res, graph);
+                break;
+            }
+
             case '/config': {
                 // Config provenance — shows where each config value comes from
                 const os = await import('node:os');
@@ -689,14 +726,21 @@ async function serveStatic(req: IncomingMessage, res: ServerResponse, staticDir:
         const ext = path.extname(filePath);
         res.writeHead(200, {
             'Content-Type': MIME_TYPES[ext] || 'application/octet-stream',
-            'Cache-Control': 'no-cache',
+            'Cache-Control': 'no-store, no-cache, must-revalidate, max-age=0',
+            'Pragma': 'no-cache',
+            'Expires': '0',
         });
         res.end(data);
     } catch {
         // Fallback to index.html for SPA routing
         try {
             const indexData = await fs.readFile(path.join(staticDir, 'index.html'));
-            res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+            res.writeHead(200, {
+                'Content-Type': 'text/html; charset=utf-8',
+                'Cache-Control': 'no-store, no-cache, must-revalidate, max-age=0',
+                'Pragma': 'no-cache',
+                'Expires': '0',
+            });
             res.end(indexData);
         } catch {
             sendError(res, 'Not found', 404);

--- a/src/dashboard/static/app.js
+++ b/src/dashboard/static/app.js
@@ -147,6 +147,28 @@ const i18n = {
     recentGitMemories: 'Recent Git Memories',
     commit: 'Commit',
     created: 'Created',
+    knowledgeTitle: 'Knowledge Base',
+    knowledgeSubtitle: 'Project-scoped engineering knowledge distilled from durable memory',
+    knowledgeObservationsUsed: 'Observations Used',
+    knowledgeMiniSkillsUsed: 'Mini-skills Used',
+    knowledgeRefs: 'Refs',
+    knowledgeGenerated: 'Generated',
+    knowledgeQuickJump: 'Sections',
+    knowledgeNoItems: 'No entries in this section yet',
+    knowledgeNoItemsDesc: 'This section will fill in as durable project knowledge is stored.',
+    knowledgeUnavailable: 'Knowledge Base Unavailable',
+    knowledgeUnavailableDesc: 'Could not load /api/knowledge for the selected project.',
+    knowledgeEmpty: 'No Knowledge Base Entries',
+    knowledgeEmptyDesc: 'Store durable observations or promote mini-skills to populate this read-only project wiki.',
+    knowledgeProvenance: 'Provenance',
+    knowledgeEntry: 'entry',
+    knowledgeEntries: 'entries',
+    knowledgeSectionProjectOverview: 'Project Overview',
+    knowledgeSectionCoreDecisions: 'Core Decisions',
+    knowledgeSectionOperationalKnowledge: 'Operational Knowledge',
+    knowledgeSectionKnownGotchas: 'Known Gotchas',
+    knowledgeSectionGitBackedFacts: 'Git-backed Facts',
+    knowledgeSectionPromotedSkills: 'Promoted Skills',
 
     // Config
     configTitle: 'Config Provenance',
@@ -333,6 +355,7 @@ const i18n = {
     // Nav tooltips + labels
     navDashboard: 'Dashboard',
     navGitMemory: 'Git Memory',
+    navKnowledge: 'Knowledge Base',
     navGraph: 'Knowledge Graph',
     navObservations: 'Observations',
     navRetention: 'Retention',
@@ -342,6 +365,7 @@ const i18n = {
     navTeam: 'Agent Team',
     navLabelDashboard: 'Overview',
     navLabelGitMemory: 'Git Memory',
+    navLabelKnowledge: 'Knowledge',
     navLabelGraph: 'Graph',
     navLabelObservations: 'Observations',
     navLabelRetention: 'Retention',
@@ -506,17 +530,39 @@ const i18n = {
 
     // Git Memory
     gitMemoryTitle: 'Git 记忆',
-    gitMemorySubtitle: '来自 git 提交的记忆 — 不可变的事实源',
+    gitMemorySubtitle: '来自 git 提交的记忆 — 真实来源且不可变',
     totalGitMemories: 'Git 记忆总数',
-    uniqueCommits: '唯一提交数',
+    uniqueCommits: '唯一提交',
     typeCoverage: '类型覆盖',
     noGitMemory: '暂无 Git 记忆',
     noGitMemoryDesc: '使用以下命令安装 post-commit hook: memorix git-hook-install',
     noGitMemoriesYet: '暂无 Git 记忆',
     noGitMemoriesHint: '安装 post-commit hook 以自动捕获 git 记忆：',
-    recentGitMemories: '最近的 Git 记忆',
+    recentGitMemories: '最近 Git 记忆',
     commit: '提交',
     created: '创建时间',
+    knowledgeTitle: '知识库',
+    knowledgeSubtitle: '从持久项目记忆中提炼出的工程知识',
+    knowledgeObservationsUsed: '使用的观察',
+    knowledgeMiniSkillsUsed: '使用的 Mini-skills',
+    knowledgeRefs: '引用',
+    knowledgeGenerated: '生成于',
+    knowledgeQuickJump: '章节',
+    knowledgeNoItems: '本章节暂无条目',
+    knowledgeNoItemsDesc: '当项目中出现持久知识后，本章节会自动填充。',
+    knowledgeUnavailable: '知识库不可用',
+    knowledgeUnavailableDesc: '无法为所选项目加载 /api/knowledge。',
+    knowledgeEmpty: '暂无知识库条目',
+    knowledgeEmptyDesc: '存储持久观察或提升 mini-skill 后，此只读项目 wiki 会自动填充。',
+    knowledgeProvenance: '来源',
+    knowledgeEntry: '条',
+    knowledgeEntries: '条',
+    knowledgeSectionProjectOverview: '项目概览',
+    knowledgeSectionCoreDecisions: '核心决策',
+    knowledgeSectionOperationalKnowledge: '操作知识',
+    knowledgeSectionKnownGotchas: '已知陷阱',
+    knowledgeSectionGitBackedFacts: 'Git 事实',
+    knowledgeSectionPromotedSkills: '提升技能',
 
     // Config
     configTitle: '配置溯源',
@@ -708,6 +754,7 @@ const i18n = {
     // Nav tooltips
     navDashboard: '仪表盘',
     navGitMemory: 'Git 记忆',
+    navKnowledge: '知识库',
     navGraph: '知识图谱',
     navObservations: '观察记录',
     navRetention: '记忆衰减',
@@ -717,6 +764,7 @@ const i18n = {
     navTeam: 'Agent 团队',
     navLabelDashboard: '概览',
     navLabelGitMemory: 'Git 记忆',
+    navLabelKnowledge: '知识库',
     navLabelGraph: '图谱',
     navLabelObservations: '观察',
     navLabelRetention: '衰减',
@@ -774,8 +822,8 @@ function setLang(lang) {
   if (label) label.textContent = lang === 'en' ? '中文' : 'EN';
 
   // Update nav tooltips + labels
-  const tooltipMap = { dashboard: 'navDashboard', 'git-memory': 'navGitMemory', graph: 'navGraph', observations: 'navObservations', retention: 'navRetention', config: 'navConfig', identity: 'navIdentity', sessions: 'navSessions', team: 'navTeam' };
-  const labelMap = { dashboard: 'navLabelDashboard', 'git-memory': 'navLabelGitMemory', graph: 'navLabelGraph', observations: 'navLabelObservations', retention: 'navLabelRetention', config: 'navLabelConfig', identity: 'navLabelIdentity', sessions: 'navLabelSessions', team: 'navLabelTeam' };
+  const tooltipMap = { dashboard: 'navDashboard', 'git-memory': 'navGitMemory', knowledge: 'navKnowledge', graph: 'navGraph', observations: 'navObservations', retention: 'navRetention', config: 'navConfig', identity: 'navIdentity', sessions: 'navSessions', team: 'navTeam' };
+  const labelMap = { dashboard: 'navLabelDashboard', 'git-memory': 'navLabelGitMemory', knowledge: 'navLabelKnowledge', graph: 'navLabelGraph', observations: 'navLabelObservations', retention: 'navLabelRetention', config: 'navLabelConfig', identity: 'navLabelIdentity', sessions: 'navLabelSessions', team: 'navLabelTeam' };
   document.querySelectorAll('.nav-btn').forEach(b => {
     const page = b.dataset.page;
     if (page && tooltipMap[page]) b.title = t(tooltipMap[page]);
@@ -866,7 +914,7 @@ document.addEventListener('DOMContentLoaded', () => {
 // Router & Navigation
 // ============================================================
 
-const pages = ['dashboard', 'git-memory', 'graph', 'observations', 'retention', 'config', 'identity', 'sessions', 'team'];
+const pages = ['dashboard', 'git-memory', 'knowledge', 'graph', 'observations', 'retention', 'config', 'identity', 'sessions', 'team'];
 let currentPage = 'dashboard';
 
 function navigate(page) {
@@ -1167,6 +1215,7 @@ async function loadPage(page) {
   switch (page) {
     case 'dashboard': await loadDashboard(); break;
     case 'git-memory': await loadGitMemory(); break;
+    case 'knowledge': await loadKnowledge(); break;
     case 'graph': await loadGraph(); break;
     case 'observations': await loadObservations(); break;
     case 'retention': await loadRetention(); break;
@@ -1415,6 +1464,201 @@ function renderPieChart(canvasId, entries, icons) {
   ctx.font = '10px system-ui';
   ctx.fillStyle = getComputedStyle(document.documentElement).getPropertyValue('--text-muted').trim() || '#888';
   ctx.fillText('total', cx, cy + 10);
+}
+
+async function loadKnowledge() {
+  const container = document.getElementById('page-knowledge');
+  container.innerHTML = '<div class="loading knowledge-loading"><div class="spinner"></div><div class="knowledge-loading-text">' + t('loading') + '</div></div>';
+
+  const kb = await api('knowledge');
+  if (!kb) {
+    container.innerHTML = `
+      <div class="page-header">
+        <h1 class="page-title">${t('knowledgeTitle')}</h1>
+        <p class="page-subtitle">${t('knowledgeSubtitle')}</p>
+      </div>
+      <div class="panel knowledge-error-panel">
+        <div class="panel-body">
+          <div class="knowledge-state-icon"><span class="iconify" data-icon="lucide:book-x"></span></div>
+          <div class="empty-state-title">${t('knowledgeUnavailable')}</div>
+          <div class="empty-state-desc">${t('knowledgeUnavailableDesc')}</div>
+          <button class="team-refresh-btn" id="knowledge-retry-btn" style="margin:16px auto 0;">${t('teamRefresh')}</button>
+        </div>
+      </div>
+    `;
+    const retry = document.getElementById('knowledge-retry-btn');
+    if (retry) retry.addEventListener('click', () => {
+      delete loaded.knowledge;
+      loadPage('knowledge');
+    });
+    return;
+  }
+
+  const sections = normalizeKnowledgeSections(kb.sections || []);
+  const totalItems = sections.reduce((sum, section) => sum + (section.items || []).length, 0);
+  const stats = kb.stats || { observationsUsed: 0, miniSkillsUsed: 0, refs: 0 };
+  const overviewSection = sections.find(s => s.id === 'project-overview');
+  const mainSections = sections.filter(s => s.id !== 'project-overview');
+
+  container.innerHTML = `
+    <div class="knowledge-page-shell">
+      <div class="knowledge-topbar">
+        <div class="page-header knowledge-header">
+          <div class="knowledge-title-block">
+            <h1 class="page-title">${escapeHtml(t('knowledgeTitle'))}</h1>
+            <p class="page-subtitle">${t('knowledgeSubtitle')}</p>
+            <div class="knowledge-project-line" title="${escapeHtml(kb.projectId || '')}">${escapeHtml(kb.projectId || '')}</div>
+          </div>
+          <div class="knowledge-generated">
+            <span>${t('knowledgeGenerated')}</span>
+            <strong>${escapeHtml(formatTime(kb.generatedAt))}</strong>
+          </div>
+        </div>
+
+        <div class="knowledge-stats-grid">
+          <div class="stat-card" data-accent="purple">
+            <div class="stat-label">${t('knowledgeObservationsUsed')}</div>
+            <div class="stat-value">${stats.observationsUsed || 0}</div>
+          </div>
+          <div class="stat-card" data-accent="cyan">
+            <div class="stat-label">${t('knowledgeMiniSkillsUsed')}</div>
+            <div class="stat-value">${stats.miniSkillsUsed || 0}</div>
+          </div>
+          <div class="stat-card" data-accent="green">
+            <div class="stat-label">${t('knowledgeRefs')}</div>
+            <div class="stat-value">${stats.refs || 0}</div>
+          </div>
+        </div>
+
+        <nav class="knowledge-jump" aria-label="${t('knowledgeQuickJump')}">
+          <span class="knowledge-jump-label">${t('knowledgeQuickJump')}</span>
+          ${sections.map(section => `<a href="#${knowledgeAnchor(section.id)}" class="knowledge-jump-chip">${escapeHtml(section.title)} <span>${(section.items || []).length}</span></a>`).join('')}
+        </nav>
+
+        ${overviewSection ? renderKnowledgeOverviewCard(overviewSection) : ''}
+      </div>
+
+      ${totalItems === 0 ? `
+        <div class="panel knowledge-empty-overview">
+          <div class="panel-body">
+            <div class="knowledge-state-icon"><span class="iconify" data-icon="lucide:book-open"></span></div>
+            <div class="empty-state-title">${t('knowledgeEmpty')}</div>
+            <div class="empty-state-desc">${t('knowledgeEmptyDesc')}</div>
+          </div>
+        </div>
+      ` : `
+        <div class="knowledge-sections-region">
+          ${mainSections.map(renderKnowledgeSection).join('')}
+        </div>
+      `}
+    </div>
+  `;
+}
+
+function normalizeKnowledgeSections(sections) {
+  const byId = new Map(sections.map(section => [section.id, section]));
+  const order = [
+    ['project-overview', 'knowledgeSectionProjectOverview'],
+    ['core-decisions', 'knowledgeSectionCoreDecisions'],
+    ['operational-knowledge', 'knowledgeSectionOperationalKnowledge'],
+    ['known-gotchas', 'knowledgeSectionKnownGotchas'],
+    ['git-backed-facts', 'knowledgeSectionGitBackedFacts'],
+    ['promoted-skills', 'knowledgeSectionPromotedSkills'],
+  ];
+  return order.map(([id, titleKey]) => {
+    const section = byId.get(id);
+    const localizedTitle = t(titleKey);
+    if (section) return { ...section, title: localizedTitle };
+    return { id, title: localizedTitle, items: [], empty: true };
+  });
+}
+
+function knowledgeEntryLabel(count) {
+  return count === 1 ? t('knowledgeEntry') : t('knowledgeEntries');
+}
+
+function renderKnowledgeOverviewCard(section) {
+  const item = (section.items || [])[0];
+  if (!item) {
+    return `
+      <section class="knowledge-overview-card knowledge-overview-card--empty" id="${knowledgeAnchor(section.id)}">
+        <div class="knowledge-overview-meta">
+          <span class="knowledge-overview-label">${escapeHtml(section.title)}</span>
+          <span class="knowledge-section-meta">0 ${t('knowledgeEntries')}</span>
+        </div>
+        <div class="knowledge-overview-body">
+          <p class="knowledge-summary">${t('knowledgeNoItemsDesc')}</p>
+        </div>
+      </section>
+    `;
+  }
+  return `
+    <section class="knowledge-overview-card" id="${knowledgeAnchor(section.id)}">
+      <div class="knowledge-overview-meta">
+        <span class="knowledge-overview-label">${escapeHtml(section.title)}</span>
+        <span class="knowledge-overview-title" title="${escapeHtml(item.title || '')}">${escapeHtml(item.title || t('untitled'))}</span>
+      </div>
+      <div class="knowledge-overview-body">
+        <p class="knowledge-summary knowledge-summary--overview">${escapeHtml(item.summary || '')}</p>
+        <div class="knowledge-ref-list">${renderKnowledgeRefs(item.refs || [])}</div>
+      </div>
+    </section>
+  `;
+}
+
+function renderKnowledgeSection(section) {
+  const items = section.items || [];
+  return `
+    <section class="panel knowledge-section" id="${knowledgeAnchor(section.id)}">
+      <div class="panel-header knowledge-section-header">
+        <span class="panel-title">${escapeHtml(section.title)}</span>
+        <span class="knowledge-section-meta">${items.length} ${knowledgeEntryLabel(items.length)}</span>
+      </div>
+      <div class="panel-body knowledge-section-body">
+        ${items.length === 0 ? renderKnowledgeEmptySection() : items.map(renderKnowledgeItem).join('')}
+      </div>
+    </section>
+  `;
+}
+
+function renderKnowledgeItem(item) {
+  const refs = item.refs || [];
+  return `
+    <article class="knowledge-item">
+      <div class="knowledge-item-head">
+        <h3 title="${escapeHtml(item.title || t('untitled'))}">${escapeHtml(item.title || t('untitled'))}</h3>
+        <span class="type-badge" data-type="${escapeHtml(item.type || 'unknown')}">${escapeHtml(item.type || t('unknown'))}</span>
+      </div>
+      ${item.entityName ? `<div class="knowledge-entity" title="${escapeHtml(item.entityName)}">${escapeHtml(item.entityName)}</div>` : ''}
+      <p class="knowledge-summary">${escapeHtml(item.summary || '')}</p>
+      ${refs.length > 0 ? `<div class="knowledge-ref-list">${renderKnowledgeRefs(refs)}</div>` : ''}
+    </article>
+  `;
+}
+
+function renderKnowledgeRefs(refs) {
+  if (refs.length === 0) return '<span class="knowledge-ref-empty">—</span>';
+  return refs.map(ref => {
+    const kind = ref.kind || 'observation';
+    const title = ref.title ? ` title="${escapeHtml(ref.title)}"` : '';
+    return `<span class="knowledge-ref-chip" data-kind="${escapeHtml(kind)}"${title}>${escapeHtml(ref.id || kind)}</span>`;
+  }).join('');
+}
+
+function renderKnowledgeEmptySection() {
+  return `
+    <div class="knowledge-section-empty">
+      <span class="iconify" data-icon="lucide:circle-dashed"></span>
+      <div>
+        <strong>${t('knowledgeNoItems')}</strong>
+        <span>${t('knowledgeNoItemsDesc')}</span>
+      </div>
+    </div>
+  `;
+}
+
+function knowledgeAnchor(id) {
+  return `knowledge-${String(id || 'section').replace(/[^a-z0-9_-]/gi, '-')}`;
 }
 
 // ============================================================

--- a/src/dashboard/static/app.js
+++ b/src/dashboard/static/app.js
@@ -336,6 +336,34 @@ const i18n = {
     graphTopToBottom: 'Top → Bottom',
     graphMore: 'more',
 
+    // Knowledge Graph (semantic)
+    kgTitle: 'Knowledge Graph',
+    kgSubtitle: 'Semantic knowledge topology — section clusters, evidence links, provenance',
+    kgNodes: 'nodes',
+    kgEdges: 'edges',
+    kgClusters: 'clusters',
+    kgNoData: 'No Knowledge Graph Data',
+    kgNoDataDesc: 'Store durable observations or promote mini-skills to generate a semantic knowledge graph.',
+    kgClusterFilter: 'Section Cluster',
+    kgEdgeTypeFilter: 'Edge Type',
+    kgEdgeSupports: 'supports',
+    kgEdgeRelatesTo: 'relates to',
+    kgEdgeMentions: 'mentions',
+    kgEdgeDerivedFrom: 'derived from',
+    kgInspectorSummary: 'Summary',
+    kgInspectorProvenance: 'Provenance',
+    kgInspectorSection: 'Section',
+    kgInspectorEntity: 'Entity',
+    kgInspectorEvidence: 'Evidence',
+    kgInspectorRelatedEdges: 'Related Edges',
+    kgInspectorNoEdges: 'No edges',
+    kgDataMode: 'Data Source',
+    kgModeSemantic: 'Semantic KG',
+    kgModeEntity: 'Entity Graph',
+    kgViewMode: 'View Mode',
+    kgFocused: 'Focused',
+    kgFullGraph: 'Full Graph',
+
     // Identity (additional)
     identityCurrentProject: 'Current Project',
     identityHistoricalProjects: 'Historical Projects',
@@ -735,6 +763,34 @@ const i18n = {
     graphTopToBottom: '从上到下',
     graphMore: '更多',
 
+    // Knowledge Graph (semantic)
+    kgTitle: '知识图谱',
+    kgSubtitle: '语义知识拓扑 — 分区聚类、证据关联、溯源',
+    kgNodes: '个节点',
+    kgEdges: '条边',
+    kgClusters: '个聚类',
+    kgNoData: '暂无知识图谱数据',
+    kgNoDataDesc: '存储持久观察或提升迷你技能以生成语义知识图谱。',
+    kgClusterFilter: '分区聚类',
+    kgEdgeTypeFilter: '边类型',
+    kgEdgeSupports: '支撑',
+    kgEdgeRelatesTo: '关联',
+    kgEdgeMentions: '提及',
+    kgEdgeDerivedFrom: '派生自',
+    kgInspectorSummary: '摘要',
+    kgInspectorProvenance: '溯源',
+    kgInspectorSection: '分区',
+    kgInspectorEntity: '实体',
+    kgInspectorEvidence: '证据',
+    kgInspectorRelatedEdges: '相关边',
+    kgInspectorNoEdges: '无边',
+    kgDataMode: '数据源',
+    kgModeSemantic: '语义图谱',
+    kgModeEntity: '实体图谱',
+    kgViewMode: '视图模式',
+    kgFocused: '聚焦',
+    kgFullGraph: '全量',
+
     // Identity (additional)
     identityCurrentProject: '当前项目',
     identityHistoricalProjects: '历史项目',
@@ -812,6 +868,14 @@ function t(key) {
   return (i18n[currentLang] && i18n[currentLang][key]) || i18n.en[key] || key;
 }
 
+function onDomReady(fn) {
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', fn, { once: true });
+  } else {
+    fn();
+  }
+}
+
 function setLang(lang) {
   currentLang = lang;
   localStorage.setItem('memorix-lang', lang);
@@ -858,7 +922,7 @@ function setLang(lang) {
 }
 
 // Init lang toggle button
-document.addEventListener('DOMContentLoaded', () => {
+onDomReady(() => {
   const btn = document.getElementById('lang-toggle');
   const label = document.getElementById('lang-label');
   if (label) label.textContent = currentLang === 'en' ? '中文' : 'EN';
@@ -901,7 +965,7 @@ function applyTheme(theme) {
 // Apply saved theme immediately
 applyTheme(currentTheme);
 
-document.addEventListener('DOMContentLoaded', () => {
+onDomReady(() => {
   const themeBtn = document.getElementById('theme-toggle');
   if (themeBtn) {
     themeBtn.addEventListener('click', () => {
@@ -1199,7 +1263,7 @@ async function initProjectSwitcher() {
   }
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+onDomReady(() => {
   initProjectSwitcher();
 });
 
@@ -1672,9 +1736,21 @@ async function loadGraph() {
   const container = document.getElementById('page-graph');
   container.innerHTML = '<div class="loading"><div class="spinner"></div></div>';
 
+  // Try semantic Knowledge Graph first
+  try {
+    const kg = await api('knowledge-graph');
+    if (kg && kg.nodes && kg.nodes.length > 0) {
+      renderSemanticGraph(kg);
+      return;
+    }
+  } catch (_e) {
+    // Fallback to entity graph
+  }
+
+  // Fallback: entity/relation graph
   const graph = await api('graph');
   if (!graph || (graph.entities.length === 0 && graph.relations.length === 0)) {
-    container.innerHTML = emptyState('<span class="iconify" data-icon="lucide:network" style="font-size:36px;"></span>', t('noGraphData'), t('noGraphDataDesc'));
+    container.innerHTML = emptyState('<span class="iconify" data-icon="lucide:network" style="font-size:36px;"></span>', t('kgNoData'), t('kgNoDataDesc'));
     return;
   }
 
@@ -1724,6 +1800,610 @@ async function loadGraph() {
   `;
 
   renderGraph(graph);
+}
+
+// ============================================================
+// Semantic Knowledge Graph Renderer — Apache ECharts 5
+// Force layout, section categories, evidence-based edges
+// ============================================================
+
+function renderSemanticGraph(kg) {
+  const container = document.getElementById('page-graph');
+
+  // Section color palette (vivid for both light/dark themes)
+  const sectionPalette = {
+    'core-decisions': '#7B9FD9',
+    'operational-knowledge': '#7CC598',
+    'known-gotchas': '#E08585',
+    'git-backed-facts': '#56D6A6',
+    'promoted-skills': '#C9A8FF',
+  };
+  const defaultSectionColor = '#A893C2';
+
+  function getSectionColor(sectionId) {
+    return sectionPalette[sectionId] || defaultSectionColor;
+  }
+
+  // Edge type styles — solid hex + opacity controlled by G6 strokeOpacity
+  const edgeStyleMap = {
+    'supports':     { color: '#69F0AE', arrow: true,  dash: false,  label: t('kgEdgeSupports') },
+    'relates_to':   { color: '#80D8FF', arrow: false, dash: [4, 4], label: t('kgEdgeRelatesTo') },
+    'mentions':     { color: '#D0BCFF', arrow: true,  dash: false,  label: t('kgEdgeMentions') },
+    'derived_from': { color: '#FFB74D', arrow: true,  dash: [6, 3], label: t('kgEdgeDerivedFrom') },
+  };
+
+  // Section label i18n map (matches knowledgeSection* keys)
+  const sectionI18nKeys = {
+    'core-decisions': 'knowledgeSectionCoreDecisions',
+    'operational-knowledge': 'knowledgeSectionOperationalKnowledge',
+    'known-gotchas': 'knowledgeSectionKnownGotchas',
+    'git-backed-facts': 'knowledgeSectionGitBackedFacts',
+    'promoted-skills': 'knowledgeSectionPromotedSkills',
+  };
+  function sectionLabel(sectionId) {
+    const key = sectionI18nKeys[sectionId];
+    return key ? t(key) : sectionId;
+  }
+
+  // State
+  let activeSections = new Set((kg.clusters || []).map(c => c.sectionId));
+  let activeEdgeTypes = new Set(Object.keys(edgeStyleMap).filter(type => type !== 'relates_to'));
+  let selectedNodeId = null;
+  let echartsInstance = null;
+  let echartsResizeObserver = null;
+  let focusedMode = true; // default: show top-N nodes only
+  const FOCUSED_TOP_N = 40; // max nodes in focused view
+  const MAX_EDGES_PER_NODE_FOCUSED = 4; // cap per-node edges (top-K by priority) to keep graph readable
+  const FOCUSED_EDGE_BUDGET = 120; // hard visual budget for first-render readability
+
+  function isLight() { return document.documentElement.getAttribute('data-theme') === 'light'; }
+
+  // Compute degree (edge count) for each node
+  const nodeDegreeMap = new Map();
+  for (const edge of kg.edges) {
+    nodeDegreeMap.set(edge.source, (nodeDegreeMap.get(edge.source) || 0) + 1);
+    nodeDegreeMap.set(edge.target, (nodeDegreeMap.get(edge.target) || 0) + 1);
+  }
+
+  // Section ordering for stable category index
+  const SECTION_ORDER = ['core-decisions', 'operational-knowledge', 'known-gotchas', 'git-backed-facts', 'promoted-skills'];
+
+  // Build ECharts graph data: { categories, nodes, links }
+  function buildEChartsData() {
+    // Determine which nodes to show
+    let visibleNodes = kg.nodes.filter(n => activeSections.has(n.sectionId));
+    if (focusedMode && visibleNodes.length > FOCUSED_TOP_N) {
+      visibleNodes.sort((a, b) => {
+        const scoreA = (a.evidenceCount || 0) + (nodeDegreeMap.get(a.id) || 0) * 2;
+        const scoreB = (b.evidenceCount || 0) + (nodeDegreeMap.get(b.id) || 0) * 2;
+        return scoreB - scoreA;
+      });
+      visibleNodes = visibleNodes.slice(0, FOCUSED_TOP_N);
+    }
+    const visibleNodeIds = new Set(visibleNodes.map(n => n.id));
+
+    // Categories (one per section, ECharts uses index reference from nodes)
+    const categories = SECTION_ORDER.map(sectionId => ({
+      name: sectionLabel(sectionId),
+      sectionId,
+      itemStyle: { color: getSectionColor(sectionId) },
+    }));
+    const categoryIndexBySection = Object.fromEntries(SECTION_ORDER.map((s, i) => [s, i]));
+    const visibleBySection = new Map(SECTION_ORDER.map(sectionId => [sectionId, []]));
+    visibleNodes.forEach(node => {
+      const group = visibleBySection.get(node.sectionId) || [];
+      group.push(node);
+      visibleBySection.set(node.sectionId, group);
+    });
+
+    const sectionCenters = {
+      'core-decisions': { x: -360, y: -170 },
+      'operational-knowledge': { x: 0, y: 0 },
+      'known-gotchas': { x: -340, y: 190 },
+      'git-backed-facts': { x: 360, y: -150 },
+      'promoted-skills': { x: 350, y: 190 },
+    };
+
+    function stableNodePosition(node, index) {
+      const group = visibleBySection.get(node.sectionId) || [];
+      const total = Math.max(1, group.length);
+      const center = sectionCenters[node.sectionId] || { x: 0, y: 0 };
+      const ring = Math.floor(index / 10);
+      const ringIndex = index % 10;
+      const radius = total === 1 ? 0 : 34 + ring * 42;
+      const angleStep = (Math.PI * 2) / Math.min(10, total);
+      const angleOffset = SECTION_ORDER.indexOf(node.sectionId) * 0.55;
+      const angle = ringIndex * angleStep + angleOffset;
+      return {
+        x: Math.round(center.x + Math.cos(angle) * radius),
+        y: Math.round(center.y + Math.sin(angle) * radius),
+      };
+    }
+
+    // Nodes (stable coordinates; dragging a node must not trigger global force rotation)
+    const nodes = visibleNodes.map(node => {
+      const symbolSize = Math.max(14, Math.min(10 + Math.sqrt(node.evidenceCount || 1) * 4, 32));
+      const sectionIndex = (visibleBySection.get(node.sectionId) || []).findIndex(n => n.id === node.id);
+      const pos = stableNodePosition(node, Math.max(0, sectionIndex));
+      return {
+        id: node.id,
+        name: node.label.length > 28 ? node.label.slice(0, 26) + '\u2026' : node.label,
+        x: pos.x,
+        y: pos.y,
+        category: categoryIndexBySection[node.sectionId] ?? 0,
+        symbolSize,
+        value: node.evidenceCount || 0,
+        sectionId: node.sectionId,
+        nodeType: node.nodeType,
+        entityName: node.entityName || '',
+        evidenceCount: node.evidenceCount || 0,
+        summary: node.summary || '',
+        refs: node.refs || [],
+        fullLabel: node.label,
+      };
+    });
+
+    // Collect candidate edges (both endpoints visible + active type)
+    const edgePriority = { supports: 3, derived_from: 2, mentions: 1, relates_to: 0 };
+    const candidateEdges = kg.edges.filter(e =>
+      activeEdgeTypes.has(e.edgeType) &&
+      visibleNodeIds.has(e.source) &&
+      visibleNodeIds.has(e.target),
+    );
+
+    // In focused mode, cap each node's edges to top-K strongest by type priority
+    let finalEdges = candidateEdges;
+    if (focusedMode && candidateEdges.length > 0) {
+      // Sort all candidates by priority descending (stronger types first)
+      const sorted = [...candidateEdges].sort(
+        (a, b) => (edgePriority[b.edgeType] ?? 0) - (edgePriority[a.edgeType] ?? 0),
+      );
+      const perNodeCount = new Map();
+      finalEdges = [];
+      for (const e of sorted) {
+        if (finalEdges.length >= FOCUSED_EDGE_BUDGET) break;
+        const sCount = perNodeCount.get(e.source) || 0;
+        const tCount = perNodeCount.get(e.target) || 0;
+        if (sCount >= MAX_EDGES_PER_NODE_FOCUSED || tCount >= MAX_EDGES_PER_NODE_FOCUSED) continue;
+        perNodeCount.set(e.source, sCount + 1);
+        perNodeCount.set(e.target, tCount + 1);
+        finalEdges.push(e);
+      }
+    }
+
+    // Build ECharts link objects
+    const links = finalEdges.map(edge => {
+      const style = edgeStyleMap[edge.edgeType] || {};
+      return {
+        id: edge.id,
+        source: edge.source,
+        target: edge.target,
+        edgeType: edge.edgeType,
+        edgeLabel: style.label || edge.edgeType,
+        lineStyle: {
+          color: style.color || '#999',
+          opacity: 0.5,
+          width: 1.1,
+          curveness: 0.12,
+          type: Array.isArray(style.dash) ? 'dashed' : 'solid',
+        },
+        symbol: style.arrow ? ['none', 'arrow'] : ['none', 'none'],
+        symbolSize: [4, 7],
+      };
+    });
+
+    return { categories, nodes, links };
+  }
+
+  let lastRenderedCounts = { nodes: 0, edges: 0 };
+
+  // Render the page shell
+  container.innerHTML = `
+    <div class="kg-page-shell">
+      <div class="page-header">
+        <h1 class="page-title">${t('kgTitle')}</h1>
+        <p class="page-subtitle">${t('kgSubtitle')}</p>
+      </div>
+      <div class="graph-layout">
+        <div class="graph-filter-panel" id="kg-filter-panel"></div>
+        <div id="graph-container">
+          <div id="echarts-mount" style="width:100%;height:100%;"></div>
+          <div class="graph-status-bar">
+            <span class="graph-status-item" id="gs-nodes"></span>
+            <span class="graph-status-item" id="gs-edges"></span>
+            <span class="graph-status-item" id="gs-clusters"></span>
+            <div class="graph-zoom-controls">
+              <button class="graph-zoom-btn" id="gz-out">\u2212</button>
+              <button class="graph-zoom-btn" id="gz-fit">\u2B21</button>
+              <button class="graph-zoom-btn" id="gz-in">+</button>
+            </div>
+          </div>
+        </div>
+        <div class="graph-inspector" id="graph-inspector">
+          <div class="gi-empty"><div class="gi-empty-icon">\u2B21</div>${t('graphSelectNode')}</div>
+        </div>
+      </div>
+    </div>
+  `;
+
+  function initEChartsGraph() {
+    const mountEl = document.getElementById('echarts-mount');
+    if (!mountEl || typeof echarts === 'undefined') return;
+
+    // Ensure container has dimensions before init
+    if (mountEl.clientWidth === 0 || mountEl.clientHeight === 0) {
+      // Defer until layout finishes
+      requestAnimationFrame(() => initEChartsGraph());
+      return;
+    }
+
+    // Dispose previous instance if any
+    if (echartsInstance) {
+      try { echartsInstance.dispose(); } catch (_) { /* noop */ }
+      echartsInstance = null;
+    }
+
+    const data = buildEChartsData();
+    lastRenderedCounts = { nodes: data.nodes.length, edges: data.links.length };
+    const light = isLight();
+    const labelColor = light ? '#1C1B1F' : '#E6E1E5';
+    const labelMutedColor = light ? '#666' : '#999';
+    const tooltipBg = light ? 'rgba(255,255,255,0.96)' : 'rgba(20,20,28,0.96)';
+    const tooltipBorder = light ? 'rgba(0,0,0,0.1)' : 'rgba(255,255,255,0.12)';
+
+    echartsInstance = echarts.init(mountEl, null, { renderer: 'canvas' });
+
+    const wrap = (txt) => String(txt ?? '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+    const option = {
+      backgroundColor: 'transparent',
+      tooltip: {
+        trigger: 'item',
+        backgroundColor: tooltipBg,
+        borderColor: tooltipBorder,
+        borderWidth: 1,
+        textStyle: { color: labelColor, fontSize: 12, fontFamily: 'Inter, system-ui, sans-serif' },
+        extraCssText: 'box-shadow: 0 4px 16px rgba(0,0,0,0.18); border-radius: 8px; padding: 10px 12px; max-width: 320px;',
+        formatter: (params) => {
+          if (params.dataType === 'node') {
+            const d = params.data;
+            const summary = d.summary ? String(d.summary).slice(0, 160) : '';
+            return (
+              `<div style="font-weight:600;font-size:13px;margin-bottom:4px;line-height:1.35;">${wrap(d.fullLabel || d.name)}</div>` +
+              `<div style="font-size:11px;color:${labelMutedColor};margin-bottom:6px;">${wrap(d.nodeType || '')}${d.entityName ? ' \u00b7 ' + wrap(d.entityName) : ''}</div>` +
+              `<div style="font-size:11px;color:${labelMutedColor};">${d.evidenceCount || 0} ${wrap(t('kgInspectorEvidence'))}</div>` +
+              (summary ? `<div style="font-size:11.5px;line-height:1.5;margin-top:8px;color:${labelColor};opacity:0.85;">${wrap(summary)}\u2026</div>` : '')
+            );
+          }
+          if (params.dataType === 'edge') {
+            return `<div style="font-size:12px;">${wrap(params.data.edgeLabel || params.data.edgeType)}</div>`;
+          }
+          return '';
+        },
+      },
+      legend: [{
+        data: data.categories.map(c => c.name),
+        textStyle: { color: labelColor, fontSize: 11 },
+        top: 8,
+        right: 12,
+        itemWidth: 10,
+        itemHeight: 10,
+        itemGap: 12,
+        icon: 'circle',
+        selectedMode: false,
+      }],
+      animationDuration: 500,
+      animationEasingUpdate: 'quinticInOut',
+      series: [{
+        type: 'graph',
+        layout: 'none',
+        roam: true,
+        draggable: true,
+        zoom: 1,
+        scaleLimit: { min: 0.2, max: 4 },
+        edgeSymbol: ['none', 'arrow'],
+        edgeSymbolSize: [0, 8],
+        categories: data.categories,
+        data: data.nodes,
+        edges: data.links,
+        label: {
+          show: true,
+          position: 'right',
+          formatter: '{b}',
+          color: labelColor,
+          fontSize: 11,
+          fontFamily: 'Inter, system-ui, sans-serif',
+          backgroundColor: light ? 'rgba(255,255,255,0.82)' : 'rgba(15,15,23,0.72)',
+          padding: [2, 5],
+          borderRadius: 3,
+        },
+        labelLayout: { hideOverlap: true, moveOverlap: 'shiftY' },
+        itemStyle: {
+          opacity: 0.92,
+          borderColor: light ? 'rgba(0,0,0,0.22)' : 'rgba(255,255,255,0.2)',
+          borderWidth: 1,
+          shadowColor: light ? 'rgba(0,0,0,0.18)' : 'rgba(0,0,0,0.45)',
+          shadowBlur: 8,
+        },
+        emphasis: {
+          focus: 'adjacency',
+          label: { show: true, fontWeight: 700, fontSize: 12 },
+          itemStyle: { borderColor: light ? '#6750A4' : '#D0BCFF', borderWidth: 2 },
+          lineStyle: { width: 2.5, opacity: 1 },
+        },
+        blur: {
+          itemStyle: { opacity: 0.18 },
+          label: { opacity: 0.25 },
+          lineStyle: { opacity: 0.06 },
+        },
+        lineStyle: { opacity: 0.55, curveness: 0.15, width: 1.2 },
+      }],
+    };
+
+    echartsInstance.setOption(option);
+
+    // Click handlers — use ECharts event API (auto-cleaned on dispose) instead of zrender
+    echartsInstance.on('click', (params) => {
+      if (params.dataType === 'node') {
+        const id = params.data?.id;
+        if (id) {
+          selectedNodeId = id;
+          showKGInspector(id);
+        }
+      }
+    });
+    // Click on blank canvas deselects (ECharts emits click with empty target at chart level).
+    // Use `click` event at series level only; do NOT intercept zrender events so roam/pan works.
+    // User reported pan-on-empty-canvas not working when zr click was intercepted.
+
+    // Resize observer
+    if (echartsResizeObserver) {
+      try { echartsResizeObserver.disconnect(); } catch (_) { /* noop */ }
+    }
+    if (typeof ResizeObserver !== 'undefined') {
+      echartsResizeObserver = new ResizeObserver(() => {
+        if (echartsInstance) echartsInstance.resize();
+      });
+      echartsResizeObserver.observe(mountEl);
+    }
+
+    window._kgEChart = echartsInstance;
+    window._kgShowInspector = showKGInspector;
+
+    updateStatusBar();
+    bindZoomControls();
+  }
+
+  function bindZoomControls() {
+    const outBtn = document.getElementById('gz-out');
+    const fitBtn = document.getElementById('gz-fit');
+    const inBtn = document.getElementById('gz-in');
+    const setZoom = (factor) => {
+      if (!echartsInstance) return;
+      const opt = echartsInstance.getOption();
+      const cur = (opt.series && opt.series[0] && opt.series[0].zoom) || 1;
+      echartsInstance.setOption({ series: [{ zoom: Math.min(4, Math.max(0.2, cur * factor)) }] });
+    };
+    if (outBtn) outBtn.onclick = () => setZoom(0.75);
+    if (fitBtn) fitBtn.onclick = () => {
+      if (echartsInstance) echartsInstance.setOption({ series: [{ zoom: 1, center: null }] });
+    };
+    if (inBtn) inBtn.onclick = () => setZoom(1.35);
+  }
+
+  function updateStatusBar() {
+    const gsNodes = document.getElementById('gs-nodes');
+    const gsEdges = document.getElementById('gs-edges');
+    const gsClusters = document.getElementById('gs-clusters');
+    const shownNodes = focusedMode ? Math.min(kg.nodes.length, FOCUSED_TOP_N) : kg.nodes.length;
+    const shownLabel = focusedMode && kg.nodes.length > FOCUSED_TOP_N ? `${shownNodes}/${kg.nodes.length}` : `${kg.nodes.length}`;
+    if (gsNodes) gsNodes.textContent = `${shownLabel} ${t('kgNodes')}`;
+    const edgeLabel = lastRenderedCounts.edges < kg.edges.length
+      ? `${lastRenderedCounts.edges}/${kg.edges.length}`
+      : `${kg.edges.length}`;
+    if (gsEdges) gsEdges.textContent = `${edgeLabel} ${t('kgEdges')}`;
+    if (gsClusters) gsClusters.textContent = `${(kg.clusters || []).length} ${t('kgClusters')}`;
+  }
+
+  // Inspector
+  function showKGInspector(nodeId) {
+    const inspector = document.getElementById('graph-inspector');
+    if (!inspector) return;
+    if (!nodeId) {
+      inspector.innerHTML = '<div class="gi-empty"><div class="gi-empty-icon">\u2B21</div>' + t('graphSelectNode') + '</div>';
+      return;
+    }
+    const node = kg.nodes.find(n => n.id === nodeId);
+    if (!node) {
+      inspector.innerHTML = '<div class="gi-empty"><div class="gi-empty-icon">\u2B21</div>' + t('graphSelectNode') + '</div>';
+      return;
+    }
+    const color = getSectionColor(node.sectionId);
+    const relatedEdges = kg.edges.filter(e => e.source === nodeId || e.target === nodeId);
+
+    const refsHtml = (node.refs || []).length > 0
+      ? node.refs.map(r => `<span class="knowledge-ref-chip" data-kind="${escapeHtml(r.kind)}">${escapeHtml(r.id)}</span>`).join('')
+      : '<span style="font-size:12px;color:var(--text-muted);">—</span>';
+
+    const edgeHtml = relatedEdges.length > 0
+      ? relatedEdges.map(e => {
+          const dir = e.source === nodeId;
+          const other = dir ? e.target : e.source;
+          const otherNode = kg.nodes.find(n => n.id === other);
+          const style = edgeStyleMap[e.edgeType] || {};
+          return `<div class="gi-rel-item">
+            <span class="gi-rel-arrow">${dir ? '\u2192' : '\u2190'}</span>
+            <span class="gi-rel-type" style="color:${style.color || 'var(--text-muted)'}">${escapeHtml(style.label || e.edgeType)}</span>
+            <span class="gi-rel-target" data-kg-nav="${escapeHtml(other)}">${escapeHtml(otherNode?.label || other)}</span>
+          </div>`;
+        }).join('')
+      : '<div style="font-size:12px;color:var(--text-muted);font-style:italic;">' + t('kgInspectorNoEdges') + '</div>';
+
+    inspector.innerHTML = `
+      <div class="gi-header">
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:4px;">
+          <span style="width:10px;height:10px;border-radius:50%;background:${color};flex-shrink:0;"></span>
+          <div class="gi-name">${escapeHtml(node.label)}</div>
+        </div>
+        <div class="gi-type">${escapeHtml(node.nodeType)}</div>
+      </div>
+      <div class="gi-stats">
+        <div class="gi-stat"><div class="gi-stat-value">${node.evidenceCount}</div><div class="gi-stat-label">${t('kgInspectorEvidence')}</div></div>
+        <div class="gi-stat"><div class="gi-stat-value">${relatedEdges.length}</div><div class="gi-stat-label">${t('kgInspectorRelatedEdges')}</div></div>
+      </div>
+      <div class="gi-section">
+        <div class="gi-section-title">${t('kgInspectorSection')}</div>
+        <div style="font-size:12px;color:${color};font-weight:500;">${escapeHtml(sectionLabel(node.sectionId))}</div>
+      </div>
+      ${node.entityName ? `<div class="gi-section"><div class="gi-section-title">${t('kgInspectorEntity')}</div><div style="font-size:12px;color:var(--accent-cyan);font-family:var(--font-mono);">${escapeHtml(node.entityName)}</div></div>` : ''}
+      <div class="gi-section">
+        <div class="gi-section-title">${t('kgInspectorSummary')}</div>
+        <div style="font-size:12px;color:var(--text-secondary);line-height:1.5;">${escapeHtml(node.summary || '—')}</div>
+      </div>
+      <div class="gi-section">
+        <div class="gi-section-title">${t('kgInspectorProvenance')}</div>
+        <div class="knowledge-ref-list">${refsHtml}</div>
+      </div>
+      <div class="gi-section">
+        <div class="gi-section-title">${t('kgInspectorRelatedEdges')} <span class="gi-section-count">${relatedEdges.length}</span></div>
+        ${edgeHtml}
+      </div>
+    `;
+
+    inspector.querySelectorAll('[data-kg-nav]').forEach(el => {
+      el.addEventListener('click', () => {
+        const targetId = el.dataset.kgNav;
+        if (echartsInstance) {
+          try {
+            echartsInstance.dispatchAction({ type: 'highlight', seriesIndex: 0, dataType: 'node', name: kg.nodes.find(n => n.id === targetId)?.label });
+          } catch (_) { /* noop */ }
+        }
+        showKGInspector(targetId);
+      });
+    });
+  }
+
+  // Filter panel
+  function renderKGFilterPanel() {
+    const panel = document.getElementById('kg-filter-panel');
+    if (!panel) return;
+
+    const clusterEntries = (kg.clusters || []).map(c => [c.sectionId, c]);
+    const clusterHtml = `
+      <div class="gfp-section">
+        <div class="gfp-label">${t('kgClusterFilter')}</div>
+        <div class="gfp-radio-group">
+          ${clusterEntries.map(([id, cluster]) => `
+            <button class="gfp-check${activeSections.has(id) ? ' active' : ''}" data-section-filter="${escapeHtml(id)}">
+              <span class="gfp-check-box">\u2713</span>
+              <span class="gfp-type-dot" style="background:${getSectionColor(id)}"></span>
+              ${escapeHtml(sectionLabel(cluster.sectionId))}
+              <span class="gfp-check-count">${cluster.nodeCount}</span>
+            </button>
+          `).join('')}
+        </div>
+      </div>
+    `;
+
+    const edgeTypeEntries = Object.entries(edgeStyleMap);
+    const edgeTypeHtml = `
+      <div class="gfp-section">
+        <div class="gfp-label">${t('kgEdgeTypeFilter')}</div>
+        <div class="gfp-radio-group">
+          ${edgeTypeEntries.map(([type, style]) => `
+            <button class="gfp-check${activeEdgeTypes.has(type) ? ' active' : ''}" data-edge-type-filter="${escapeHtml(type)}">
+              <span class="gfp-check-box">\u2713</span>
+              <span style="color:${style.color};font-size:11px;">\u2192</span>
+              ${escapeHtml(style.label)}
+              <span class="gfp-check-count">${kg.edges.filter(e => e.edgeType === type).length}</span>
+            </button>
+          `).join('')}
+        </div>
+      </div>
+    `;
+
+    const searchHtml = `
+      <div class="gfp-section">
+        <div class="gfp-label">${t('graphSearch')}</div>
+        <input type="text" class="gfp-search" id="kg-search" placeholder="${t('graphFindEntity')}" autocomplete="off" />
+      </div>
+    `;
+
+    const viewModeHtml = `
+      <div class="gfp-section">
+        <div class="gfp-label">${t('kgViewMode')}</div>
+        <div class="gfp-depth-row">
+          <button class="gfp-depth-btn${focusedMode ? ' active' : ''}" data-view-mode="focused">${t('kgFocused')}</button>
+          <button class="gfp-depth-btn${!focusedMode ? ' active' : ''}" data-view-mode="full">${t('kgFullGraph')}</button>
+        </div>
+      </div>
+    `;
+
+    panel.innerHTML = searchHtml + viewModeHtml + clusterHtml + edgeTypeHtml;
+
+    // Bind section filters
+    panel.querySelectorAll('[data-section-filter]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const id = btn.dataset.sectionFilter;
+        if (activeSections.has(id)) activeSections.delete(id);
+        else activeSections.add(id);
+        initEChartsGraph();
+        renderKGFilterPanel();
+      });
+    });
+
+    // Bind edge type filters
+    panel.querySelectorAll('[data-edge-type-filter]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const type = btn.dataset.edgeTypeFilter;
+        if (activeEdgeTypes.has(type)) activeEdgeTypes.delete(type);
+        else activeEdgeTypes.add(type);
+        initEChartsGraph();
+        renderKGFilterPanel();
+      });
+    });
+
+    // Bind view mode toggle
+    panel.querySelectorAll('[data-view-mode]').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const mode = btn.dataset.viewMode;
+        focusedMode = mode === 'focused';
+        initEChartsGraph();
+        renderKGFilterPanel();
+      });
+    });
+
+    // Bind search
+    const searchInput = document.getElementById('kg-search');
+    if (searchInput) {
+      searchInput.addEventListener('input', () => {
+        const q = searchInput.value.toLowerCase();
+        if (!echartsInstance) return;
+        try {
+          echartsInstance.dispatchAction({ type: 'downplay', seriesIndex: 0 });
+        } catch (_) { /* noop */ }
+        if (!q) return;
+        // Highlight matched nodes (which auto-blurs others via emphasis.focus 'adjacency' isn't ideal here;
+        // instead, use 'highlight' on matching dataIndex array for visual emphasis)
+        const data = buildEChartsData();
+        const matchIndexes = [];
+        data.nodes.forEach((n, idx) => {
+          const match = (n.fullLabel || '').toLowerCase().includes(q) ||
+                        (n.nodeType || '').toLowerCase().includes(q) ||
+                        (n.entityName || '').toLowerCase().includes(q);
+          if (match) matchIndexes.push(idx);
+        });
+        if (matchIndexes.length > 0) {
+          try {
+            echartsInstance.dispatchAction({ type: 'highlight', seriesIndex: 0, dataIndex: matchIndexes });
+          } catch (_) { /* noop */ }
+        }
+      });
+    }
+  }
+
+  initEChartsGraph();
+  renderKGFilterPanel();
 }
 
 // ============================================================

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -4,6 +4,9 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate">
+  <meta http-equiv="Pragma" content="no-cache">
+  <meta http-equiv="Expires" content="0">
   <title>Memorix — Memory Control Plane</title>
   <link rel="stylesheet" href="/style.css">
   <script src="https://code.iconify.design/3/3.1.0/iconify.min.js"></script>
@@ -179,11 +182,20 @@
     <div id="page-team" class="page"></div>
   </main>
 
-  <!-- Cytoscape.js + Dagre layout for topology graph -->
+  <!-- Apache ECharts 5 — Knowledge Graph renderer -->
+  <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.1/dist/echarts.min.js"></script>
+  <!-- Cytoscape.js + Dagre — legacy entity-graph fallback -->
   <script src="https://unpkg.com/cytoscape@3.30.4/dist/cytoscape.min.js"></script>
   <script src="https://unpkg.com/dagre@0.8.5/dist/dagre.min.js"></script>
   <script src="https://unpkg.com/cytoscape-dagre@2.5.0/cytoscape-dagre.js"></script>
-  <script src="/app.js"></script>
+  <script>
+    // Cache-bust app.js by appending mtime-based version so edits always hit the browser.
+    (function () {
+      var s = document.createElement('script');
+      s.src = '/app.js?v=' + Date.now();
+      document.body.appendChild(s);
+    })();
+  </script>
 </body>
 
 </html>

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -65,6 +65,13 @@
         </svg>
         <span class="nav-label">Git Memory</span>
       </button>
+      <button class="nav-btn" data-page="knowledge">
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/>
+          <path d="M4 4.5A2.5 2.5 0 0 1 6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5z"/>
+        </svg>
+        <span class="nav-label">Knowledge</span>
+      </button>
       <button class="nav-btn" data-page="graph">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <circle cx="12" cy="5" r="3"/>
@@ -162,6 +169,7 @@
   <main id="app">
     <div id="page-dashboard" class="page active"></div>
     <div id="page-git-memory" class="page"></div>
+    <div id="page-knowledge" class="page"></div>
     <div id="page-graph" class="page"></div>
     <div id="page-observations" class="page"></div>
     <div id="page-retention" class="page"></div>

--- a/src/dashboard/static/style.css
+++ b/src/dashboard/static/style.css
@@ -2706,6 +2706,620 @@ mark {
   color: var(--accent-green);
 }
 
+#page-knowledge.page.active {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+  padding: 24px 28px;
+  box-sizing: border-box;
+  overflow: hidden;
+}
+
+.knowledge-page-shell {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  width: 100%;
+  gap: 14px;
+}
+
+.knowledge-topbar {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  flex: 0 0 auto;
+}
+
+.knowledge-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 0;
+}
+
+.knowledge-title-block {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.knowledge-title-block .page-title {
+  margin-bottom: 4px;
+  font-size: 22px;
+  letter-spacing: -0.3px;
+}
+
+.knowledge-title-block .page-subtitle {
+  font-size: 13px;
+}
+
+.knowledge-project-line {
+  display: inline-block;
+  max-width: min(760px, 100%);
+  margin-top: 8px;
+  padding: 4px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  background: var(--bg-surface);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: top;
+}
+
+.knowledge-generated {
+  flex-shrink: 0;
+  min-width: 160px;
+  padding: 8px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+}
+
+.knowledge-generated span {
+  display: block;
+  margin-bottom: 2px;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.knowledge-generated strong {
+  display: block;
+  color: var(--text-secondary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.knowledge-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-bottom: 0;
+}
+
+#page-knowledge .knowledge-stats-grid .stat-card {
+  padding: 14px 16px;
+  border-radius: var(--radius-md);
+  box-shadow: none;
+}
+
+#page-knowledge .knowledge-stats-grid .stat-card:hover {
+  transform: none;
+  box-shadow: var(--elevation-1);
+}
+
+#page-knowledge .knowledge-stats-grid .stat-label {
+  margin-bottom: 6px;
+  font-size: 10px;
+  letter-spacing: 0.6px;
+}
+
+#page-knowledge .knowledge-stats-grid .stat-value {
+  font-size: 24px;
+}
+
+.knowledge-jump {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding: 8px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+}
+
+.knowledge-jump-label {
+  margin: 0 4px 0 0;
+  color: var(--text-muted);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.knowledge-jump-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 240px;
+  min-height: 26px;
+  padding: 3px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-pill);
+  color: var(--text-secondary);
+  background: var(--bg-base);
+  font-size: 12px;
+  font-weight: 500;
+  text-decoration: none;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.knowledge-jump-chip:hover {
+  border-color: rgba(208, 188, 255, 0.28);
+  background: var(--bg-card-hover);
+  color: var(--text-primary);
+}
+
+.knowledge-jump-chip span {
+  flex-shrink: 0;
+  min-width: 16px;
+  padding: 0 6px;
+  border-radius: var(--radius-pill);
+  background: rgba(208, 188, 255, 0.1);
+  color: var(--accent-purple);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-align: center;
+}
+
+.knowledge-overview-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 12px 16px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  scroll-margin-top: 24px;
+}
+
+.knowledge-overview-card--empty {
+  background: rgba(255, 255, 255, 0.015);
+  border-style: dashed;
+  border-color: var(--border-medium);
+}
+
+.knowledge-overview-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 0 0 220px;
+  min-width: 0;
+}
+
+.knowledge-overview-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.knowledge-overview-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.knowledge-overview-body {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.knowledge-summary--overview {
+  margin: 0;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+}
+
+.knowledge-sections-region {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-auto-rows: 1fr;
+  gap: 14px;
+}
+
+.knowledge-sections-region > .knowledge-section:last-child:nth-child(3n+2) {
+  grid-column: span 2;
+}
+
+.knowledge-sections-region > .knowledge-section:last-child:nth-child(3n+1) {
+  grid-column: 1 / -1;
+}
+
+.knowledge-section {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  max-height: 100%;
+  scroll-margin-top: 24px;
+  background: var(--bg-card);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  box-shadow: none;
+  overflow: hidden;
+}
+
+.knowledge-section .panel-header.knowledge-section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-surface);
+  flex: 0 0 auto;
+}
+
+.knowledge-section .panel-title {
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.knowledge-section-meta {
+  color: var(--text-muted);
+  font-size: 11px;
+  font-family: var(--font-mono);
+  white-space: nowrap;
+}
+
+.knowledge-section-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+  overflow-y: auto;
+}
+
+.knowledge-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+}
+
+.knowledge-item-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
+.knowledge-item-head h3 {
+  margin: 0;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.knowledge-item-head .type-badge {
+  flex-shrink: 0;
+  font-size: 10px;
+  padding: 2px 6px;
+}
+
+.knowledge-entity {
+  max-width: 100%;
+  color: var(--accent-cyan);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.knowledge-summary {
+  display: -webkit-box;
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 12.5px;
+  line-height: 1.5;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 3;
+  line-clamp: 3;
+  overflow-wrap: anywhere;
+}
+
+.knowledge-ref-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 2px;
+}
+
+.knowledge-ref-chip {
+  display: inline-flex;
+  align-items: center;
+  max-width: 100%;
+  padding: 1px 6px;
+  border: 1px solid rgba(128, 216, 255, 0.16);
+  border-radius: var(--radius-pill);
+  background: rgba(128, 216, 255, 0.07);
+  color: var(--accent-cyan);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  line-height: 1.4;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.knowledge-ref-chip[data-kind="mini-skill"] {
+  border-color: rgba(208, 188, 255, 0.18);
+  background: rgba(208, 188, 255, 0.08);
+  color: var(--accent-purple);
+}
+
+.knowledge-ref-chip[data-kind="git"] {
+  border-color: rgba(105, 240, 174, 0.18);
+  background: rgba(105, 240, 174, 0.08);
+  color: var(--accent-green);
+}
+
+.knowledge-ref-empty {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.knowledge-section-empty {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 14px;
+  border: 1px dashed var(--border-medium);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.015);
+  color: var(--text-muted);
+}
+
+.knowledge-section-empty .iconify {
+  flex-shrink: 0;
+  color: var(--text-muted);
+  font-size: 18px;
+}
+
+.knowledge-section-empty strong,
+.knowledge-section-empty span {
+  display: block;
+}
+
+.knowledge-section-empty strong {
+  margin-bottom: 2px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+
+.knowledge-section-empty span {
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+.knowledge-empty-overview,
+.knowledge-error-panel {
+  flex: 1 1 auto;
+  min-height: 0;
+  margin-bottom: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.knowledge-empty-overview .panel-body,
+.knowledge-error-panel .panel-body {
+  padding: 42px 24px;
+  text-align: center;
+}
+
+.knowledge-state-icon {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 12px;
+  color: var(--accent-purple);
+  font-size: 36px;
+}
+
+.knowledge-loading {
+  flex-direction: column;
+  gap: 12px;
+  color: var(--text-muted);
+  font-size: 13px;
+}
+
+@media (max-width: 1399px) {
+  .knowledge-sections-region {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .knowledge-sections-region > .knowledge-section:last-child:nth-child(3n+2),
+  .knowledge-sections-region > .knowledge-section:last-child:nth-child(3n+1) {
+    grid-column: auto;
+  }
+
+  .knowledge-sections-region > .knowledge-section:last-child:nth-child(odd) {
+    grid-column: 1 / -1;
+  }
+}
+
+@media (max-width: 900px) {
+  #page-knowledge.page.active {
+    height: auto;
+    min-height: 100vh;
+    overflow: visible;
+    padding: 20px 18px;
+  }
+
+  .knowledge-page-shell {
+    flex: 0 0 auto;
+  }
+
+  .knowledge-stats-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .knowledge-sections-region {
+    grid-template-columns: 1fr;
+    grid-auto-rows: auto;
+  }
+
+  .knowledge-sections-region > .knowledge-section:last-child {
+    grid-column: auto;
+  }
+
+  .knowledge-section {
+    max-height: none;
+  }
+
+  .knowledge-section-body {
+    max-height: 60vh;
+  }
+
+  .knowledge-overview-card {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .knowledge-overview-meta {
+    flex: 0 0 auto;
+  }
+
+  .knowledge-header {
+    display: block;
+  }
+
+  .knowledge-generated {
+    width: fit-content;
+    max-width: 100%;
+    margin-top: 12px;
+  }
+}
+
+@media (max-width: 600px) {
+  #page-knowledge.page.active {
+    padding: 14px 12px;
+  }
+
+  #page-knowledge .page-title {
+    font-size: 20px;
+    line-height: 1.25;
+    overflow-wrap: anywhere;
+  }
+
+  #page-knowledge .page-subtitle {
+    font-size: 12.5px;
+    line-height: 1.45;
+  }
+
+  .knowledge-stats-grid {
+    grid-template-columns: 1fr;
+  }
+
+  #page-knowledge .knowledge-stats-grid .stat-card {
+    padding: 12px 14px;
+  }
+
+  #page-knowledge .knowledge-stats-grid .stat-value {
+    font-size: 22px;
+  }
+
+  .knowledge-title-block {
+    width: 100%;
+  }
+
+  .knowledge-generated {
+    width: 100%;
+    min-width: 0;
+    padding: 8px 12px;
+  }
+
+  .knowledge-generated strong {
+    overflow-wrap: anywhere;
+  }
+
+  .knowledge-jump {
+    align-items: stretch;
+    padding: 8px;
+  }
+
+  .knowledge-jump-label {
+    width: 100%;
+  }
+
+  .knowledge-jump-chip {
+    max-width: 100%;
+    min-width: 0;
+    flex: 1 1 100%;
+    justify-content: flex-start;
+  }
+
+  .knowledge-jump-chip span {
+    margin-left: auto;
+  }
+
+  .knowledge-item-head {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .knowledge-section-body {
+    max-height: 50vh;
+    padding: 8px;
+  }
+
+  .knowledge-item {
+    padding: 8px 10px;
+  }
+
+  .knowledge-section-empty {
+    padding: 10px 12px;
+  }
+}
+
 /* ============================================================
  * Config Provenance Page
  * ============================================================ */

--- a/src/dashboard/static/style.css
+++ b/src/dashboard/static/style.css
@@ -671,6 +671,8 @@ body {
 .graph-layout {
   display: flex;
   gap: 0;
+  flex: 1 1 auto;
+  min-height: 0;
   height: calc(100vh - 140px);
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
@@ -881,6 +883,8 @@ body {
 #cytoscape-mount {
   flex: 1;
   min-height: 0;
+  height: 100%;
+  overflow: hidden;
 }
 
 .graph-status-bar {
@@ -1081,6 +1085,48 @@ body {
 
 .gi-rel-target:hover {
   color: var(--accent-purple);
+}
+
+/* ── Knowledge Graph Page Shell ──────────────────────────── */
+.kg-page-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.kg-page-shell .page-header {
+  flex-shrink: 0;
+  padding: 16px 20px 8px;
+}
+
+.kg-page-shell .graph-layout {
+  flex: 1;
+  min-height: 0;
+}
+
+@media (max-width: 768px) {
+  .kg-page-shell .graph-layout {
+    flex-direction: column;
+    height: auto;
+    min-height: 60vh;
+  }
+  .kg-page-shell .graph-filter-panel {
+    width: 100% !important;
+    max-height: 180px;
+    border-right: none;
+    border-bottom: 1px solid var(--border-subtle);
+    flex-shrink: 0;
+  }
+  .kg-page-shell .graph-inspector {
+    width: 100% !important;
+    max-height: 200px;
+    border-left: none;
+    border-top: 1px solid var(--border-subtle);
+  }
+  .kg-page-shell #graph-container {
+    min-height: 300px;
+  }
 }
 
 /* ── Graph Tooltip ────────────────────────────────────────── */
@@ -2706,7 +2752,8 @@ mark {
   color: var(--accent-green);
 }
 
-#page-knowledge.page.active {
+#page-knowledge.page.active,
+#page-graph.page.active {
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -3187,7 +3234,8 @@ mark {
 }
 
 @media (max-width: 900px) {
-  #page-knowledge.page.active {
+  #page-knowledge.page.active,
+  #page-graph.page.active {
     height: auto;
     min-height: 100vh;
     overflow: visible;
@@ -3240,7 +3288,8 @@ mark {
 }
 
 @media (max-width: 600px) {
-  #page-knowledge.page.active {
+  #page-knowledge.page.active,
+  #page-graph.page.active {
     padding: 14px 12px;
   }
 

--- a/src/hooks/handler.ts
+++ b/src/hooks/handler.ts
@@ -132,6 +132,13 @@ function markTriggered(eventKey: string): void {
   cooldowns.set(eventKey, Date.now());
 }
 
+function buildCooldownKey(input: NormalizedHookInput, content: string): string {
+  if (input.event === 'user_prompt' || input.event === 'post_response') {
+    return `${input.event}:${input.sessionId}:${content.slice(0, 160)}`;
+  }
+  return `${input.event}:${input.filePath ?? input.command ?? input.toolName ?? 'general'}`;
+}
+
 /**
  * Reset all cooldowns (for testing only — in production each hook call is a separate process).
  */
@@ -430,7 +437,9 @@ export async function handleHookEvent(input: NormalizedHookInput): Promise<{
   }
 
   // Minimum length gate
-  const minLen = input.event === 'user_prompt' ? MIN_PROMPT_LENGTH : policy.minLength;
+  const minLen = (input.event === 'user_prompt' || input.event === 'post_response')
+    ? MIN_PROMPT_LENGTH
+    : policy.minLength;
   if (content.length < minLen) {
     return { observation: null, output: defaultOutput };
   }
@@ -459,7 +468,7 @@ export async function handleHookEvent(input: NormalizedHookInput): Promise<{
   }
 
   // Cooldown (per-file or per-command, not per-tool-category)
-  const cooldownKey = `${input.event}:${input.filePath ?? input.command ?? input.toolName ?? 'general'}`;
+  const cooldownKey = buildCooldownKey(input, content);
   if (isInCooldown(cooldownKey)) {
     return { observation: null, output: defaultOutput };
   }

--- a/src/hooks/installers/index.ts
+++ b/src/hooks/installers/index.ts
@@ -287,7 +287,7 @@ function generateKiroHookFiles(): Array<{ filename: string; content: string }> {
  * protocol used by all agents. spawnSync works in both Node.js and Bun
  * runtimes (OpenCode may fall back to Node.js on Windows).
  */
-const OPENCODE_PLUGIN_VERSION = 5;
+const OPENCODE_PLUGIN_VERSION = 6;
 
 function generateOpenCodePlugin(): string {
   return `/**
@@ -306,6 +306,8 @@ import { spawnSync } from 'node:child_process';
 export const MemorixPlugin = async ({ project, client, $, directory, worktree }) => {
   // Generate a stable session ID for this plugin lifetime
   const sessionId = \`opencode-\${Date.now().toString(36)}-\${Math.random().toString(36).slice(2, 8)}\`;
+  let pendingAssistantResponse = null;
+  let lastDeliveredAssistantKey = '';
 
   /**
    * Send event JSON to \`memorix hook\` via child_process.spawnSync.
@@ -338,6 +340,33 @@ export const MemorixPlugin = async ({ project, client, $, directory, worktree })
     }
   }
 
+  function extractMessageInfo(input) {
+    if (input && typeof input === 'object') {
+      if (input.info && typeof input.info === 'object') return input.info;
+      if (input.message && typeof input.message === 'object') return input.message;
+      if (input.properties && typeof input.properties === 'object') {
+        if (input.properties.info && typeof input.properties.info === 'object') return input.properties.info;
+        if (input.properties.message && typeof input.properties.message === 'object') return input.properties.message;
+      }
+    }
+    return input;
+  }
+
+  function extractMessageText(message) {
+    if (!message || typeof message !== 'object') return '';
+    if (typeof message.content === 'string') return message.content.trim();
+    const parts = Array.isArray(message.parts) ? message.parts : [];
+    return parts
+      .map((part) => {
+        if (!part || typeof part !== 'object') return '';
+        if (typeof part.text === 'string') return part.text;
+        if (typeof part.content === 'string') return part.content;
+        return '';
+      })
+      .join('')
+      .trim();
+  }
+
   return {
     /** Session created — record session start */
     'session.created': async ({ session }) => {
@@ -350,6 +379,21 @@ export const MemorixPlugin = async ({ project, client, $, directory, worktree })
 
     /** Session idle — record session end */
     'session.idle': async ({ session }) => {
+      if (pendingAssistantResponse?.text) {
+        const deliveryKey = pendingAssistantResponse.id
+          ? \`\${pendingAssistantResponse.id}:\${pendingAssistantResponse.text}\`
+          : pendingAssistantResponse.text;
+        if (deliveryKey !== lastDeliveredAssistantKey) {
+          runHook({
+            agent: 'opencode',
+            hook_event_name: 'message.updated',
+            ai_response: pendingAssistantResponse.text,
+            message_id: pendingAssistantResponse.id,
+            cwd: directory,
+          });
+          lastDeliveredAssistantKey = deliveryKey;
+        }
+      }
       runHook({
         agent: 'opencode',
         hook_event_name: 'session.idle',
@@ -376,6 +420,19 @@ export const MemorixPlugin = async ({ project, client, $, directory, worktree })
         command: input?.command ?? input?.name ?? '',
         cwd: directory,
       });
+    },
+
+    /** Message updated — cache the latest assistant response until session.idle */
+    'message.updated': async (input, output) => {
+      const message = extractMessageInfo(input);
+      const role = message?.role ?? input?.role ?? input?.info?.role;
+      if (role !== 'assistant') return;
+      const text = extractMessageText(message);
+      if (!text) return;
+      pendingAssistantResponse = {
+        id: message?.id ?? input?.id ?? input?.messageID,
+        text,
+      };
     },
 
     /** Session compacted — record post-compact event */
@@ -698,7 +755,7 @@ export async function installHooks(
       return {
         agent,
         configPath: pluginPath,
-        events: ['session_start', 'session_end', 'post_tool', 'post_edit', 'post_compact', 'post_command'],
+        events: ['session_start', 'session_end', 'post_tool', 'post_edit', 'post_compact', 'post_command', 'post_response'],
         generated: { note: 'OpenCode plugin installed at ' + pluginPath },
       };
     }

--- a/src/hooks/normalizer.ts
+++ b/src/hooks/normalizer.ts
@@ -402,6 +402,9 @@ function normalizeOpenCode(payload: Record<string, unknown>, event: HookEvent): 
   if (event === 'post_command') {
     result.command = (payload.command as string) ?? '';
   }
+  if (event === 'post_response') {
+    result.aiResponse = (payload.ai_response as string) ?? '';
+  }
 
   return result;
 }

--- a/src/memory/formation/evaluate.ts
+++ b/src/memory/formation/evaluate.ts
@@ -31,6 +31,7 @@ const TYPE_WEIGHTS: Record<ObservationType, number> = {
   'discovery':        0.55,
   'what-changed':     0.45,
   'session-request':  0.40,
+  'probe':            0.10,
 };
 
 /** Patterns indicating high-specificity content (boost value) */

--- a/src/memory/retention.ts
+++ b/src/memory/retention.ts
@@ -49,6 +49,12 @@ const TYPE_IMPORTANCE: Record<string, ImportanceLevel> = {
   'why-it-exists': 'medium',
   discovery: 'low',
   'session-request': 'low',
+  probe: 'low',
+};
+
+/** Per-type retention period overrides (in days). When set, replaces the importance-based base retention. */
+const TYPE_RETENTION_OVERRIDE: Partial<Record<string, number>> = {
+  probe: 7, // Operational heartbeats: expire after ~7 days regardless of source/valueCategory
 };
 
 // ── Immunity ─────────────────────────────────────────────────────────
@@ -85,6 +91,15 @@ function getValueCategoryMultiplier(doc: MemorixDocument): number {
  * Combines base retention (from importance/type) with source and valueCategory multipliers.
  */
 export function getEffectiveRetentionDays(doc: MemorixDocument): number {
+  const typeOverride = TYPE_RETENTION_OVERRIDE[doc.type];
+  if (typeOverride !== undefined) {
+    // Type-specific override: use the override directly, ignoring importance-based base retention.
+    // Source multiplier still applies so that e.g. hook-sourced probes decay even faster.
+    // valueCategory multiplier is intentionally excluded for type-override types:
+    // probe + core must NOT extend to 14 days -- probe is always short-lived.
+    const raw = typeOverride * getSourceRetentionMultiplier(doc);
+    return Math.max(MIN_RETENTION_DAYS, raw);
+  }
   const importance = getImportanceLevel(doc);
   const raw = RETENTION_DAYS[importance] * getSourceRetentionMultiplier(doc) * getValueCategoryMultiplier(doc);
   return Math.max(MIN_RETENTION_DAYS, raw);
@@ -95,6 +110,9 @@ export function getEffectiveRetentionDays(doc: MemorixDocument): number {
  * Immune observations maintain a minimum relevance score.
  */
 export function isImmune(doc: MemorixDocument): boolean {
+  // Probe observations are operational heartbeats -- never immune, regardless of valueCategory or access.
+  if (doc.type === 'probe') return false;
+
   // formation-classified core memories are immune regardless of type
   if (doc.valueCategory === 'core') return true;
 
@@ -114,6 +132,9 @@ export function isImmune(doc: MemorixDocument): boolean {
  * Return a human-readable reason for why an observation is immune, or null if not immune.
  */
 export function getImmunityReason(doc: MemorixDocument): string | null {
+  // Probe observations are never immune
+  if (doc.type === 'probe') return null;
+
   if (doc.valueCategory === 'core') return 'core valueCategory (formation-classified)';
   const importance = getImportanceLevel(doc);
   if (importance === 'critical') return 'critical importance';

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -30,6 +30,7 @@ const TYPE_EMOJI: Record<string, string> = {
   'what-changed': '[CHANGE]',
   'why-it-exists': '[DECISION]',
   'session-request': '[SESSION]',
+  'probe': '[PROBE]',
 };
 const TYPE_WEIGHTS: Record<string, number> = {
   'gotcha': 6,
@@ -201,6 +202,11 @@ export function scoreObservationForSessionContext(obs: Observation, projectToken
   if (obs.valueCategory === 'core') {
     // Formation-classified core memory: high-value, prefer in working context
     score += 2;
+  }
+
+  // Probe observations are operational heartbeats — never surface as priority session context
+  if (obs.type === 'probe') {
+    score -= 100;
   }
 
   return score;

--- a/src/server.ts
+++ b/src/server.ts
@@ -91,6 +91,7 @@ const OBSERVATION_TYPES: [string, ...string[]] = [
   'why-it-exists',
   'decision',
   'trade-off',
+  'probe',
 ];
 
 /**

--- a/src/skills/mini-skills.ts
+++ b/src/skills/mini-skills.ts
@@ -68,6 +68,15 @@ export async function promoteToMiniSkill(
     );
   }
 
+  // R1c: Probe observations are operational heartbeats -- never promotable, even with force=true
+  const probes = observations.filter(o => o.type === 'probe');
+  if (probes.length > 0) {
+    throw new Error(
+      `Cannot promote probe observations — they are operational heartbeats, not durable knowledge. ` +
+      `Blocked: ${probes.map(o => `#${o.id} "${o.title.substring(0, 60)}"`).join(', ')}.`,
+    );
+  }
+
   if (!options?.force) {
     // R2: No command-log noise
     const commandLogs = observations.filter(o => COMMAND_LOG_TITLE.test(o.title));

--- a/src/store/orama-store.ts
+++ b/src/store/orama-store.ts
@@ -476,6 +476,14 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
       const doc = hit.document as unknown as MemorixDocument;
       return (doc.status || 'active') === statusFilter;
     })
+    // Post-filter: exclude probe observations from default search.
+    // Probe is operational memory (heartbeats, connectivity checks) — not durable knowledge.
+    // Only included when the caller explicitly requests type: 'probe'.
+    .filter((hit) => {
+      if (options.type === 'probe') return true;
+      const doc = hit.document as unknown as MemorixDocument;
+      return doc.type !== 'probe';
+    })
     .map((hit) => {
       const doc = hit.document as unknown as MemorixDocument;
       const obsType = doc.type as ObservationType;

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,6 +52,7 @@ export interface KnowledgeGraph {
  * [DECISION] decision          — Architecture decision
  * [TRADEOFF] trade-off         — Deliberate compromise
  * [REASONING] reasoning         — Why this approach was chosen (System 2 reasoning trace)
+ * [PROBE] probe                — Operational heartbeat / connectivity check (short-lived, excluded from default search)
  */
 export type ObservationType =
   | 'session-request'
@@ -63,7 +64,8 @@ export type ObservationType =
   | 'why-it-exists'
   | 'decision'
   | 'trade-off'
-  | 'reasoning';
+  | 'reasoning'
+  | 'probe';
 
 /** Map from ObservationType to display icon */
 export const OBSERVATION_ICONS: Record<ObservationType, string> = {
@@ -77,6 +79,7 @@ export const OBSERVATION_ICONS: Record<ObservationType, string> = {
   'decision': '[DECISION]',
   'trade-off': '[TRADEOFF]',
   'reasoning': '[REASONING]',
+  'probe': '[PROBE]',
 };
 
 /** Observation lifecycle status */

--- a/src/wiki/generator.ts
+++ b/src/wiki/generator.ts
@@ -1,0 +1,237 @@
+import type { Observation, MiniSkill } from '../types.js';
+import type { KnowledgeSourceRef, KnowledgeItem, KnowledgeSection, ProjectKnowledgeOverview } from './types.js';
+
+const COMMAND_LOG_TITLE = /^(Ran:|Command:|Executed:)\s/i;
+
+interface SectionDef {
+  id: string;
+  title: string;
+  typeMatch: (o: Observation) => boolean;
+}
+
+const SECTION_DEFS: SectionDef[] = [
+  {
+    id: 'core-decisions',
+    title: 'Core Decisions',
+    typeMatch: (o) => o.type === 'decision' || o.type === 'trade-off' || o.type === 'reasoning',
+  },
+  {
+    id: 'operational-knowledge',
+    title: 'Operational Knowledge',
+    typeMatch: (o) =>
+      o.type === 'how-it-works' ||
+      o.type === 'what-changed' ||
+      o.type === 'why-it-exists' ||
+      o.type === 'discovery' ||
+      o.type === 'session-request',
+  },
+  {
+    id: 'known-gotchas',
+    title: 'Known Gotchas',
+    typeMatch: (o) => o.type === 'gotcha' || o.type === 'problem-solution',
+  },
+];
+
+function isExcludedType(o: Observation): boolean {
+  return o.type === 'probe';
+}
+
+function isCommandLog(o: Observation): boolean {
+  return COMMAND_LOG_TITLE.test(o.title || '');
+}
+
+function isInactive(o: Observation): boolean {
+  const status = o.status ?? 'active';
+  return status !== 'active';
+}
+
+function isOtherProject(o: Observation, projectId: string): boolean {
+  return o.projectId !== projectId;
+}
+
+function contextualHasSubstance(o: Observation): boolean {
+  if (o.valueCategory !== 'contextual') return true;
+  const hasFacts = (o.facts?.length ?? 0) > 0;
+  const hasConcepts = (o.concepts?.length ?? 0) > 0;
+  const hasFiles = (o.filesModified?.length ?? 0) > 0;
+  const hasEntity = !!(o.entityName && o.entityName !== 'quick-note' && o.entityName !== 'unknown');
+  return hasFacts || hasConcepts || hasFiles || hasEntity;
+}
+
+function isEligible(o: Observation, projectId: string): boolean {
+  if (isExcludedType(o)) return false;
+  if (isCommandLog(o)) return false;
+  if (isInactive(o)) return false;
+  if (isOtherProject(o, projectId)) return false;
+  if (o.valueCategory === 'ephemeral') return false;
+  if (!contextualHasSubstance(o)) return false;
+  return true;
+}
+
+function obsToItem(o: Observation): KnowledgeItem {
+  const ref: KnowledgeSourceRef = {
+    kind: o.source === 'git' ? 'git' : 'observation',
+    id: `obs:${o.id}`,
+    title: o.title,
+  };
+  return {
+    title: o.title,
+    summary: o.narrative?.slice(0, 200) || '',
+    type: o.type,
+    entityName: o.entityName || undefined,
+    refs: [ref],
+  };
+}
+
+function skillToItem(s: MiniSkill): KnowledgeItem {
+  const ref: KnowledgeSourceRef = {
+    kind: 'mini-skill',
+    id: `skill:${s.id}`,
+    title: s.title,
+  };
+  const obsRefs: KnowledgeSourceRef[] = s.sourceObservationIds.map(
+    (oid) => ({ kind: 'observation' as const, id: `obs:${oid}` }),
+  );
+  return {
+    title: s.title,
+    summary: s.instruction?.slice(0, 200) || '',
+    type: 'mini-skill',
+    entityName: s.sourceEntity || undefined,
+    refs: [ref, ...obsRefs],
+  };
+}
+
+function buildGitSection(observations: Observation[]): KnowledgeSection {
+  const gitObs = observations.filter(
+    (o) => o.source === 'git' && o.sourceDetail === 'git-ingest',
+  );
+  const items = gitObs.map(obsToItem);
+  return {
+    id: 'git-backed-facts',
+    title: 'Git-backed Facts',
+    items,
+    empty: items.length === 0,
+  };
+}
+
+function buildSkillsSection(skills: MiniSkill[]): KnowledgeSection {
+  const items = skills.map(skillToItem);
+  return {
+    id: 'promoted-skills',
+    title: 'Promoted Skills',
+    items,
+    empty: items.length === 0,
+  };
+}
+
+function buildProjectOverview(
+  projectId: string,
+  eligibleObs: Observation[],
+  skills: MiniSkill[],
+): KnowledgeSection {
+  const refs: KnowledgeSourceRef[] = [
+    ...eligibleObs.slice(0, 5).map((o) => ({
+      kind: o.source === 'git' ? 'git' as const : 'observation' as const,
+      id: `obs:${o.id}`,
+      title: o.title,
+    })),
+    ...skills.slice(0, 5).map((s) => ({
+      kind: 'mini-skill' as const,
+      id: `skill:${s.id}`,
+      title: s.title,
+    })),
+  ];
+
+  if (refs.length === 0) {
+    return {
+      id: 'project-overview',
+      title: 'Project Overview',
+      items: [],
+      empty: true,
+    };
+  }
+
+  const lines: string[] = [];
+  lines.push(`Project: ${projectId}`);
+  lines.push(`Observations in KB: ${eligibleObs.length}`);
+  lines.push(`Promoted skills: ${skills.length}`);
+
+  const entityCounts = new Map<string, number>();
+  for (const o of eligibleObs) {
+    if (o.entityName) {
+      entityCounts.set(o.entityName, (entityCounts.get(o.entityName) || 0) + 1);
+    }
+  }
+  const topEntities = [...entityCounts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 5);
+  if (topEntities.length > 0) {
+    lines.push(`Top entities: ${topEntities.map(([name, count]) => `${name} (${count})`).join(', ')}`);
+  }
+
+  return {
+    id: 'project-overview',
+    title: 'Project Overview',
+    items: [{
+      title: projectId,
+      summary: lines.join('\n'),
+      type: 'overview',
+      refs,
+    }],
+  };
+}
+
+export interface GenerateOptions {
+  projectId: string;
+  observations: Observation[];
+  miniSkills: MiniSkill[];
+  generatedAt?: string;
+}
+
+export function generateKnowledgeBase(options: GenerateOptions): ProjectKnowledgeOverview {
+  const { projectId, observations, miniSkills } = options;
+
+  const eligible = observations.filter((o) => isEligible(o, projectId));
+  const scopedMiniSkills = miniSkills.filter(s => s.projectId === projectId);
+
+  const typedSections: KnowledgeSection[] = SECTION_DEFS.map((def) => {
+    const matched = eligible.filter(def.typeMatch);
+    const items = matched.map(obsToItem);
+    return {
+      id: def.id,
+      title: def.title,
+      items,
+      empty: items.length === 0,
+    };
+  });
+
+  const projectOverview = buildProjectOverview(projectId, eligible, scopedMiniSkills);
+  const gitSection = buildGitSection(eligible);
+  const skillsSection = buildSkillsSection(scopedMiniSkills);
+
+  const sections: KnowledgeSection[] = [
+    projectOverview,
+    ...typedSections,
+    gitSection,
+    skillsSection,
+  ];
+
+  const allRefs = sections.flatMap((s) => s.items.flatMap((i) => i.refs));
+  const obsRefCount = allRefs.filter((r) => r.kind === 'observation' || r.kind === 'git').length;
+  const skillRefCount = allRefs.filter((r) => r.kind === 'mini-skill').length;
+
+  return {
+    title: 'Knowledge Base',
+    subtitle: 'LLM Wiki',
+    projectId,
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+    sections,
+    stats: {
+      observationsUsed: eligible.length,
+      miniSkillsUsed: scopedMiniSkills.length,
+      refs: obsRefCount + skillRefCount,
+    },
+  };
+}
+
+export { isEligible, isExcludedType, isCommandLog, contextualHasSubstance };

--- a/src/wiki/knowledge-graph.ts
+++ b/src/wiki/knowledge-graph.ts
@@ -1,0 +1,347 @@
+import type { Observation, MiniSkill } from '../types.js';
+import type {
+  KnowledgeSourceRef,
+  SemanticNode,
+  SemanticEdge,
+  SemanticEdgeType,
+  KnowledgeGraphCluster,
+  KnowledgeGraphStats,
+  ProjectKnowledgeGraph,
+} from './types.js';
+import { isEligible } from './generator.js';
+
+// -- Section definitions (must match generator.ts SECTION_DEFS) --
+
+interface SectionDef {
+  id: string;
+  label: string;
+  typeMatch: (o: Observation) => boolean;
+}
+
+const SECTION_DEFS: SectionDef[] = [
+  {
+    id: 'core-decisions',
+    label: 'Core Decisions',
+    typeMatch: (o) => o.type === 'decision' || o.type === 'trade-off' || o.type === 'reasoning',
+  },
+  {
+    id: 'operational-knowledge',
+    label: 'Operational Knowledge',
+    typeMatch: (o) =>
+      o.type === 'how-it-works' ||
+      o.type === 'what-changed' ||
+      o.type === 'why-it-exists' ||
+      o.type === 'discovery' ||
+      o.type === 'session-request',
+  },
+  {
+    id: 'known-gotchas',
+    label: 'Known Gotchas',
+    typeMatch: (o) => o.type === 'gotcha' || o.type === 'problem-solution',
+  },
+];
+
+const GIT_SECTION: SectionDef = {
+  id: 'git-backed-facts',
+  label: 'Git-backed Facts',
+  typeMatch: (o) => o.source === 'git' && o.sourceDetail === 'git-ingest',
+};
+
+const SKILLS_SECTION: SectionDef = {
+  id: 'promoted-skills',
+  label: 'Promoted Skills',
+  typeMatch: () => false, // skills handled separately
+};
+
+const ALL_SECTIONS: SectionDef[] = [...SECTION_DEFS, GIT_SECTION, SKILLS_SECTION];
+
+// -- Edge inference rules --
+// Infer semantic edges between observations based on shared attributes.
+// Rules (no LLM, deterministic):
+// 1. supports: same entityName, different section -> source supports target
+// 2. relates_to: same entityName, same section -> bidirectional
+// 3. mentions: entityName of A appears in concepts/facts of B -> A mentions B
+// 4. derived_from: mini-skill source obs -> skill node
+
+function inferEdges(
+  nodes: SemanticNode[],
+  entityNameIndex: Map<string, SemanticNode[]>,
+): SemanticEdge[] {
+  const edges: SemanticEdge[] = [];
+  const seen = new Set<string>();
+  const maxRelatesEdgesPerEntitySection = 8;
+
+  function addEdge(source: string, target: string, edgeType: SemanticEdgeType): void {
+    const key = `${source}:${edgeType}:${target}`;
+    if (seen.has(key)) return;
+    if (source === target) return;
+    seen.add(key);
+    edges.push({
+      id: `e_${edges.length}_${source}_${target}`,
+      source,
+      target,
+      edgeType,
+    });
+  }
+
+  function rankNodesForEntity(a: SemanticNode, b: SemanticNode): number {
+    const evidenceDiff = (b.evidenceCount || 0) - (a.evidenceCount || 0);
+    if (evidenceDiff !== 0) return evidenceDiff;
+    return a.id.localeCompare(b.id);
+  }
+
+  // 1 & 2: Entity-name based edges
+  for (const [, group] of entityNameIndex) {
+    if (group.length < 2) continue;
+
+    const bySection = new Map<string, SemanticNode[]>();
+    for (const node of group) {
+      const sectionGroup = bySection.get(node.sectionId) || [];
+      sectionGroup.push(node);
+      bySection.set(node.sectionId, sectionGroup);
+    }
+
+    for (const sectionGroup of bySection.values()) {
+      const ranked = [...sectionGroup].sort(rankNodesForEntity);
+      if (ranked.length === 2) {
+        addEdge(ranked[0].id, ranked[1].id, 'relates_to');
+        addEdge(ranked[1].id, ranked[0].id, 'relates_to');
+        continue;
+      }
+      const anchor = ranked[0];
+      for (const node of ranked.slice(1, maxRelatesEdgesPerEntitySection + 1)) {
+        addEdge(anchor.id, node.id, 'relates_to');
+      }
+    }
+
+    const sectionAnchors = [...bySection.entries()]
+      .map(([sectionId, sectionGroup]) => ({
+        sectionId,
+        anchor: [...sectionGroup].sort(rankNodesForEntity)[0],
+      }))
+      .sort((a, b) => sectionPriority(a.sectionId) - sectionPriority(b.sectionId));
+
+    for (let i = 0; i < sectionAnchors.length; i++) {
+      for (let j = i + 1; j < sectionAnchors.length; j++) {
+        const from = sectionAnchors[i].anchor;
+        const to = sectionAnchors[j].anchor;
+        const edgeType = sectionPriority(sectionAnchors[i].sectionId) === sectionPriority(sectionAnchors[j].sectionId)
+          ? 'relates_to'
+          : 'supports';
+        addEdge(from.id, to.id, edgeType);
+      }
+    }
+  }
+
+  // 3: Concept/fact cross-reference edges (mentions)
+  for (const node of nodes) {
+    if (!node.refs.length) continue;
+    for (const ref of node.refs) {
+      for (const other of nodes) {
+        if (other.id === node.id) continue;
+        if (ref.title && other.label.toLowerCase().includes(ref.title.toLowerCase().slice(0, 20))) {
+          addEdge(node.id, other.id, 'mentions');
+        }
+      }
+    }
+  }
+
+  return edges;
+}
+
+function sectionPriority(sectionId: string): number {
+  const order = ['core-decisions', 'known-gotchas', 'operational-knowledge', 'git-backed-facts', 'promoted-skills'];
+  const idx = order.indexOf(sectionId);
+  return idx >= 0 ? idx : order.length;
+}
+
+function sectionIdForObs(o: Observation): string {
+  // Git-backed facts take priority over type-based sections
+  if (GIT_SECTION.typeMatch(o)) return GIT_SECTION.id;
+  for (const def of SECTION_DEFS) {
+    if (def.typeMatch(o)) return def.id;
+  }
+  return 'operational-knowledge'; // fallback
+}
+
+// -- Graph store entity/relation types --
+
+export interface GraphStoreEntity {
+  name: string;
+  entityType: string;
+  observations: string[];
+}
+
+export interface GraphStoreRelation {
+  from: string;
+  to: string;
+  relationType: string;
+}
+
+// Map graph-store relationType to SemanticEdgeType
+function mapRelationType(relationType: string): SemanticEdgeType {
+  const lower = relationType.toLowerCase();
+  if (lower.includes('support') || lower.includes('depend')) return 'supports';
+  if (lower.includes('relat') || lower.includes('connect') || lower.includes('associat')) return 'relates_to';
+  if (lower.includes('mention') || lower.includes('refer')) return 'mentions';
+  if (lower.includes('deriv') || lower.includes('origin') || lower.includes('source')) return 'derived_from';
+  return 'relates_to'; // default fallback
+}
+
+// -- Main generator --
+
+export interface GenerateGraphOptions {
+  projectId: string;
+  observations: Observation[];
+  miniSkills: MiniSkill[];
+  generatedAt?: string;
+  graphEntities?: GraphStoreEntity[];
+  graphRelations?: GraphStoreRelation[];
+}
+
+export function generateKnowledgeGraph(options: GenerateGraphOptions): ProjectKnowledgeGraph {
+  const { projectId, observations, miniSkills, graphEntities, graphRelations } = options;
+
+  const eligible = observations.filter((o) => isEligible(o, projectId));
+  const scopedMiniSkills = miniSkills.filter((s) => s.projectId === projectId);
+
+  // Build nodes from eligible observations
+  const nodes: SemanticNode[] = [];
+  const entityNameIndex = new Map<string, SemanticNode[]>();
+
+  for (const o of eligible) {
+    const sectionId = sectionIdForObs(o);
+    const ref: KnowledgeSourceRef = {
+      kind: o.source === 'git' ? 'git' : 'observation',
+      id: `obs:${o.id}`,
+      title: o.title,
+    };
+    const node: SemanticNode = {
+      id: `obs:${o.id}`,
+      label: o.title,
+      nodeType: o.type,
+      sectionId,
+      entityName: o.entityName || undefined,
+      evidenceCount: (o.facts?.length ?? 0) + (o.concepts?.length ?? 0) + (o.filesModified?.length ?? 0),
+      summary: o.narrative?.slice(0, 200) || '',
+      refs: [ref],
+    };
+    nodes.push(node);
+
+    if (o.entityName) {
+      const group = entityNameIndex.get(o.entityName) || [];
+      group.push(node);
+      entityNameIndex.set(o.entityName, group);
+    }
+  }
+
+  // Build nodes from mini-skills
+  for (const s of scopedMiniSkills) {
+    const ref: KnowledgeSourceRef = {
+      kind: 'mini-skill',
+      id: `skill:${s.id}`,
+      title: s.title,
+    };
+    const obsRefs: KnowledgeSourceRef[] = s.sourceObservationIds.map(
+      (oid) => ({ kind: 'observation' as const, id: `obs:${oid}` }),
+    );
+    const node: SemanticNode = {
+      id: `skill:${s.id}`,
+      label: s.title,
+      nodeType: 'mini-skill',
+      sectionId: 'promoted-skills',
+      entityName: s.sourceEntity || undefined,
+      evidenceCount: obsRefs.length,
+      summary: s.instruction?.slice(0, 200) || '',
+      refs: [ref, ...obsRefs],
+    };
+    nodes.push(node);
+
+    if (s.sourceEntity) {
+      const group = entityNameIndex.get(s.sourceEntity) || [];
+      group.push(node);
+      entityNameIndex.set(s.sourceEntity, group);
+    }
+  }
+
+  // Infer edges from observation/skill semantics
+  const edges = inferEdges(nodes, entityNameIndex);
+
+  // Add derived_from edges: skill -> source obs
+  for (const s of scopedMiniSkills) {
+    const skillNodeId = `skill:${s.id}`;
+    for (const oid of s.sourceObservationIds) {
+      const obsNodeId = `obs:${oid}`;
+      if (nodes.some((n) => n.id === obsNodeId)) {
+        edges.push({
+          id: `e_${edges.length}_${skillNodeId}_${obsNodeId}`,
+          source: skillNodeId,
+          target: obsNodeId,
+          edgeType: 'derived_from',
+        });
+      }
+    }
+  }
+
+  // Merge graph-store relations into semantic edges
+  // Only include relations where both endpoints map to existing nodes
+  if (graphRelations && graphRelations.length > 0) {
+    const entityNodeMap = new Map<string, string>(); // entityName -> first matching nodeId
+    for (const n of nodes) {
+      if (n.entityName && !entityNodeMap.has(n.entityName)) {
+        entityNodeMap.set(n.entityName, n.id);
+      }
+    }
+
+    const seen = new Set(edges.map((e) => `${e.source}:${e.edgeType}:${e.target}`));
+
+    for (const rel of graphRelations) {
+      const srcId = entityNodeMap.get(rel.from);
+      const tgtId = entityNodeMap.get(rel.to);
+      if (!srcId || !tgtId) continue; // skip if either endpoint not in project scope
+      if (srcId === tgtId) continue;
+      const edgeType = mapRelationType(rel.relationType);
+      const key = `${srcId}:${edgeType}:${tgtId}`;
+      if (seen.has(key)) continue; // skip duplicates
+      seen.add(key);
+      edges.push({
+        id: `e_gr_${edges.length}_${srcId}_${tgtId}`,
+        source: srcId,
+        target: tgtId,
+        edgeType,
+      });
+    }
+  }
+
+  // Build clusters from sections
+  const sectionCounts: Record<string, number> = {};
+  for (const n of nodes) {
+    sectionCounts[n.sectionId] = (sectionCounts[n.sectionId] || 0) + 1;
+  }
+
+  const clusters: KnowledgeGraphCluster[] = ALL_SECTIONS
+    .filter((def) => (sectionCounts[def.id] ?? 0) > 0)
+    .map((def) => ({
+      id: `cluster:${def.id}`,
+      label: def.label,
+      sectionId: def.id,
+      nodeCount: sectionCounts[def.id] ?? 0,
+    }));
+
+  const stats: KnowledgeGraphStats = {
+    totalNodes: nodes.length,
+    totalEdges: edges.length,
+    clusterCount: clusters.length,
+    sectionCounts,
+  };
+
+  return {
+    title: 'Knowledge Graph',
+    projectId,
+    generatedAt: options.generatedAt ?? new Date().toISOString(),
+    nodes,
+    edges,
+    clusters,
+    stats,
+  };
+}

--- a/src/wiki/types.ts
+++ b/src/wiki/types.ts
@@ -1,0 +1,33 @@
+export interface KnowledgeSourceRef {
+  kind: 'observation' | 'mini-skill' | 'git';
+  id: string;
+  title?: string;
+}
+
+export interface KnowledgeItem {
+  title: string;
+  summary: string;
+  type: string;
+  entityName?: string;
+  refs: KnowledgeSourceRef[];
+}
+
+export interface KnowledgeSection {
+  id: string;
+  title: string;
+  items: KnowledgeItem[];
+  empty?: boolean;
+}
+
+export interface ProjectKnowledgeOverview {
+  title: 'Knowledge Base';
+  subtitle: 'LLM Wiki';
+  projectId: string;
+  generatedAt: string;
+  sections: KnowledgeSection[];
+  stats: {
+    observationsUsed: number;
+    miniSkillsUsed: number;
+    refs: number;
+  };
+}

--- a/src/wiki/types.ts
+++ b/src/wiki/types.ts
@@ -31,3 +31,55 @@ export interface ProjectKnowledgeOverview {
     refs: number;
   };
 }
+
+// -- Knowledge Graph types --
+
+export type SemanticEdgeType = 'supports' | 'relates_to' | 'mentions' | 'derived_from';
+
+export interface SemanticNode {
+  id: string;
+  label: string;
+  /** Observation type or 'mini-skill' or 'section-cluster' */
+  nodeType: string;
+  /** Section this node belongs to (e.g. 'core-decisions') */
+  sectionId: string;
+  /** Entity name if applicable */
+  entityName?: string;
+  /** Number of provenance refs / evidence items */
+  evidenceCount: number;
+  /** Summary text (truncated) */
+  summary: string;
+  /** Source refs for inspector */
+  refs: KnowledgeSourceRef[];
+}
+
+export interface SemanticEdge {
+  id: string;
+  source: string;
+  target: string;
+  edgeType: SemanticEdgeType;
+}
+
+export interface KnowledgeGraphCluster {
+  id: string;
+  label: string;
+  sectionId: string;
+  nodeCount: number;
+}
+
+export interface KnowledgeGraphStats {
+  totalNodes: number;
+  totalEdges: number;
+  clusterCount: number;
+  sectionCounts: Record<string, number>;
+}
+
+export interface ProjectKnowledgeGraph {
+  title: 'Knowledge Graph';
+  projectId: string;
+  generatedAt: string;
+  nodes: SemanticNode[];
+  edges: SemanticEdge[];
+  clusters: KnowledgeGraphCluster[];
+  stats: KnowledgeGraphStats;
+}

--- a/tests/cli/init-shared.test.ts
+++ b/tests/cli/init-shared.test.ts
@@ -1,0 +1,18 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { getEnvTemplateTarget } from '../../src/cli/commands/init-shared.js';
+
+describe('getEnvTemplateTarget', () => {
+  const targetDir = path.join('C:', 'workspace', 'memorix-project');
+
+  it('uses .env.example when the project does not already have one', () => {
+    expect(getEnvTemplateTarget(targetDir, { hasDotenvExample: false }))
+      .toBe(path.join(targetDir, '.env.example'));
+  });
+
+  it('falls back to .env.memorix-example when .env.example already exists', () => {
+    expect(getEnvTemplateTarget(targetDir, { hasDotenvExample: true }))
+      .toBe(path.join(targetDir, '.env.memorix-example'));
+  });
+});

--- a/tests/hooks/normalizer.test.ts
+++ b/tests/hooks/normalizer.test.ts
@@ -180,6 +180,19 @@ describe('Hook Normalizer', () => {
       expect(input.aiResponse).toBe('I fixed the bug by...');
     });
 
+    it('should normalize OpenCode message.updated → post_response with aiResponse', () => {
+      const input = normalizeHookInput({
+        agent: 'opencode',
+        hook_event_name: 'message.updated',
+        ai_response: 'Finished implementing the fix and updated the tests.',
+        session_id: 'oc-1',
+        cwd: '/project',
+      });
+      expect(input.agent).toBe('opencode');
+      expect(input.event).toBe('post_response');
+      expect(input.aiResponse).toBe('Finished implementing the fix and updated the tests.');
+    });
+
     it('should normalize Windsurf MCP tool use', () => {
       const input = normalizeHookInput({
         agent_action_name: 'post_mcp_tool_use',

--- a/tests/hooks/opencode-compaction.test.ts
+++ b/tests/hooks/opencode-compaction.test.ts
@@ -57,6 +57,11 @@ describe('Issue #45: OpenCode compaction', () => {
       expect(result.events).toContain('post_compact');
     });
 
+    it('should include post_response in returned events list', async () => {
+      const result = await installHooks('opencode', tmpDir);
+      expect(result.events).toContain('post_response');
+    });
+
     it('should NOT include pre_compact in returned events list', async () => {
       const result = await installHooks('opencode', tmpDir);
       expect(result.events).not.toContain('pre_compact');
@@ -151,6 +156,15 @@ describe('Issue #80: OpenCode plugin must use correct event keys', () => {
     expect(content).toContain("'tool.execute.after':");
   });
 
+  it('should use message.updated as direct hook key', async () => {
+    await installHooks('opencode', tmpDir);
+    const pluginPath = path.join(tmpDir, '.opencode', 'plugins', 'memorix.js');
+    const content = await fs.readFile(pluginPath, 'utf-8');
+    expect(content).toContain("'message.updated':");
+    expect(content).toContain('pendingAssistantResponse');
+    expect(content).toContain('hook_event_name: \'message.updated\'');
+  });
+
   it('should NOT contain catch-all event handler', async () => {
     await installHooks('opencode', tmpDir);
     const pluginPath = path.join(tmpDir, '.opencode', 'plugins', 'memorix.js');
@@ -191,11 +205,11 @@ describe('Issue #80: OpenCode plugin must use correct event keys', () => {
 
   // ─── Plugin version ───
 
-  it('should generate version 5 plugin (spawnSync, cross-runtime)', async () => {
+  it('should generate version 6 plugin (assistant response capture + spawnSync)', async () => {
     await installHooks('opencode', tmpDir);
     const pluginPath = path.join(tmpDir, '.opencode', 'plugins', 'memorix.js');
     const content = await fs.readFile(pluginPath, 'utf-8');
-    expect(content).toContain('@generated-version 5');
+    expect(content).toContain('@generated-version 6');
   });
 
   // ─── Hooks status: verified field ───
@@ -276,15 +290,16 @@ describe('Issue #80: OpenCode plugin must use correct event keys', () => {
 
   // ─── Reinstall ───
 
-  it('should reinstall after uninstall with correct v5 format', async () => {
+  it('should reinstall after uninstall with correct v6 format', async () => {
     await installHooks('opencode', tmpDir);
     await uninstallHooks('opencode', tmpDir);
     await installHooks('opencode', tmpDir);
 
     const pluginPath = path.join(tmpDir, '.opencode', 'plugins', 'memorix.js');
     const content = await fs.readFile(pluginPath, 'utf-8');
-    expect(content).toContain('@generated-version 5');
+    expect(content).toContain('@generated-version 6');
     expect(content).toContain("'session.created':");
+    expect(content).toContain("'message.updated':");
     expect(content).toContain('spawnSync');
   });
 });

--- a/tests/hooks/opencode-e2e-pipeline.test.ts
+++ b/tests/hooks/opencode-e2e-pipeline.test.ts
@@ -87,6 +87,18 @@ describe('OpenCode e2e pipeline: event → normalize → handle → store', () =
       });
       expect(input.event).toBe('post_compact');
     });
+
+    it('should normalize message.updated → post_response with AI text', () => {
+      const input = normalizeHookInput({
+        agent: 'opencode',
+        hook_event_name: 'message.updated',
+        ai_response: 'I updated the auth flow and added coverage for token refresh.',
+        cwd: '/project',
+        session_id: 'oc-abc123',
+      });
+      expect(input.event).toBe('post_response');
+      expect(input.aiResponse).toBe('I updated the auth flow and added coverage for token refresh.');
+    });
   });
 
   // ─── Handler: OpenCode events produce observations ───
@@ -232,6 +244,41 @@ describe('OpenCode e2e pipeline: event → normalize → handle → store', () =
       const { observation } = await handleHookEvent(input);
       // No content → below 50 char minimum → no observation
       expect(observation).toBeNull();
+    });
+
+    it('message.updated should produce a post_response observation for assistant text', async () => {
+      const input: NormalizedHookInput = {
+        ...baseInput,
+        event: 'post_response',
+        sessionId: 'oc-test-010',
+        cwd: '/project',
+        aiResponse: 'Implemented the OpenCode hook fix by caching assistant messages and flushing them on session idle.',
+      };
+      const { observation, output } = await handleHookEvent(input);
+      expect(observation).not.toBeNull();
+      expect(observation!.narrative).toContain('caching assistant messages');
+      expect(output.continue).toBe(true);
+    });
+
+    it('distinct post_response events in the same session should not collide in cooldown', async () => {
+      const first: NormalizedHookInput = {
+        ...baseInput,
+        event: 'post_response',
+        sessionId: 'oc-test-011',
+        cwd: '/project',
+        aiResponse: 'First assistant response about auth token rotation and refresh handling.',
+      };
+      const second: NormalizedHookInput = {
+        ...baseInput,
+        event: 'post_response',
+        sessionId: 'oc-test-011',
+        cwd: '/project',
+        aiResponse: 'Second assistant response about dashboard knowledge graph rendering.',
+      };
+      const firstResult = await handleHookEvent(first);
+      const secondResult = await handleHookEvent(second);
+      expect(firstResult.observation).not.toBeNull();
+      expect(secondResult.observation).not.toBeNull();
     });
   });
 

--- a/tests/integration/dashboard-project-scope.test.ts
+++ b/tests/integration/dashboard-project-scope.test.ts
@@ -185,6 +185,83 @@ describe('Standalone Dashboard Project Scope', () => {
     expect(titles).not.toContain('Token expiry');
   });
 
+  // ── /api/knowledge-graph project scope ──
+
+  it('GET /api/knowledge-graph returns project-scoped semantic graph', async () => {
+    const { status, body } = await fetchJson('/api/knowledge-graph');
+    expect(status).toBe(200);
+
+    expect(body.title).toBe('Knowledge Graph');
+    expect(body.projectId).toBe(PROJECT_A);
+    expect(body.nodes.length).toBeGreaterThan(0);
+    expect(body.clusters.length).toBeGreaterThan(0);
+    expect(body.stats.totalNodes).toBeGreaterThan(0);
+
+    // No nodes from project B
+    const nodeIds = body.nodes.map((n: any) => n.id);
+    expect(nodeIds).not.toContain('obs:3');
+    expect(nodeIds).not.toContain('obs:4');
+  });
+
+  it('GET /api/knowledge-graph?project=... returns requested project graph only', async () => {
+    const { status, body } = await fetchJson(`/api/knowledge-graph?project=${encodeURIComponent(PROJECT_B)}`);
+    expect(status).toBe(200);
+
+    expect(body.projectId).toBe(PROJECT_B);
+    // Project B has billing-service observations
+    const labels = body.nodes.map((n: any) => n.label);
+    expect(labels).toContain('Use Stripe');
+    expect(labels).toContain('Webhook retry');
+    expect(labels).not.toContain('Use JWT');
+    expect(labels).not.toContain('Token expiry');
+  });
+
+  it('GET /api/knowledge-graph excludes resolved observations', async () => {
+    const { status, body } = await fetchJson('/api/knowledge-graph');
+    expect(status).toBe(200);
+
+    // Project A has obs 1 (active), 2 (active), 5 (resolved)
+    // Only 1 and 2 should appear as nodes
+    const nodeIds = body.nodes.map((n: any) => n.id);
+    expect(nodeIds).toContain('obs:1');
+    expect(nodeIds).toContain('obs:2');
+    expect(nodeIds).not.toContain('obs:5');
+  });
+
+  it('GET /api/knowledge-graph response shape supports showKGInspector', async () => {
+    const { status, body } = await fetchJson('/api/knowledge-graph');
+    expect(status).toBe(200);
+
+    // Every node must have fields that showKGInspector reads
+    for (const node of body.nodes) {
+      expect(node).toHaveProperty('id');
+      expect(node).toHaveProperty('label');
+      expect(node).toHaveProperty('nodeType');
+      expect(node).toHaveProperty('sectionId');
+      expect(node).toHaveProperty('evidenceCount');
+      expect(node).toHaveProperty('summary');
+      expect(node).toHaveProperty('refs');
+      // sectionId must be a known i18n key target
+      expect(['core-decisions', 'operational-knowledge', 'known-gotchas', 'git-backed-facts', 'promoted-skills']).toContain(node.sectionId);
+    }
+
+    // Every edge must have fields that the renderer uses
+    for (const edge of body.edges) {
+      expect(edge).toHaveProperty('id');
+      expect(edge).toHaveProperty('source');
+      expect(edge).toHaveProperty('target');
+      expect(edge).toHaveProperty('edgeType');
+      expect(['supports', 'relates_to', 'mentions', 'derived_from']).toContain(edge.edgeType);
+    }
+
+    // Clusters must have sectionId for i18n lookup
+    for (const cluster of body.clusters) {
+      expect(cluster).toHaveProperty('id');
+      expect(cluster).toHaveProperty('sectionId');
+      expect(cluster).toHaveProperty('nodeCount');
+    }
+  });
+
   it('GET /api/projects counts only active observations per project', async () => {
     const { status, body } = await fetchJson('/api/projects');
     expect(status).toBe(200);

--- a/tests/integration/dashboard-project-scope.test.ts
+++ b/tests/integration/dashboard-project-scope.test.ts
@@ -155,6 +155,36 @@ describe('Standalone Dashboard Project Scope', () => {
     expect(body.nextId).toBe(7);
   });
 
+  it('GET /api/knowledge returns project-scoped Knowledge Base overview', async () => {
+    const { status, body } = await fetchJson('/api/knowledge');
+    expect(status).toBe(200);
+
+    expect(body.title).toBe('Knowledge Base');
+    expect(body.subtitle).toBe('LLM Wiki');
+    expect(body.projectId).toBe(PROJECT_A);
+    expect(body.stats.observationsUsed).toBe(2);
+
+    const titles = body.sections.flatMap((section: any) => section.items.map((item: any) => item.title));
+    expect(titles).toContain('Use JWT');
+    expect(titles).toContain('Token expiry');
+    expect(titles).not.toContain('Use Stripe');
+    expect(titles).not.toContain('Webhook retry');
+  });
+
+  it('GET /api/knowledge?project=... returns requested project knowledge only', async () => {
+    const { status, body } = await fetchJson(`/api/knowledge?project=${encodeURIComponent(PROJECT_B)}`);
+    expect(status).toBe(200);
+
+    expect(body.projectId).toBe(PROJECT_B);
+    expect(body.stats.observationsUsed).toBe(2);
+
+    const titles = body.sections.flatMap((section: any) => section.items.map((item: any) => item.title));
+    expect(titles).toContain('Use Stripe');
+    expect(titles).toContain('Webhook retry');
+    expect(titles).not.toContain('Use JWT');
+    expect(titles).not.toContain('Token expiry');
+  });
+
   it('GET /api/projects counts only active observations per project', async () => {
     const { status, body } = await fetchJson('/api/projects');
     expect(status).toBe(200);

--- a/tests/memory/probe-observation.test.ts
+++ b/tests/memory/probe-observation.test.ts
@@ -1,0 +1,431 @@
+/**
+ * Probe Observation Type Tests
+ *
+ * Covers:
+ * - Store: type: "probe" is accepted, invalid types are rejected
+ * - Search: default search excludes probe, explicit type: "probe" includes it
+ * - Retention: probe is short-lived (~7 days), not immune
+ * - Session: probe is heavily penalized, never surfaces as priority context
+ * - Mini-skill: probe cannot be promoted to mini-skill
+ * - Formation: probe has very low TYPE_WEIGHT (0.10)
+ * - CLI: coerceObservationType accepts "probe"
+ * - Dashboard: probe excluded from typeCounts and recentObservations
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../src/embedding/provider.js', () => ({
+  getEmbeddingProvider: async () => null,
+  isVectorSearchAvailable: async () => false,
+  isEmbeddingExplicitlyDisabled: () => true,
+  resetProvider: () => {},
+}));
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { storeObservation, initObservations, getObservation } from '../../src/memory/observations.js';
+import { resetDb, searchObservations } from '../../src/store/orama-store.js';
+import { isImmune, getImmunityReason, getEffectiveRetentionDays, getImportanceLevel } from '../../src/memory/retention.js';
+import { scoreObservationForSessionContext } from '../../src/memory/session.js';
+import { promoteToMiniSkill } from '../../src/skills/mini-skills.js';
+import { runEvaluate } from '../../src/memory/formation/evaluate.js';
+import type { ExtractResult } from '../../src/memory/formation/types.js';
+import { coerceObservationType } from '../../src/cli/commands/operator-shared.js';
+import type { MemorixDocument, Observation } from '../../src/types.js';
+
+const PROJECT_ID = 'test/probe-type';
+
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-probe-'));
+  await resetDb();
+  await initObservations(testDir);
+});
+
+// Store
+
+describe('Store: probe type', () => {
+  it('stores type: "probe" successfully', async () => {
+    const { observation } = await storeObservation({
+      entityName: 'health-check',
+      type: 'probe',
+      title: 'Agent connectivity check',
+      narrative: 'Heartbeat to verify agent is online and responsive.',
+      projectId: PROJECT_ID,
+    });
+    expect(observation.type).toBe('probe');
+    expect(observation.id).toBeGreaterThan(0);
+  });
+
+  it('retrieves stored probe observation', async () => {
+    const { observation } = await storeObservation({
+      entityName: 'health-check',
+      type: 'probe',
+      title: 'Agent connectivity check',
+      narrative: 'Heartbeat to verify agent is online and responsive.',
+      projectId: PROJECT_ID,
+    });
+    const loaded = getObservation(observation.id);
+    expect(loaded?.type).toBe('probe');
+    expect(loaded?.title).toBe('Agent connectivity check');
+  });
+
+  it('stores probe alongside other types without conflict', async () => {
+    await storeObservation({
+      entityName: 'auth',
+      type: 'decision',
+      title: 'Use JWT',
+      narrative: 'Stateless auth.',
+      projectId: PROJECT_ID,
+    });
+    const { observation: probe } = await storeObservation({
+      entityName: 'health',
+      type: 'probe',
+      title: 'Connectivity check',
+      narrative: 'Heartbeat.',
+      projectId: PROJECT_ID,
+    });
+    await storeObservation({
+      entityName: 'cache',
+      type: 'gotcha',
+      title: 'Cache invalidation bug',
+      narrative: 'Race condition.',
+      projectId: PROJECT_ID,
+    });
+    expect(probe.type).toBe('probe');
+  });
+});
+
+// Search
+
+describe('Search: probe exclusion and inclusion', () => {
+  beforeEach(async () => {
+    await storeObservation({
+      entityName: 'auth',
+      type: 'decision',
+      title: 'Use JWT for authentication',
+      narrative: 'We chose JWT because it is stateless.',
+      projectId: PROJECT_ID,
+    });
+    await storeObservation({
+      entityName: 'health',
+      type: 'probe',
+      title: 'Agent heartbeat connectivity check',
+      narrative: 'Heartbeat to verify agent is online.',
+      projectId: PROJECT_ID,
+    });
+    await storeObservation({
+      entityName: 'cache',
+      type: 'gotcha',
+      title: 'Cache invalidation race condition',
+      narrative: 'Race condition in cache invalidation.',
+      projectId: PROJECT_ID,
+    });
+  });
+
+  it('default search excludes probe observations', async () => {
+    const results = await searchObservations({
+      query: 'connectivity heartbeat',
+      projectId: PROJECT_ID,
+      status: 'active',
+    });
+    const probeResults = results.filter(r => r.type === 'probe');
+    expect(probeResults.length).toBe(0);
+  });
+
+  it('default search returns non-probe observations', async () => {
+    const results = await searchObservations({
+      query: 'authentication JWT',
+      projectId: PROJECT_ID,
+      status: 'active',
+    });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every(r => r.type !== 'probe')).toBe(true);
+  });
+
+  it('explicit type: "probe" search returns probe observations', async () => {
+    const results = await searchObservations({
+      query: 'connectivity heartbeat',
+      type: 'probe',
+      projectId: PROJECT_ID,
+      status: 'active',
+    });
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.every(r => r.type === 'probe')).toBe(true);
+  });
+
+  it('explicit type: "probe" search does not return non-probe observations', async () => {
+    const results = await searchObservations({
+      query: 'authentication JWT',
+      type: 'probe',
+      projectId: PROJECT_ID,
+      status: 'active',
+    });
+    expect(results.every(r => r.type === 'probe')).toBe(true);
+  });
+
+  it('broad query without type filter excludes probe', async () => {
+    const results = await searchObservations({
+      query: '',
+      projectId: PROJECT_ID,
+      status: 'active',
+    });
+    const probeResults = results.filter(r => r.type === 'probe');
+    expect(probeResults.length).toBe(0);
+  });
+});
+
+// Retention
+
+describe('Retention: probe is short-lived', () => {
+  function makeDoc(overrides: Partial<MemorixDocument> = {}): MemorixDocument {
+    return {
+      id: 'obs-1',
+      observationId: 1,
+      entityName: 'test-entity',
+      type: 'probe',
+      title: 'Agent heartbeat',
+      narrative: 'Connectivity check.',
+      facts: '',
+      filesModified: '',
+      concepts: '',
+      tokens: 50,
+      createdAt: new Date().toISOString(),
+      projectId: PROJECT_ID,
+      accessCount: 0,
+      lastAccessedAt: '',
+      status: 'active',
+      source: 'agent',
+      sourceDetail: '',
+      valueCategory: '',
+      ...overrides,
+    };
+  }
+
+  it('probe gets low importance level', () => {
+    const doc = makeDoc();
+    expect(getImportanceLevel(doc)).toBe('low');
+  });
+
+  it('probe effective retention is ~7 days (TYPE_RETENTION_OVERRIDE)', () => {
+    const doc = makeDoc({ sourceDetail: 'explicit', valueCategory: '' });
+    const days = getEffectiveRetentionDays(doc);
+    // 7 (override) × 1.0 (explicit source) × 1.0 (no valueCategory) = 7
+    expect(days).toBe(7);
+  });
+
+  it('probe + hook source decays faster (7 × 0.5 = 3.5, floored at 7)', () => {
+    const doc = makeDoc({ sourceDetail: 'hook', valueCategory: '' });
+    const days = getEffectiveRetentionDays(doc);
+    // 7 × 0.5 = 3.5, but MIN_RETENTION_DAYS floor = 7
+    expect(days).toBe(7);
+  });
+
+  it('probe + ephemeral valueCategory decays faster (7 × 0.5 = 3.5, floored at 7)', () => {
+    const doc = makeDoc({ sourceDetail: '', valueCategory: 'ephemeral' });
+    const days = getEffectiveRetentionDays(doc);
+    // 7 × 0.5 = 3.5, but MIN_RETENTION_DAYS floor = 7
+    expect(days).toBe(7);
+  });
+
+  it('probe is not immune from archiving', () => {
+    const doc = makeDoc();
+    expect(isImmune(doc)).toBe(false);
+  });
+
+  it('probe with core valueCategory is still not immune', () => {
+    const doc = makeDoc({ valueCategory: 'core' });
+    expect(isImmune(doc)).toBe(false);
+  });
+
+  it('probe retention is much shorter than decision (high importance)', () => {
+    const probeDoc = makeDoc({ type: 'probe' });
+    const decisionDoc = makeDoc({ type: 'decision' });
+    expect(getEffectiveRetentionDays(probeDoc)).toBeLessThan(getEffectiveRetentionDays(decisionDoc));
+  });
+
+  it('probe + core valueCategory does NOT extend retention to 14 days', () => {
+    const doc = makeDoc({ valueCategory: 'core' });
+    const days = getEffectiveRetentionDays(doc);
+    // probe override is 7 days; valueCategory multiplier is excluded for type-override types
+    expect(days).toBe(7);
+  });
+
+  it('probe with high accessCount is still not immune', () => {
+    const doc = makeDoc({ accessCount: 10 });
+    expect(isImmune(doc)).toBe(false);
+  });
+
+  it('getImmunityReason returns null for probe', () => {
+    const doc = makeDoc();
+    expect(getImmunityReason(doc)).toBeNull();
+  });
+
+  it('getImmunityReason returns null for probe even with core valueCategory', () => {
+    const doc = makeDoc({ valueCategory: 'core' });
+    expect(getImmunityReason(doc)).toBeNull();
+  });
+});
+
+// Session injection
+
+describe('Session: probe is excluded from priority context', () => {
+  it('probe gets heavy negative score in session context', () => {
+    const obs: Observation = {
+      id: 1,
+      entityName: 'health',
+      type: 'probe',
+      title: 'Agent heartbeat',
+      narrative: 'Connectivity check.',
+      facts: [],
+      filesModified: [],
+      concepts: [],
+      tokens: 50,
+      createdAt: new Date().toISOString(),
+      projectId: PROJECT_ID,
+      status: 'active',
+      source: 'agent',
+      sourceDetail: 'explicit',
+      valueCategory: 'ephemeral',
+    };
+    const score = scoreObservationForSessionContext(obs, []);
+    // Probe penalty is -100, so score should be deeply negative
+    expect(score).toBeLessThan(-50);
+  });
+
+  it('probe scores much lower than decision in session context', () => {
+    const probeObs: Observation = {
+      id: 1,
+      entityName: 'health',
+      type: 'probe',
+      title: 'Agent heartbeat',
+      narrative: 'Connectivity check.',
+      facts: [],
+      filesModified: [],
+      concepts: [],
+      tokens: 50,
+      createdAt: new Date().toISOString(),
+      projectId: PROJECT_ID,
+      status: 'active',
+      source: 'agent',
+      sourceDetail: 'explicit',
+    };
+    const decisionObs: Observation = {
+      id: 2,
+      entityName: 'auth',
+      type: 'decision',
+      title: 'Use JWT',
+      narrative: 'Stateless auth.',
+      facts: [],
+      filesModified: [],
+      concepts: [],
+      tokens: 50,
+      createdAt: new Date().toISOString(),
+      projectId: PROJECT_ID,
+      status: 'active',
+      source: 'agent',
+      sourceDetail: 'explicit',
+    };
+    const probeScore = scoreObservationForSessionContext(probeObs, []);
+    const decisionScore = scoreObservationForSessionContext(decisionObs, []);
+    expect(probeScore).toBeLessThan(decisionScore);
+  });
+});
+
+// Mini-skill promotion
+
+describe('Mini-skill: probe cannot be promoted', () => {
+  it('probe observation is rejected from mini-skill promotion', async () => {
+    const { observation } = await storeObservation({
+      entityName: 'health',
+      type: 'probe',
+      title: 'Agent heartbeat',
+      narrative: 'Connectivity check.',
+      projectId: PROJECT_ID,
+    });
+    const obs = getObservation(observation.id)!;
+    await expect(
+      promoteToMiniSkill(testDir, PROJECT_ID, [obs])
+    ).rejects.toThrow(/Cannot promote probe observations/);
+  });
+
+  it('probe is still rejected with force=true', async () => {
+    const { observation } = await storeObservation({
+      entityName: 'health',
+      type: 'probe',
+      title: 'Agent heartbeat',
+      narrative: 'Connectivity check.',
+      projectId: PROJECT_ID,
+    });
+    const obs = getObservation(observation.id)!;
+    await expect(
+      promoteToMiniSkill(testDir, PROJECT_ID, [obs], { force: true })
+    ).rejects.toThrow(/Cannot promote probe observations/);
+  });
+});
+
+// Formation evaluation
+
+function makeExtractResult(overrides: Partial<ExtractResult> = {}): ExtractResult {
+  return {
+    title: 'Agent heartbeat',
+    titleImproved: false,
+    narrative: 'Connectivity check.',
+    facts: [],
+    extractedFacts: [],
+    entityName: 'health',
+    entityResolved: false,
+    type: 'probe',
+    typeCorrected: false,
+    ...overrides,
+  };
+}
+
+describe('Formation: probe has very low TYPE_WEIGHT', () => {
+  it('probe evaluation returns low value score', () => {
+    const result = runEvaluate(makeExtractResult());
+    // probe TYPE_WEIGHT is 0.10, so score should be very low
+    expect(result.score).toBeLessThan(0.3);
+  });
+
+  it('probe is classified as ephemeral', () => {
+    const result = runEvaluate(makeExtractResult());
+    expect(result.category).toBe('ephemeral');
+  });
+
+  it('probe scores much lower than gotcha', () => {
+    const probeResult = runEvaluate(makeExtractResult());
+    const gotchaResult = runEvaluate(makeExtractResult({
+      type: 'gotcha',
+      title: 'Token expiry bug',
+      narrative: 'Tokens expire before refresh.',
+      entityName: 'auth',
+    }));
+    expect(probeResult.score).toBeLessThan(gotchaResult.score);
+  });
+});
+
+// CLI coercion
+
+describe('CLI: coerceObservationType accepts probe', () => {
+  it('coerceObservationType("probe") returns "probe"', () => {
+    expect(coerceObservationType('probe')).toBe('probe');
+  });
+
+  it('coerceObservationType rejects invalid type', () => {
+    expect(() => coerceObservationType('invalid-type')).toThrow(/Unknown observation type/);
+  });
+
+  it('coerceObservationType accepts all standard types including probe', () => {
+    const validTypes = [
+      'session-request', 'gotcha', 'problem-solution', 'how-it-works',
+      'what-changed', 'discovery', 'why-it-exists', 'decision',
+      'trade-off', 'reasoning', 'probe',
+    ];
+    for (const t of validTypes) {
+      expect(coerceObservationType(t)).toBe(t);
+    }
+  });
+});

--- a/tests/tui/data-scope.test.ts
+++ b/tests/tui/data-scope.test.ts
@@ -121,3 +121,29 @@ describe('getRecentMemories project scope', () => {
     vi.doUnmock('../../src/store/persistence.js');
   });
 });
+
+describe('getKnowledgeBase project scope', () => {
+  it('returns only knowledge from the specified project', async () => {
+    vi.doMock('../../src/project/detector.js', () => ({
+      detectProject: () => ({ id: PROJECT_A, name: 'project-a', rootPath: testDir, gitRemote: 'none' }),
+    }));
+    vi.doMock('../../src/store/persistence.js', async () => {
+      const actual = await vi.importActual('../../src/store/persistence.js') as any;
+      return { ...actual, getProjectDataDir: async () => dataDir };
+    });
+
+    const { getKnowledgeBase } = await import('../../src/cli/tui/data.js');
+    const kb = await getKnowledgeBase(PROJECT_A);
+
+    // Should return a valid overview for project A
+    expect(kb).not.toBeNull();
+    expect(kb!.projectId).toBe(PROJECT_A);
+    expect(kb!.title).toBe('Knowledge Base');
+    expect(kb!.subtitle).toBe('LLM Wiki');
+    // Project A has 2 active observations, Project B has 2 -- only A's should be counted
+    expect(kb!.stats.observationsUsed).toBe(2);
+
+    vi.doUnmock('../../src/project/detector.js');
+    vi.doUnmock('../../src/store/persistence.js');
+  });
+});

--- a/tests/tui/interaction.test.tsx
+++ b/tests/tui/interaction.test.tsx
@@ -26,6 +26,7 @@ import { WorkbenchApp } from '../../src/cli/tui/App.js';
    mockSearchMemories,
    mockStoreQuickMemory,
    mockGetDoctorSummary,
+   mockGetKnowledgeBase,
    mockDetectMode,
    mockGetProjectDataDir,
    mockChatStore,
@@ -37,6 +38,7 @@ import { WorkbenchApp } from '../../src/cli/tui/App.js';
    mockSearchMemories: vi.fn(),
    mockStoreQuickMemory: vi.fn(),
    mockGetDoctorSummary: vi.fn(),
+   mockGetKnowledgeBase: vi.fn(),
    mockDetectMode: vi.fn(),
    mockGetProjectDataDir: vi.fn(),
    mockChatStore: {
@@ -61,6 +63,7 @@ import { WorkbenchApp } from '../../src/cli/tui/App.js';
      searchMemories: mockSearchMemories,
      storeQuickMemory: mockStoreQuickMemory,
      getDoctorSummary: mockGetDoctorSummary,
+     getKnowledgeBase: mockGetKnowledgeBase,
      detectMode: mockDetectMode,
    };
  });
@@ -132,6 +135,7 @@ describe('useNavigation', () => {
     expect(ESC_RETURNABLE_VIEWS.has('doctor')).toBe(true);
     expect(ESC_RETURNABLE_VIEWS.has('configure')).toBe(true);
     expect(ESC_RETURNABLE_VIEWS.has('search')).toBe(true);
+    expect(ESC_RETURNABLE_VIEWS.has('wiki')).toBe(true);
     // Home is not esc-returnable (already home)
     expect(ESC_RETURNABLE_VIEWS.has('home' as any)).toBe(false);
   });
@@ -1232,7 +1236,7 @@ describe('HeaderBar', () => {
 
 // ── StatusMessage rendering test ────────────────────────────────────
 
-import { StatusMessage, HomeView, IntegrateView } from '../../src/cli/tui/Panels.js';
+import { StatusMessage, HomeView, IntegrateView, WikiView } from '../../src/cli/tui/Panels.js';
 import { ChatView } from '../../src/cli/tui/ChatView.js';
 import { ContextRail } from '../../src/cli/tui/ContextRail.js';
 
@@ -1369,6 +1373,88 @@ describe('IntegrateView', () => {
       <IntegrateView statusText="Installed gemini-cli integration" />,
     );
     expect(lastFrame()).toContain('Installed gemini-cli integration');
+    unmount();
+  });
+});
+
+// -- WikiView tests --
+
+describe('WikiView', () => {
+  it('renders Knowledge Base heading and LLM Wiki label', () => {
+    const { lastFrame, unmount } = render(
+      <WikiView knowledge={null} loading={false} />,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain('Knowledge Base');
+    expect(frame).toContain('LLM Wiki');
+    unmount();
+  });
+
+  it('renders empty state when no knowledge available', () => {
+    const { lastFrame, unmount } = render(
+      <WikiView knowledge={null} loading={false} />,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain('No knowledge available');
+    unmount();
+  });
+
+  it('renders loading state', () => {
+    const { lastFrame, unmount } = render(
+      <WikiView knowledge={null} loading={true} />,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain('Knowledge Base');
+    expect(frame).toContain('Loading');
+    unmount();
+  });
+
+  it('renders sections and source refs with knowledge data', () => {
+    const kb: import('../../src/wiki/types.js').ProjectKnowledgeOverview = {
+      title: 'Knowledge Base',
+      subtitle: 'LLM Wiki',
+      projectId: 'test/project',
+      generatedAt: new Date().toISOString(),
+      sections: [
+        {
+          id: 'project-overview',
+          title: 'Project Overview',
+          items: [{ title: 'test/project', summary: 'Project: test/project', type: 'overview', refs: [] }],
+        },
+        {
+          id: 'core-decisions',
+          title: 'Core Decisions',
+          items: [{
+            title: 'Use JWT for auth',
+            summary: 'We chose JWT because it is stateless.',
+            type: 'decision',
+            entityName: 'auth',
+            refs: [{ kind: 'observation', id: 'obs:1', title: 'Use JWT for auth' }],
+          }],
+          empty: false,
+        },
+        {
+          id: 'known-gotchas',
+          title: 'Known Gotchas',
+          items: [],
+          empty: true,
+        },
+      ],
+      stats: { observationsUsed: 1, miniSkillsUsed: 0, refs: 1 },
+    };
+    const { lastFrame, unmount } = render(
+      <WikiView knowledge={kb} loading={false} />,
+    );
+    const frame = lastFrame()!;
+    expect(frame).toContain('Knowledge Base');
+    expect(frame).toContain('LLM Wiki');
+    expect(frame).toContain('test/project');
+    expect(frame).toContain('Core Decisions');
+    expect(frame).toContain('Use JWT for auth');
+    expect(frame).toContain('obs:1');
+    expect(frame).toContain('Known Gotchas');
+    expect(frame).toContain('(empty)');
+    expect(frame).toContain('Esc to return home');
     unmount();
   });
 });

--- a/tests/tui/theme.test.ts
+++ b/tests/tui/theme.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { computeLayoutWidths, getHomeSeparatorWidth, getStatusMessageRows } from '../../src/cli/tui/theme.js';
+import { computeLayoutWidths, getHomeSeparatorWidth, getStatusMessageRows, SLASH_COMMANDS } from '../../src/cli/tui/theme.js';
 
 describe('tui layout helpers', () => {
   it('clamps the home separator width for very narrow content areas', () => {
@@ -17,5 +17,12 @@ describe('tui layout helpers', () => {
   it('never returns a negative content width on tiny terminals', () => {
     expect(computeLayoutWidths(3).contentWidth).toBe(0);
     expect(computeLayoutWidths(4).contentWidth).toBe(0);
+  });
+
+  it('includes the Knowledge Base slash command', () => {
+    const wiki = SLASH_COMMANDS.find(command => command.name === '/wiki');
+    expect(wiki).toBeDefined();
+    expect(wiki?.alias).toBe('/knowledge');
+    expect(wiki?.description).toBe('Knowledge Base');
   });
 });

--- a/tests/wiki/generator.test.ts
+++ b/tests/wiki/generator.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Knowledge Base Generator Tests
+ *
+ * Covers:
+ * - excludes probe observations
+ * - excludes command logs (Ran:/Command:/Executed: titles)
+ * - excludes other projects
+ * - excludes resolved/archived observations
+ * - includes core observations
+ * - includes contextual only with facts/concepts/files/entity
+ * - includes reasoning in appropriate section
+ * - includes mini-skills with skill:<id> refs
+ * - preserves source refs on every item
+ * - empty state works
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateKnowledgeBase, isEligible, isExcludedType, isCommandLog, contextualHasSubstance } from '../../src/wiki/generator.js';
+import type { Observation, MiniSkill } from '../../src/types.js';
+
+const PROJECT_ID = 'test/knowledge-base';
+const OTHER_PROJECT_ID = 'other/project';
+const FIXED_TIMESTAMP = '2026-01-01T00:00:00.000Z';
+let nextObservationId = 1;
+let nextSkillId = 1;
+
+function makeObs(overrides: Partial<Observation> = {}): Observation {
+  return {
+    id: overrides.id ?? nextObservationId++,
+    entityName: 'test-entity',
+    type: 'decision',
+    title: 'Test observation',
+    narrative: 'A test narrative for the knowledge base.',
+    facts: [],
+    filesModified: [],
+    concepts: [],
+    tokens: 50,
+    createdAt: FIXED_TIMESTAMP,
+    projectId: PROJECT_ID,
+    status: 'active',
+    source: 'agent',
+    sourceDetail: 'explicit',
+    valueCategory: 'core',
+    ...overrides,
+  };
+}
+
+function makeSkill(overrides: Partial<MiniSkill> = {}): MiniSkill {
+  return {
+    id: overrides.id ?? nextSkillId++,
+    sourceObservationIds: [100],
+    sourceEntity: 'test-entity',
+    title: 'Test skill',
+    instruction: 'Do the right thing',
+    trigger: 'When you encounter this scenario',
+    facts: ['fact 1'],
+    projectId: PROJECT_ID,
+    createdAt: FIXED_TIMESTAMP,
+    usedCount: 0,
+    tags: [],
+    ...overrides,
+  };
+}
+
+// Filtering
+
+describe('Filtering: isEligible', () => {
+  it('excludes probe type', () => {
+    const obs = makeObs({ type: 'probe' });
+    expect(isEligible(obs, PROJECT_ID)).toBe(false);
+  });
+
+  it('excludes command log titles', () => {
+    expect(isCommandLog(makeObs({ title: 'Ran: npm test' }))).toBe(true);
+    expect(isCommandLog(makeObs({ title: 'Command: git push' }))).toBe(true);
+    expect(isCommandLog(makeObs({ title: 'Executed: build' }))).toBe(true);
+    expect(isCommandLog(makeObs({ title: 'Normal decision' }))).toBe(false);
+    expect(isEligible(makeObs({ title: 'Ran: npm test' }), PROJECT_ID)).toBe(false);
+  });
+
+  it('excludes other projects', () => {
+    const obs = makeObs({ projectId: 'other/project' });
+    expect(isEligible(obs, PROJECT_ID)).toBe(false);
+  });
+
+  it('excludes resolved observations', () => {
+    const obs = makeObs({ status: 'resolved' });
+    expect(isEligible(obs, PROJECT_ID)).toBe(false);
+  });
+
+  it('excludes archived observations', () => {
+    const obs = makeObs({ status: 'archived' });
+    expect(isEligible(obs, PROJECT_ID)).toBe(false);
+  });
+
+  it('excludes ephemeral valueCategory', () => {
+    const obs = makeObs({ valueCategory: 'ephemeral' });
+    expect(isEligible(obs, PROJECT_ID)).toBe(false);
+  });
+
+  it('includes core valueCategory', () => {
+    const obs = makeObs({ valueCategory: 'core' });
+    expect(isEligible(obs, PROJECT_ID)).toBe(true);
+  });
+
+  it('includes contextual with facts', () => {
+    const obs = makeObs({ valueCategory: 'contextual', facts: ['important fact'] });
+    expect(isEligible(obs, PROJECT_ID)).toBe(true);
+  });
+
+  it('includes contextual with concepts', () => {
+    const obs = makeObs({ valueCategory: 'contextual', concepts: ['architecture'] });
+    expect(isEligible(obs, PROJECT_ID)).toBe(true);
+  });
+
+  it('includes contextual with filesModified', () => {
+    const obs = makeObs({ valueCategory: 'contextual', filesModified: ['src/main.ts'] });
+    expect(isEligible(obs, PROJECT_ID)).toBe(true);
+  });
+
+  it('includes contextual with meaningful entityName', () => {
+    const obs = makeObs({ valueCategory: 'contextual', entityName: 'auth-module' });
+    expect(isEligible(obs, PROJECT_ID)).toBe(true);
+  });
+
+  it('excludes contextual without substance', () => {
+    const obs = makeObs({ valueCategory: 'contextual', facts: [], concepts: [], filesModified: [], entityName: 'quick-note' });
+    expect(isEligible(obs, PROJECT_ID)).toBe(false);
+  });
+});
+
+// Section assignment
+
+describe('Section assignment', () => {
+  it('places decisions in Core Decisions', () => {
+    const obs = makeObs({ type: 'decision', title: 'Use JWT' });
+    const kb = generateKnowledgeBase({ projectId: PROJECT_ID, observations: [obs], miniSkills: [] });
+    const section = kb.sections.find(s => s.id === 'core-decisions');
+    expect(section).toBeDefined();
+    expect(section!.items.length).toBe(1);
+    expect(section!.items[0].title).toBe('Use JWT');
+  });
+
+  it('places trade-offs in Core Decisions', () => {
+    const obs = makeObs({ type: 'trade-off', title: 'Speed vs safety' });
+    const kb = generateKnowledgeBase({ projectId: PROJECT_ID, observations: [obs], miniSkills: [] });
+    const section = kb.sections.find(s => s.id === 'core-decisions');
+    expect(section!.items.length).toBe(1);
+  });
+
+  it('places gotchas in Known Gotchas', () => {
+    const obs = makeObs({ type: 'gotcha', title: 'Token expiry bug' });
+    const kb = generateKnowledgeBase({ projectId: PROJECT_ID, observations: [obs], miniSkills: [] });
+    const section = kb.sections.find(s => s.id === 'known-gotchas');
+    expect(section!.items.length).toBe(1);
+  });
+
+  it('places problem-solution in Known Gotchas', () => {
+    const obs = makeObs({ type: 'problem-solution', title: 'Fix race condition' });
+    const kb = generateKnowledgeBase({ projectId: PROJECT_ID, observations: [obs], miniSkills: [] });
+    const section = kb.sections.find(s => s.id === 'known-gotchas');
+    expect(section!.items.length).toBe(1);
+  });
+
+  it('places reasoning in Core Decisions', () => {
+    const obs = makeObs({ type: 'reasoning', title: 'Why we chose PostgreSQL' });
+    const kb = generateKnowledgeBase({ projectId: PROJECT_ID, observations: [obs], miniSkills: [] });
+    const section = kb.sections.find(s => s.id === 'core-decisions');
+    expect(section!.items.length).toBe(1);
+  });
+
+  it('places how-it-works in Operational Knowledge', () => {
+    const obs = makeObs({ type: 'how-it-works', title: 'Auth flow' });
+    const kb = generateKnowledgeBase({ projectId: PROJECT_ID, observations: [obs], miniSkills: [] });
+    const section = kb.sections.find(s => s.id === 'operational-knowledge');
+    expect(section!.items.length).toBe(1);
+  });
+
+  it('places git-ingest in Git-backed Facts', () => {
+    const obs = makeObs({ source: 'git', sourceDetail: 'git-ingest', title: 'Commit: add auth' });
+    const kb = generateKnowledgeBase({ projectId: PROJECT_ID, observations: [obs], miniSkills: [] });
+    const section = kb.sections.find(s => s.id === 'git-backed-facts');
+    expect(section!.items.length).toBe(1);
+  });
+});
+
+// Mini-skills
+
+describe('Mini-skills', () => {
+  it('includes mini-skills with skill:<id> refs', () => {
+    const skill = makeSkill({ id: 5, title: 'Auth pattern' });
+    const kb = generateKnowledgeBase({ projectId: PROJECT_ID, observations: [], miniSkills: [skill] });
+    const section = kb.sections.find(s => s.id === 'promoted-skills');
+    expect(section!.items.length).toBe(1);
+    expect(section!.items[0].refs.some(r => r.id === 'skill:5')).toBe(true);
+  });
+
+  it('includes source observation refs in mini-skill items', () => {
+    const skill = makeSkill({ id: 3, sourceObservationIds: [10, 20] });
+    const kb = generateKnowledgeBase({ projectId: PROJECT_ID, observations: [], miniSkills: [skill] });
+    const section = kb.sections.find(s => s.id === 'promoted-skills');
+    const item = section!.items[0];
+    expect(item.refs.some(r => r.id === 'obs:10')).toBe(true);
+    expect(item.refs.some(r => r.id === 'obs:20')).toBe(true);
+  });
+
+  it('excludes mini-skills from other projects from skills, overview refs, and stats', () => {
+    const inProjectSkill = makeSkill({ id: 7, title: 'Project skill', projectId: PROJECT_ID });
+    const otherProjectSkill = makeSkill({ id: 8, title: 'Other project skill', projectId: OTHER_PROJECT_ID });
+    const kb = generateKnowledgeBase({
+      projectId: PROJECT_ID,
+      observations: [],
+      miniSkills: [inProjectSkill, otherProjectSkill],
+      generatedAt: FIXED_TIMESTAMP,
+    });
+
+    const skillsSection = kb.sections.find(s => s.id === 'promoted-skills');
+    expect(skillsSection!.items.map(item => item.title)).toEqual(['Project skill']);
+    expect(skillsSection!.items.flatMap(item => item.refs).some(ref => ref.id === 'skill:8')).toBe(false);
+
+    const projectOverview = kb.sections.find(s => s.id === 'project-overview');
+    expect(projectOverview!.items.flatMap(item => item.refs).some(ref => ref.id === 'skill:7')).toBe(true);
+    expect(projectOverview!.items.flatMap(item => item.refs).some(ref => ref.id === 'skill:8')).toBe(false);
+    expect(kb.stats.miniSkillsUsed).toBe(1);
+  });
+});
+
+// Source refs
+
+describe('Source refs', () => {
+  it('every item has at least one source ref', () => {
+    const observations = [
+      makeObs({ type: 'decision', title: 'D1' }),
+      makeObs({ type: 'gotcha', title: 'G1' }),
+      makeObs({ type: 'how-it-works', title: 'H1' }),
+    ];
+    const kb = generateKnowledgeBase({ projectId: PROJECT_ID, observations, miniSkills: [makeSkill()] });
+    for (const section of kb.sections) {
+      for (const item of section.items) {
+        if (item.type !== 'overview') {
+          expect(item.refs.length).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+
+  it('observation ref uses obs:<id> format', () => {
+    const obs = makeObs({ id: 42, type: 'decision', title: 'D1' });
+    const kb = generateKnowledgeBase({ projectId: PROJECT_ID, observations: [obs], miniSkills: [] });
+    const section = kb.sections.find(s => s.id === 'core-decisions');
+    expect(section!.items[0].refs[0].id).toBe('obs:42');
+  });
+
+  it('git observation ref has kind=git', () => {
+    const obs = makeObs({ id: 55, source: 'git', sourceDetail: 'git-ingest', title: 'Commit' });
+    const kb = generateKnowledgeBase({ projectId: PROJECT_ID, observations: [obs], miniSkills: [] });
+    const section = kb.sections.find(s => s.id === 'git-backed-facts');
+    expect(section!.items[0].refs[0].kind).toBe('git');
+  });
+});
+
+// Empty state
+
+describe('Empty state', () => {
+  it('returns valid overview with no observations or skills', () => {
+    const kb = generateKnowledgeBase({ projectId: PROJECT_ID, observations: [], miniSkills: [] });
+    expect(kb.title).toBe('Knowledge Base');
+    expect(kb.subtitle).toBe('LLM Wiki');
+    expect(kb.projectId).toBe(PROJECT_ID);
+    expect(kb.stats.observationsUsed).toBe(0);
+    expect(kb.stats.miniSkillsUsed).toBe(0);
+    expect(kb.sections.length).toBeGreaterThan(0);
+    // All typed sections should be empty
+    for (const section of kb.sections) {
+      if (section.id !== 'project-overview') {
+        expect(section.empty).toBe(true);
+      }
+    }
+  });
+});
+
+// Stats
+
+describe('Stats', () => {
+  it('counts observations and skills correctly', () => {
+    const observations = [
+      makeObs({ type: 'decision', title: 'D1' }),
+      makeObs({ type: 'gotcha', title: 'G1' }),
+    ];
+    const skills = [makeSkill({ id: 1 }), makeSkill({ id: 2 })];
+    const kb = generateKnowledgeBase({ projectId: PROJECT_ID, observations, miniSkills: skills });
+    expect(kb.stats.observationsUsed).toBe(2);
+    expect(kb.stats.miniSkillsUsed).toBe(2);
+    expect(kb.stats.refs).toBeGreaterThan(0);
+  });
+});
+
+// Project scope
+
+describe('Project scope', () => {
+  it('only includes observations from the specified project', () => {
+    const obs1 = makeObs({ type: 'decision', title: 'In-project', projectId: PROJECT_ID });
+    const obs2 = makeObs({ type: 'decision', title: 'Other-project', projectId: 'other/project' });
+    const kb = generateKnowledgeBase({ projectId: PROJECT_ID, observations: [obs1, obs2], miniSkills: [] });
+    const section = kb.sections.find(s => s.id === 'core-decisions');
+    expect(section!.items.length).toBe(1);
+    expect(section!.items[0].title).toBe('In-project');
+  });
+});
+
+describe('Determinism', () => {
+  it('returns equal output for the same inputs and fixed generatedAt', () => {
+    const observations = [makeObs({ id: 500, type: 'decision', title: 'Stable decision' })];
+    const skills = [makeSkill({ id: 600, title: 'Stable skill' })];
+    const options = { projectId: PROJECT_ID, observations, miniSkills: skills, generatedAt: FIXED_TIMESTAMP };
+
+    const first = generateKnowledgeBase(options);
+    const second = generateKnowledgeBase(options);
+
+    expect(first.generatedAt).toBe(FIXED_TIMESTAMP);
+    expect(first).toEqual(second);
+  });
+});

--- a/tests/wiki/knowledge-graph.test.ts
+++ b/tests/wiki/knowledge-graph.test.ts
@@ -1,0 +1,478 @@
+/**
+ * Knowledge Graph Generator Tests
+ *
+ * Covers:
+ * - other project observations do not leak into graph
+ * - probe observations are excluded from graph nodes
+ * - resolved/archived observations are excluded
+ * - graph with no relations still produces useful nodes from KB semantics
+ * - deterministic output: fixed input → fixed output
+ * - section clusters match KB section definitions
+ * - edges inferred between same-entity observations
+ * - mini-skill derived_from edges
+ * - stats are accurate
+ */
+
+import { describe, it, expect } from 'vitest';
+import { generateKnowledgeGraph } from '../../src/wiki/knowledge-graph.js';
+import type { Observation, MiniSkill } from '../../src/types.js';
+
+const PROJECT_ID = 'test/kg-project';
+const OTHER_PROJECT_ID = 'other/kg-project';
+const FIXED_TIMESTAMP = '2026-01-01T00:00:00.000Z';
+let nextObservationId = 1;
+let nextSkillId = 1;
+
+function makeObs(overrides: Partial<Observation> = {}): Observation {
+  return {
+    id: overrides.id ?? nextObservationId++,
+    entityName: 'test-entity',
+    type: 'decision',
+    title: 'Test observation',
+    narrative: 'A test narrative for the knowledge graph.',
+    facts: [],
+    filesModified: [],
+    concepts: [],
+    tokens: 50,
+    createdAt: FIXED_TIMESTAMP,
+    projectId: PROJECT_ID,
+    status: 'active',
+    source: 'agent',
+    sourceDetail: 'explicit',
+    valueCategory: 'core',
+    ...overrides,
+  };
+}
+
+function makeSkill(overrides: Partial<MiniSkill> = {}): MiniSkill {
+  return {
+    id: overrides.id ?? nextSkillId++,
+    sourceObservationIds: [100],
+    sourceEntity: 'test-entity',
+    title: 'Test skill',
+    instruction: 'Do the right thing',
+    trigger: 'When you encounter this scenario',
+    facts: ['fact 1'],
+    projectId: PROJECT_ID,
+    createdAt: FIXED_TIMESTAMP,
+    usedCount: 0,
+    tags: [],
+    ...overrides,
+  };
+}
+
+// Project scope isolation
+
+describe('Project scope isolation', () => {
+  it('other project observations do not leak into graph', () => {
+    const obs1 = makeObs({ id: 1, type: 'decision', title: 'In-project', projectId: PROJECT_ID });
+    const obs2 = makeObs({ id: 2, type: 'decision', title: 'Other-project', projectId: OTHER_PROJECT_ID });
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: [obs1, obs2], miniSkills: [] });
+    expect(kg.nodes.length).toBe(1);
+    expect(kg.nodes[0].label).toBe('In-project');
+  });
+
+  it('other project mini-skills do not leak into graph', () => {
+    const skill1 = makeSkill({ id: 1, title: 'Project skill', projectId: PROJECT_ID });
+    const skill2 = makeSkill({ id: 2, title: 'Other skill', projectId: OTHER_PROJECT_ID });
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: [], miniSkills: [skill1, skill2] });
+    expect(kg.nodes.length).toBe(1);
+    expect(kg.nodes[0].label).toBe('Project skill');
+  });
+});
+
+// Exclusion rules
+
+describe('Exclusion rules', () => {
+  it('probe observations are excluded from graph nodes', () => {
+    const obs = makeObs({ type: 'probe', title: 'Probe heartbeat' });
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: [obs], miniSkills: [] });
+    expect(kg.nodes.length).toBe(0);
+  });
+
+  it('resolved observations are excluded', () => {
+    const obs = makeObs({ status: 'resolved', title: 'Resolved obs' });
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: [obs], miniSkills: [] });
+    expect(kg.nodes.length).toBe(0);
+  });
+
+  it('archived observations are excluded', () => {
+    const obs = makeObs({ status: 'archived', title: 'Archived obs' });
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: [obs], miniSkills: [] });
+    expect(kg.nodes.length).toBe(0);
+  });
+
+  it('ephemeral observations are excluded', () => {
+    const obs = makeObs({ valueCategory: 'ephemeral', title: 'Ephemeral obs' });
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: [obs], miniSkills: [] });
+    expect(kg.nodes.length).toBe(0);
+  });
+});
+
+// No relations but still useful nodes
+
+describe('No graph relations — still useful nodes from KB semantics', () => {
+  it('produces nodes even when no edges exist (single entity)', () => {
+    const obs = makeObs({ id: 10, type: 'decision', title: 'Solo decision', entityName: 'unique-entity' });
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: [obs], miniSkills: [] });
+    expect(kg.nodes.length).toBe(1);
+    expect(kg.edges.length).toBe(0);
+    expect(kg.clusters.length).toBe(1);
+    expect(kg.clusters[0].sectionId).toBe('core-decisions');
+  });
+
+  it('produces clusters for each section that has nodes', () => {
+    const obs = [
+      makeObs({ id: 10, type: 'decision', title: 'D1' }),
+      makeObs({ id: 11, type: 'gotcha', title: 'G1' }),
+      makeObs({ id: 12, type: 'how-it-works', title: 'H1' }),
+    ];
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: obs, miniSkills: [] });
+    expect(kg.nodes.length).toBe(3);
+    expect(kg.clusters.length).toBe(3);
+    const sectionIds = kg.clusters.map(c => c.sectionId).sort();
+    expect(sectionIds).toEqual(['core-decisions', 'known-gotchas', 'operational-knowledge']);
+  });
+});
+
+// Determinism
+
+describe('Determinism', () => {
+  it('returns equal output for the same inputs and fixed generatedAt', () => {
+    const observations = [makeObs({ id: 500, type: 'decision', title: 'Stable decision' })];
+    const skills = [makeSkill({ id: 600, title: 'Stable skill' })];
+    const options = { projectId: PROJECT_ID, observations, miniSkills: skills, generatedAt: FIXED_TIMESTAMP };
+
+    const first = generateKnowledgeGraph(options);
+    const second = generateKnowledgeGraph(options);
+
+    expect(first.generatedAt).toBe(FIXED_TIMESTAMP);
+    expect(first).toEqual(second);
+  });
+});
+
+// Edge inference
+
+describe('Edge inference', () => {
+  it('infers relates_to edges between same-entity observations in same section', () => {
+    const obs = [
+      makeObs({ id: 1, type: 'decision', title: 'D1', entityName: 'auth-module' }),
+      makeObs({ id: 2, type: 'decision', title: 'D2', entityName: 'auth-module' }),
+    ];
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: obs, miniSkills: [] });
+    const relatesEdges = kg.edges.filter(e => e.edgeType === 'relates_to');
+    // Bidirectional: 2 relates_to edges
+    expect(relatesEdges.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('infers supports edges between same-entity observations in different sections', () => {
+    const obs = [
+      makeObs({ id: 1, type: 'decision', title: 'D1', entityName: 'auth-module' }),
+      makeObs({ id: 2, type: 'how-it-works', title: 'H1', entityName: 'auth-module' }),
+    ];
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: obs, miniSkills: [] });
+    const supportsEdges = kg.edges.filter(e => e.edgeType === 'supports');
+    // decision supports operational-knowledge
+    expect(supportsEdges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('infers derived_from edges from mini-skill to source observations', () => {
+    const obs = makeObs({ id: 10, type: 'decision', title: 'Source obs' });
+    const skill = makeSkill({ id: 1, title: 'Promoted skill', sourceObservationIds: [10] });
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: [obs], miniSkills: [skill] });
+    const derivedEdges = kg.edges.filter(e => e.edgeType === 'derived_from');
+    expect(derivedEdges.length).toBe(1);
+    expect(derivedEdges[0].source).toBe('skill:1');
+    expect(derivedEdges[0].target).toBe('obs:10');
+  });
+
+  it('no self-edges', () => {
+    const obs = makeObs({ id: 1, type: 'decision', title: 'D1', entityName: 'auth' });
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: [obs], miniSkills: [] });
+    for (const edge of kg.edges) {
+      expect(edge.source).not.toBe(edge.target);
+    }
+  });
+
+  it('does not create a dense relates_to clique for many observations on one entity', () => {
+    const obs = Array.from({ length: 16 }, (_, idx) =>
+      makeObs({
+        id: 1000 + idx,
+        type: 'what-changed',
+        title: `Handoff ${idx}`,
+        entityName: 'busy-handoff',
+        facts: idx % 3 === 0 ? ['important'] : [],
+      }),
+    );
+
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: obs, miniSkills: [] });
+    const relatesEdges = kg.edges.filter(e => e.edgeType === 'relates_to');
+    const degree = new Map<string, number>();
+    for (const edge of relatesEdges) {
+      degree.set(edge.source, (degree.get(edge.source) || 0) + 1);
+      degree.set(edge.target, (degree.get(edge.target) || 0) + 1);
+    }
+
+    expect(relatesEdges.length).toBeLessThanOrEqual(8);
+    expect(Math.max(...degree.values())).toBeLessThanOrEqual(8);
+  });
+});
+
+// Section clusters
+
+describe('Section clusters', () => {
+  it('clusters match KB section definitions', () => {
+    const obs = [
+      makeObs({ id: 1, type: 'decision', title: 'D1' }),
+      makeObs({ id: 2, type: 'gotcha', title: 'G1' }),
+      makeObs({ id: 3, type: 'how-it-works', title: 'H1' }),
+      makeObs({ id: 4, source: 'git', sourceDetail: 'git-ingest', title: 'Git1' }),
+    ];
+    const skill = makeSkill({ id: 1, title: 'Skill1' });
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: obs, miniSkills: [skill] });
+    const sectionIds = kg.clusters.map(c => c.sectionId).sort();
+    expect(sectionIds).toEqual(['core-decisions', 'git-backed-facts', 'known-gotchas', 'operational-knowledge', 'promoted-skills']);
+  });
+
+  it('nodeCount in cluster matches actual nodes in that section', () => {
+    const obs = [
+      makeObs({ id: 1, type: 'decision', title: 'D1' }),
+      makeObs({ id: 2, type: 'decision', title: 'D2' }),
+      makeObs({ id: 3, type: 'gotcha', title: 'G1' }),
+    ];
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: obs, miniSkills: [] });
+    const coreCluster = kg.clusters.find(c => c.sectionId === 'core-decisions');
+    expect(coreCluster!.nodeCount).toBe(2);
+    const gotchaCluster = kg.clusters.find(c => c.sectionId === 'known-gotchas');
+    expect(gotchaCluster!.nodeCount).toBe(1);
+  });
+});
+
+// Stats
+
+describe('Stats', () => {
+  it('stats are accurate', () => {
+    const obs = [
+      makeObs({ id: 1, type: 'decision', title: 'D1', entityName: 'auth' }),
+      makeObs({ id: 2, type: 'gotcha', title: 'G1', entityName: 'auth' }),
+    ];
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: obs, miniSkills: [] });
+    expect(kg.stats.totalNodes).toBe(2);
+    expect(kg.stats.clusterCount).toBe(2);
+    expect(kg.stats.sectionCounts['core-decisions']).toBe(1);
+    expect(kg.stats.sectionCounts['known-gotchas']).toBe(1);
+  });
+});
+
+// Node properties
+
+describe('Node properties', () => {
+  it('node id uses obs:<id> format for observations', () => {
+    const obs = makeObs({ id: 42, type: 'decision', title: 'D1' });
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: [obs], miniSkills: [] });
+    expect(kg.nodes[0].id).toBe('obs:42');
+  });
+
+  it('node id uses skill:<id> format for mini-skills', () => {
+    const skill = makeSkill({ id: 7, title: 'Skill' });
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: [], miniSkills: [skill] });
+    expect(kg.nodes[0].id).toBe('skill:7');
+  });
+
+  it('node has provenance refs', () => {
+    const obs = makeObs({ id: 42, type: 'decision', title: 'D1' });
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: [obs], miniSkills: [] });
+    expect(kg.nodes[0].refs.length).toBeGreaterThan(0);
+    expect(kg.nodes[0].refs[0].id).toBe('obs:42');
+  });
+
+  it('evidenceCount reflects facts + concepts + filesModified', () => {
+    const obs = makeObs({ id: 1, type: 'decision', title: 'D1', facts: ['f1', 'f2'], concepts: ['c1'], filesModified: ['a.ts', 'b.ts'] });
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: [obs], miniSkills: [] });
+    expect(kg.nodes[0].evidenceCount).toBe(5);
+  });
+});
+
+// Title and metadata
+
+describe('Title and metadata', () => {
+  it('has correct title and projectId', () => {
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: [], miniSkills: [] });
+    expect(kg.title).toBe('Knowledge Graph');
+    expect(kg.projectId).toBe(PROJECT_ID);
+  });
+
+  it('uses generatedAt when provided', () => {
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: [], miniSkills: [], generatedAt: FIXED_TIMESTAMP });
+    expect(kg.generatedAt).toBe(FIXED_TIMESTAMP);
+  });
+});
+
+// Graph-store relation merging
+
+describe('Graph-store relation merging', () => {
+  it('graph-store relation survives into semantic edges', () => {
+    const obs = [
+      makeObs({ id: 1, type: 'decision', title: 'D1', entityName: 'auth-module' }),
+      makeObs({ id: 2, type: 'how-it-works', title: 'H1', entityName: 'billing-service' }),
+    ];
+    const relations = [
+      { from: 'auth-module', to: 'billing-service', relationType: 'supports' },
+    ];
+    const kg = generateKnowledgeGraph({
+      projectId: PROJECT_ID,
+      observations: obs,
+      miniSkills: [],
+      graphEntities: [],
+      graphRelations: relations,
+    });
+    // The graph-store relation should produce a semantic edge
+    const grEdges = kg.edges.filter(e => e.id.startsWith('e_gr_'));
+    expect(grEdges.length).toBeGreaterThanOrEqual(1);
+    // It should connect obs:1 (auth-module) -> obs:2 (billing-service)
+    const authToBilling = grEdges.find(e => e.source === 'obs:1' && e.target === 'obs:2');
+    expect(authToBilling).toBeDefined();
+    expect(authToBilling!.edgeType).toBe('supports');
+  });
+
+  it('graph-store relation with unknown entity is skipped', () => {
+    const obs = [
+      makeObs({ id: 1, type: 'decision', title: 'D1', entityName: 'auth-module' }),
+    ];
+    const relations = [
+      { from: 'auth-module', to: 'nonexistent-entity', relationType: 'relates_to' },
+    ];
+    const kg = generateKnowledgeGraph({
+      projectId: PROJECT_ID,
+      observations: obs,
+      miniSkills: [],
+      graphEntities: [],
+      graphRelations: relations,
+    });
+    const grEdges = kg.edges.filter(e => e.id.startsWith('e_gr_'));
+    expect(grEdges.length).toBe(0);
+  });
+
+  it('graph-store relation duplicates are skipped', () => {
+    const obs = [
+      makeObs({ id: 1, type: 'decision', title: 'D1', entityName: 'auth-module' }),
+      makeObs({ id: 2, type: 'how-it-works', title: 'H1', entityName: 'billing-service' }),
+    ];
+    // Same-entity inference already creates a relates_to or supports edge,
+    // so the graph-store relation with same mapped type should not duplicate
+    const relations = [
+      { from: 'auth-module', to: 'billing-service', relationType: 'supports' },
+    ];
+    const kg = generateKnowledgeGraph({
+      projectId: PROJECT_ID,
+      observations: obs,
+      miniSkills: [],
+      graphEntities: [],
+      graphRelations: relations,
+    });
+    const authToBilling = kg.edges.filter(
+      e => e.source === 'obs:1' && e.target === 'obs:2' && e.edgeType === 'supports',
+    );
+    // Should have at most 1 edge with this exact source:edgeType:target
+    expect(authToBilling.length).toBeLessThanOrEqual(1);
+  });
+
+  it('graph-store relationType is mapped to semantic edgeType', () => {
+    const obs = [
+      makeObs({ id: 1, type: 'decision', title: 'D1', entityName: 'alpha' }),
+      makeObs({ id: 2, type: 'how-it-works', title: 'H1', entityName: 'beta' }),
+      makeObs({ id: 3, type: 'gotcha', title: 'G1', entityName: 'gamma' }),
+    ];
+    const relations = [
+      { from: 'alpha', to: 'beta', relationType: 'depends_on' },
+      { from: 'beta', to: 'gamma', relationType: 'references' },
+      { from: 'alpha', to: 'gamma', relationType: 'derived_from_source' },
+    ];
+    const kg = generateKnowledgeGraph({
+      projectId: PROJECT_ID,
+      observations: obs,
+      miniSkills: [],
+      graphEntities: [],
+      graphRelations: relations,
+    });
+    const grEdges = kg.edges.filter(e => e.id.startsWith('e_gr_'));
+    expect(grEdges.length).toBeGreaterThanOrEqual(3);
+    const depends = grEdges.find(e => e.source === 'obs:1' && e.target === 'obs:2');
+    expect(depends?.edgeType).toBe('supports');
+    const refs = grEdges.find(e => e.source === 'obs:2' && e.target === 'obs:3');
+    expect(refs?.edgeType).toBe('mentions');
+    const derived = grEdges.find(e => e.source === 'obs:1' && e.target === 'obs:3');
+    expect(derived?.edgeType).toBe('derived_from');
+  });
+});
+
+// Cluster labels are i18n-ready (sectionId-based, not hardcoded English)
+
+describe('Cluster labels are i18n-ready', () => {
+  it('cluster labels match section IDs that map to i18n keys, not raw English', () => {
+    const obs = [
+      makeObs({ id: 1, type: 'decision', title: 'D1' }),
+      makeObs({ id: 2, type: 'gotcha', title: 'G1' }),
+    ];
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: obs, miniSkills: [] });
+    // Clusters must have sectionId that maps to a known i18n key
+    const knownSectionIds = ['core-decisions', 'operational-knowledge', 'known-gotchas', 'git-backed-facts', 'promoted-skills'];
+    for (const cluster of kg.clusters) {
+      expect(knownSectionIds).toContain(cluster.sectionId);
+    }
+  });
+
+  it('cluster label is present but frontend should use i18n key, not API label', () => {
+    const obs = [makeObs({ id: 1, type: 'decision', title: 'D1' })];
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: obs, miniSkills: [] });
+    // API returns English label as default, but frontend must use sectionId -> i18n
+    const cluster = kg.clusters.find(c => c.sectionId === 'core-decisions');
+    expect(cluster).toBeDefined();
+    expect(cluster!.label).toBe('Core Decisions'); // API default
+    // Frontend should NOT display this label directly in ZH mode
+    // It should use sectionId to look up the ZH i18n key
+  });
+});
+
+// EdgeType style data completeness
+
+describe('EdgeType style data', () => {
+  it('every edgeType in output has a matching style definition in frontend edgeStyleMap', () => {
+    const obs = [
+      makeObs({ id: 1, type: 'decision', title: 'D1', entityName: 'auth' }),
+      makeObs({ id: 2, type: 'how-it-works', title: 'H1', entityName: 'auth' }),
+      makeObs({ id: 3, type: 'gotcha', title: 'G1', entityName: 'auth' }),
+    ];
+    const skill = makeSkill({ id: 1, title: 'Skill', sourceObservationIds: [1] });
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: obs, miniSkills: [skill] });
+
+    // All edge types produced must be in the known set
+    const knownEdgeTypes = ['supports', 'relates_to', 'mentions', 'derived_from'];
+    const producedEdgeTypes = new Set(kg.edges.map(e => e.edgeType));
+    for (const et of producedEdgeTypes) {
+      expect(knownEdgeTypes).toContain(et);
+    }
+  });
+
+  it('each edgeType has color, arrow, dash, and label style properties in edgeStyleMap', () => {
+    // This test verifies the frontend edgeStyleMap structure is complete
+    // The actual edgeStyleMap is in app.js, but we verify the type contract
+    const edgeStyleMap = {
+      'supports': { color: 'rgba(105,240,174,0.35)', arrow: 'triangle', dash: false, label: 'supports' },
+      'relates_to': { color: 'rgba(128,216,255,0.25)', arrow: 'none', dash: [4, 4], label: 'relates to' },
+      'mentions': { color: 'rgba(208,188,255,0.25)', arrow: 'triangle-cross', dash: false, label: 'mentions' },
+      'derived_from': { color: 'rgba(255,183,77,0.35)', arrow: 'triangle', dash: [6, 3], label: 'derived from' },
+    };
+    for (const [type, style] of Object.entries(edgeStyleMap)) {
+      expect(style).toHaveProperty('color');
+      expect(style).toHaveProperty('arrow');
+      expect(style).toHaveProperty('dash');
+      expect(style).toHaveProperty('label');
+      expect(typeof style.color).toBe('string');
+      expect(typeof style.arrow).toBe('string');
+      expect(typeof style.label).toBe('string');
+      // dash can be boolean or number array
+      expect(typeof style.dash === 'boolean' || Array.isArray(style.dash)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Starts the Memorix 1.0.9 mainline with the first knowledge-layer and dashboard work:

- protect existing .env.example files during init
- add probe / observation-only memory type for operational heartbeats
- fix OpenCode assistant response capture via message.updated + session.idle
- add a read-only project Knowledge Base / LLM Wiki layer
- add the Dashboard Knowledge page
- add a semantic Knowledge Graph view with scoped graph-store relation preservation

## Notes

This keeps the memory layer architecture intact. The Knowledge Base and Knowledge Graph are read-only product surfaces built from existing durable memory, reasoning, git facts, graph relations, and mini-skills.

## Validation

- git diff --check
- npm run lint
- node --check src/dashboard/static/app.js
- npx vitest run tests/wiki/knowledge-graph.test.ts tests/integration/dashboard-project-scope.test.ts --testTimeout 15000
- npm run build