### PR TITLE
fix(search): attach document vectors during index hydration so CJK paraphrase recall works

### DIFF
--- a/src/memory/observations.ts
+++ b/src/memory/observations.ts
@@ -729,11 +729,14 @@ export async function reindexObservations(): Promise<number> {
   // Batch-generate all embeddings at once (much faster than individual calls)
   let embeddings: (number[] | null)[] = observations.map(() => null);
   const provider = await getEmbeddingProvider();
-  const canBatchEmbedAtStartup = provider !== null && !provider.name.startsWith('api-');
-
-  if (provider && !canBatchEmbedAtStartup) {
-    console.error('[memorix] Startup reindex: skipping synchronous API embeddings; background backfill will hydrate vectors');
-  }
+  // ── CJK semantic-recall fix (fork patch) ─────────────────────────────
+  // Upstream skipped synchronous embedding for `api-` providers ("background
+  // backfill will hydrate vectors"), but that backfill never reaches the served
+  // index, leaving documents vector-less → Chinese paraphrase recall returns 0.
+  // We now embed for ALL providers, including `api-`. The embed text matches
+  // store-time text, so the warm on-disk vector cache is hit for already-embedded
+  // docs (no extra API call); only genuinely new docs cost a request.
+  const canBatchEmbedAtStartup = provider !== null;
 
   if (canBatchEmbedAtStartup) {
     try {

--- a/src/store/orama-store.ts
+++ b/src/store/orama-store.ts
@@ -248,12 +248,44 @@ export async function batchGenerateEmbeddings(texts: string[]): Promise<(number[
 export async function hydrateIndex(observations: any[]): Promise<number> {
   const database = await getDb();
 
+  // ── CJK semantic-recall fix (fork patch) ─────────────────────────────
+  // Upstream hydrateIndex inserts documents WITHOUT a vector, so the served
+  // Orama index is BM25-only even when an embedding provider is configured.
+  // Pure-Chinese paraphrase queries (no character overlap) then return 0,
+  // because document vectors never reach the index.
+  //
+  // Fix: when embeddings are enabled, embed each document's searchable text and
+  // attach it as the `embedding` field the index schema expects. The embed text
+  // is the SAME canonical form used at store-time
+  // (`[title, narrative, ...facts].join(' ')`), so the warm on-disk vector cache
+  // (`.embedding-api-cache.json`, keyed by text hash) is hit for already-embedded
+  // docs — no extra API call. Uncached docs are computed once and cached.
+  // Dimension-mismatched or failed vectors are skipped (doc still indexed,
+  // BM25-only), so this never crashes hydration.
+  let docVectors: (number[] | null)[] = observations.map(() => null);
+  const activeVectorDimensions = getVectorDimensions();
+  if (embeddingEnabled && activeVectorDimensions !== null && observations.length > 0) {
+    try {
+      const texts = observations.map((obs) =>
+        [obs?.title ?? '', obs?.narrative ?? '', ...(Array.isArray(obs?.facts) ? obs.facts : [])].join(' '),
+      );
+      docVectors = await batchGenerateEmbeddings(texts);
+    } catch {
+      // Best-effort: fall back to BM25-only hydration if batch embedding fails.
+      docVectors = observations.map(() => null);
+    }
+  }
+
   let inserted = 0;
-  for (const obs of observations) {
+  for (let i = 0; i < observations.length; i++) {
+    const obs = observations[i];
     if (!obs || !obs.id || !obs.projectId) continue;
     try {
       const id = makeOramaObservationId(obs.projectId, obs.id);
       if (getByID(database, id)) continue;
+      const vec = docVectors[i];
+      const compatibleVec =
+        vec && activeVectorDimensions !== null && vec.length === activeVectorDimensions ? vec : null;
       const doc: MemorixDocument = {
         id,
         observationId: obs.id,
@@ -273,6 +305,7 @@ export async function hydrateIndex(observations: any[]): Promise<number> {
         source: obs.source || 'agent',
         documentType: 'observation',
         knowledgeLayer: resolveKnowledgeLayer('observation', obs.sourceDetail, obs.source),
+        ...(compatibleVec ? { embedding: compatibleVec } : {}),
       };
       await insert(database, doc);
       rememberObservationDoc(doc);

--- a/tests/memory/vector-stability.test.ts
+++ b/tests/memory/vector-stability.test.ts
@@ -280,7 +280,7 @@ describe('Vector Stability', () => {
     expect(getVectorMissingIds()).toContain(observation.id);
   });
 
-  it('reindexObservations skips synchronous batch embedding when the active provider is remote API', async () => {
+  it('reindexObservations batch embeds when the active provider is remote API', async () => {
     const oramaStore = await import('../../src/store/orama-store.js');
     const embeddingProvider = await import('../../src/embedding/provider.js');
     const persistence = await import('../../src/store/persistence.js');
@@ -319,7 +319,9 @@ describe('Vector Stability', () => {
     const count = await reindexObservations();
 
     expect(count).toBe(1);
-    expect(oramaStore.batchGenerateEmbeddings).not.toHaveBeenCalled();
+    expect(oramaStore.batchGenerateEmbeddings).toHaveBeenCalledWith([
+      'Remote API startup reindex Should not block MCP startup on remote embedding backfill',
+    ]);
     expect(getVectorMissingIds()).toContain(41);
   });
 });


### PR DESCRIPTION
## Problem

`hydrateIndex` inserted observation docs **without an embedding field** and ignored the on-disk vector cache, so the served Orama index was **BM25-only even with an embedding provider configured**.

The user-visible symptom: pure-Chinese paraphrase queries (no character overlap with the stored text) returned **0 results**, because document vectors never reached the index. BM25 cannot match a CJK paraphrase that shares no characters with the original — only the vector side can, and it was silently absent.

## Fix

- **`src/store/orama-store.ts` — `hydrateIndex`**: batch-embed each doc's searchable text (`[title, narrative, ...facts].join(' ')`, matching the store-time text so the warm disk cache is hit) and attach the `embedding` field the schema already expects.
- **`src/memory/observations.ts` — `reindexObservations`**: stop skipping synchronous embedding for `api-` providers; embed for all providers (the cache makes this cheap).

Matching the store-time text is what lets hydration reuse the existing on-disk vector cache instead of paying to re-embed.

## Verification

- Zero-overlap Chinese paraphrase now retrieves the memory with a meaningful vector score, and correctly discriminates against unrelated docs.
- `tests/memory/vector-stability.test.ts`: **11/11 pass**.
- **No regressions**: the set of failing test files on this branch is identical to the set on pristine `main` (pre-existing failures in `cli/`, `codegraph/`, `config/`, `hooks/`, `orchestrate/` — unrelated to search). Note the suite is flaky run-to-run; `tests/orchestrate/verify-gate.test.ts` passes 20/20 in isolation on both this branch and `main`.

Branch is rebased on current `main` (`de0bbac`).
