### PR TITLE
fix(mcp): speed up stdio handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [1.1.4] - 2026-07-01
 
 ### Changed
 - **Contributor attribution** -- Added post-release credit metadata for the 1.1.3 fixes accepted from #105 and #98 so GitHub can associate the accepted work with the contributing accounts.
+
+### Fixed
+- **Stdio MCP startup latency** -- `memorix serve` now registers MCP tools before loading the full project memory runtime, then warms the runtime in the background. This keeps `initialize` / `tools/list` fast for IDEs and registries even when the local memory corpus is large, while real tool calls still wait for project runtime readiness before executing.
 
 ## [1.1.3] - 2026-06-29
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",
@@ -9579,10 +9579,10 @@
     },
     "packages/agent-core": {
       "name": "@memorix/agent-core",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
-        "@memorix/ai": "1.1.3",
+        "@memorix/ai": "1.1.4",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -9650,7 +9650,7 @@
     },
     "packages/ai": {
       "name": "@memorix/ai",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -9695,12 +9695,12 @@
     },
     "packages/memcode": {
       "name": "@memorix/memcode",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
-        "@memorix/agent-core": "1.1.3",
-        "@memorix/ai": "1.1.3",
-        "@memorix/tui": "1.1.3",
+        "@memorix/agent-core": "1.1.4",
+        "@memorix/ai": "1.1.4",
+        "@memorix/tui": "1.1.4",
         "@opentui/core": "^0.3.4",
         "@opentui/react": "^0.3.4",
         "@silvia-odwyer/photon-node": "0.3.4",
@@ -9798,7 +9798,7 @@
     },
     "packages/tui": {
       "name": "@memorix/tui",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@memorix/agent-core",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -29,7 +29,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@memorix/ai": "1.1.3",
+		"@memorix/ai": "1.1.4",
 		"ignore": "7.0.5",
 		"typebox": "1.1.38",
 		"yaml": "2.9.0"

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@memorix/ai",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/memcode/package.json
+++ b/packages/memcode/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@memorix/memcode",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"description": "Memorix-native coding agent CLI with terminal chat, project memory, hooks, and session management",
 	"type": "module",
 	"piConfig": {
@@ -34,9 +34,9 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@memorix/agent-core": "1.1.3",
-		"@memorix/ai": "1.1.3",
-		"@memorix/tui": "1.1.3",
+		"@memorix/agent-core": "1.1.4",
+		"@memorix/ai": "1.1.4",
+		"@memorix/tui": "1.1.4",
 		"@opentui/core": "^0.3.4",
 		"@opentui/react": "^0.3.4",
 		"@silvia-odwyer/photon-node": "0.3.4",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@memorix/tui",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -100,8 +100,8 @@ export default defineCommand({
     const allowUntracked = args['allow-untracked'] ?? false;
     const toolProfile = resolveToolProfile({ explicit: args.mode, envValue: process.env.MEMORIX_MODE, fallback: 'lite' });
     const serverOptions = detected
-      ? { toolProfile }
-      : { allowUntrackedFallback: allowUntracked, deferProjectInitUntilBound: !allowUntracked, toolProfile };
+      ? { toolProfile, deferProjectRuntimeInit: true }
+      : { allowUntrackedFallback: allowUntracked, deferProjectInitUntilBound: !allowUntracked, deferProjectRuntimeInit: true, toolProfile };
     const { server, projectId, deferredInit, switchProject } = await createMemorixServer(projectRoot, undefined, undefined, serverOptions);
     const transport = new StdioServerTransport();
     await server.connect(transport);
@@ -180,7 +180,10 @@ export default defineCommand({
       });
     } catch { /* notification handler setup is optional */ }
 
-    deferredInit().catch(e => console.error(`[memorix] Deferred init error:`, e));
+    const deferredInitTimer = setTimeout(() => {
+      deferredInit().catch(e => console.error(`[memorix] Deferred init error:`, e));
+    }, 5_000);
+    deferredInitTimer.unref?.();
     // Fire-and-forget: background update check. Default is notify-only.
     import('../update-checker.js').then(m => m.checkForUpdates()).catch(() => {});
   },

