### PR TITLE
feat: finalize 1.1 release closeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/memorix"><img src="https://img.shields.io/npm/v/memorix.svg?style=for-the-badge&logo=npm&color=cb3837" alt="npm"></a>
+  <a href="https://www.npmjs.com/package/memorix"><img src="https://img.shields.io/npm/dm/memorix.svg?style=for-the-badge&logo=npm&label=monthly%20downloads&color=7c3aed" alt="monthly downloads"></a>
   <a href="https://github.com/AVIDS2/memorix/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/AVIDS2/memorix/ci.yml?style=for-the-badge&label=CI&logo=github" alt="CI"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-2563eb?style=for-the-badge" alt="license"></a>
   <a href="https://github.com/AVIDS2/memorix"><img src="https://img.shields.io/github/stars/AVIDS2/memorix?style=for-the-badge&logo=github&color=facc15" alt="stars"></a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,6 +11,7 @@
 
 <p align="center">
   <a href="https://www.npmjs.com/package/memorix"><img src="https://img.shields.io/npm/v/memorix.svg?style=for-the-badge&logo=npm&color=cb3837" alt="npm"></a>
+  <a href="https://www.npmjs.com/package/memorix"><img src="https://img.shields.io/npm/dm/memorix.svg?style=for-the-badge&logo=npm&label=monthly%20downloads&color=7c3aed" alt="monthly downloads"></a>
   <a href="https://github.com/AVIDS2/memorix/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/AVIDS2/memorix/ci.yml?style=for-the-badge&label=CI&logo=github" alt="CI"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-2563eb?style=for-the-badge" alt="license"></a>
   <a href="https://github.com/AVIDS2/memorix"><img src="https://img.shields.io/github/stars/AVIDS2/memorix?style=for-the-badge&logo=github&color=facc15" alt="stars"></a>

