### PR TITLE
fix(config): accept snake-case keys in config get

### DIFF
--- a/src/cli/commands/config-get.ts
+++ b/src/cli/commands/config-get.ts
@@ -29,10 +29,17 @@ export default defineCommand({
 function readDotted(source: Record<string, unknown>, key: string): unknown {
   let cursor: unknown = source;
   for (const part of key.split('.')) {
-    if (!cursor || typeof cursor !== 'object' || !(part in cursor)) return undefined;
-    cursor = (cursor as Record<string, unknown>)[part];
+    if (!cursor || typeof cursor !== 'object') return undefined;
+    const record = cursor as Record<string, unknown>;
+    const normalizedPart = part in record ? part : snakeToCamel(part);
+    if (!(normalizedPart in record)) return undefined;
+    cursor = record[normalizedPart];
   }
   return cursor;
+}
+
+function snakeToCamel(value: string): string {
+  return value.replace(/_([a-z])/g, (_, char: string) => char.toUpperCase());
 }
 
 function formatValue(value: unknown, key: string): string {

--- a/tests/cli/config-command.test.ts
+++ b/tests/cli/config-command.test.ts
@@ -105,6 +105,26 @@ describe('memorix config commands', () => {
     expect(infoMock).toHaveBeenCalledWith('agent.model: test-model');
   });
 
+  it('accepts TOML-style snake_case dotted keys for resolved config values', async () => {
+    tempDir = mkdtempSync(join(process.env.TEMP ?? process.cwd(), 'memorix-config-get-snake-'));
+    const homeDir = join(tempDir, 'home');
+    mkdirSync(join(homeDir, '.memorix'), { recursive: true });
+    homedirMock.mockReturnValue(homeDir);
+    writeFileSync(join(homeDir, '.memorix', 'config.toml'), [
+      '[codegraph]',
+      'exclude_patterns = ["vendor/**", "generated/**"]',
+    ].join('\n'), 'utf8');
+    const command = (await import('../../src/cli/commands/config-get.js')).default;
+
+    await command.run?.({
+      args: { key: 'codegraph.exclude_patterns' },
+      rawArgs: ['codegraph.exclude_patterns'],
+      cmd: command,
+    } as any);
+
+    expect(infoMock).toHaveBeenCalledWith('codegraph.exclude_patterns: ["vendor/**","generated/**"]');
+  });
+
   it('redacts only sensitive config keys when printing dotted values', async () => {
     process.env.MEMORIX_EMBEDDING_MODEL = 'text-embedding-v4';
     process.env.MEMORIX_EMBEDDING_API_KEY = 'embedding-test-secret';


### PR DESCRIPTION
## Summary
- lets `memorix config get` resolve TOML-style snake_case dotted keys against camelCase resolved config fields
- covers `codegraph.exclude_patterns`, the inspection path requested in #119 / implemented by #120

## Verification
- `npm test -- tests/cli/config-command.test.ts tests/config/resolved-config.test.ts tests/config/toml-loader.test.ts`
- `npm run lint`

Note: `npm run build` was attempted in the temporary review worktree, but that worktree uses a junction to the main repo's `node_modules` and workspace package resolution failed for `packages/memcode` / `undici`. CI will run build in a normal checkout.