### PR TITLE
fix(session): don't hijack projectRoot binding to a nested git subdirectory

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -2692,28 +2692,36 @@ export async function createMemorixServer(
       // mechanism for HTTP/control-plane multi-project support.
       if (explicitRoot && typeof explicitRoot === 'string') {
         let bound = await switchProject(explicitRoot);
-        // Fallback: workspace root may contain a git project in a subdirectory
+        // switchProject returns false in two distinct cases that must NOT be conflated:
+        //   (a) explicitRoot IS a valid git repo, but it's the already-bound project
+        //       (a same-project no-op) — this is success, and we must NOT scan subdirs,
+        //       or we'd hijack the binding to a nested/vendored repo under explicitRoot.
+        //   (b) explicitRoot is NOT a git repo — only then may the workspace root hold a
+        //       git project in a subdirectory, so the subdir scan is the right fallback.
+        // Resolve explicitRoot's own identity first to tell (a) from (b).
         if (!bound) {
-          const { findGitInSubdirs } = await import('./project/detector.js');
-          const subGit = findGitInSubdirs(explicitRoot);
-          if (subGit) {
-            bound = await switchProject(subGit);
-          }
-        }
-        // switchProject returns false for "same project, no-op" — that's still success,
-        // but ONLY when the canonical projectId matches the currently bound project.
-        // We must NOT treat "different valid repo at a different path" as a no-op success.
-        if (!bound && projectResolved) {
           const { detectProjectWithDiagnostics: diagnose } = await import('./project/detector.js');
           const diag = diagnose(explicitRoot);
           if (diag.project) {
-            const { registerAlias: regAlias } = await import('./project/aliases.js');
-            const resolvedCanonical = await regAlias(diag.project);
-            if (resolvedCanonical === project.id) {
-              // Same canonical project — switchProject returned false because it's a no-op.
-              bound = true;
+            // (a) explicitRoot is itself a git repo. switchProject only returns false here
+            // when it's a same-project no-op; treat as success when the canonical id matches
+            // the currently bound project. (A different valid repo would have switched → true.)
+            if (projectResolved) {
+              const { registerAlias: regAlias } = await import('./project/aliases.js');
+              const resolvedCanonical = await regAlias(diag.project);
+              if (resolvedCanonical === project.id) {
+                bound = true;
+              }
             }
-            // else: different canonical project — fall through to fail-closed path below
+            // Same path, different canonical: fall through to fail-closed path below.
+            // Crucially, do NOT scan subdirs — explicitRoot is a real repo.
+          } else {
+            // (b) explicitRoot has no git repo — workspace root may contain one in a subdir.
+            const { findGitInSubdirs } = await import('./project/detector.js');
+            const subGit = findGitInSubdirs(explicitRoot);
+            if (subGit) {
+              bound = await switchProject(subGit);
+            }
           }
         }
         if (!bound) {

--- a/tests/integration/session-nested-subdir-binding.test.ts
+++ b/tests/integration/session-nested-subdir-binding.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Regression: memorix_session_start must not hijack the binding to a nested
+ * git subdirectory when re-binding to the already-bound parent repo.
+ *
+ * Repro of the CC↔worker scope mismatch: a stdio `memorix serve` starts already
+ * resolved to the parent repo (from its launch cwd). A subsequent
+ * memorix_session_start({ projectRoot: <parent> }) is a same-project no-op, which
+ * switchProject() signals by returning false. The handler used to misread that
+ * false as "not bound" and fall back to scanning subdirectories, which bound the
+ * session to the first nested git repo (e.g. a vendored `local/<sub>`) instead.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../../src/embedding/provider.js', () => ({
+  getEmbeddingProvider: async () => null,
+  isVectorSearchAvailable: async () => false,
+  isEmbeddingExplicitlyDisabled: () => true,
+  resetProvider: () => {},
+}));
+
+vi.mock('../../src/llm/provider.js', () => ({
+  initLLM: () => null,
+  isLLMEnabled: () => false,
+  getLLMConfig: () => null,
+  setLLMConfig: () => {},
+}));
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { createMemorixServer } from '../../src/server.js';
+import { resetDb } from '../../src/store/orama-store.js';
+
+let tempHome: string;
+const origHome = process.env.HOME;
+const origUserProfile = process.env.USERPROFILE;
+
+async function createFakeGitRepo(root: string, remote?: string): Promise<void> {
+  await fs.mkdir(path.join(root, '.git'), { recursive: true });
+  const config = remote ? `[remote "origin"]\n\turl = ${remote}\n` : '';
+  await fs.writeFile(path.join(root, '.git', 'config'), config, 'utf8');
+}
+
+function getHandler(server: any, name: string): (args: Record<string, unknown>) => Promise<any> {
+  const handler = server._registeredTools?.[name]?.handler;
+  expect(handler).toBeTypeOf('function');
+  return handler;
+}
+
+function getText(result: any): string {
+  return (result?.content ?? [])
+    .filter((item: any) => item?.type === 'text')
+    .map((item: any) => item.text)
+    .join('\n');
+}
+
+beforeEach(async () => {
+  tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-nested-home-'));
+  process.env.HOME = tempHome;
+  process.env.USERPROFILE = tempHome;
+  await resetDb();
+});
+
+afterEach(() => {
+  process.env.HOME = origHome;
+  process.env.USERPROFILE = origUserProfile;
+});
+
+describe('memorix_session_start nested-subdir binding', () => {
+  it('keeps the parent repo bound and does NOT hijack to a nested git subdir', async () => {
+    const work = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-nested-work-'));
+    const parent = path.join(work, 'parent');
+    await fs.mkdir(parent, { recursive: true });
+    // Parent repo HAS a remote → canonical id "AVIDS2/parent-repo"
+    await createFakeGitRepo(parent, 'https://github.com/AVIDS2/parent-repo.git');
+    // Nested vendored repo WITHOUT a remote → id "local/nested-pkg"
+    const nested = path.join(parent, 'nested-pkg');
+    await fs.mkdir(nested, { recursive: true });
+    await createFakeGitRepo(nested);
+
+    // Server starts resolved to the parent (stdio-style: launch cwd = parent).
+    const { server } = await createMemorixServer(parent);
+    const sessionStart = getHandler(server as any, 'memorix_session_start');
+
+    const result = await sessionStart({ projectRoot: parent, agent: 'cc' });
+    const text = getText(result);
+
+    expect(text).toContain('AVIDS2/parent-repo');
+    expect(text).not.toContain('local/nested-pkg');
+  });
+});


### PR DESCRIPTION
# fix(session): don't hijack `projectRoot` binding to a nested git subdirectory

## Problem

When two clients share the same Memorix store but connect over different
transports, they can resolve the **same directory** to **different projects**,
so they silently stop sharing memory.

Concretely:

- A **stdio** `memorix serve` (e.g. Claude Code) starts already *resolved* to a
  project from its launch cwd.
- A later `memorix_session_start({ projectRoot: <that same repo> })` then binds
  the session to a **nested/vendored git repo** under the project root
  (e.g. `local/<subdir>`) instead of the project itself.
- An **HTTP-daemon** client (which starts `__unresolved__`) binds the very same
  `projectRoot` correctly to the parent repo.

Result: the two agents think they're in different projects and never see each
other's memories.

## Root cause

In the `memorix_session_start` handler, `switchProject(projectRoot)` returns
`false` in **two distinct** situations that were conflated:

1. `projectRoot` **is** a valid git repo, but it's the **already-bound** project
   — a same-project no-op. This is success.
2. `projectRoot` is **not** a git repo — only here should the workspace root be
   scanned for a git project in a subdirectory.

The handler treated *both* `false` cases as "not bound" and fell through to the
`findGitInSubdirs` fallback, which bound the session to the first nested git
repo it found. The same-project no-op (case 1) therefore got hijacked to a
subdirectory whenever the resolved project root happened to contain a vendored
git repo.

The HTTP path avoided this only incidentally: it starts unresolved, so the first
`switchProject` performs a real switch (returns `true`) and never reaches the
fallback.

## Fix

Only fall back to the subdirectory scan when `projectRoot` itself is **not** a
git repo. When it *is* a real repo, a `false` from `switchProject` means a
same-project no-op (success) — never scan subdirs. The diagnostic resolution of
`projectRoot` is done first to tell the two cases apart.

## Test

Adds `tests/integration/session-nested-subdir-binding.test.ts`, which reproduces
the hijack: a server started resolved to a parent repo (with remote) that
contains a nested git repo (no remote). `memorix_session_start({ projectRoot:
<parent> })` must keep the parent bound and must not switch to `local/<nested>`.

Red before the fix, green after. Existing `serve-http`, `tool-profile`, and
project-detector suites continue to pass.
