### PR TITLE
Add configurable CodeGraph exclude patterns

### DIFF
--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -103,6 +103,8 @@ MCP:
 
 `memorix context` defaults to `--refresh auto`, so first use can seed CodeGraph Memory without a separate manual `memorix codegraph refresh`. Its brief puts live package/changelog/Git facts before memory hints and flags old `progress.txt` / dev-log notes as historical when they predate the latest changelog, so agents should treat current facts as the source of truth when files disagree. Task lenses keep the packet shaped to the work: bugfix briefs prefer failing tests and repros, release briefs prefer metadata/changelog/package checks, and onboarding briefs prefer docs and entry points while hiding unrelated suspect details. Use `--refresh never` for read-only inspection and `--refresh always` when you want to force a fresh scan.
 
+Project-specific generated, vendored, or cache paths can be excluded from CodeGraph Memory with `[codegraph].exclude_patterns` in `memorix.toml` or `~/.memorix/config.toml` (`codegraph.excludePatterns` in legacy YAML). User patterns extend the built-in excludes and are applied to indexing, Project Context suggested reads, and Context Pack suggested reads.
+
 SessionStart hooks keep the default minimal hint lightweight. When memory behavior is configured with `sessionInject=full`, Memorix injects the compact Memory Autopilot brief at session start instead of only listing recent text memories.
 
 The intended loop for agents is: get the project brief when it helps, inspect the suggested current files, use stale or unbound memory only as a lead, store durable outcomes after the work changes the project, and resolve obsolete memories.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -60,6 +60,9 @@ skip_merge_commits = true
 exclude_patterns = ["*.lock", "dist/**"]
 noise_keywords = ["format", "typo"]
 
+[codegraph]
+exclude_patterns = ["vendor/**", "third_party/**", "generated/**"]
+
 [server]
 transport = "stdio"
 dashboard = true
@@ -196,6 +199,21 @@ Common keys:
 Project identity is still resolved from the real `.git` root. A project
 `memorix.toml` is an override file under that root; it does not create or rename
 the Memorix project ID.
+
+### `[codegraph]`
+
+CodeGraph Memory and Project Context path filtering.
+
+Common keys:
+
+- `exclude_patterns = ["vendor/**", "third_party/**", "generated/**"]`
+
+Legacy YAML uses `codegraph.excludePatterns` for the same setting.
+
+These patterns extend Memorix's built-in CodeGraph excludes (`node_modules`,
+build outputs, worktrees, and similar generated directories). Matching paths are
+skipped during CodeGraph indexing and hidden from Project Context / Context Pack
+suggested reads.
 
 ### `[server]`
 

--- a/src/cli/commands/codegraph.ts
+++ b/src/cli/commands/codegraph.ts
@@ -3,6 +3,7 @@ import { CodeGraphStore } from '../../codegraph/store.js';
 import { indexProjectLite } from '../../codegraph/lite-provider.js';
 import { assembleContextPackForTask, buildContextPackPrompt } from '../../codegraph/context-pack.js';
 import { backfillMissingObservationCodeRefs } from '../../codegraph/binder.js';
+import { getResolvedConfig } from '../../config/resolved-config.js';
 import { getAllObservations } from '../../memory/observations.js';
 import { emitError, emitResult, getCliProjectContext, parsePositiveInt } from './operator-shared.js';
 
