### PR TITLE
docs: credit accepted 1.1.3 contributor fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed
+- **Contributor attribution** -- Added post-release credit metadata for the 1.1.3 fixes accepted from #105 and #98 so GitHub can associate the accepted work with the contributing accounts.
+
 ## [1.1.3] - 2026-06-29
 
 ### Added


### PR DESCRIPTION
## Summary
- Adds a post-release Unreleased changelog note for contributor attribution cleanup.
- Uses GitHub-linked `Co-authored-by` trailers for the #105 and #98 contributors so GitHub can associate accepted 1.1.3 work with their accounts.

## Why
The accepted #105 commit preserved the git author name, but its author email was `bot@memorix.local`, which GitHub does not map to the contributor account. This tiny follow-up gives GitHub account-linked attribution without changing the already-published v1.1.3 tag/npm package.

## Test Plan
- `git diff --check`