### PR TITLE
fix: ground autopilot context in current project facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - **Agent tool allowlist auditability** -- Agent-core now has explicit turn allowlist lookup and regression coverage proving a tool absent from the active turn context cannot execute.
 - **Session selector search safety** -- memcode session search no longer executes user-provided `re:` input as a regular expression; regex-shaped input is treated as literal search text.
+- **Autopilot current-truth grounding** -- `memorix context` and `memorix_project_context` now put live package, changelog, Git branch/commit, and stale progress-note warnings before memory hints so agents do not mistake old dev-log files for the current project state.
 
 ## [1.1.4] - 2026-07-01
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -96,11 +96,11 @@ memorix codegraph context-pack --task "continue auth bug"
 
 MCP:
 
-- `memorix_project_context` builds the default Memory Autopilot brief. It can auto-refresh CodeGraph Memory when the index is missing or stale, then returns Start here files, reliable code-bound memories, stale/suspect cautions, and verification hints.
+- `memorix_project_context` builds the default Memory Autopilot brief. It can auto-refresh CodeGraph Memory when the index is missing or stale, then returns current project facts, Start here files, reliable code-bound memories, stale/suspect cautions, and verification hints.
 - `memorix_codegraph_status` returns provider/index counts for the current project.
 - `memorix_context_pack` builds a task-specific packet with reliable current memories, lower-trust unbound memories, current code facts, freshness warnings, suggested reads, and suggested verification.
 
-`memorix context` defaults to `--refresh auto`, so first use can seed CodeGraph Memory without a separate manual `memorix codegraph refresh`. Use `--refresh never` for read-only inspection and `--refresh always` when you want to force a fresh scan.
+`memorix context` defaults to `--refresh auto`, so first use can seed CodeGraph Memory without a separate manual `memorix codegraph refresh`. Its brief puts live package/changelog/Git facts before memory hints and flags old `progress.txt` / dev-log notes as historical when they predate the latest changelog, so agents should treat current facts as the source of truth when files disagree. Use `--refresh never` for read-only inspection and `--refresh always` when you want to force a fresh scan.
 
 SessionStart hooks keep the default minimal hint lightweight. When memory behavior is configured with `sessionInject=full`, Memorix injects the compact Memory Autopilot brief at session start instead of only listing recent text memories.
 

