### PR TITLE
Fix Orama index consistency during search and hydration

### DIFF
--- a/src/store/orama-store.ts
+++ b/src/store/orama-store.ts
@@ -8,7 +8,7 @@
  * Vector search (embeddings) will be added in P1 phase.
  */
 
-import { create, insert, search, remove, update, count, type AnyOrama } from '@orama/orama';
+import { create, insert, search, remove, update, count, getByID, type AnyOrama } from '@orama/orama';
 import type { MemorixDocument, SearchOptions, IndexEntry, KnowledgeLayer } from '../types.js';
 import { OBSERVATION_ICONS, type ObservationType } from '../types.js';
 import { resolveKnowledgeLayer } from '../skills/mini-skills.js';
@@ -52,9 +52,13 @@ function makeEntryKey(projectId: string | undefined, observationId: number): str
   return `${projectId ?? ''}::${observationId}`;
 }
 
-function rememberObservationDoc(doc: MemorixDocument): void {
-  if (!doc.projectId || typeof doc.observationId !== 'number') return;
-  docByObservationKey.set(makeEntryKey(doc.projectId, doc.observationId), doc);
+function rememberObservationDoc(doc: MemorixDocument): MemorixDocument {
+  const publicDoc = { ...doc };
+  delete publicDoc.embedding;
+  if (doc.projectId && typeof doc.observationId === 'number') {
+    docByObservationKey.set(makeEntryKey(doc.projectId, doc.observationId), publicDoc);
+  }
+  return publicDoc;
 }
 
 function isCommandLikeQuery(query: string): boolean {
@@ -243,15 +247,15 @@ export async function batchGenerateEmbeddings(texts: string[]): Promise<(number[
  */
 export async function hydrateIndex(observations: any[]): Promise<number> {
   const database = await getDb();
-  const currentCount = await count(database);
-  if (currentCount > 0) return 0; // already hydrated
 
   let inserted = 0;
   for (const obs of observations) {
     if (!obs || !obs.id || !obs.projectId) continue;
     try {
+      const id = makeOramaObservationId(obs.projectId, obs.id);
+      if (getByID(database, id)) continue;
       const doc: MemorixDocument = {
-        id: makeOramaObservationId(obs.projectId, obs.id),
+        id,
         observationId: obs.id,
         entityName: obs.entityName || '',
         type: obs.type || 'discovery',
@@ -376,6 +380,7 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
   let searchParams: Record<string, unknown> = {
     term: originalQuery,
     limit: requestLimit,
+    includeVectors: true,
     ...(Object.keys(filters).length > 0 ? { where: filters } : {}),
     // Search specific fields (not tokens, accessCount, etc.)
     properties: ['title', 'entityName', 'narrative', 'facts', 'concepts', 'filesModified'],
@@ -458,6 +463,7 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
       const vectorOnlyParams: Record<string, unknown> = {
         term: '',
         limit: requestLimit,
+        includeVectors: true,
         ...(Object.keys(filters).length > 0 ? { where: filters } : {}),
         mode: 'vector',
         vector: {
@@ -887,6 +893,7 @@ export async function getObservationsByIds(
 
     const searchResult = await search(database, {
       term: '',
+      includeVectors: true,
       where: {
         observationId: { eq: id },
         ...(projectId ? { projectId } : {}),
@@ -895,7 +902,7 @@ export async function getObservationsByIds(
     });
 
     if (searchResult.hits.length > 0) {
-      results.push(searchResult.hits[0].document as unknown as MemorixDocument);
+      results.push(rememberObservationDoc(searchResult.hits[0].document as unknown as MemorixDocument));
     }
   }
 

--- a/tests/memory/orama-detail-cache.test.ts
+++ b/tests/memory/orama-detail-cache.test.ts
@@ -1,9 +1,19 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import { getByID, insert } from '@orama/orama';
 
-import { getObservationsByIds, insertObservation, resetDb } from '../../src/store/orama-store.js';
+import { getDb, getObservationsByIds, resetDb } from '../../src/store/orama-store.js';
+
+vi.mock('../../src/embedding/provider.js', () => ({
+	getEmbeddingProvider: vi.fn(async () => ({
+		name: 'test',
+		dimensions: 2,
+		embed: async () => [0.6, 0.8],
+		embedBatch: async () => [[0.6, 0.8]],
+	})),
+}));
 
 describe('Orama detail cache', () => {
-	it('returns a cached observation document by id even after in-memory observation state is cleared', async () => {
+	it('returns vector-free detail without damaging a cache-miss document', async () => {
 		const projectId = 'AVIDS2/memorix';
 
 		const doc = {
@@ -25,15 +35,20 @@ describe('Orama detail cache', () => {
 			source: 'agent',
 			sourceDetail: 'explicit',
 			valueCategory: 'contextual',
+			embedding: [0.6, 0.8],
 		};
 
 		await resetDb();
-		await insertObservation(doc as any);
+		const db = await getDb();
+		await insert(db, doc);
 
-		const docs = await getObservationsByIds([42], projectId);
+		const first = await getObservationsByIds([42], projectId);
+		const second = await getObservationsByIds([42], projectId);
 
-		expect(docs).toHaveLength(1);
-		expect(docs[0]?.title).toBe('Cached detail lookup');
-		expect(docs[0]?.projectId).toBe(projectId);
+		expect(first).toHaveLength(1);
+		expect(second).toHaveLength(1);
+		expect(first[0]).not.toHaveProperty('embedding');
+		expect(second[0]).not.toHaveProperty('embedding');
+		expect(getByID(db, doc.id)).toMatchObject({ embedding: [0.6, 0.8] });
 	});
 });

--- a/tests/search/orama-store-semantic.test.ts
+++ b/tests/search/orama-store-semantic.test.ts
@@ -106,6 +106,49 @@ describe('orama-store semantic hybrid search', () => {
     expect(entries[0]?.title).toContain('vector gate');
   });
 
+  it('keeps a vector-backed observation searchable after access tracking', async () => {
+    const {
+      getObservationsByIds,
+      insertObservation,
+      makeOramaObservationId,
+      searchObservations,
+    } = await import('../../src/store/orama-store.js');
+
+    const now = new Date().toISOString();
+    await insertObservation({
+      id: makeOramaObservationId('AVIDS2/memorix', 3),
+      observationId: 3,
+      entityName: 'search-stability',
+      type: 'problem-solution',
+      title: 'Search survivor observation',
+      narrative: 'Access tracking must not remove this document from Orama.',
+      facts: 'The observation has a valid vector.',
+      filesModified: 'src/store/orama-store.ts',
+      concepts: 'search-stability',
+      tokens: 20,
+      createdAt: now,
+      projectId: 'AVIDS2/memorix',
+      accessCount: 0,
+      lastAccessedAt: now,
+      status: 'active',
+      source: 'agent',
+      embedding: [0.6, 0.8],
+    });
+
+    const options = {
+      query: 'survivor',
+      projectId: 'AVIDS2/memorix',
+      limit: 5,
+    };
+    const first = await searchObservations(options);
+    const second = await searchObservations(options);
+    const detail = await getObservationsByIds([3], 'AVIDS2/memorix');
+
+    expect(first.map((entry) => entry.id)).toContain(3);
+    expect(second.map((entry) => entry.id)).toContain(3);
+    expect(detail[0]).not.toHaveProperty('embedding');
+  });
+
   it('keeps vector/hybrid results inside the requested project', async () => {
     const {
       insertObservation,

--- a/tests/store/hydrate-index.test.ts
+++ b/tests/store/hydrate-index.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { resetDb, hydrateIndex, makeOramaObservationId } from '../../src/store/orama-store.js';
-import { count, search } from '@orama/orama';
+import { getByID, insert, search } from '@orama/orama';
 
 // Minimal observation shape matching what hydrateIndex expects
 function makeObs(id: number, status: string, title: string) {
@@ -75,20 +75,44 @@ describe('hydrateIndex – status handling', () => {
     expect(inserted).toBe(2);
   });
 
-  it('is idempotent – second call is a no-op', async () => {
+  it('hydrates missing observations when a mini-skill already populated the index', async () => {
     const observations = [
       makeObs(30, 'active', 'First hydration'),
       makeObs(31, 'resolved', 'First hydration resolved'),
     ];
 
+    const { getDb } = await import('../../src/store/orama-store.js');
+    const db = await getDb();
+    await insert(db, {
+      id: 'skill:test%2Fhydrate-project:1',
+      observationId: 1,
+      entityName: 'test-skill',
+      type: 'mini-skill',
+      title: 'Preloaded mini-skill',
+      narrative: 'This document makes the shared index non-empty.',
+      facts: '',
+      filesModified: '',
+      concepts: 'hydration',
+      tokens: 10,
+      createdAt: new Date().toISOString(),
+      projectId: 'test/hydrate-project',
+      accessCount: 0,
+      lastAccessedAt: '',
+      status: 'active',
+      source: 'agent',
+      sourceDetail: 'explicit',
+      valueCategory: 'core',
+      documentType: 'mini-skill',
+      knowledgeLayer: 'promoted',
+    });
+
     const first = await hydrateIndex(observations);
     expect(first).toBe(2);
 
-    // Second call with more observations should return 0 (already hydrated)
-    const second = await hydrateIndex([
-      ...observations,
-      makeObs(32, 'archived', 'Late arrival'),
-    ]);
+    const second = await hydrateIndex(observations);
     expect(second).toBe(0);
+
+    expect(getByID(db, makeOramaObservationId('test/hydrate-project', 30))).toBeDefined();
+    expect(getByID(db, makeOramaObservationId('test/hydrate-project', 31))).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary

- preserve vectors in internal Orama searches used by access tracking while stripping embeddings from public/detail cache results
- protect cache-miss observation ID lookup without mutating the stored vector-backed document
- reconcile hydration by exact composite observation IDs instead of skipping all observations when the shared index is merely non-empty
- add regression coverage for repeated vector-backed search, vector-free detail caching, cache-miss lookup, and partial hydration with a preloaded mini-skill

Fixes #122

## Verification

- targeted tests: 11/11 passed
- relevant regression tests: 106/106 passed
- `npm run lint`: passed
- `npm run build`: passed
- `git diff --check`: passed

The patched full suite completed with 2464/2469 tests passing. The same five project-scope failures reproduce on clean `main` at `816415b5fbc79d451b3f86796832388a0956606f`: four dashboard project-scope failures and release-blockers B2. This PR does not address those baseline failures and does not claim a green full suite.