--- a/packages/memcode/src/modes/interactive/components/startup-welcome-card.ts
+++ b/packages/memcode/src/modes/interactive/components/startup-welcome-card.ts
@@ -14,30 +14,27 @@ export interface StartupWelcomeCardOptions {
 const PIXEL_RESET = "\x1b[0m";
 
 const PIXEL_PALETTE: Record<string, string> = {
-	O: "#ff8c4a",
-	B: "#ff6b3d",
-	W: "#fff7e8",
-	d: "#c94f2f",
-	E: "#111111",
+	n: "#5b4a7a",
+	N: "#7a68a0",
+	P: "#d7cbe8",
+	p: "#e8dff5",
+	M: "#c8c4cf",
+	m: "#a09baa",
+	W: "#eae8f0",
+	O: "#e8a050",
+	B: "#d08838",
 };
 
-const CRAB_PIXEL_ROWS = [
-	"  OOO          OOO  ",
-	" OBBBO        OBBBO ",
-	"   OBO        OBO   ",
-	"    OBBO    OBBO    ",
-	"      OOOOOOOO      ",
-	"    OBBBBBBBBBBO    ",
-	"   OBBBWBBBBWBBBO   ",
-	"  OBBBBEBBBBEBBBBO  ",
-	"  OBBBBBBBBBBBBBBO  ",
-	" OBBBBBBBBBBBBBBBBO ",
-	"  OBBBBOBBBBBOBBBO  ",
-	"   OBBBOOOOOOBBBO   ",
-	"  OBO          OBO  ",
-	" OBO            OBO ",
-	"OBdO            OBdO",
-	" OO              OO ",
+const MEMORY_DRIVE_PIXEL_ROWS = [
+	"     NPPPPPPPPPPPPPPPN",
+	"     NPpppppppppppppPN",
+	"MWWWmNPpppppppppppppPN",
+	"MWWWmNPppppppppOppppPN",
+	"MmmmmNPpppppppppppppPN",
+	"MmmmmNPpppppppppppppPN",
+	"     NPpppppppppppppPN",
+	"     NPpppppppppppppPN",
+	"     NPPPPPPPPPPPPPPPN",
 ] as const;
 
 function ansiFg(color: string): string {
@@ -62,9 +59,9 @@ function pixelColor(pixel: string): string | undefined {
 	return PIXEL_PALETTE[pixel];
 }
 
-function renderCrabSprite(): string[] {
-	const width = Math.max(...CRAB_PIXEL_ROWS.map((row) => row.length));
-	const rows = CRAB_PIXEL_ROWS.map((row) => row.padEnd(width, " "));
+function renderMemoryDriveSprite(): string[] {
+	const width = Math.max(...MEMORY_DRIVE_PIXEL_ROWS.map((row) => row.length));
+	const rows = MEMORY_DRIVE_PIXEL_ROWS.map((row) => row.padEnd(width, " "));
 	const rendered: string[] = [];
 	for (let y = 0; y < rows.length; y += 2) {
 		const upper = rows[y] ?? "";
@@ -174,7 +171,7 @@ export class StartupWelcomeCard implements Component {
 			centerAnsi(theme.bold(theme.fg("text", "Ready when you are")), width),
 			centerAnsi(theme.fg("dim", "native memory inside memcode"), width),
 			"",
-			...renderCrabSprite().map((line) => centerAnsi(line, width)),
+			...renderMemoryDriveSprite().map((line) => centerAnsi(line, width)),
 			"",
 			padAnsi(formatMeta("model", this.options.getModelLabel()), width),
 			padAnsi(formatMeta("project", this.options.getProjectLabel()), width),

--- a/packages/memcode/src/modes/interactive/interactive-mode.ts
+++ b/packages/memcode/src/modes/interactive/interactive-mode.ts
@@ -4307,41 +4307,18 @@ export class InteractiveMode {
 	 */
 	private showSelector(
 		create: (done: () => void) => { component: Component; focus: Component },
-		options?: { transientOverlay?: boolean },
 	): void {
-		if (options?.transientOverlay) {
-			let handle: OverlayHandle | undefined;
-			const done = () => {
-				handle?.hide();
-				this.ui.setFocus(this.editor);
-			};
-			const { component, focus } = create(done);
-			handle = this.ui.showOverlay(component, {
-				width: "100%",
-				maxHeight: "100%",
-				row: 0,
-				col: 0,
-				nonCapturing: true,
-			});
-			if (focus === component) {
-				handle.focus();
-			} else {
-				this.ui.setFocus(focus);
-			}
-			this.ui.requestRender();
-			return;
-		}
-
 		const done = () => {
 			this.editorContainer.clear();
 			this.editorContainer.addChild(this.editor);
 			this.ui.setFocus(this.editor);
+			this.ui.requestRenderAndClearScrollback();
 		};
 		const { component, focus } = create(done);
 		this.editorContainer.clear();
 		this.editorContainer.addChild(component);
 		this.ui.setFocus(focus);
-		this.ui.requestRender();
+		this.ui.requestRenderAndClearScrollback();
 	}
 
 	private showSettingsSelector(): void {
@@ -4974,49 +4951,45 @@ export class InteractiveMode {
 	}
 
 	private showSessionSelector(): void {
-		this.showSelector(
-			(done) => {
-				const selector = new SessionSelectorComponent(
-					(onProgress) =>
-						SessionManager.list(this.sessionManager.getCwd(), this.sessionManager.getSessionDir(), onProgress),
-					(onProgress) =>
-						this.sessionManager.usesDefaultSessionDir()
-							? SessionManager.listAll(onProgress)
-							: SessionManager.listAll(this.sessionManager.getSessionDir(), onProgress),
-					async (sessionPath) => {
-						const result = await this.handleResumeSession(sessionPath);
-						if (!result.cancelled) {
-							done();
-						} else {
-							selector.setDisabled(false);
-							this.ui.requestRender();
-						}
-					},
-					() => {
+		this.showSelector((done) => {
+			const selector = new SessionSelectorComponent(
+				(onProgress) => SessionManager.list(this.sessionManager.getCwd(), this.sessionManager.getSessionDir(), onProgress),
+				(onProgress) =>
+					this.sessionManager.usesDefaultSessionDir()
+						? SessionManager.listAll(onProgress)
+						: SessionManager.listAll(this.sessionManager.getSessionDir(), onProgress),
+				async (sessionPath) => {
+					const result = await this.handleResumeSession(sessionPath);
+					if (!result.cancelled) {
 						done();
+					} else {
+						selector.setDisabled(false);
 						this.ui.requestRender();
+					}
+				},
+				() => {
+					done();
+					this.ui.requestRender();
+				},
+				() => {
+					void this.shutdown();
+				},
+				() => this.ui.requestRender(),
+				{
+					renameSession: async (sessionFilePath: string, nextName: string | undefined) => {
+						const next = (nextName ?? "").trim();
+						if (!next) return;
+						const mgr = SessionManager.open(sessionFilePath);
+						mgr.appendSessionInfo(next);
 					},
-					() => {
-						void this.shutdown();
-					},
-					() => this.ui.requestRender(),
-					{
-						renameSession: async (sessionFilePath: string, nextName: string | undefined) => {
-							const next = (nextName ?? "").trim();
-							if (!next) return;
-							const mgr = SessionManager.open(sessionFilePath);
-							mgr.appendSessionInfo(next);
-						},
-						showRenameHint: true,
-						keybindings: this.keybindings,
-					},
+					showRenameHint: true,
+					keybindings: this.keybindings,
+				},
 
-					this.sessionManager.getSessionFile(),
-				);
-				return { component: selector, focus: selector };
-			},
-			{ transientOverlay: true },
-		);
+				this.sessionManager.getSessionFile(),
+			);
+			return { component: selector, focus: selector };
+		});
 	}
 
 	private async handleResumeSession(

--- a/packages/memcode/test/interactive-mode-status.test.ts
+++ b/packages/memcode/test/interactive-mode-status.test.ts
@@ -220,9 +220,9 @@ describe("InteractiveMode.handleResumeSession", () => {
 });
 
 describe("InteractiveMode.showSelector", () => {
-	test("can render session-switch selectors as transient overlays", () => {
-		const component = new TestFocusableComponent("Resume Session");
-		const handle = { hide: vi.fn(), focus: vi.fn() };
+	test("renders selectors inline and clears terminal scrollback on enter and exit", () => {
+		const component = new TestFocusableComponent("Theme");
+		let done!: () => void;
 		const fakeThis: any = {
 			editor: new TestFocusableComponent("editor"),
 			editorContainer: {
@@ -230,25 +230,30 @@ describe("InteractiveMode.showSelector", () => {
 				addChild: vi.fn(),
 			},
 			ui: {
-				showOverlay: vi.fn(() => handle),
 				setFocus: vi.fn(),
-				requestRender: vi.fn(),
+				requestRenderAndClearScrollback: vi.fn(),
 			},
 		};
 
 		(InteractiveMode as any).prototype.showSelector.call(
 			fakeThis,
-			() => ({ component, focus: component }),
-			{ transientOverlay: true },
+			(doneCallback: () => void) => {
+				done = doneCallback;
+				return { component, focus: component };
+			},
 		);
 
-		expect(fakeThis.editorContainer.clear).not.toHaveBeenCalled();
-		expect(fakeThis.editorContainer.addChild).not.toHaveBeenCalledWith(component);
-		expect(fakeThis.ui.showOverlay).toHaveBeenCalledWith(
-			component,
-			expect.objectContaining({ nonCapturing: true }),
-		);
-		expect(handle.focus).toHaveBeenCalledTimes(1);
+		expect(fakeThis.editorContainer.clear).toHaveBeenCalledTimes(1);
+		expect(fakeThis.editorContainer.addChild).toHaveBeenCalledWith(component);
+		expect(fakeThis.ui.setFocus).toHaveBeenLastCalledWith(component);
+		expect(fakeThis.ui.requestRenderAndClearScrollback).toHaveBeenCalledTimes(1);
+
+		done();
+
+		expect(fakeThis.editorContainer.clear).toHaveBeenCalledTimes(2);
+		expect(fakeThis.editorContainer.addChild).toHaveBeenLastCalledWith(fakeThis.editor);
+		expect(fakeThis.ui.setFocus).toHaveBeenLastCalledWith(fakeThis.editor);
+		expect(fakeThis.ui.requestRenderAndClearScrollback).toHaveBeenCalledTimes(2);
 	});
 });
 

--- a/packages/tui/src/tui.ts
+++ b/packages/tui/src/tui.ts
@@ -1376,7 +1376,7 @@ export class TUI extends Container {
 		// First render - just output everything without clearing (assumes clean screen)
 		if (this.previousLines.length === 0 && !widthChanged && !heightChanged) {
 			logRedraw("first render");
-			fullRender(false);
+			fullRender(true);
 			return;
 		}
 

--- a/packages/tui/test/viewport-scroll.test.ts
+++ b/packages/tui/test/viewport-scroll.test.ts
@@ -214,6 +214,37 @@ describe("TUI viewport scrolling", () => {
 		tui.stop();
 	});
 
+	it("first render clears in place and renders only the visible viewport", async () => {
+		const terminal = new VirtualTerminal(20, 4);
+		const tui = new TUI(terminal);
+		const component = new LinesComponent([
+			"Welcome card",
+			"Startup diagnostics",
+			"Prompt 1",
+			"Response 1",
+			"Prompt 2",
+			"Response 2",
+			"Editor",
+			"Footer",
+		]);
+		tui.addChild(component);
+		tui.start();
+		await terminal.waitForRender();
+
+		const output = terminal.getOutput();
+		assert.ok(output.includes("\x1b[2J\x1b[H"), `first render did not clear/home first:\n${output}`);
+		assert.ok(!output.includes("Welcome card"), `first render appended hidden startup content:\n${output}`);
+		assert.ok(!output.includes("Startup diagnostics"), `first render appended hidden startup diagnostics:\n${output}`);
+		assert.deepStrictEqual(terminal.getViewport(), [
+			"Prompt 2",
+			"Response 2",
+			"Editor",
+			"Footer",
+		]);
+
+		tui.stop();
+	});
+
 	it("closing a full-screen overlay after content shrinks clears the overlay in place", async () => {
 		const terminal = new VirtualTerminal(30, 6);
 		const tui = new TUI(terminal);


### PR DESCRIPTION
## Summary
- Restore the README monthly downloads badge in both README variants
- Replace the memcode startup crab with the memory drive mascot in the bundled root output
- Fix selector rendering and first-render scrollback behavior to avoid flicker and hidden transcript leakage

## Verification
- npm --prefix packages/memcode test -- test/interactive-mode-status.test.ts test/startup-welcome-card.test.ts
- node --test packages/tui/test/viewport-scroll.test.ts
- npm run build
- git diff --check