--- a/src/server.ts
+++ b/src/server.ts
@@ -209,6 +209,12 @@ export interface SharedTeamInstances {
 export interface CreateMemorixServerOptions {
   allowUntrackedFallback?: boolean;
   deferProjectInitUntilBound?: boolean;
+  /**
+   * Register tools and return before loading the full project memory runtime.
+   * Intended for stdio clients and registries where MCP initialize/tools/list must
+   * complete quickly even when the local memory corpus is large.
+   */
+  deferProjectRuntimeInit?: boolean;
   dashboardMode?: 'standalone' | 'control-plane';
   dashboardPort?: number;
   toolProfile?: ToolProfile;
@@ -231,6 +237,7 @@ export async function createMemorixServer(
   // Detect current project — strict .git-based detection
   const allowUntrackedFallback = options.allowUntrackedFallback ?? true;
   const deferProjectInitUntilBound = options.deferProjectInitUntilBound ?? false;
+  const deferProjectRuntimeInit = options.deferProjectRuntimeInit ?? false;
   const dashboardMode = options.dashboardMode ?? (sharedTeam ? 'control-plane' : 'standalone');
   const configuredDashboardPort = options.dashboardPort ?? (dashboardMode === 'control-plane' ? 3211 : 3210);
   const toolProfile = resolveToolProfile({
@@ -298,7 +305,9 @@ export async function createMemorixServer(
     loadDotenv(project.rootPath);
   } catch { /* config init is best-effort */ }
 
-  // Initialize components
+  // Initialize lightweight components. Full observation/graph indexing can be
+  // deferred for stdio so MCP initialize/tools/list are not blocked by a large
+  // local memory corpus or embedding provider startup.
   await initObservationStore(projectDir);
   await initMiniSkillStore(projectDir);
   await initSessionStore(projectDir);
@@ -307,10 +316,13 @@ export async function createMemorixServer(
     console.error(`[memorix] ObservationStore backend: ${store.getBackendName()}, generation: ${store.getGeneration()}`);
   }
   let graphManager = new KnowledgeGraphManager(projectDir);
-  await graphManager.init();
-  await initObservations(projectDir);
+  if (!deferProjectRuntimeInit) {
+    await graphManager.init();
+    await initObservations(projectDir);
+  }
 
   const lightweightUnresolvedSession = !projectResolved && deferProjectInitUntilBound;
+  let projectRuntimeInitPromise: Promise<void> | null = null;
 
   const initializeProjectRuntime = async (logPrefix: 'startup' | 'switch'): Promise<void> => {
     await initObservationStore(projectDir);
@@ -345,7 +357,7 @@ export async function createMemorixServer(
     }
   };
 
-  if (!lightweightUnresolvedSession) {
+  if (!lightweightUnresolvedSession && !deferProjectRuntimeInit) {
   // Auto-merge obvious alias groups by scanning observed projectIds in data.
   // This detects splits like local/foo + user/foo (legacy data migration)
   try {
@@ -384,6 +396,50 @@ export async function createMemorixServer(
     // Noisy per-probe 'awaiting binding' log was removed to reduce terminal spam.
   }
 
+  const ensureProjectRuntimeInitialized = async (): Promise<void> => {
+    if (lightweightUnresolvedSession || !deferProjectRuntimeInit) return;
+    if (!projectRuntimeInitPromise) {
+      projectRuntimeInitPromise = (async () => {
+        // Auto-merge obvious alias groups by scanning observed projectIds in data.
+        try {
+          const { getAllObservations } = await import('./memory/observations.js');
+          await initObservations(projectDir);
+          const allObs = getAllObservations();
+          const observedIds = [...new Set(allObs.map(o => o.projectId))];
+          const merged = await autoMergeByBaseName(observedIds);
+          if (merged > 0) {
+            console.error(`[memorix] Auto-merged ${merged} alias group(s) by base name`);
+          }
+        } catch { /* auto-merge is optional */ }
+
+        // Migrate existing observations to canonical project ID for ALL alias groups.
+        try {
+          const { getAllAliasGroups } = await import('./project/aliases.js');
+          const groups = await getAllAliasGroups();
+          let totalMigrated = 0;
+          for (const group of groups) {
+            if (group.aliases.length > 1) {
+              const migrated = await migrateProjectIds(group.aliases, group.canonical);
+              if (migrated > 0) {
+                console.error(`[memorix] Migrated ${migrated} observations → ${group.canonical}`);
+                totalMigrated += migrated;
+              }
+            }
+          }
+          if (totalMigrated > 0) {
+            console.error(`[memorix] Total migrated: ${totalMigrated} observations across ${groups.filter(g => g.aliases.length > 1).length} project(s)`);
+          }
+        } catch { /* migration is optional */ }
+
+        await initializeProjectRuntime('startup');
+      })().catch((err) => {
+        projectRuntimeInitPromise = null;
+        throw err;
+      });
+    }
+    await projectRuntimeInitPromise;
+  };
+
   const requireResolvedProject = (action: string) => {
     if (projectResolved) return null;
     return {
@@ -410,6 +466,15 @@ export async function createMemorixServer(
   server.registerTool = ((name: string, ...args: unknown[]) => {
     if (!isToolInProfile(name, toolProfile)) {
       return undefined as never;
+    }
+    const maybeConfig = args[0];
+    const maybeHandler = args[1];
+    if (typeof maybeHandler === 'function' && typeof maybeConfig === 'object' && maybeConfig !== null) {
+      const wrappedHandler = async (...handlerArgs: unknown[]) => {
+        await ensureProjectRuntimeInitialized();
+        return await maybeHandler(...handlerArgs);
+      };
+      return (originalRegisterTool as (...innerArgs: unknown[]) => unknown)(name, maybeConfig, wrappedHandler, ...args.slice(2)) as never;
     }
     return (originalRegisterTool as (...innerArgs: unknown[]) => unknown)(name, ...args) as never;
   }) as typeof server.registerTool;
@@ -3948,6 +4013,8 @@ export async function createMemorixServer(
   // Deferred initialization — runs AFTER transport connect so MCP handshake isn't blocked.
   // Sync advisory scan and file watcher are non-essential for tool functionality.
   const deferredInit = async () => {
+    await ensureProjectRuntimeInitialized();
+
     // Check hook installation status and guide user
     try {
       const { getHookStatus } = await import('./hooks/installers/index.js');

--- a/tests/integration/tool-profile.test.ts
+++ b/tests/integration/tool-profile.test.ts
@@ -159,4 +159,21 @@ describe('Tool profile registration', () => {
     const statusText = getText(await teamStatus({ action: 'status' }));
     expect(statusText).toContain('1 active / 1 total');
   }, 30000);
+
+  it('should register tools before deferred stdio runtime initialization', async () => {
+    const fastDir = await createGitProjectDir('memorix-profile-fast-start-');
+    const { server } = await createMemorixServer(
+      fastDir,
+      undefined,
+      undefined,
+      { toolProfile: 'lite', deferProjectRuntimeInit: true } as any,
+    );
+
+    const tools = getToolNames(server as any);
+    expect(tools).toContain('memorix_codegraph_status');
+    expect(tools).toContain('memorix_project_context');
+
+    const status = await getHandler(server as any, 'memorix_codegraph_status')({});
+    expect(getText(status)).toContain('"provider"');
+  }, 30000);
 });


### PR DESCRIPTION
## Summary
- defer full project runtime initialization for stdio MCP servers so initialize/tools-list are not blocked by large local memory indexes
- wrap tool handlers so real tool calls still wait for runtime initialization before executing
- delay stdio deferred background init slightly to keep registry/IDE handshakes fast

## Verification
- npm run lint
- npx vitest run tests/integration/tool-profile.test.ts tests/cli/serve.test.ts --no-file-parallelism --maxWorkers=1 --minWorkers=1
- npm run build
- npm pack --dry-run
- manual MCP smoke: local dist connect+tools/list completed in ~1.67s, memorix_codegraph_status call succeeded

## Context
The published 1.1.3 package can time out during stdio MCP connect on a project with a large local memory corpus because startup initializes observations, embeddings, and search indexes before the client receives tools/list. This likely explains the Glama build failure notification.