### PR TITLE
fix: remove unowned product domain defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.2] - 2026-06-27
+
+### Fixed
+- **Removed unowned product-domain defaults** -- Removed hardcoded unowned product-domain references from memcode defaults, tests, and generated help text. Version checks now use the official npm registry endpoint, changelog links point to GitHub releases, OpenRouter attribution uses the GitHub repository URL, and `/share` falls back to the GitHub gist URL unless the user explicitly sets `MEMCODE_SHARE_VIEWER_URL`.
+- **Disabled default install report endpoint** -- memcode no longer sends install/update pings to any default product-domain endpoint. A report endpoint is used only when `MEMCODE_INSTALL_REPORT_URL` is explicitly configured by the user.
+
 ## [1.1.1] - 2026-06-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",
@@ -9579,10 +9579,10 @@
     },
     "packages/agent-core": {
       "name": "@memorix/agent-core",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
-        "@memorix/ai": "1.1.1",
+        "@memorix/ai": "1.1.2",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -9650,7 +9650,7 @@
     },
     "packages/ai": {
       "name": "@memorix/ai",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -9695,12 +9695,12 @@
     },
     "packages/memcode": {
       "name": "@memorix/memcode",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
-        "@memorix/agent-core": "1.1.1",
-        "@memorix/ai": "1.1.1",
-        "@memorix/tui": "1.1.1",
+        "@memorix/agent-core": "1.1.2",
+        "@memorix/ai": "1.1.2",
+        "@memorix/tui": "1.1.2",
         "@opentui/core": "^0.3.4",
         "@opentui/react": "^0.3.4",
         "@silvia-odwyer/photon-node": "0.3.4",
@@ -9798,7 +9798,7 @@
     },
     "packages/tui": {
       "name": "@memorix/tui",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@memorix/agent-core",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -29,7 +29,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@memorix/ai": "1.1.1",
+		"@memorix/ai": "1.1.2",
 		"ignore": "7.0.5",
 		"typebox": "1.1.38",
 		"yaml": "2.9.0"

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@memorix/ai",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/memcode/package.json
+++ b/packages/memcode/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@memorix/memcode",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "Memorix-native coding agent CLI with terminal chat, project memory, hooks, and session management",
 	"type": "module",
 	"piConfig": {
@@ -34,9 +34,9 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@memorix/agent-core": "1.1.1",
-		"@memorix/ai": "1.1.1",
-		"@memorix/tui": "1.1.1",
+		"@memorix/agent-core": "1.1.2",
+		"@memorix/ai": "1.1.2",
+		"@memorix/tui": "1.1.2",
 		"@opentui/core": "^0.3.4",
 		"@opentui/react": "^0.3.4",
 		"@silvia-odwyer/photon-node": "0.3.4",

--- a/packages/memcode/src/cli/args.ts
+++ b/packages/memcode/src/cli/args.ts
@@ -378,7 +378,7 @@ ${chalk.bold("Environment Variables:")}
   MEMCODE_PACKAGE_DIR              - Override package directory (for Nix/Guix store paths)
   MEMCODE_OFFLINE                  - Disable startup network operations when set to 1/true/yes
   MEMCODE_TELEMETRY                - Override install telemetry when set to 1/true/yes or 0/false/no
-  MEMCODE_SHARE_VIEWER_URL         - Base URL for /share command (default: https://memorix.dev/session/)
+  MEMCODE_SHARE_VIEWER_URL         - Optional custom base URL for /share previews (default: GitHub gist URL)
 
 ${chalk.bold("Built-in Tool Names:")}
   read   - Read file contents

--- a/packages/memcode/src/config.ts
+++ b/packages/memcode/src/config.ts
@@ -475,11 +475,10 @@ export function expandTildePath(path: string): string {
 	return normalizePath(path);
 }
 
-const DEFAULT_SHARE_VIEWER_URL = "https://memorix.dev/session/";
-
 /** Get the share viewer URL for a gist ID */
-export function getShareViewerUrl(gistId: string): string {
-	const baseUrl = process.env.MEMCODE_SHARE_VIEWER_URL || DEFAULT_SHARE_VIEWER_URL;
+export function getShareViewerUrl(gistId: string, gistUrl?: string): string {
+	const baseUrl = process.env.MEMCODE_SHARE_VIEWER_URL;
+	if (!baseUrl) return gistUrl ?? `https://gist.github.com/${gistId}`;
 	return `${baseUrl}#${gistId}`;
 }
 

--- a/packages/memcode/src/core/provider-attribution.ts
+++ b/packages/memcode/src/core/provider-attribution.ts
@@ -7,6 +7,7 @@ const NVIDIA_NIM_HOST = "integrate.api.nvidia.com";
 const CLOUDFLARE_API_HOST = "api.cloudflare.com";
 const CLOUDFLARE_AI_GATEWAY_HOST = "gateway.ai.cloudflare.com";
 const OPENCODE_HOST = "opencode.ai";
+const MEMCODE_PROJECT_URL = "https://github.com/AVIDS2/memorix";
 
 function matchesHost(baseUrl: string, expectedHost: string): boolean {
 	try {
@@ -43,7 +44,7 @@ function getDefaultAttributionHeaders(
 
 	if (isOpenRouterModel(model)) {
 		return {
-			"HTTP-Referer": "https://memorix.dev",
+			"HTTP-Referer": MEMCODE_PROJECT_URL,
 			"X-OpenRouter-Title": "memcode",
 			"X-OpenRouter-Categories": "cli-agent",
 		};

--- a/packages/memcode/src/modes/interactive/interactive-mode.ts
+++ b/packages/memcode/src/modes/interactive/interactive-mode.ts
@@ -1034,7 +1034,21 @@ export class InteractiveMode {
 			return;
 		}
 
-		void fetch(`https://memorix.dev/api/report-install?version=${encodeURIComponent(version)}`, {
+		const endpoint = process.env.MEMCODE_INSTALL_REPORT_URL?.trim();
+		if (!endpoint) {
+			return;
+		}
+
+		let url: string;
+		try {
+			const parsed = new URL(endpoint);
+			parsed.searchParams.set("version", version);
+			url = parsed.toString();
+		} catch {
+			return;
+		}
+
+		void fetch(url, {
 			headers: {
 				"User-Agent": getPiUserAgent(version),
 			},
@@ -4073,7 +4087,7 @@ export class InteractiveMode {
 	showNewVersionNotification(release: LatestPiRelease): void {
 		const action = theme.fg("accent", `${APP_NAME} update`);
 		const updateInstruction = theme.fg("muted", `New version ${release.version} is available. Run `) + action;
-		const changelogUrl = "https://memorix.dev/changelog";
+		const changelogUrl = "https://github.com/AVIDS2/memorix/releases/latest";
 		const changelogLink = getCapabilities().hyperlinks
 			? hyperlink(theme.fg("accent", "open changelog"), changelogUrl)
 			: theme.fg("accent", changelogUrl);
@@ -5709,8 +5723,7 @@ export class InteractiveMode {
 				return;
 			}
 
-			// Create the preview URL
-			const previewUrl = getShareViewerUrl(gistId);
+			const previewUrl = getShareViewerUrl(gistId, gistUrl);
 			this.showStatus(`Share URL: ${previewUrl}\nGist: ${gistUrl}`);
 		} catch (error: unknown) {
 			if (!loader.signal.aborted) {

--- a/packages/memcode/src/utils/version-check.ts
+++ b/packages/memcode/src/utils/version-check.ts
@@ -1,6 +1,6 @@
 import { getPiUserAgent } from "./pi-user-agent.ts";
 
-const LATEST_VERSION_URL = "https://memorix.dev/api/latest-version";
+const LATEST_VERSION_URL = "https://registry.npmjs.org/memorix/latest";
 const DEFAULT_VERSION_CHECK_TIMEOUT_MS = 10000;
 
 export interface LatestPiRelease {
@@ -69,6 +69,7 @@ export async function getLatestPiRelease(
 	if (!response.ok) return undefined;
 
 	const data = (await response.json()) as {
+		name?: unknown;
 		packageName?: unknown;
 		version?: unknown;
 		note?: unknown;
@@ -78,10 +79,12 @@ export async function getLatestPiRelease(
 	}
 	const packageName =
 		typeof data.packageName === "string" && data.packageName.trim() ? data.packageName.trim() : undefined;
+	const npmPackageName =
+		typeof data.name === "string" && data.name.trim() ? data.name.trim() : undefined;
 	const note = typeof data.note === "string" && data.note.trim() ? data.note.trim() : undefined;
 	return {
 		version: data.version.trim(),
-		packageName,
+		...(packageName || npmPackageName ? { packageName: packageName ?? npmPackageName } : {}),
 		...(note ? { note } : {}),
 	};
 }

--- a/packages/memcode/test/config.test.ts
+++ b/packages/memcode/test/config.test.ts
@@ -6,12 +6,14 @@ import {
 	detectInstallMethod,
 	getSelfUpdateCommand,
 	getSelfUpdateUnavailableInstruction,
+	getShareViewerUrl,
 	getUpdateInstruction,
 } from "../src/config.ts";
 
 const execPathDescriptor = Object.getOwnPropertyDescriptor(process, "execPath");
 const originalPath = process.env.PATH;
 const originalMemcodePackageDir = process.env.MEMCODE_PACKAGE_DIR;
+const originalShareViewerUrl = process.env.MEMCODE_SHARE_VIEWER_URL;
 const originalArgv1 = process.argv[1];
 let tempDir: string | undefined;
 
@@ -36,6 +38,11 @@ afterEach(() => {
 	} else {
 		process.env.MEMCODE_PACKAGE_DIR = originalMemcodePackageDir;
 	}
+	if (originalShareViewerUrl === undefined) {
+		delete process.env.MEMCODE_SHARE_VIEWER_URL;
+	} else {
+		process.env.MEMCODE_SHARE_VIEWER_URL = originalShareViewerUrl;
+	}
 	if (originalArgv1 === undefined) {
 		process.argv.splice(1, 1);
 	} else {
@@ -46,6 +53,24 @@ afterEach(() => {
 		rmSync(tempDir, { recursive: true, force: true });
 		tempDir = undefined;
 	}
+});
+
+describe("getShareViewerUrl", () => {
+	test("defaults to the GitHub gist URL returned by gh", () => {
+		delete process.env.MEMCODE_SHARE_VIEWER_URL;
+
+		expect(getShareViewerUrl("abc123", "https://gist.github.com/user/abc123")).toBe(
+			"https://gist.github.com/user/abc123",
+		);
+	});
+
+	test("uses an explicit custom viewer URL when configured", () => {
+		process.env.MEMCODE_SHARE_VIEWER_URL = "https://viewer.example/session/";
+
+		expect(getShareViewerUrl("abc123", "https://gist.github.com/user/abc123")).toBe(
+			"https://viewer.example/session/#abc123",
+		);
+	});
 });
 
 function getGlobalNpmRoot(prefix: string, mode: "inferred" | "npm-command"): string {

--- a/packages/memcode/test/pi-user-agent.test.ts
+++ b/packages/memcode/test/pi-user-agent.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { getPiUserAgent } from "../src/utils/pi-user-agent.ts";
 
 describe("getPiUserAgent", () => {
-	it("formats the user agent expected by memorix.dev", () => {
+	it("formats the memcode user agent", () => {
 		const runtime = process.versions.bun ? `bun/${process.versions.bun}` : `node/${process.version}`;
 		const userAgent = getPiUserAgent("1.2.3");
 

--- a/packages/memcode/test/sdk-openrouter-attribution.test.ts
+++ b/packages/memcode/test/sdk-openrouter-attribution.test.ts
@@ -149,7 +149,7 @@ describe("createAgentSession provider attribution headers", () => {
 	it("adds default attribution headers for OpenRouter models", async () => {
 		const headers = await captureHeaders(createModel("openrouter", "https://openrouter.ai/api/v1"));
 
-		expect(headers?.["HTTP-Referer"]).toBe("https://memorix.dev");
+		expect(headers?.["HTTP-Referer"]).toBe("https://github.com/AVIDS2/memorix");
 		expect(headers?.["X-OpenRouter-Title"]).toBe("memcode");
 		expect(headers?.["X-OpenRouter-Categories"]).toBe("cli-agent");
 	});
@@ -167,7 +167,7 @@ describe("createAgentSession provider attribution headers", () => {
 	it("adds attribution headers for custom providers routed through OpenRouter", async () => {
 		const headers = await captureHeaders(createModel("custom-openrouter", "https://openrouter.ai/api/v1"));
 
-		expect(headers?.["HTTP-Referer"]).toBe("https://memorix.dev");
+		expect(headers?.["HTTP-Referer"]).toBe("https://github.com/AVIDS2/memorix");
 		expect(headers?.["X-OpenRouter-Title"]).toBe("memcode");
 		expect(headers?.["X-OpenRouter-Categories"]).toBe("cli-agent");
 	});
@@ -175,7 +175,7 @@ describe("createAgentSession provider attribution headers", () => {
 	it("preserves legacy OpenRouter base URL substring attribution matching", async () => {
 		const headers = await captureHeaders(createModel("custom-openrouter", "not-a-url-openrouter.ai"));
 
-		expect(headers?.["HTTP-Referer"]).toBe("https://memorix.dev");
+		expect(headers?.["HTTP-Referer"]).toBe("https://github.com/AVIDS2/memorix");
 		expect(headers?.["X-OpenRouter-Title"]).toBe("memcode");
 		expect(headers?.["X-OpenRouter-Categories"]).toBe("cli-agent");
 	});
@@ -234,7 +234,7 @@ describe("createAgentSession provider attribution headers", () => {
 			createModel("openrouter", "https://openrouter.ai/api/v1", "nvidia/nemotron-3-super-120b-a12b"),
 		);
 
-		expect(headers?.["HTTP-Referer"]).toBe("https://memorix.dev");
+		expect(headers?.["HTTP-Referer"]).toBe("https://github.com/AVIDS2/memorix");
 		expect(headers?.["X-BILLING-INVOKE-ORIGIN"]).toBeUndefined();
 	});
 

--- a/packages/memcode/test/version-check.test.ts
+++ b/packages/memcode/test/version-check.test.ts
@@ -41,13 +41,13 @@ describe("version checks", () => {
 		await expect(checkForNewPiVersion("1.2.2")).resolves.toEqual({ version: "1.2.3" });
 	});
 
-	it("uses the memorix.dev version check api with a memcode user agent", async () => {
+	it("uses the npm registry version check api with a memcode user agent", async () => {
 		const fetchMock = vi.fn(async () => Response.json({ version: "1.2.4" }));
 		vi.stubGlobal("fetch", fetchMock);
 
 		await expect(getLatestPiVersion("1.2.3")).resolves.toBe("1.2.4");
 		expect(fetchMock).toHaveBeenCalledWith(
-			"https://memorix.dev/api/latest-version",
+			"https://registry.npmjs.org/memorix/latest",
 			expect.objectContaining({
 				headers: expect.objectContaining({
 					"User-Agent": expect.stringMatching(/^memcode\/1\.2\.3 /),
@@ -60,14 +60,14 @@ describe("version checks", () => {
 	it("returns the active package metadata from the version check api", async () => {
 		const fetchMock = vi.fn(async () =>
 			Response.json({
-				packageName: "@new-scope/pi",
+				name: "memorix",
 				version: "1.2.4",
 			}),
 		);
 		vi.stubGlobal("fetch", fetchMock);
 
 		await expect(getLatestPiRelease("1.2.3")).resolves.toEqual({
-			packageName: "@new-scope/pi",
+			packageName: "memorix",
 			version: "1.2.4",
 		});
 	});

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@memorix/tui",
-	"version": "1.1.1",
+	"version": "1.1.2",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",


### PR DESCRIPTION
## Summary
- remove unowned product-domain defaults from memcode runtime paths
- switch version checks to the npm registry endpoint
- make install reporting opt-in via MEMCODE_INSTALL_REPORT_URL
- make share previews fall back to the GitHub gist URL unless MEMCODE_SHARE_VIEWER_URL is configured
- bump root and workspace packages to 1.1.2

## Verification
- npm test (from clean temporary junction path to avoid sibling worktree interference)
- npm run build
- rg -n "memorix\.dev" . --hidden -g "!node_modules/**" -g "!.git/**" (no matches)
- git diff --check
- npm pack --dry-run --json
- npm pack --workspaces --dry-run --json