### PR TITLE
fix(dashboard): prevent knowledge graph mention cliques

### DIFF
--- a/src/wiki/knowledge-graph.ts
+++ b/src/wiki/knowledge-graph.ts
@@ -60,8 +60,8 @@ const ALL_SECTIONS: SectionDef[] = [...SECTION_DEFS, GIT_SECTION, SKILLS_SECTION
 // Rules (no LLM, deterministic):
 // 1. supports: same entityName, different section -> source supports target
 // 2. relates_to: same entityName, same section -> bidirectional
-// 3. mentions: entityName of A appears in concepts/facts of B -> A mentions B
-// 4. derived_from: mini-skill source obs -> skill node
+// 3. derived_from: mini-skill source obs -> skill node
+// Explicit graph-store references are merged later as mentions edges.
 
 function inferEdges(
   nodes: SemanticNode[],
@@ -129,19 +129,6 @@ function inferEdges(
           ? 'relates_to'
           : 'supports';
         addEdge(from.id, to.id, edgeType);
-      }
-    }
-  }
-
-  // 3: Concept/fact cross-reference edges (mentions)
-  for (const node of nodes) {
-    if (!node.refs.length) continue;
-    for (const ref of node.refs) {
-      for (const other of nodes) {
-        if (other.id === node.id) continue;
-        if (ref.title && other.label.toLowerCase().includes(ref.title.toLowerCase().slice(0, 20))) {
-          addEdge(node.id, other.id, 'mentions');
-        }
       }
     }
   }

--- a/tests/wiki/knowledge-graph.test.ts
+++ b/tests/wiki/knowledge-graph.test.ts
@@ -216,6 +216,22 @@ describe('Edge inference', () => {
     expect(relatesEdges.length).toBeLessThanOrEqual(8);
     expect(Math.max(...degree.values())).toBeLessThanOrEqual(8);
   });
+
+  it('does not infer mention cliques from repeated provenance titles', () => {
+    const obs = Array.from({ length: 20 }, (_, idx) =>
+      makeObs({
+        id: 2000 + idx,
+        type: 'gotcha',
+        title: 'HTTP quota fallback memory',
+        entityName: `quota-${idx}`,
+      }),
+    );
+
+    const kg = generateKnowledgeGraph({ projectId: PROJECT_ID, observations: obs, miniSkills: [] });
+    const mentionsEdges = kg.edges.filter(e => e.edgeType === 'mentions');
+
+    expect(mentionsEdges.length).toBe(0);
+  });
 });
 
 // Section clusters


### PR DESCRIPTION
﻿## Summary

Fixes the Knowledge Graph edge explosion seen when many observations share the same title, such as repeated HTTP quota fallback memories.

## Root Cause

The semantic graph inferred mentions edges from each node's own provenance ref title, then matched that title against every other node label. For repeated titles, this produced a directed clique: 272 nodes became 73,712 mentions edges.

## Fix

- Stop inferring mentions from provenance titles.
- Keep explicit graph-store references/mentions as the source for mentions edges.
- Add a regression test proving repeated provenance titles do not create mention cliques.

## Validation

- git diff --check HEAD~1..HEAD
- npx vitest run tests/wiki/knowledge-graph.test.ts --testNamePattern "provenance titles|graph-store relationType"
- npm run lint
- npx vitest run tests/wiki/knowledge-graph.test.ts tests/integration/dashboard-project-scope.test.ts --testTimeout 15000
- npm run build