@@ -49,6 +50,7 @@ export default defineCommand({
       const store = new CodeGraphStore();
       await store.init(dataDir);
       const explicitAction = Boolean(positional[0] || (args.action as string | undefined));
+      const exclude = getResolvedConfig({ projectRoot: project.rootPath }).codegraph.excludePatterns;
 
       switch (action) {
         case 'status': {
@@ -64,6 +66,7 @@ export default defineCommand({
           const indexed = await indexProjectLite({
             projectId: project.id,
             projectRoot: project.rootPath,
+            exclude,
           });
           store.replaceProjectIndex(project.id, indexed);
           const activeObservations = getAllObservations()
@@ -99,6 +102,7 @@ export default defineCommand({
             task,
             observations,
             limit,
+            exclude,
           });
           emitResult({ project, pack }, buildContextPackPrompt(pack), asJson);
           return;

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -318,8 +318,10 @@ export default defineCommand({
       try {
         const { CodeGraphStore } = await import('../../codegraph/store.js');
         const { buildProjectContextOverview } = await import('../../codegraph/project-context.js');
+        const { getResolvedConfig } = await import('../../config/resolved-config.js');
         const codeStore = new CodeGraphStore();
         await codeStore.init(dataDir);
+        const exclude = getResolvedConfig({ projectRoot: projectRoot || process.cwd() }).codegraph.excludePatterns;
         const overview = buildProjectContextOverview({
           project: {
             id: projectId,
@@ -328,6 +330,7 @@ export default defineCommand({
           },
           store: codeStore,
           observations: projectObservations,
+          exclude,
         });
         const languageText = overview.code.languages.length > 0
           ? overview.code.languages.map((item: any) => `${item.language} ${item.files}`).join(', ')

--- a/src/codegraph/auto-context.ts
+++ b/src/codegraph/auto-context.ts
@@ -1,5 +1,6 @@
 import { existsSync, statSync } from 'node:fs';
 import path from 'node:path';
+import { getResolvedConfig } from '../config/resolved-config.js';
 import type { ProjectInfo } from '../types.js';
 import { backfillMissingObservationCodeRefs, type CodeRefBackfillResult } from './binder.js';
 import { collectCurrentProjectFacts, type CurrentProjectFacts } from './current-facts.js';
@@ -100,11 +101,13 @@ export async function buildAutoProjectContext(input: {
   refresh?: AutoContextRefreshMode;
   maxAgeMs?: number;
   now?: Date;
+  exclude?: string[];
 }): Promise<AutoProjectContext> {
   const refreshMode = input.refresh ?? 'auto';
   const now = input.now ?? new Date();
   const task = input.task?.trim();
   const lens = resolveTaskLens(task);
+  const exclude = input.exclude ?? getResolvedConfig({ projectRoot: input.project.rootPath }).codegraph.excludePatterns;
   const store = new CodeGraphStore();
   await store.init(input.dataDir);
 
@@ -126,6 +129,7 @@ export async function buildAutoProjectContext(input: {
       const indexed = await indexProjectLite({
         projectId: input.project.id,
         projectRoot: input.project.rootPath,
+        exclude,
       });
       store.replaceProjectIndex(input.project.id, indexed);
       const backfill = await backfillMissingObservationCodeRefs(
@@ -147,11 +151,13 @@ export async function buildAutoProjectContext(input: {
     project: input.project,
     store,
     observations: input.observations,
+    exclude,
   });
   const explain = buildProjectContextExplain({
     project: input.project,
     store,
     observations: input.observations,
+    exclude,
   });
 
   return {

--- a/src/codegraph/context-pack.ts
+++ b/src/codegraph/context-pack.ts
@@ -1,6 +1,7 @@
 import { evaluateCodeRefFreshness } from './freshness.js';
 import type { CodeFile, CodeRefStatus, CodeSymbol, ObservationCodeRef } from './types.js';
 import type { CodeGraphStore } from './store.js';
+import { isCodeGraphExcludedPath } from './exclude.js';
 
 export interface ContextPackMemory {
   id: number;
@@ -52,6 +53,7 @@ export interface AssembleContextPackInput {
   files: CodeFile[];
   symbols: CodeSymbol[];
   suggestedVerification?: string[];
+  exclude?: string[];
 }
 
 function uniq<T>(items: T[]): T[] {
@@ -66,14 +68,6 @@ function tokenize(text: string): string[] {
 
 function timestampOf(observation: ContextPackObservation): number {
   return Date.parse(observation.updatedAt ?? observation.createdAt ?? '') || 0;
-}
-
-function isGeneratedPath(path: string): boolean {
-  const normalized = path.replace(/\\/g, '/');
-  return (
-    /(^|\/)(dist|build|coverage|\.next|\.turbo|node_modules|\.git|\.tmp|\.worktrees)(\/|$)/i.test(normalized) ||
-    /(^|\/)\.claude\/worktrees(\/|$)/i.test(normalized)
-  );
 }
 
 function relevanceScore(observation: ContextPackObservation, taskTokens: string[]): number {
@@ -137,6 +131,7 @@ export function assembleContextPackForTask(input: {
   observations: ContextPackObservation[];
   limit?: number;
   suggestedVerification?: string[];
+  exclude?: string[];
 }): ContextPack {
   const selected = selectRelevantObservations(input.observations, input.task, input.limit ?? 20);
   const refs = selected.flatMap(obs => input.store.listObservationRefs(input.projectId, obs.id));
@@ -151,6 +146,7 @@ export function assembleContextPackForTask(input: {
     files,
     symbols,
     suggestedVerification: input.suggestedVerification,
+    exclude: input.exclude,
   });
 }
 
@@ -172,6 +168,7 @@ export function assembleContextPack(input: AssembleContextPackInput): ContextPac
 
     const file = ref.fileId ? files.get(ref.fileId) : undefined;
     const symbol = ref.symbolId ? symbols.get(ref.symbolId) : undefined;
+    if (file && isCodeGraphExcludedPath(file.path, input.exclude)) continue;
     const freshness = evaluateCodeRefFreshness(ref, file, symbol);
 
     if (freshness.status === 'current') {
@@ -247,8 +244,8 @@ export function buildContextPackPrompt(pack: ContextPack): string {
   const reliableMemories = pack.memories.filter(memory => memory.status === 'current');
   const unboundMemories = pack.memories.filter(memory => memory.status === 'unbound');
   const lines: string[] = ['## Task', pack.task, '', '## Reliable Memories'];
-  const visibleCodeFacts = pack.codeFacts.filter(fact => !isGeneratedPath(fact.path)).slice(0, 5);
-  const visibleSuggestedReads = pack.suggestedReads.filter(path => !isGeneratedPath(path)).slice(0, 5);
+  const visibleCodeFacts = pack.codeFacts.filter(fact => !isCodeGraphExcludedPath(fact.path)).slice(0, 5);
+  const visibleSuggestedReads = pack.suggestedReads.filter(path => !isCodeGraphExcludedPath(path)).slice(0, 5);
 
   if (reliableMemories.length === 0) lines.push('- none');
   for (const memory of reliableMemories) {

--- a/src/codegraph/exclude.ts
+++ b/src/codegraph/exclude.ts
@@ -1,0 +1,47 @@
+export const DEFAULT_CODEGRAPH_EXCLUDES = [
+  'node_modules/**',
+  'dist/**',
+  'build/**',
+  'coverage/**',
+  '.next/**',
+  '.turbo/**',
+  '.git/**',
+  '.tmp/**',
+  '.worktrees/**',
+  '.claude/worktrees/**',
+];
+
+export function normalizeCodeGraphExcludePatterns(exclude?: string[]): string[] {
+  return [...new Set([
+    ...DEFAULT_CODEGRAPH_EXCLUDES,
+    ...(exclude ?? []).map(pattern => pattern.trim()).filter(Boolean),
+  ])];
+}
+
+export function isCodeGraphExcludedPath(path: string, exclude?: string[]): boolean {
+  const normalized = normalizeCodePath(path);
+  return normalizeCodeGraphExcludePatterns(exclude).some((pattern) => matchesPattern(normalized, normalizeCodePath(pattern)));
+}
+
+function normalizeCodePath(path: string): string {
+  return path.replace(/\\/g, '/').replace(/^\.\/+/, '');
+}
+
+function matchesPattern(path: string, pattern: string): boolean {
+  if (pattern.endsWith('/**')) {
+    const base = pattern.slice(0, -3);
+    if (base.startsWith('**/')) {
+      const suffix = base.slice(3);
+      return path === suffix || path.endsWith(`/${suffix}`) || path.includes(`/${suffix}/`);
+    }
+    if (!base.includes('/')) {
+      return path === base || path.startsWith(`${base}/`) || path.includes(`/${base}/`);
+    }
+    return path === base || path.startsWith(`${base}/`);
+  }
+  if (pattern.startsWith('**/')) {
+    const suffix = pattern.slice(3);
+    return path === suffix || path.endsWith(`/${suffix}`);
+  }
+  return path === pattern || path.startsWith(`${pattern}/`);
+}

--- a/src/codegraph/lite-provider.ts
+++ b/src/codegraph/lite-provider.ts
@@ -3,6 +3,7 @@ import { readdirSync, readFileSync, statSync, type Dirent } from 'node:fs';
 import { join, relative } from 'node:path';
 import type { CodeEdge, CodeFile, CodeSymbol } from './types.js';
 import { makeCodeEdgeId, makeCodeFileId, makeCodeSymbolId, normalizeCodePath } from './ids.js';
+import { isCodeGraphExcludedPath, normalizeCodeGraphExcludePatterns } from './exclude.js';
 
 export interface LiteIndexOptions {
   projectId: string;
@@ -169,19 +170,6 @@ function languageForPath(path: string): string {
   return LANGUAGE_BY_EXTENSION.get(ext) ?? 'unknown';
 }
 
-function isExcluded(path: string, exclude: string[]): boolean {
-  const normalized = normalizeCodePath(path);
-  return exclude.some((pattern) => {
-    const p = normalizeCodePath(pattern);
-    if (p.endsWith('/**')) {
-      const base = p.slice(0, -3);
-      return normalized === base || normalized.startsWith(`${base}/`);
-    }
-    if (p.startsWith('**/')) return normalized.endsWith(p.slice(3));
-    return normalized === p || normalized.startsWith(`${p}/`);
-  });
-}
-
 function walk(root: string, exclude: string[], maxFiles: number): string[] {
   const out: string[] = [];
   const visit = (dir: string) => {
@@ -196,7 +184,7 @@ function walk(root: string, exclude: string[], maxFiles: number): string[] {
     for (const entry of entries) {
       const abs = join(dir, entry.name);
       const rel = normalizeCodePath(relative(root, abs));
-      if (isExcluded(rel, exclude)) continue;
+      if (isCodeGraphExcludedPath(rel, exclude)) continue;
       if (entry.isDirectory()) {
         if (entry.name === '.git' || entry.name === '.worktrees' || entry.name === '.tmp' || entry.name === 'node_modules') continue;
         if (rel === '.claude/worktrees' || rel.startsWith('.claude/worktrees/')) continue;
@@ -290,18 +278,7 @@ function extractImportEdges(projectId: string, file: CodeFile, text: string, ind
 }
 
 export async function indexProjectLite(options: LiteIndexOptions): Promise<LiteIndexResult> {
-  const exclude = options.exclude ?? [
-    'node_modules/**',
-    'dist/**',
-    'build/**',
-    'coverage/**',
-    '.next/**',
-    '.turbo/**',
-    '.git/**',
-    '.tmp/**',
-    '.worktrees/**',
-    '.claude/worktrees/**',
-  ];
+  const exclude = normalizeCodeGraphExcludePatterns(options.exclude);
   const maxFiles = options.maxFiles ?? 5000;
   const indexedAt = new Date().toISOString();
   const paths = walk(options.projectRoot, exclude, maxFiles);

--- a/src/codegraph/project-context.ts
+++ b/src/codegraph/project-context.ts
@@ -2,6 +2,7 @@ import type { ProjectInfo } from '../types.js';
 import { evaluateCodeRefFreshness } from './freshness.js';
 import type { CodeFile, CodeRefStatus, CodeSymbol, ObservationCodeRef } from './types.js';
 import type { CodeGraphStore } from './store.js';
+import { isCodeGraphExcludedPath } from './exclude.js';
 
 export interface ProjectContextObservation {
   id: number;
@@ -77,29 +78,17 @@ function countLanguages(files: CodeFile[]): LanguageSummary[] {
     .sort((a, b) => a.language.localeCompare(b.language));
 }
 
-function normalizePath(path: string): string {
-  return path.replace(/\\/g, '/');
-}
-
-function isGeneratedPath(path: string): boolean {
-  const normalized = normalizePath(path);
-  return (
-    /(^|\/)(dist|build|coverage|\.next|\.turbo|node_modules|\.git|\.tmp|\.worktrees)(\/|$)/i.test(normalized) ||
-    /(^|\/)\.claude\/worktrees(\/|$)/i.test(normalized)
-  );
-}
-
 function suggestedReadRank(path: string): number {
-  const normalized = normalizePath(path);
+  const normalized = path.replace(/\\/g, '/');
   if (normalized.startsWith('src/')) return 0;
   if (normalized.startsWith('tests/') || normalized.startsWith('test/')) return 0;
   if (normalized.startsWith('packages/') && normalized.includes('/src/')) return 2;
   return 3;
 }
 
-function compactSuggestedReads(paths: string[], limit = 8): string[] {
+function compactSuggestedReads(paths: string[], limit = 8, exclude?: string[]): string[] {
   return uniq(paths)
-    .filter(path => !isGeneratedPath(path))
+    .filter(path => !isCodeGraphExcludedPath(path, exclude))
     .sort((a, b) => suggestedReadRank(a) - suggestedReadRank(b))
     .slice(0, limit);
 }
@@ -108,6 +97,7 @@ function collectGraph(
   store: CodeGraphStore,
   projectId: string,
   observations: ProjectContextObservation[],
+  exclude?: string[],
 ): {
   files: CodeFile[];
   symbols: CodeSymbol[];
@@ -139,7 +129,9 @@ function collectGraph(
 
     const observation = observationsById.get(ref.observationId);
     if (!observation) continue;
-    if (result.status === 'current' && file) suggestedReads.push(file.path);
+    const excluded = file ? isCodeGraphExcludedPath(file.path, exclude) : false;
+    if (result.status === 'current' && file && !excluded) suggestedReads.push(file.path);
+    if (excluded) continue;
     sources.push({
       observationId: observation.id,
       title: observation.title,
@@ -157,7 +149,7 @@ function collectGraph(
     refs,
     freshness,
     sources,
-    suggestedReads: compactSuggestedReads(suggestedReads),
+    suggestedReads: compactSuggestedReads(suggestedReads, 8, exclude),
   };
 }
 
@@ -165,9 +157,10 @@ export function buildProjectContextOverview(input: {
   project: Pick<ProjectInfo, 'id' | 'name' | 'rootPath'>;
   store: CodeGraphStore;
   observations: ProjectContextObservation[];
+  exclude?: string[];
 }): ProjectContextOverview {
   const active = activeObservations(input.observations, input.project.id);
-  const graph = collectGraph(input.store, input.project.id, active);
+  const graph = collectGraph(input.store, input.project.id, active, input.exclude);
   const status = input.store.status(input.project.id);
 
   return {
@@ -194,10 +187,11 @@ export function buildProjectContextExplain(input: {
   project: Pick<ProjectInfo, 'id' | 'name' | 'rootPath'>;
   store: CodeGraphStore;
   observations: ProjectContextObservation[];
+  exclude?: string[];
 }): ProjectContextExplain {
   const overview = buildProjectContextOverview(input);
   const active = activeObservations(input.observations, input.project.id);
-  const graph = collectGraph(input.store, input.project.id, active);
+  const graph = collectGraph(input.store, input.project.id, active, input.exclude);
   return {
     project: input.project,
     sources: graph.sources.sort((a, b) => a.observationId - b.observationId || (a.path ?? '').localeCompare(b.path ?? '')),

--- a/src/config/resolved-config.ts
+++ b/src/config/resolved-config.ts
@@ -51,6 +51,9 @@ export interface ResolvedMemorixConfig {
     excludePatterns?: string[];
     noiseKeywords?: string[];
   };
+  codegraph: {
+    excludePatterns?: string[];
+  };
   server: {
     transport?: 'stdio' | 'http';
     dashboard?: boolean;
@@ -146,6 +149,9 @@ export function getResolvedConfig(options: ResolvedLaneOptions = {}): ResolvedMe
       skipMergeCommits: firstBool(toml.git?.skip_merge_commits, yaml.git?.skipMergeCommits),
       excludePatterns: firstArray(toml.git?.exclude_patterns, yaml.git?.excludePatterns),
       noiseKeywords: firstArray(toml.git?.noise_keywords, yaml.git?.noiseKeywords),
+    },
+    codegraph: {
+      excludePatterns: firstArray(toml.codegraph?.exclude_patterns, yaml.codegraph?.excludePatterns),
     },
     server: {
       transport: first(toml.server?.transport, yaml.server?.transport),

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -39,6 +39,9 @@ export interface MemorixTomlConfig {
     exclude_patterns?: string[];
     noise_keywords?: string[];
   };
+  codegraph?: {
+    exclude_patterns?: string[];
+  };
   server?: {
     transport?: 'stdio' | 'http';
     dashboard?: boolean;
@@ -91,6 +94,7 @@ function mergeTomlConfig(base: MemorixTomlConfig, override: MemorixTomlConfig): 
     embedding: { ...base.embedding, ...override.embedding },
     hooks: { ...base.hooks, ...override.hooks },
     git: { ...base.git, ...override.git },
+    codegraph: { ...base.codegraph, ...override.codegraph },
     server: { ...base.server, ...override.server },
   };
 }

--- a/src/config/yaml-loader.ts
+++ b/src/config/yaml-loader.ts
@@ -64,6 +64,12 @@ export interface MemorixYamlConfig {
     noiseKeywords?: string[];
   };
 
+  /** CodeGraph / Project Context configuration */
+  codegraph?: {
+    /** File patterns to exclude from CodeGraph indexing and context suggestions */
+    excludePatterns?: string[];
+  };
+
   /** Behavior settings */
   behavior?: {
     /** Session start injection mode */
@@ -184,6 +190,7 @@ export function loadYamlConfig(projectRoot?: string | null): MemorixYamlConfig {
     agent: { ...userConfig.agent, ...projectConfig.agent },
     embedding: { ...userConfig.embedding, ...projectConfig.embedding },
     git: { ...userConfig.git, ...projectConfig.git },
+    codegraph: { ...userConfig.codegraph, ...projectConfig.codegraph },
     behavior: { ...userConfig.behavior, ...projectConfig.behavior },
     server: { ...userConfig.server, ...projectConfig.server },
     team: { ...userConfig.team, ...projectConfig.team },

--- a/src/server.ts
+++ b/src/server.ts
@@ -1295,8 +1295,10 @@ export async function createMemorixServer(
       return withFreshIndex(async () => {
         const { CodeGraphStore } = await import('./codegraph/store.js');
         const { assembleContextPackForTask, buildContextPackPrompt } = await import('./codegraph/context-pack.js');
+        const { getResolvedConfig } = await import('./config/resolved-config.js');
         const store = new CodeGraphStore();
         await store.init(projectDir);
+        const exclude = getResolvedConfig({ projectRoot: project.rootPath }).codegraph.excludePatterns;
 
         const observations = getAllObservations()
           .filter(obs => obs.projectId === project.id && (obs.status ?? 'active') === 'active')
@@ -1307,6 +1309,7 @@ export async function createMemorixServer(
           task,
           observations,
           limit: typeof limit === 'number' ? limit : 20,
+          exclude,
         });
         const text = buildContextPackPrompt(pack);
 

--- a/tests/cli/context-command.test.ts
+++ b/tests/cli/context-command.test.ts
@@ -7,6 +7,8 @@ import codegraphCommand from '../../src/cli/commands/codegraph.js';
 import contextCommand from '../../src/cli/commands/context.js';
 import doctorCommand from '../../src/cli/commands/doctor.js';
 import explainCommand from '../../src/cli/commands/explain.js';
+import { resetResolvedConfigCache } from '../../src/config/resolved-config.js';
+import { resetTomlConfigCache } from '../../src/config/toml-loader.js';
 import { initObservations, storeObservation } from '../../src/memory/observations.js';
 import { closeAllDatabases } from '../../src/store/sqlite-db.js';
 import { resetObservationStore } from '../../src/store/obs-store.js';
@@ -56,6 +58,8 @@ describe('project context CLI commands', () => {
     process.chdir(repoDir);
     process.env.MEMORIX_DATA_DIR = dataDir;
     process.env.MEMORIX_EMBEDDING = 'off';
+    resetTomlConfigCache();
+    resetResolvedConfigCache();
   });
 
   afterEach(async () => {
@@ -73,6 +77,8 @@ describe('project context CLI commands', () => {
     resetObservationStore();
     resetSessionStore();
     resetTeamStore();
+    resetTomlConfigCache();
+    resetResolvedConfigCache();
     await resetDb();
     closeAllDatabases();
     rmSync(sandboxRoot, { recursive: true, force: true });
@@ -221,6 +227,38 @@ describe('project context CLI commands', () => {
         stale: 0,
       },
     });
+  });
+
+  it('applies CodeGraph excludes to doctor suggested reads', async () => {
+    mkdirSync(path.join(repoDir, 'vendor', 'cache'), { recursive: true });
+    writeFileSync(path.join(repoDir, 'vendor', 'cache', 'tool.ts'), 'export function cachedTool() { return true; }\n', 'utf8');
+    await runCommand(codegraphCommand, { _: ['refresh'], json: true });
+    await initObservations(dataDir);
+    await storeObservation({
+      entityName: 'cache',
+      type: 'decision',
+      title: 'Vendor cache tool',
+      narrative: 'Keep vendor/cache/tool.ts for cache behavior.',
+      filesModified: ['vendor/cache/tool.ts'],
+      projectId: 'local/repo',
+    });
+    await storeObservation({
+      entityName: 'auth',
+      type: 'decision',
+      title: 'Auth middleware',
+      narrative: 'Continue edits in src/auth.ts when changing login verification.',
+      filesModified: ['src/auth.ts'],
+      projectId: 'local/repo',
+    });
+    writeFileSync(path.join(repoDir, 'memorix.toml'), '[codegraph]\nexclude_patterns = ["vendor/**"]\n', 'utf8');
+    resetTomlConfigCache();
+    resetResolvedConfigCache();
+
+    const result = await runCommand(doctorCommand, {});
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain('src/auth.ts');
+    expect(result.stdout).not.toContain('vendor/cache/tool.ts');
   });
 
   it('scopes doctor observation counts to the current project', async () => {

--- a/tests/codegraph/context-pack.test.ts
+++ b/tests/codegraph/context-pack.test.ts
@@ -198,6 +198,64 @@ describe('buildContextPackPrompt', () => {
     expect(pack.suggestedReads).toEqual(['src/auth.ts']);
   });
 
+  it('filters user-excluded CodeGraph paths from code facts and suggested reads', () => {
+    const pack = assembleContextPack({
+      task: 'continue auth bug',
+      observations: [
+        { id: 1, title: 'Cache auth memory', type: 'decision' },
+        { id: 2, title: 'Source auth memory', type: 'decision' },
+      ],
+      refs: [
+        {
+          id: 'coderef:cache',
+          projectId: 'org/repo',
+          observationId: 1,
+          fileId: 'file:cache',
+          capturedFileHash: 'cache-hash',
+          status: 'current',
+          reason: 'bound by file path',
+          createdAt: '2026-06-29T00:00:00.000Z',
+        },
+        {
+          id: 'coderef:auth',
+          projectId: 'org/repo',
+          observationId: 2,
+          fileId: 'file:auth',
+          capturedFileHash: 'auth-hash',
+          status: 'current',
+          reason: 'bound by file path',
+          createdAt: '2026-06-29T00:00:00.000Z',
+        },
+      ],
+      files: [
+        {
+          id: 'file:cache',
+          projectId: 'org/repo',
+          path: 'vendor/cache/tool.ts',
+          contentHash: 'cache-hash',
+          indexedAt: '2026-06-29T00:01:00.000Z',
+        },
+        {
+          id: 'file:auth',
+          projectId: 'org/repo',
+          path: 'src/auth.ts',
+          contentHash: 'auth-hash',
+          indexedAt: '2026-06-29T00:01:00.000Z',
+        },
+      ],
+      symbols: [],
+      exclude: ['vendor/**'],
+    });
+
+    expect(pack.memories).toEqual([
+      expect.objectContaining({ id: 2, status: 'current' }),
+    ]);
+    expect(pack.codeFacts).toEqual([
+      expect.objectContaining({ path: 'src/auth.ts' }),
+    ]);
+    expect(pack.suggestedReads).toEqual(['src/auth.ts']);
+  });
+
   it('selects task-relevant observations before falling back to recency', () => {
     const selected = selectRelevantObservations([
       {

--- a/tests/codegraph/lite-provider.test.ts
+++ b/tests/codegraph/lite-provider.test.ts
@@ -142,6 +142,27 @@ describe('CodeGraph Lite provider', () => {
     expect(result.symbols.map(symbol => symbol.name)).toEqual(['main']);
   });
 
+  it('extends default excludes with user CodeGraph exclude patterns', async () => {
+    const dir = makeRoot();
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    mkdirSync(join(dir, 'vendor'), { recursive: true });
+    mkdirSync(join(dir, 'packages', 'app', 'generated'), { recursive: true });
+    mkdirSync(join(dir, 'dist'), { recursive: true });
+    writeFileSync(join(dir, 'src', 'main.ts'), 'export function main() {}\n');
+    writeFileSync(join(dir, 'vendor', 'vendored.ts'), 'export function vendored() {}\n');
+    writeFileSync(join(dir, 'packages', 'app', 'generated', 'schema.ts'), 'export function generatedSchema() {}\n');
+    writeFileSync(join(dir, 'dist', 'generated.ts'), 'export function generated() {}\n');
+
+    const result = await indexProjectLite({
+      projectId: 'org/repo',
+      projectRoot: dir,
+      exclude: ['vendor/**', '**/generated/**'],
+    });
+
+    expect(result.files.map(file => file.path)).toEqual(['src/main.ts']);
+    expect(result.symbols.map(symbol => symbol.name)).toEqual(['main']);
+  });
+
   it('continues indexing when a discovered file cannot be read', async () => {
     vi.resetModules();
     vi.doMock('node:fs', () => ({

--- a/tests/codegraph/project-context.test.ts
+++ b/tests/codegraph/project-context.test.ts
@@ -272,4 +272,43 @@ describe('project context service', () => {
       'src/extra2.ts',
     ]);
   });
+
+  it('filters user-excluded CodeGraph paths from suggested reads', async () => {
+    const store = new CodeGraphStore();
+    await store.init(tempDir());
+    store.replaceProjectIndex('org/repo', {
+      files: [
+        makeFile('file:cache', 'vendor/cache/tool.ts'),
+        makeFile('file:auth', 'src/auth.ts'),
+      ],
+      symbols: [],
+      edges: [],
+    });
+    store.upsertObservationRefs([
+      makeRef(1, 'file:cache'),
+      makeRef(2, 'file:auth'),
+    ]);
+
+    const observations = [
+      { id: 1, projectId: 'org/repo', title: 'Cache memory', type: 'decision', status: 'active' },
+      { id: 2, projectId: 'org/repo', title: 'Auth memory', type: 'decision', status: 'active' },
+    ];
+
+    const overview = buildProjectContextOverview({
+      project: { id: 'org/repo', name: 'repo', rootPath: 'C:/repo' },
+      store,
+      observations,
+      exclude: ['vendor/**'],
+    });
+    const explain = buildProjectContextExplain({
+      project: { id: 'org/repo', name: 'repo', rootPath: 'C:/repo' },
+      store,
+      observations,
+      exclude: ['vendor/**'],
+    });
+
+    expect(overview.suggestedReads).toEqual(['src/auth.ts']);
+    expect(overview.freshness.current).toBe(2);
+    expect(explain.sources.map(source => source.path)).toEqual(['src/auth.ts']);
+  });
 });

--- a/tests/config/resolved-config.test.ts
+++ b/tests/config/resolved-config.test.ts
@@ -164,6 +164,22 @@ describe('resolved config', () => {
     expect(cfg.git.excludePatterns).toEqual(['dist/**', '*.lock']);
   });
 
+  it('resolves CodeGraph exclude patterns from TOML above legacy YAML', () => {
+    writeFileSync(join(HOME, '.memorix', 'config.toml'), [
+      '[codegraph]',
+      'exclude_patterns = ["vendor/**", "**/generated/**"]',
+    ].join('\n'), 'utf8');
+    writeFileSync(join(HOME, '.memorix', 'memorix.yml'), [
+      'codegraph:',
+      '  excludePatterns:',
+      '    - ignored-from-yaml/**',
+    ].join('\n'), 'utf8');
+
+    const cfg = getResolvedConfig({ projectRoot: null, homeDir: HOME });
+
+    expect(cfg.codegraph.excludePatterns).toEqual(['vendor/**', '**/generated/**']);
+  });
+
   it('uses git TOML settings in runtime getGitConfig after project root detection', () => {
     writeFileSync(join(PROJECT, 'memorix.toml'), [
       '[git]',

--- a/tests/config/toml-loader.test.ts
+++ b/tests/config/toml-loader.test.ts
@@ -62,6 +62,9 @@ describe('loadTomlConfig', () => {
       'max_diff_size = 2048',
       'skip_merge_commits = false',
       'exclude_patterns = ["dist/**", "*.lock"]',
+      '',
+      '[codegraph]',
+      'exclude_patterns = ["vendor/**", "**/generated/**"]',
     ].join('\n'), 'utf8');
 
     const cfg = loadTomlConfig({ projectRoot: null, homeDir: HOME });
@@ -75,5 +78,6 @@ describe('loadTomlConfig', () => {
     expect(cfg.git?.max_diff_size).toBe(2048);
     expect(cfg.git?.skip_merge_commits).toBe(false);
     expect(cfg.git?.exclude_patterns).toEqual(['dist/**', '*.lock']);
+    expect(cfg.codegraph?.exclude_patterns).toEqual(['vendor/**', '**/generated/**']);
   });
 });

--- a/tests/integration/tool-profile.test.ts
+++ b/tests/integration/tool-profile.test.ts
@@ -25,7 +25,14 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { createMemorixServer } from '../../src/server.js';
+import { CodeGraphStore } from '../../src/codegraph/store.js';
+import { resetResolvedConfigCache } from '../../src/config/resolved-config.js';
+import { resetTomlConfigCache } from '../../src/config/toml-loader.js';
+import { storeObservation } from '../../src/memory/observations.js';
+import { getProjectDataDir } from '../../src/store/persistence.js';
 import { resetDb } from '../../src/store/orama-store.js';
+import { resetObservationStore } from '../../src/store/obs-store.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
 
 let testDir: string;
 
@@ -211,5 +218,85 @@ describe('Tool profile registration', () => {
     expect(text).toContain('Memorix Autopilot Brief');
     expect(text).toContain('Task lens: bugfix');
     expect(text).toContain('run the smallest failing test or repro first');
+  }, 30000);
+
+  it('should apply CodeGraph exclude patterns to the MCP context pack handler', async () => {
+    const dir = await createGitProjectDir('memorix-profile-context-pack-exclude-');
+    const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-profile-context-pack-data-'));
+    const previousDataDir = process.env.MEMORIX_DATA_DIR;
+    process.env.MEMORIX_DATA_DIR = dataDir;
+    resetTomlConfigCache();
+    resetResolvedConfigCache();
+
+    try {
+      await fs.writeFile(path.join(dir, 'memorix.toml'), [
+        '[codegraph]',
+        'exclude_patterns = ["vendor/**"]',
+      ].join('\n'), 'utf8');
+
+      const { server, projectId } = await createMemorixServer(
+        dir,
+        undefined,
+        undefined,
+        { toolProfile: 'micro' } as any,
+      );
+      const projectDataDir = await getProjectDataDir(projectId);
+      const codeStore = new CodeGraphStore();
+      await codeStore.init(projectDataDir);
+      const indexedAt = '2026-07-07T00:00:00.000Z';
+      codeStore.upsertFiles([
+        {
+          id: 'file:vendor-cache',
+          projectId,
+          path: 'vendor/cache/tool.ts',
+          contentHash: 'vendor-cache-hash',
+          indexedAt,
+        },
+        {
+          id: 'file:auth',
+          projectId,
+          path: 'src/auth.ts',
+          contentHash: 'auth-hash',
+          indexedAt,
+        },
+      ]);
+
+      await storeObservation({
+        entityName: 'cache',
+        type: 'decision',
+        title: 'Vendor cache decision',
+        narrative: 'Keep vendor/cache/tool.ts for cache behavior.',
+        filesModified: ['vendor/cache/tool.ts'],
+        projectId,
+      });
+      await storeObservation({
+        entityName: 'auth',
+        type: 'decision',
+        title: 'Auth source decision',
+        narrative: 'Keep src/auth.ts for auth behavior.',
+        filesModified: ['src/auth.ts'],
+        projectId,
+      });
+
+      const contextPack = getHandler(server as any, 'memorix_context_pack');
+      const text = getText(await contextPack({ task: 'continue auth cache bug' }));
+
+      expect(text).toContain('Auth source decision');
+      expect(text).toContain('src/auth.ts');
+      expect(text).not.toContain('Vendor cache decision');
+      expect(text).not.toContain('vendor/cache/tool.ts');
+    } finally {
+      if (previousDataDir === undefined) {
+        delete process.env.MEMORIX_DATA_DIR;
+      } else {
+        process.env.MEMORIX_DATA_DIR = previousDataDir;
+      }
+      resetTomlConfigCache();
+      resetResolvedConfigCache();
+      resetObservationStore();
+      await resetDb();
+      closeAllDatabases();
+      await fs.rm(dataDir, { recursive: true, force: true });
+    }
   }, 30000);
 });


### PR DESCRIPTION
## Summary
- adds [codegraph].exclude_patterns / legacy YAML codegraph.excludePatterns
- applies excludes to Lite indexing, Project Context, Context Pack, MCP context pack, and doctor
- documents config and adds regression tests

## Verification
- targeted tests: 7 files / 43 tests passed
- `npm run lint`: passed
- `npm run build`: passed
- full `npm test`: 202 files / 2467 tests passed
- `git diff --check`: passed
- smoke on /home/grig/.codex: plugins/cache/** removed 48 files, filtered index has 0 plugins/cache, Project Context prompt/context JSON have no plugins/cache/

Closes #119
