### PR TITLE
fix(config): load dotenv before resolving embedding/LLM lanes

### DIFF
--- a/src/config/resolved-config.ts
+++ b/src/config/resolved-config.ts
@@ -11,6 +11,7 @@ import {
 import { loadFileConfig } from './legacy-loader.js';
 import { loadTomlConfig } from './toml-loader.js';
 import { loadYamlConfig } from './yaml-loader.js';
+import { loadDotenv } from './dotenv-loader.js';
 
 export interface ResolvedLaneOptions {
   projectRoot?: string | null;
@@ -66,6 +67,13 @@ export interface ResolvedMemorixConfig {
 export function getResolvedConfig(options: ResolvedLaneOptions = {}): ResolvedMemorixConfig {
   const homeDir = options.homeDir ?? homedir();
   const projectRoot = options.projectRoot === undefined ? detectProject()?.rootPath ?? null : options.projectRoot;
+
+  // Make .env a first-class config source so every consumer of this resolved
+  // config (embedding API key, LLM base URL, etc.) sees values from
+  // ~/.memorix/.env / <project>/.env. loadDotenv() is idempotent — guarded by
+  // a module-level `dotenvLoaded` flag — so repeat calls within one process
+  // are essentially free, and it never overrides an already-set process env.
+  loadDotenv(projectRoot === null ? undefined : projectRoot ?? undefined, { userHomeDir: homeDir });
 
   const toml = loadTomlConfig({ projectRoot: projectRoot ?? null, homeDir });
   const yaml = loadYamlConfig(projectRoot ?? null);


### PR DESCRIPTION
## Summary

- Make ~\.memorix/.env and <project>/.env a first-class config source for every consumer of the resolved memorix config (embedding API key, LLM base URL, agent API key, etc.).
- One-line change: add loadDotenv(projectRoot, { userHomeDir }) at the top of getResolvedConfig() in src/config/resolved-config.ts.

## Problem

CLI subcommands other than status silently fell back to BM25-only search and printed:

```
[memorix] Failed to init API embedding: No API key for embedding.
Set MEMORIX_EMBEDDING_API_KEY or configure embedding.apiKey in memorix.yml / ~/.memorix/config.json.
[memorix] Embedding provider temporarily unavailable - will retry after 30s
```

Root cause:

- loadDotenv() is currently called explicitly only inside src/cli/commands/status.ts:30 and src/cli/commands/serve-http.ts:1016.
- getResolvedConfig() (which embedding.apiKey etc. ultimately read from) does NOT call loadDotenv, so process.env.MEMORIX_EMBEDDING_API_KEY stays undefined for search, remember, recent, audit, doctor, serve, etc.
- api-provider.ts then throws 'No API key for embedding' and degrades to BM25.

## Fix

A single, idempotent loadDotenv() call inside getResolvedConfig(). The function is guarded by a module-level dotenvLoaded flag, so repeat calls within one process are essentially free, and dotenv-loader.ts:79 (if (!(key in process.env))) ensures it never overrides already-set env vars - preserving the documented 'system env > dotenv' priority.

## Diff

```diff
 import { loadYamlConfig } from './yaml-loader.js';
+import { loadDotenv } from './dotenv-loader.js';

 export interface ResolvedLaneOptions {
   ...
 }

 export function getResolvedConfig(options: ResolvedLaneOptions = {}): ResolvedMemorixConfig {
   const homeDir = options.homeDir ?? homedir();
   const projectRoot = options.projectRoot === undefined ? detectProject()?.rootPath ?? null : options.projectRoot;

+  // Make .env a first-class config source so every consumer of this resolved
+  // config (embedding API key, LLM base URL, etc.) sees values from
+  // ~/.memorix/.env / <project>/.env. loadDotenv() is idempotent - guarded by
+  // a module-level dotenvLoaded flag - so repeat calls within one process
+  // are essentially free, and it never overrides an already-set process env.
+  loadDotenv(projectRoot === null ? undefined : projectRoot ?? undefined, { userHomeDir: homeDir });
+
   const toml = loadTomlConfig({ projectRoot: projectRoot ?? null, homeDir });
   ...
 }
```

## Verification (before / after)

| | Before | After |
|---|---|---|
| Init line | Failed to init API embedding: No API key for embedding. | API embedding: Qwen/Qwen3-Embedding-4B @ https://api.siliconflow.cn/v1 (1024d) [cached dims] |
| Result count (search 'fastmcp' --limit 1) | Found 1 memories (BM25 only) | Found 8 memories (hybrid BM25 + vector) |
| memorix remember | emits Embedding provider unavailable (using BM25 until embedding recovers; queued obs-N for retry) | no fallback notice; embedding succeeds |
| Disk embed cache growth | stuck at 181 | grows (latest: 223+) |
| memorix status | unchanged (already correct) | unchanged |

## Risk assessment

- Low blast radius. The change touches one well-known entry point (getResolvedConfig) with a single, idempotent call. No new public API.
- Behavior preserved on miss. If no .env file exists, loadDotenv is a no-op.
- System env wins. The if (!(key in process.env)) guard means MEMORIX_* exports from MCP host env blocks and shell-exported variables still take precedence over the dotenv files - matching the priority documented in dotenv-loader.ts:25-30.
- Performance. getResolvedConfig is called on every config read; the second-and-later invocations short-circuit on dotenvLoaded, so per-invocation overhead is a single boolean comparison.
- No additional deps. loadDotenv already exists and is exported.

## Test plan

- memorix search 'fastmcp' --limit 3 should now report API embedding: ... [cached dims] and return hybrid results (>=3 hits with semantically relevant memories).
- memorix remember 'foo' should no longer mention Embedding provider unavailable or queued obs-N for retry.
- memorix status output identical to before the change.
- Pre-set MEMORIX_EMBEDDING_API_KEY in the shell before launching memorix -> embedding lane reads the shell value (proves system env > dotenv priority is preserved).

## Out of scope (separate issues)

- canvas node-gyp failure on bun install (Visual Studio / node-gyp 13 incompatibility) - affects only TUI bitmap features.
- DTS phase warning Cannot find module '@memorix/agent-core' - affects only .d.ts generation, not runtime.
- Redundant explicit loadDotenv() calls in status.ts / serve-http.ts are still safe (idempotent) but could be removed in a follow-up cleanup.

Generated with the pi coding agent.