--- a/src/cli/commands/context.ts
+++ b/src/cli/commands/context.ts
@@ -39,6 +39,7 @@ export default defineCommand({
       emitResult(
         {
           project,
+          currentFacts: context.currentFacts,
           overview: context.overview,
           refresh: context.refresh,
           ...(context.task ? { task: context.task } : {}),

--- a/src/codegraph/auto-context.ts
+++ b/src/codegraph/auto-context.ts
@@ -1,5 +1,6 @@
 import type { ProjectInfo } from '../types.js';
 import { backfillMissingObservationCodeRefs, type CodeRefBackfillResult } from './binder.js';
+import { collectCurrentProjectFacts, type CurrentProjectFacts } from './current-facts.js';
 import { indexProjectLite } from './lite-provider.js';
 import {
   buildProjectContextExplain,
@@ -23,6 +24,7 @@ export interface AutoContextRefreshResult {
 export interface AutoProjectContext {
   project: Pick<ProjectInfo, 'id' | 'name' | 'rootPath'>;
   task?: string;
+  currentFacts: CurrentProjectFacts;
   overview: ProjectContextOverview;
   explain: ProjectContextExplain;
   refresh: AutoContextRefreshResult;
@@ -77,6 +79,7 @@ export async function buildAutoProjectContext(input: {
   now?: Date;
 }): Promise<AutoProjectContext> {
   const refreshMode = input.refresh ?? 'auto';
+  const now = input.now ?? new Date();
   const store = new CodeGraphStore();
   await store.init(input.dataDir);
 
@@ -85,7 +88,7 @@ export async function buildAutoProjectContext(input: {
     mode: refreshMode,
     status: initialStatus,
     maxAgeMs: input.maxAgeMs ?? DEFAULT_MAX_AGE_MS,
-    nowMs: (input.now ?? new Date()).getTime(),
+    nowMs: now.getTime(),
   });
 
   let refresh: AutoContextRefreshResult = {
@@ -129,6 +132,7 @@ export async function buildAutoProjectContext(input: {
   return {
     project: input.project,
     ...(input.task?.trim() ? { task: input.task.trim() } : {}),
+    currentFacts: collectCurrentProjectFacts({ project: input.project, now }),
     overview,
     explain,
     refresh,
@@ -154,11 +158,48 @@ function dedupeSourcesByObservation(
   return [...byObservation.values()];
 }
 
+function formatCurrentFactsLines(facts: CurrentProjectFacts): string[] {
+  const lines = ['Current project facts'];
+  if (facts.packageVersion) lines.push(`- Package version: ${facts.packageVersion}`);
+  if (facts.latestChangelog) {
+    lines.push(`- Latest changelog: ${facts.latestChangelog.version}${facts.latestChangelog.date ? ` (${facts.latestChangelog.date})` : ''}`);
+  }
+
+  const gitParts: string[] = [];
+  if (facts.git.detached) {
+    gitParts.push('detached HEAD');
+  } else if (facts.git.branch) {
+    gitParts.push(`branch ${facts.git.branch}`);
+  }
+  if (facts.git.commit) gitParts.push(`commit ${facts.git.commit}`);
+  gitParts.push(facts.git.dirty ? 'dirty worktree' : 'clean worktree');
+  lines.push(`- Git: ${gitParts.join(', ')}`);
+  if (facts.git.latestCommit) lines.push(`- Latest commit: ${facts.git.latestCommit}`);
+  lines.push('- Current facts above outrank progress/dev-log files when they conflict.');
+
+  if (facts.staleNotes.length > 0) {
+    lines.push('', 'Historical/stale project notes');
+    for (const note of facts.staleNotes.slice(0, 3)) {
+      const details = [
+        note.lastUpdated ? `last updated ${note.lastUpdated}` : undefined,
+        note.branchHint ? `branch hint ${note.branchHint}` : undefined,
+        note.reason,
+      ].filter(Boolean).join('; ');
+      lines.push(`- ${note.path}${details ? ` (${details})` : ''}; treat as historical unless the task specifically asks for it.`);
+    }
+  }
+
+  return lines;
+}
+
 export function formatAutoProjectContextSummary(context: AutoProjectContext): string {
   const reliableSources = dedupeSourcesByObservation(context.explain.sources.filter(source => source.status === 'current'));
   const lines = [
     `Memorix Autopilot Brief for ${context.project.name}`,
     context.task ? `Task: ${context.task}` : '',
+    '',
+    ...formatCurrentFactsLines(context.currentFacts),
+    '',
     `- Code memory: ${context.overview.code.files} files / ${context.overview.code.symbols} symbols / ${context.overview.code.refs} memory links`,
     `- Languages: ${formatLanguages(context.overview)}`,
     `- Memories: ${context.overview.memory.active} active / ${context.overview.memory.total} total`,
@@ -189,6 +230,8 @@ export function formatAutoProjectContextPrompt(context: AutoProjectContext): str
   const lines = [
     `Memorix Autopilot Brief for ${context.project.name}`,
     context.task ? `Task: ${context.task}` : '',
+    '',
+    ...formatCurrentFactsLines(context.currentFacts),
     '',
     'Project state',
     `- Code memory: ${context.overview.code.files} files, ${context.overview.code.symbols} symbols, ${context.overview.code.refs} memory links`,

--- a/src/codegraph/current-facts.ts
+++ b/src/codegraph/current-facts.ts
@@ -1,0 +1,163 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import type { ProjectInfo } from '../types.js';
+
+export interface CurrentProjectFacts {
+  packageVersion?: string;
+  latestChangelog?: {
+    version: string;
+    date?: string;
+  };
+  git: {
+    branch?: string;
+    commit?: string;
+    latestCommit?: string;
+    dirty: boolean;
+    detached: boolean;
+  };
+  staleNotes: ProjectStaleNote[];
+}
+
+export interface ProjectStaleNote {
+  path: string;
+  lastUpdated?: string;
+  branchHint?: string;
+  reason: string;
+}
+
+const STALE_NOTE_MAX_AGE_MS = 14 * 24 * 60 * 60 * 1000;
+
+function readTextIfExists(filePath: string): string | null {
+  try {
+    if (!existsSync(filePath)) return null;
+    return readFileSync(filePath, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function readPackageVersion(rootPath: string): string | undefined {
+  const text = readTextIfExists(path.join(rootPath, 'package.json'));
+  if (!text) return undefined;
+  try {
+    const parsed = JSON.parse(text) as { version?: unknown };
+    return typeof parsed.version === 'string' ? parsed.version : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readLatestChangelog(rootPath: string): CurrentProjectFacts['latestChangelog'] {
+  const text = readTextIfExists(path.join(rootPath, 'CHANGELOG.md'));
+  if (!text) return undefined;
+  const match = text.match(/^##\s+\[?v?([^\]\s]+)\]?\s*(?:-\s*(\d{4}-\d{2}-\d{2}))?/m);
+  if (!match) return undefined;
+  return {
+    version: match[1],
+    ...(match[2] ? { date: match[2] } : {}),
+  };
+}
+
+function runGit(rootPath: string, args: string[]): string | undefined {
+  try {
+    return execFileSync('git', ['-C', rootPath, ...args], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 3000,
+    }).trim() || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readGitFacts(rootPath: string): CurrentProjectFacts['git'] {
+  const branch = runGit(rootPath, ['branch', '--show-current']);
+  const commit = runGit(rootPath, ['rev-parse', '--short', 'HEAD']);
+  const latestCommit = runGit(rootPath, ['log', '-1', '--pretty=%s']);
+  const dirty = Boolean(runGit(rootPath, ['status', '--porcelain']));
+  return {
+    ...(branch ? { branch } : {}),
+    ...(commit ? { commit } : {}),
+    ...(latestCommit ? { latestCommit } : {}),
+    dirty,
+    detached: !branch,
+  };
+}
+
+function parseProgressNote(content: string): Pick<ProjectStaleNote, 'lastUpdated' | 'branchHint'> {
+  const lastUpdated = content.match(/Last updated\*\*:\s*(\d{4}-\d{2}-\d{2})/i)
+    ?? content.match(/Last updated:\s*(\d{4}-\d{2}-\d{2})/i);
+  const branchHint = content.match(/Branch\*\*:\s*([^\r\n]+)/i)
+    ?? content.match(/Branch:\s*([^\r\n]+)/i);
+  return {
+    ...(lastUpdated?.[1] ? { lastUpdated: lastUpdated[1].trim() } : {}),
+    ...(branchHint?.[1] ? { branchHint: branchHint[1].trim().replace(/^`|`$/g, '') } : {}),
+  };
+}
+
+function compareDateStrings(a?: string, b?: string): number | null {
+  if (!a || !b) return null;
+  const aMs = Date.parse(`${a}T00:00:00Z`);
+  const bMs = Date.parse(`${b}T00:00:00Z`);
+  if (!Number.isFinite(aMs) || !Number.isFinite(bMs)) return null;
+  return aMs - bMs;
+}
+
+function detectStaleProgressNotes(input: {
+  rootPath: string;
+  latestChangelog?: CurrentProjectFacts['latestChangelog'];
+  now: Date;
+}): ProjectStaleNote[] {
+  const candidates = [
+    'progress.txt',
+    'docs/dev-log/progress.txt',
+    'docs/memcode/dev-log/progress.txt',
+  ];
+  const notes: ProjectStaleNote[] = [];
+
+  for (const relPath of candidates) {
+    const content = readTextIfExists(path.join(input.rootPath, relPath));
+    if (!content) continue;
+    const parsed = parseProgressNote(content);
+    const olderThanChangelog = compareDateStrings(parsed.lastUpdated, input.latestChangelog?.date);
+    const updatedAtMs = parsed.lastUpdated ? Date.parse(`${parsed.lastUpdated}T00:00:00Z`) : NaN;
+    const olderThanAgeLimit = Number.isFinite(updatedAtMs)
+      ? input.now.getTime() - updatedAtMs > STALE_NOTE_MAX_AGE_MS
+      : false;
+
+    if (olderThanChangelog !== null && olderThanChangelog < 0) {
+      notes.push({
+        path: relPath,
+        ...parsed,
+        reason: `older than latest changelog ${input.latestChangelog?.version}${input.latestChangelog?.date ? ` (${input.latestChangelog.date})` : ''}`,
+      });
+    } else if (olderThanAgeLimit) {
+      notes.push({
+        path: relPath,
+        ...parsed,
+        reason: 'older than 14 days',
+      });
+    }
+  }
+
+  return notes;
+}
+
+export function collectCurrentProjectFacts(input: {
+  project: Pick<ProjectInfo, 'rootPath'>;
+  now: Date;
+}): CurrentProjectFacts {
+  const latestChangelog = readLatestChangelog(input.project.rootPath);
+  const packageVersion = readPackageVersion(input.project.rootPath);
+  return {
+    ...(packageVersion ? { packageVersion } : {}),
+    ...(latestChangelog ? { latestChangelog } : {}),
+    git: readGitFacts(input.project.rootPath),
+    staleNotes: detectStaleProgressNotes({
+      rootPath: input.project.rootPath,
+      latestChangelog,
+      now: input.now,
+    }),
+  };
+}

--- a/tests/cli/context-command.test.ts
+++ b/tests/cli/context-command.test.ts
@@ -134,6 +134,16 @@ describe('project context CLI commands', () => {
   });
 
   it('emits structured project context JSON', async () => {
+    writeFileSync(
+      path.join(repoDir, 'package.json'),
+      JSON.stringify({ name: 'repo', version: '9.9.9' }, null, 2),
+      'utf8',
+    );
+    writeFileSync(
+      path.join(repoDir, 'CHANGELOG.md'),
+      '# Changelog\n\n## [9.9.9] - 2026-07-02\n',
+      'utf8',
+    );
     await seedProjectContext();
 
     const result = await runCommand(contextCommand, { json: true });
@@ -147,6 +157,8 @@ describe('project context CLI commands', () => {
     ]);
     expect(parsed.overview.memory.active).toBe(1);
     expect(parsed.overview.suggestedReads).toContain('src/auth.ts');
+    expect(parsed.currentFacts.packageVersion).toBe('9.9.9');
+    expect(parsed.currentFacts.latestChangelog).toEqual({ version: '9.9.9', date: '2026-07-02' });
   });
 
   it('explains where the context came from without exposing storage internals', async () => {

--- a/tests/codegraph/auto-context.test.ts
+++ b/tests/codegraph/auto-context.test.ts
@@ -92,4 +92,60 @@ describe('auto project context', () => {
     expect(text).toContain('python 1');
     expect(text).not.toContain('SQLite');
   });
+
+  it('puts current project facts ahead of stale progress notes', async () => {
+    mkdirSync(path.join(repoDir, 'docs', 'memcode', 'dev-log'), { recursive: true });
+    writeFileSync(
+      path.join(repoDir, 'package.json'),
+      JSON.stringify({ name: 'repo', version: '9.9.9' }, null, 2),
+      'utf8',
+    );
+    writeFileSync(
+      path.join(repoDir, 'CHANGELOG.md'),
+      '# Changelog\n\n## [9.9.9] - 2026-07-02\n\n### Fixed\n- Current release facts.\n',
+      'utf8',
+    );
+    writeFileSync(
+      path.join(repoDir, 'docs', 'memcode', 'dev-log', 'progress.txt'),
+      [
+        '# memcode Development Progress',
+        '',
+        '> Auto-updated by agent. New sessions: read this file first.',
+        '',
+        '## Current State',
+        '- **Phase**: Release hardening',
+        '- **Branch**: feat/memcode-agent',
+        '- **Last updated**: 2026-06-18',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+
+    const context = await buildAutoProjectContext({
+      project: { id: 'local/repo', name: 'repo', rootPath: repoDir },
+      dataDir,
+      observations: getAllObservations(),
+      refresh: 'auto',
+      task: 'continue release work',
+      now: new Date('2026-07-02T12:00:00Z'),
+    });
+
+    expect(context.currentFacts.packageVersion).toBe('9.9.9');
+    expect(context.currentFacts.latestChangelog).toEqual({ version: '9.9.9', date: '2026-07-02' });
+    expect(context.currentFacts.staleNotes[0]).toMatchObject({
+      path: 'docs/memcode/dev-log/progress.txt',
+      lastUpdated: '2026-06-18',
+      branchHint: 'feat/memcode-agent',
+    });
+
+    const text = formatAutoProjectContextPrompt(context);
+    expect(text).toContain('Current project facts');
+    expect(text).toContain('Package version: 9.9.9');
+    expect(text).toContain('Latest changelog: 9.9.9 (2026-07-02)');
+    expect(text).toContain('Historical/stale project notes');
+    expect(text).toContain('docs/memcode/dev-log/progress.txt');
+    expect(text).toContain('feat/memcode-agent');
+    expect(text).toContain('Current facts above outrank progress/dev-log files when they conflict.');
+    expect(text.indexOf('Current project facts')).toBeLessThan(text.indexOf('Start here'));
+  });
 });


### PR DESCRIPTION
## Summary
- add a current project facts layer to Memory Autopilot briefs
- surface package version, latest changelog, Git branch/commit, and stale progress/dev-log warnings before memory hints
- include currentFacts in `memorix context --json` and document the current-truth precedence rule

## Verification
- npm run lint
- npm run build
- npm test
- MCP stdio smoke: `memorix_project_context` returns current facts and stale progress warning under the default 7-tool micro profile
- Claude Code guest re-test: no longer suggested switching to the stale `feat/memcode-agent` branch