### PR TITLE
release: Memorix 1.1.11 runtime integrity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.11] - 2026-07-16
+
+### Added
+- **Durable runtime maintenance** -- Added a SQLite-backed maintenance ledger for vector recovery, retention, consolidation, and Code Memory refresh. Jobs use dedupe keys, leases, heartbeats, retry backoff, resumable cursors, and operator-visible state.
+- **Isolated maintenance runner** -- Retention, consolidation, and Code Memory scans now run through a compiled child-process runner instead of sharing an MCP request/event loop. Vector recovery stays with the owning process because its Orama index is process-local.
+- **Code Memory scan safeguards** -- CodeGraph Lite now skips common dependency/build directories and source files larger than 2 MiB by default. Configure the limit with `[codegraph].max_file_bytes` or YAML `codegraph.maxFileBytes`.
+- **Maintenance diagnostics** -- Dashboard APIs and System Status now show queued/running/failed maintenance state without mixing projects.
+
+### Changed
+- **First-turn MCP readiness** -- `memorix_project_context`, `memorix_context_pack`, `memorix_graph_context`, and `memorix_codegraph_status` now read the current project's SQLite state directly before full Orama hydration. Search, writes, and sessions retain their full-runtime boundary.
+- **Bounded memory lifecycle** -- Automatic retention and consolidation process one project page at a time and resume through durable cursors, avoiding corpus-sized work in an interactive request.
+- **Incremental Code Memory** -- Changed files are reparsed, unchanged files keep their metadata, and removed/oversized files are removed from the graph without replacing the entire project graph.
+- **Mobile dashboard navigation** -- The desktop sidebar becomes a compact mobile navigation layout so dashboard content remains readable on narrow screens.
+
+### Fixed
+- **Cross-process refresh model** -- Removed the obsolete JSON-file polling watcher. SQLite generation checks are now the sole authoritative mechanism for cross-process observation freshness.
+- **Maintenance history and diagnostics** -- Completed maintenance records expire after a retention window; persisted failure messages redact credential values.
+- **Maintenance enqueue atomicity** -- History pruning now runs inside the enqueue transaction, so a failed enqueue cannot discard completed diagnostic history.
+- **Dashboard project scope** -- Knowledge, graph, retention, observation, and export reads use project-scoped SQLite queries instead of loading and filtering the full flat memory store.
+- **Behavior configuration alignment** -- TOML/YAML memory behavior settings now drive runtime injection, formation, auto-cleanup, and sync advisory behavior; legacy `config.json` is a fallback rather than a separate source of truth.
+- **Container runtime privilege** -- The official HTTP control-plane image is explicitly verified to run as the non-root `node` user.
+
 ## [1.1.10] - 2026-07-13
 
 ### Fixed

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -51,6 +51,7 @@ api_key = "..."
 inject = "minimal"
 formation = "active"
 auto_cleanup = true
+sync_advisory = true
 
 [git]
 auto_hook = false
@@ -62,6 +63,7 @@ noise_keywords = ["format", "typo"]
 
 [codegraph]
 exclude_patterns = ["vendor/**", "third_party/**", "generated/**"]
+max_file_bytes = 2097152
 
 [server]
 transport = "stdio"
@@ -182,6 +184,11 @@ Common keys:
 - `inject = "minimal"` (`full`, `minimal`, `silent`)
 - `formation = "active"` (`active`, `shadow`, `fallback`)
 - `auto_cleanup = true`
+- `sync_advisory = true`
+
+The same values are available in legacy YAML under `behavior.*`. Existing
+`~/.memorix/config.json` behavior settings are retained only as a fallback for
+older installs.
 
 ### `[git]`
 
@@ -194,7 +201,7 @@ Common keys:
 - `max_diff_size = 500`
 - `skip_merge_commits = true`
 - `exclude_patterns = ["*.lock", "dist/**"]`
-- `noise_keywords = ["format", "typo"]`
+- `noise_keywords = ["format", "typo"]` (literal phrases, case-insensitive)
 
 Project identity is still resolved from the real `.git` root. A project
 `memorix.toml` is an override file under that root; it does not create or rename
@@ -202,18 +209,22 @@ the Memorix project ID.
 
 ### `[codegraph]`
 
-CodeGraph Memory and Project Context path filtering.
+CodeGraph Memory and Project Context scan limits.
 
 Common keys:
 
 - `exclude_patterns = ["vendor/**", "third_party/**", "generated/**"]`
+- `max_file_bytes = 2097152` (2 MiB per source file by default)
 
-Legacy YAML uses `codegraph.excludePatterns` for the same setting.
+Legacy YAML uses `codegraph.excludePatterns` and `codegraph.maxFileBytes` for
+the same settings.
 
 These patterns extend Memorix's built-in CodeGraph excludes (`node_modules`,
 build outputs, worktrees, and similar generated directories). Matching paths are
 skipped during CodeGraph indexing and hidden from Project Context / Context Pack
-suggested reads.
+suggested reads. Files larger than `max_file_bytes` are also skipped so a
+generated or minified source file cannot monopolize an incremental scan. Raise
+the limit only for a repository where that file is intentional source.
 
 ### `[server]`
 

--- a/docs/GIT_MEMORY.md
+++ b/docs/GIT_MEMORY.md
@@ -101,7 +101,7 @@ ingest_on_commit = true
 max_diff_size = 500
 skip_merge_commits = true
 exclude_patterns = ["*.lock", "dist/**"]
-noise_keywords = ["^BOT:", "auto-deploy"]
+noise_keywords = ["bot:", "auto-deploy"]
 ```
 
 Key settings:
@@ -111,7 +111,7 @@ Key settings:
 - `max_diff_size`: cap how much diff content is included
 - `skip_merge_commits`: skip merge commits by default
 - `exclude_patterns`: skip commits touching only matching files
-- `noise_keywords`: skip commits whose subjects match configured patterns
+- `noise_keywords`: skip commits containing configured literal phrases (case-insensitive)
 
 See [CONFIGURATION.md](CONFIGURATION.md) for the full configuration model.
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -14,6 +14,20 @@ Memorix is designed to be light for everyday memory use and explicit about heavi
 
 The default memory path uses local SQLite as the canonical store and Orama for search/indexing. No cloud service is required.
 
+## Interactive and Maintenance Boundaries
+
+MCP transport readiness is separate from full search-index readiness. The first
+project-scoped tools (`memorix_project_context`, `memorix_context_pack`,
+`memorix_graph_context`, and `memorix_codegraph_status`) read SQLite and
+CodeGraph Memory directly, so a new agent can get a useful brief without
+waiting for unrelated historical records to hydrate into Orama.
+
+Search, writes, and session operations still wait for the in-process retrieval
+runtime when they need it. Corpus-scale retention, consolidation, and Code
+Memory refresh are queued durably and run in an isolated child process. Vector
+backfill stays with the owning process because the Orama index is local to that
+process.
+
 ## What Is Lightweight
 
 - `memorix_session_start` is lightweight by default. It opens a memory/session context and does not join orchestration coordination state unless `joinTeam: true` is explicitly set.
@@ -29,6 +43,9 @@ On the release development machine used for this check, the healthy HTTP service
 - Docker image size mostly comes from Node, npm dependencies, build artifacts, and image layers. The container runtime should be judged separately from image size.
 - Dashboard browsing can add browser-side memory and CPU outside the Memorix Node process.
 - Large imports, Git log ingestion, workspace sync, and skill generation can temporarily increase CPU and disk I/O.
+- Code Memory refresh walks the project tree. It is incremental, skips common
+  dependency/build directories, caps files by count, and skips files over 2
+  MiB by default, but very large source trees still need time to scan.
 - LLM-backed formation, reranking, extraction, and skill generation add network latency and provider cost when enabled.
 - `memorix orchestrate` can run multiple agent workers. Parallel runs also create Git worktrees under `.worktrees/`, so expect extra disk usage until successful worktrees are merged and cleaned up.
 
@@ -41,6 +58,7 @@ On the release development machine used for this check, the healthy HTTP service
 | `MEMORIX_LLM_API_KEY` / `OPENAI_API_KEY` | unset | Enable LLM-backed enrichment, extraction, rerank, or skill generation |
 | `MEMORIX_LLM_TIMEOUT_MS` | `30000` (30 s) | Bound a single LLM-backed extraction/resolve call |
 | `MEMORIX_RERANK_TIMEOUT_MS` | provider default | Bound slow LLM rerank calls |
+| `[codegraph].max_file_bytes` | `2097152` | Raise only when a large file is intentional source that should enter Code Memory |
 | `memorix retention status` | report only | Inspect whether memory growth needs cleanup |
 | `memorix retention archive` | explicit | Archive expired memories when the project gets noisy |
 | `memorix memory deduplicate` / `consolidate` | explicit | Reduce duplicate or scattered memory records |
@@ -53,6 +71,9 @@ On the release development machine used for this check, the healthy HTTP service
 - For Docker, use it when you want a managed HTTP service. Do not use image size alone as the runtime memory estimate.
 - For orchestrated subagent work, expect CPU and disk activity proportional to the spawned agents and verification commands.
 - For release checks, measure build/test/pack separately from idle service cost.
+- When Dashboard shows queued or failed maintenance work, inspect
+  `/api/maintenance` on that local dashboard before assuming a Code Memory scan
+  or lifecycle task completed.
 
 ## Current Optimization Opportunities
 
@@ -61,4 +82,6 @@ These are not release blockers, but they are reasonable future improvements:
 - Add a lightweight benchmark command that reports startup time, index size, SQLite size, and search latency.
 - Add dashboard-side performance telemetry for API latency and payload sizes.
 - Document recommended retention schedules for large projects.
+- Evaluate a persistent cross-process retrieval index only as a major-version
+  architecture change; Orama is intentionally process-local today.
 - Explore slimmer Docker layers if image size becomes a common pain point.

--- a/docs/dev-log/progress.txt
+++ b/docs/dev-log/progress.txt
@@ -1,38 +1,65 @@
 # Memorix Development Progress
 
-> Current handoff note for new agent sessions. Older package-specific notes may
-> exist under subdirectories; prefer this file for repository-wide state.
+> Current handoff note for new agent sessions. Code and release facts outrank
+> older notes when they conflict.
 
 ## Current State
-- Phase: 1.1.10 emergency patch release
-- Branch: codex/issue-124-project-context-timeout
-- Issue: #124
-- Last updated: 2026-07-13
-- Goal: release the large-project `memorix_project_context` timeout fix and follow up with the reporter.
+- Phase: 1.1.11 runtime integrity, release-ready pending branch promotion
+- Branch: `codex/1.1.11-runtime-integrity`
+- Last updated: 2026-07-16
+- Goal: make normal memory writes, first-turn context, Code Memory refresh,
+  lifecycle maintenance, and operator diagnostics predictable as data grows.
 
 ## Completed Recently
-- Reproduced #124 with 3308 active memories and confirmed the old refresh path exceeded the MCP 60-second timeout.
-- Replaced broad per-observation symbol scans with indexed exact-name lookup and bulk existing-ref reads.
-- Changed first-use backfill to load one project graph snapshot, match all missing observations in memory, and persist refs in one transaction.
-- Reused one graph snapshot per project-context request and batched project refs/referenced symbols.
-- Prevented prose-only and ambiguous symbol mentions from creating large volumes of noisy code refs.
-- Preserved Ruby namespace and punctuated method names through Lite indexing and both binding paths.
-- Bumped root and workspace metadata to `1.1.10`.
-
-## Current Follow-Up
-- Commit, publish `memorix@1.1.10`, create the GitHub release, and reply to #124 with the upgrade path.
+- Replaced normal observation write/cleanup full-table persistence with targeted
+  SQLite mutations while preserving topic-key and generation safety.
+- Made retention and consolidation project-scoped, bounded, cursor-resumable
+  maintenance jobs.
+- Added a durable SQLite maintenance queue with leases, retries, heartbeat
+  renewal, credential-redacted failure records, and completed-history pruning.
+- Added a real compiled child-process runner for retention, consolidation, and
+  Code Memory refresh; vector recovery remains in the owning Orama process.
+- Made CodeGraph Lite incremental, multi-language, dependency-aware, and safe
+  against oversized generated files. `codegraph.max_file_bytes` / TOML
+  `max_file_bytes` controls the per-file limit.
+- Let the project context, context pack, graph context, and Code Memory status
+  tools answer directly from project-scoped SQLite before full Orama hydration.
+- Added control-plane maintenance target registration and dashboard maintenance
+  diagnostics without crossing HTTP session runtime state.
+- Removed the obsolete JSON file watcher; SQLite generation checks now own
+  cross-process freshness.
+- Unified behavior settings with resolved TOML/YAML configuration so injection,
+  formation, auto-cleanup, and sync advisory do not silently fall back to a
+  separate legacy JSON path.
+- Updated dashboard System Status with maintenance state and made dashboard
+  navigation/content work on a 390px mobile viewport.
+- Added a non-root Docker regression check.
+- Made completed-job pruning part of the enqueue transaction, so a failed
+  enqueue cannot leave partially-pruned operator history behind.
 
 ## Verification Snapshot
-- TDD regression coverage passes for CodeGraph store, binder, project context, and auto context.
-- A copied real database with all refs removed improved from 57.9 seconds for 173 active memories to 12.4 seconds.
-- A scaled 3308-active first-use refresh completed in 13.3 seconds, including a forced code scan and full code-ref backfill.
-- Built stdio MCP smoke returned `memorix_project_context` successfully in 5.79 seconds.
-- Final release verification: `git diff --check`, `npm run lint`, `npm run build`, `npm test`, package dry-run, and clean-install npm smoke.
+- The full test suite passes, including runtime, CodeGraph, configuration,
+  server, dashboard, Docker, and cross-process freshness coverage.
+- `npm run lint` passes.
+- `npm run build` passes and emits `dist/maintenance-runner.js`.
+- Built runner smoke completed a real retention job through stdin/stdout.
+- Built stdio MCP smoke connected in about one second, listed 17 lite tools,
+  and called project context, context pack, graph context, and Code Memory
+  status successfully in a fresh temporary Git project.
+- Dashboard was checked in a real browser at 1440x900 and 390x844; maintenance
+  status is visible and no text is clipped by the mobile layout.
+- `npm pack --dry-run`, an actual `npm pack`, a clean temporary install, and a
+  built stdio MCP smoke all pass. Production dependency audit reports zero
+  vulnerabilities.
+- A read-only local Claude Code release review found no P0 issues; its one
+  confirmed queue transaction finding has a regression test and is fixed.
 
-## Known UX Notes
-- Before 1.1.10, `refresh: "never"` is a temporary workaround for very large active-memory corpora.
-- Current code and release facts outrank stale handoff notes or older dev logs when they conflict.
+## Known Boundary
+- Orama remains process-local. Search and stateful write/session tools still
+  wait for full runtime hydration; bootstrap-safe context tools do not.
+- CodeGraph Lite is an incremental local structural map, not a replacement for
+  an AST/language-server intelligence product.
 
 ## Next Steps
-- Commit and push the 1.1.10 release patch.
-- Tag, publish the root package, create the GitHub release, and reply to #124.
+- Commit the verified 1.1.11 change set, promote it through the normal `main`
+  branch flow, tag `v1.1.11`, and publish the already-verified npm package.

--- a/docs/superpowers/specs/2026-07-14-runtime-integrity-1.1.11-design.md
+++ b/docs/superpowers/specs/2026-07-14-runtime-integrity-1.1.11-design.md
@@ -1,0 +1,140 @@
+# Runtime Integrity 1.1.11 Design
+
+Branch: `codex/1.1.11-runtime-integrity`
+Date: 2026-07-14
+Status: implemented, awaiting release verification
+
+## Summary
+
+1.1.11 is a reliability release. It makes Memorix behave like a durable local
+runtime instead of a collection of synchronous maintenance paths hidden behind
+MCP calls. The release focuses on the paths a coding agent experiences first:
+startup, first context, writes, retrieval, Code Memory refresh, and operator
+diagnostics.
+
+The design keeps Memorix local-first. SQLite remains the source of truth;
+Orama remains the in-process retrieval index. The release does not pretend that
+all expensive work is free or instantaneous. It makes the boundary explicit:
+interactive tools return project-scoped persisted state, while corpus-scale
+work has a durable queue and runs outside the MCP request path.
+
+## Product Contract
+
+- An MCP handshake and the first project brief must not wait for a full
+  all-project Orama hydration.
+- A normal memory write must not rewrite the whole observation corpus.
+- Code Memory refresh, retention, and consolidation must not execute inside a
+  tool handler or the HTTP control-plane event loop.
+- Maintenance must survive a process restart, be observable, retry safely, and
+  not grow its own history forever.
+- A context brief may use the latest completed Code Memory scan, but must say
+  when a refresh is queued instead of implying that a scan already happened.
+- Dashboard and HTTP control-plane reads must stay project-scoped.
+
+## Readiness Model
+
+Memorix has three independent readiness states:
+
+1. **Transport readiness**: MCP initialize and `tools/list` are complete.
+2. **Interactive readiness**: project-scoped SQLite reads can answer the
+   initial context, graph-context, context-pack, and Code Memory status tools.
+3. **Maintenance readiness**: Orama hydration, vector recovery, retention,
+   consolidation, and Code Memory refresh are working or queued.
+
+Only tools that truly need the in-memory retrieval index wait for full runtime
+initialization. This is deliberate: a compact project brief is more valuable
+than making a new agent wait for unrelated historical data to load.
+
+## P1-P9 Delivery
+
+### P1: Targeted Persistence
+
+- Replace normal observation writes and status changes with targeted SQLite
+  reads/mutations.
+- Preserve topic-key convergence and generation-based cross-process freshness.
+
+### P2: Bounded Lifecycle Work
+
+- Make retention and consolidation page through one project with durable
+  cursors.
+- Treat explicit global archival/export as operator operations, not normal MCP
+  request work.
+
+### P3: Durable Maintenance Ledger
+
+- Add SQLite-backed jobs with dedupe keys, leases, heartbeat renewal, retry
+  backoff, and resumable payloads.
+- Prune completed task history after seven days while keeping failed diagnostics
+  available to operators. Sanitize credentials before persisting failures.
+
+### P4: Real Isolation for Heavy Work
+
+- Run retention, consolidation, and Code Memory refresh in a built child
+  runner, not a timer callback in the MCP process.
+- Keep vector backfill in the owning process because Orama is process-local.
+
+### P5: Incremental Code Memory at Scale
+
+- Refresh changed files only; retain unchanged file metadata and remove deleted
+  graph records safely.
+- Exclude dependency/build directories by default, cap scans by file count,
+  and skip source files larger than 2 MiB by default. The file cap is
+  configurable through `codegraph.max_file_bytes` / `max_file_bytes`.
+
+### P6: First-Tool MCP Boundary
+
+- Let `memorix_project_context`, `memorix_context_pack`,
+  `memorix_graph_context`, and `memorix_codegraph_status` read project-scoped
+  stores before full Orama hydration.
+- Keep search, writes, sessions, and all stateful operations behind full
+  runtime initialization.
+
+### P7: Cross-Process Correctness
+
+- Remove the obsolete JSON polling watcher. SQLite generation checks are the
+  authoritative cross-process refresh mechanism.
+- Register HTTP control-plane project roots durably so shared workers can run
+  isolated maintenance against the correct project.
+- Resolve runtime behavior through the same TOML/YAML chain as the rest of the
+  product, with legacy JSON behavior only as a fallback.
+
+### P8: Operator Surface and Deployment Safety
+
+- Expose maintenance summary and job diagnostics through dashboard APIs and
+  the existing System Status panel.
+- Keep the production image non-root and cover it with a release test.
+- Make the dashboard usable on mobile by replacing the desktop sidebar with a
+  compact wrapping navigation layout.
+
+### P9: Verification and Release
+
+- Cover queue leases, retries, history retention, credential redaction,
+  isolated child execution, incremental Code Memory, config resolution,
+  project-scoped dashboard reads, and bootstrap-safe tools.
+- Build the package, smoke the actual child runner, and connect a standards
+  compliant MCP client to the built stdio server.
+
+## Design Influences
+
+Cognee is useful as a design reference for separating durable knowledge state
+from compute-heavy graph enrichment and for treating lifecycle/decay as part of
+the product rather than a cleanup script. Memorix retains a different product
+shape: local project memory for existing coding agents, without requiring a
+remote graph service or making all context a graph query.
+
+## Non-Goals
+
+- Replacing a full AST code intelligence product or claiming CodeGraph Lite is
+  equivalent to a language server.
+- Moving Orama to a cross-process shared index in this patch release.
+- Adding cloud synchronization, new agent protocols, or a new user command
+  family.
+- Automatically deleting failed maintenance diagnostics.
+
+## Remaining Architectural Boundary
+
+Search remains backed by a process-local Orama index and therefore still needs
+full runtime hydration before the first search. The new bootstrap-safe tools
+give an agent useful, project-scoped context immediately; replacing Orama with
+a shared persistent retrieval index is a separate major-version decision, not
+a hidden 1.1.x refactor.

--- a/memorix.example.yml
+++ b/memorix.example.yml
@@ -45,9 +45,16 @@ git:
   # excludePatterns:        # File glob patterns — commits touching ONLY these are skipped
   #   - "*.lock"
   #   - "dist/**"
-  # noiseKeywords:          # Regex patterns — commits matching these subjects are skipped
-  #   - "^BOT:"             # Skip bot-generated commits
+  # noiseKeywords:          # Literal phrases (case-insensitive) — matching commits are skipped
+  #   - "bot:"              # Skip bot-generated commits
   #   - "auto-deploy"       # Skip CI deploy commits
+
+# ── CodeGraph Memory ──────────────────────────────────────────
+# Build an incremental local code map for task context. Large generated files
+# are skipped by default; lower this only when a repository needs it.
+# codegraph:
+#   # excludePatterns: ["vendor/**", "generated/**"]
+#   maxFileBytes: 2097152   # 2 MiB default per source file
 
 # ── Behavior Settings ────────────────────────────────────────
 behavior:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.1.10",
+      "version": "1.1.11",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",
@@ -9495,10 +9495,10 @@
     },
     "packages/agent-core": {
       "name": "@memorix/agent-core",
-      "version": "1.1.10",
+      "version": "1.1.11",
       "license": "MIT",
       "dependencies": {
-        "@memorix/ai": "1.1.10",
+        "@memorix/ai": "1.1.11",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -9566,7 +9566,7 @@
     },
     "packages/ai": {
       "name": "@memorix/ai",
-      "version": "1.1.10",
+      "version": "1.1.11",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
@@ -9611,12 +9611,12 @@
     },
     "packages/memcode": {
       "name": "@memorix/memcode",
-      "version": "1.1.10",
+      "version": "1.1.11",
       "license": "MIT",
       "dependencies": {
-        "@memorix/agent-core": "1.1.10",
-        "@memorix/ai": "1.1.10",
-        "@memorix/tui": "1.1.10",
+        "@memorix/agent-core": "1.1.11",
+        "@memorix/ai": "1.1.11",
+        "@memorix/tui": "1.1.11",
         "@opentui/core": "^0.3.4",
         "@opentui/react": "^0.3.4",
         "@silvia-odwyer/photon-node": "0.3.4",
@@ -9714,7 +9714,7 @@
     },
     "packages/tui": {
       "name": "@memorix/tui",
-      "version": "1.1.10",
+      "version": "1.1.11",
       "license": "MIT",
       "dependencies": {
         "get-east-asian-width": "1.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/packages/agent-core/package.json
+++ b/packages/agent-core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@memorix/agent-core",
-	"version": "1.1.10",
+	"version": "1.1.11",
 	"description": "General-purpose agent with transport abstraction, state management, and attachment support",
 	"type": "module",
 	"main": "./dist/index.js",
@@ -29,7 +29,7 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@memorix/ai": "1.1.10",
+		"@memorix/ai": "1.1.11",
 		"ignore": "7.0.5",
 		"typebox": "1.1.38",
 		"yaml": "2.9.0"

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@memorix/ai",
-	"version": "1.1.10",
+  "version": "1.1.11",
 	"description": "Unified LLM API with automatic model discovery and provider configuration",
 	"type": "module",
 	"main": "./dist/index.js",

--- a/packages/memcode/package.json
+++ b/packages/memcode/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@memorix/memcode",
-	"version": "1.1.10",
+	"version": "1.1.11",
 	"description": "Memorix-native coding agent CLI with terminal chat, project memory, hooks, and session management",
 	"type": "module",
 	"piConfig": {
@@ -34,9 +34,9 @@
 		"prepublishOnly": "npm run clean && npm run build"
 	},
 	"dependencies": {
-		"@memorix/agent-core": "1.1.10",
-		"@memorix/ai": "1.1.10",
-		"@memorix/tui": "1.1.10",
+		"@memorix/agent-core": "1.1.11",
+		"@memorix/ai": "1.1.11",
+		"@memorix/tui": "1.1.11",
 		"@opentui/core": "^0.3.4",
 		"@opentui/react": "^0.3.4",
 		"@silvia-odwyer/photon-node": "0.3.4",

--- a/packages/tui/package.json
+++ b/packages/tui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@memorix/tui",
-	"version": "1.1.10",
+  "version": "1.1.11",
 	"description": "Terminal User Interface library with differential rendering for efficient text-based applications",
 	"type": "module",
 	"main": "dist/index.js",

--- a/src/cli/commands/cleanup.ts
+++ b/src/cli/commands/cleanup.ts
@@ -14,8 +14,10 @@
  */
 
 import { defineCommand } from 'citty';
+import type { Observation } from '../../types.js';
 import { detectProject } from '../../project/detector.js';
 import { getProjectDataDir } from '../../store/persistence.js';
+import type { ObservationStore } from '../../store/obs-store.js';
 import { getObservationStore, initObservationStore } from '../../store/obs-store.js';
 
 /** Patterns that indicate auto-generated, low-value observations */
@@ -62,6 +64,39 @@ function isNoisePollution(obs: { title?: string; narrative?: string; entityName?
         if (p.test(text)) return { isNoise: true, reason: 'demo/test/noise' };
     }
     return { isNoise: false, reason: '' };
+}
+
+function requireObservationIds(observations: Observation[], action: string): number[] {
+    const ids = observations.map((observation) => observation.id);
+    if (ids.some((id) => typeof id !== 'number')) {
+        throw new Error(`Cannot ${action}: an observation has no persisted ID.`);
+    }
+    return ids as number[];
+}
+
+/**
+ * Apply cleanup mutations without replacing the shared observation table.
+ * Keeping lifecycle updates targeted prevents a cleanup in one project from
+ * overwriting observations written concurrently by another project.
+ */
+export async function applyCleanupMutations(
+    store: ObservationStore,
+    toArchive: Observation[],
+    toRemove: Observation[],
+): Promise<{ archived: number; removed: number }> {
+    const archiveIds = requireObservationIds(toArchive, 'archive');
+    const removeIds = requireObservationIds(toRemove, 'delete');
+    const removals = new Set(removeIds);
+    if (archiveIds.some((id) => removals.has(id))) {
+        throw new Error('Cleanup cannot archive and delete the same observation.');
+    }
+
+    await store.atomic(async (tx) => {
+        await Promise.all(archiveIds.map((id) => tx.setStatus(id, 'archived')));
+        await Promise.all(removeIds.map((id) => tx.remove(id)));
+    });
+
+    return { archived: archiveIds.length, removed: removeIds.length };
 }
 
 export default defineCommand({
@@ -112,7 +147,8 @@ export default defineCommand({
 
         const dataDir = await getProjectDataDir(projectId);
         await initObservationStore(dataDir);
-        const allObs = await getObservationStore().loadAll() as Array<{
+        const store = getObservationStore();
+        const projectObs = await store.loadByProject(projectId, { status: 'active' }) as Array<{
             id?: number;
             type?: string;
             title?: string;
@@ -125,13 +161,10 @@ export default defineCommand({
             status?: string;
         }>;
 
-        if (allObs.length === 0) {
+        if (projectObs.length === 0) {
             console.log('[OK] No observations found - nothing to clean up.');
             return;
         }
-
-        // Filter to project-scoped observations only
-        const projectObs = allObs.filter(o => o.projectId === projectId && (o.status ?? 'active') === 'active');
 
         // Categorize: low-quality
         const lowQuality = projectObs.filter(o => isLowQuality(o.title ?? ''));
@@ -231,25 +264,16 @@ export default defineCommand({
             }
         }
 
-        // Archive noise observations (set status to 'archived' instead of deleting)
-        const archiveIds = new Set(toArchive.map(o => o.id));
-        let archivedCount = 0;
-        for (const obs of allObs) {
-            if (archiveIds.has(obs.id)) {
-                (obs as any).status = 'archived';
-                archivedCount++;
-            }
-        }
-
-        // Delete low-quality/duplicate observations
-        const removeIds = new Set(toRemove.map(o => JSON.stringify(o)));
-        const remaining = allObs.filter(o => !removeIds.has(JSON.stringify(o)));
-
-        await getObservationStore().bulkReplace(remaining as any);
+        const mutation = await applyCleanupMutations(
+            store,
+            toArchive as Observation[],
+            toRemove as Observation[],
+        );
+        const remainingActive = projectObs.length - mutation.archived - mutation.removed;
 
         const parts: string[] = [];
-        if (toRemove.length > 0) parts.push(`deleted ${toRemove.length}`);
-        if (archivedCount > 0) parts.push(`archived ${archivedCount}`);
-        console.log(`[OK] ${parts.join(', ')}. ${remaining.length} observations remaining.`);
+        if (mutation.removed > 0) parts.push(`deleted ${mutation.removed}`);
+        if (mutation.archived > 0) parts.push(`archived ${mutation.archived}`);
+        console.log(`[OK] ${parts.join(', ')}. ${remainingActive} active observations remain in ${projectId}.`);
     },
 });

--- a/src/cli/commands/codegraph.ts
+++ b/src/cli/commands/codegraph.ts
@@ -1,6 +1,6 @@
 import { defineCommand } from 'citty';
 import { CodeGraphStore } from '../../codegraph/store.js';
-import { indexProjectLite } from '../../codegraph/lite-provider.js';
+import { refreshProjectLite } from '../../codegraph/lite-provider.js';
 import { assembleContextPackForTask, buildContextPackPrompt } from '../../codegraph/context-pack.js';
 import { backfillMissingObservationCodeRefs } from '../../codegraph/binder.js';
 import { getResolvedConfig } from '../../config/resolved-config.js';
@@ -50,7 +50,8 @@ export default defineCommand({
       const store = new CodeGraphStore();
       await store.init(dataDir);
       const explicitAction = Boolean(positional[0] || (args.action as string | undefined));
-      const exclude = getResolvedConfig({ projectRoot: project.rootPath }).codegraph.excludePatterns;
+      const codegraphConfig = getResolvedConfig({ projectRoot: project.rootPath }).codegraph;
+      const exclude = codegraphConfig.excludePatterns;
 
       switch (action) {
         case 'status': {
@@ -63,21 +64,22 @@ export default defineCommand({
         }
 
         case 'refresh': {
-          const indexed = await indexProjectLite({
+          const refresh = await refreshProjectLite(store, {
             projectId: project.id,
             projectRoot: project.rootPath,
             exclude,
+            maxFileBytes: codegraphConfig.maxFileBytes,
           });
-          store.replaceProjectIndex(project.id, indexed);
           const activeObservations = getAllObservations()
             .filter(obs => obs.projectId === project.id && (obs.status ?? 'active') === 'active');
           const backfill = await backfillMissingObservationCodeRefs(store, activeObservations);
           const status = store.status(project.id);
           emitResult(
-            { project, status, backfill },
+            { project, status, refresh, backfill },
             [
               'CodeGraph Memory refreshed.',
               formatStatus(status),
+              `- Files: ${refresh.changedFiles} changed, ${refresh.unchangedFiles} unchanged, ${refresh.removedFiles} removed`,
               `- Backfilled memories: ${backfill.observationsBackfilled}`,
               `- Backfilled refs: ${backfill.refsBackfilled}`,
             ].join('\n'),

--- a/src/cli/commands/retention.ts
+++ b/src/cli/commands/retention.ts
@@ -65,7 +65,7 @@ export default defineCommand({
         }
 
         case 'archive': {
-          const result = await archiveExpired(dataDir);
+          const result = await archiveExpired(dataDir, undefined, undefined, project.id);
           emitResult(
             { project, result },
             result.archived === 0
@@ -105,4 +105,3 @@ export default defineCommand({
     }
   },
 });
-

--- a/src/cli/commands/serve-http.ts
+++ b/src/cli/commands/serve-http.ts
@@ -512,6 +512,15 @@ export default defineCommand({
     const defaultDataDir = await getProjectDataDir(defaultProject.id);
     const baseDir = getBaseDataDir();
 
+    // HTTP sessions intentionally keep their own runtime globals. This worker
+    // only claims jobs that can run in an isolated process; vector recovery
+    // stays with the owning MCP session because Orama is process-local.
+    const { createControlPlaneMaintenanceWorker } = await import('../../runtime/control-plane-maintenance.js');
+    const controlPlaneMaintenanceWorker = createControlPlaneMaintenanceWorker(defaultDataDir, {
+      pollIntervalMs: 2_000,
+    });
+    controlPlaneMaintenanceWorker.start();
+
     // Cache resolved project data dirs to avoid repeated fs lookups
     const projectDataDirCache = new Map<string, string>();
     projectDataDirCache.set(defaultProject.id, defaultDataDir);
@@ -549,6 +558,15 @@ export default defineCommand({
     async function loadDashboardObservations(dataDir: string) {
       const store = await getDashboardObservationStore(dataDir);
       return store.loadAll();
+    }
+
+    async function loadDashboardProjectObservations(
+      dataDir: string,
+      projectId: string,
+      status?: string,
+    ) {
+      const store = await getDashboardObservationStore(dataDir);
+      return store.loadByProject(projectId, status ? { status } : undefined);
     }
 
     // Resolve static directory (dist/dashboard/static)
@@ -737,8 +755,7 @@ export default defineCommand({
           await initGraphStore(statsDataDir);
           const graph = { entities: getGraphStore().loadEntities(), relations: getGraphStore().loadRelations() };
 
-          const allObs = await loadDashboardObservations(statsDataDir) as Array<{
-            projectId?: string;
+          const observations = await loadDashboardProjectObservations(statsDataDir, statsProjectId, 'active') as Array<{
             type?: string;
             id?: number;
             title?: string;
@@ -751,7 +768,6 @@ export default defineCommand({
             importance?: number;
             accessCount?: number;
           }>;
-          const observations = allObs.filter(o => o.projectId === statsProjectId && (o.status ?? 'active') === 'active');
           const statsStore = await getDashboardObservationStore(statsDataDir);
           const nextId = await statsStore.loadIdCounter();
           const typeCounts: Record<string, number> = {};
@@ -820,7 +836,7 @@ export default defineCommand({
           let vectorStatus = { total: 0, missing: 0, missingIds: [] as number[], backfillRunning: false };
           try {
             const { getVectorStatus } = await import('../../memory/observations.js');
-            vectorStatus = getVectorStatus();
+            vectorStatus = getVectorStatus(statsProjectId);
           } catch { /* best effort */ }
 
           // Real search mode from the last actual search execution
@@ -851,6 +867,12 @@ export default defineCommand({
           const projectEntitySet = new Set(projectEntities.map((e: any) => e.name));
           const projectRelations = graph.relations.filter((r: any) => projectEntitySet.has(r.from) && projectEntitySet.has(r.to));
 
+          let maintenance = { total: 0, pending: 0, running: 0, retrying: 0, completed: 0, failed: 0 };
+          try {
+            const { MaintenanceJobStore } = await import('../../runtime/maintenance-jobs.js');
+            maintenance = new MaintenanceJobStore(statsDataDir).summary(statsProjectId);
+          } catch { /* optional maintenance diagnostics */ }
+
           sendJson({
             entities: projectEntities.length,
             relations: projectRelations.length,
@@ -869,14 +891,25 @@ export default defineCommand({
               recentMemories: recentGitMemories,
             },
             retentionSummary,
+            maintenance,
+          });
+          return;
+        }
+
+        if (apiPath === '/maintenance') {
+          const { projectId: maintenanceProjectId, dataDir: maintenanceDataDir } = await resolveRequestProject(url);
+          const { MaintenanceJobStore } = await import('../../runtime/maintenance-jobs.js');
+          const queue = new MaintenanceJobStore(maintenanceDataDir);
+          sendJson({
+            summary: queue.summary(maintenanceProjectId),
+            jobs: queue.list({ projectId: maintenanceProjectId, limit: 50 }),
           });
           return;
         }
 
         if (apiPath === '/observations') {
           const { projectId: obsProjectId, dataDir: obsDataDir } = await resolveRequestProject(url);
-          const allObs = await loadDashboardObservations(obsDataDir) as Array<{ projectId?: string; status?: string }>;
-          sendJson(allObs.filter(o => o.projectId === obsProjectId && (o.status ?? 'active') === 'active'));
+          sendJson(await loadDashboardProjectObservations(obsDataDir, obsProjectId, 'active'));
           return;
         }
 
@@ -887,10 +920,10 @@ export default defineCommand({
           const fullGraph = { entities: getGraphStore().loadEntities(), relations: getGraphStore().loadRelations() };
 
           // Project-scope the graph: only include entities that have observations in this project
-          const allObs = await loadDashboardObservations(graphDataDir) as Array<{ projectId?: string; entityName?: string; status?: string }>;
+          const allObs = await loadDashboardProjectObservations(graphDataDir, graphProjectId, 'active') as Array<{ entityName?: string }>;
           const projectEntityNames = new Set(
             allObs
-              .filter(o => o.projectId === graphProjectId && (o.status ?? 'active') === 'active' && o.entityName)
+              .filter(o => o.entityName)
               .map(o => o.entityName!)
           );
 
@@ -913,8 +946,7 @@ export default defineCommand({
 
         if (apiPath === '/retention') {
           const { projectId: retProjectId, dataDir: retDataDir } = await resolveRequestProject(url);
-          const allObs = await loadDashboardObservations(retDataDir) as Array<{ projectId?: string; id?: number; title?: string; type?: string; importance?: number; accessCount?: number; lastAccessedAt?: string; createdAt?: string; entityName?: string; status?: string }>;
-          const observations = allObs.filter(o => o.projectId === retProjectId && (o.status ?? 'active') === 'active');
+          const observations = await loadDashboardProjectObservations(retDataDir, retProjectId, 'active') as Array<{ id?: number; title?: string; type?: string; importance?: number; accessCount?: number; lastAccessedAt?: string; createdAt?: string; entityName?: string }>;
           const now = Date.now();
           const scored = observations.map(obs => {
             const age = now - new Date(obs.createdAt || now).getTime();
@@ -940,13 +972,11 @@ export default defineCommand({
         if (apiPath === '/knowledge') {
           const { projectId: kbProjectId, dataDir: kbDataDir } = await resolveRequestProject(url);
           const { generateKnowledgeBase } = await import('../../wiki/generator.js');
-          const { initObservations, getAllObservations } = await import('../../memory/observations.js');
           const { initMiniSkillStore, getMiniSkillStore } = await import('../../store/mini-skill-store.js');
 
-          await initObservations(kbDataDir);
           await initMiniSkillStore(kbDataDir);
 
-          const allObs = getAllObservations();
+          const allObs = await loadDashboardProjectObservations(kbDataDir, kbProjectId, 'active');
           const skills = await getMiniSkillStore().loadByProject(kbProjectId);
 
           const overview = generateKnowledgeBase({
@@ -962,23 +992,21 @@ export default defineCommand({
         if (apiPath === '/knowledge-graph') {
           const { projectId: kgProjectId, dataDir: kgDataDir } = await resolveRequestProject(url);
           const { generateKnowledgeGraph } = await import('../../wiki/knowledge-graph.js');
-          const { initObservations, getAllObservations } = await import('../../memory/observations.js');
           const { initMiniSkillStore, getMiniSkillStore } = await import('../../store/mini-skill-store.js');
           const { initGraphStore, getGraphStore } = await import('../../store/graph-store.js');
 
-          await initObservations(kgDataDir);
           await initMiniSkillStore(kgDataDir);
           await initGraphStore(kgDataDir);
 
-          const allObs = getAllObservations();
+          const allObs = await loadDashboardProjectObservations(kgDataDir, kgProjectId, 'active');
           const skills = await getMiniSkillStore().loadByProject(kgProjectId);
 
           // Project-scope graph store (same logic as /api/graph)
           const fullGraph = { entities: getGraphStore().loadEntities(), relations: getGraphStore().loadRelations() };
-          const graphObs = await loadDashboardObservations(kgDataDir) as Array<{ projectId?: string; entityName?: string; status?: string }>;
+          const graphObs = await loadDashboardProjectObservations(kgDataDir, kgProjectId, 'active') as Array<{ entityName?: string }>;
           const projectEntityNames = new Set(
             graphObs
-              .filter(o => o.projectId === kgProjectId && (o.status ?? 'active') === 'active' && o.entityName)
+              .filter(o => o.entityName)
               .map(o => o.entityName!)
           );
           const scopedEntities = fullGraph.entities.filter(e => projectEntityNames.has(e.name));
@@ -1299,8 +1327,7 @@ export default defineCommand({
           const obsId = parseInt(deleteMatch[1], 10);
           const { projectId: delProjectId, dataDir: delDataDir } = await resolveRequestProject(url);
           const store = await getDashboardObservationStore(delDataDir);
-          const allObs = await store.loadAll();
-          const matchObs = allObs.find((o: any) => o.id === obsId);
+          const matchObs = await store.getById(obsId);
           if (!matchObs) {
             sendJson({ error: 'Observation not found' }, 404);
           } else if ((matchObs as any).projectId !== delProjectId) {
@@ -1331,8 +1358,7 @@ export default defineCommand({
           const { initGraphStore, getGraphStore } = await import('../../store/graph-store.js');
           await initGraphStore(expDataDir);
           const fullGraph = { entities: getGraphStore().loadEntities(), relations: getGraphStore().loadRelations() };
-          const allObs = await loadDashboardObservations(expDataDir) as Array<{ projectId?: string; entityName?: string; status?: string }>;
-          const observations = allObs.filter(o => o.projectId === expProjectId && (o.status ?? 'active') === 'active');
+          const observations = await loadDashboardProjectObservations(expDataDir, expProjectId, 'active') as Array<{ entityName?: string }>;
           const expStore = await getDashboardObservationStore(expDataDir);
           const nextId = await expStore.loadIdCounter();
           const exportEntityNames = new Set(
@@ -1502,6 +1528,7 @@ export default defineCommand({
         console.error(`[memorix] ${suppressedProbeCount} probe connection(s) suppressed during this session`);
       }
       console.error('[memorix] Shutting down HTTP server...');
+      controlPlaneMaintenanceWorker.stop();
       // Clean up readiness and heartbeat files
       try {
         const memorixDir = (process.env.HOME || process.env.USERPROFILE || '').replace(/\\/g, '/') + '/.memorix';

--- a/src/codegraph/auto-context.ts
+++ b/src/codegraph/auto-context.ts
@@ -4,7 +4,7 @@ import { getResolvedConfig } from '../config/resolved-config.js';
 import type { ProjectInfo } from '../types.js';
 import { backfillMissingObservationCodeRefs, type CodeRefBackfillResult } from './binder.js';
 import { collectCurrentProjectFacts, type CurrentProjectFacts } from './current-facts.js';
-import { indexProjectLite } from './lite-provider.js';
+import { refreshProjectLite } from './lite-provider.js';
 import {
   buildProjectContextExplain,
   type ProjectContextExplain,
@@ -27,7 +27,7 @@ export type AutoContextRefreshMode = 'auto' | 'always' | 'never';
 export interface AutoContextRefreshResult {
   mode: AutoContextRefreshMode;
   performed: boolean;
-  reason: 'forced' | 'empty-index' | 'missing-scan-time' | 'stale-index' | 'fresh-enough' | 'disabled' | 'failed';
+  reason: 'forced' | 'empty-index' | 'missing-scan-time' | 'stale-index' | 'fresh-enough' | 'disabled' | 'queued' | 'failed';
   message: string;
   backfill?: CodeRefBackfillResult;
 }
@@ -101,12 +101,20 @@ export async function buildAutoProjectContext(input: {
   maxAgeMs?: number;
   now?: Date;
   exclude?: string[];
+  maxFileBytes?: number;
+  /**
+   * When supplied, a needed refresh is queued instead of running in this
+   * request. MCP and hook callers use this to keep their response path fast.
+   */
+  enqueueRefresh?: () => void | Promise<void>;
 }): Promise<AutoProjectContext> {
   const refreshMode = input.refresh ?? 'auto';
   const now = input.now ?? new Date();
   const task = input.task?.trim();
   const lens = resolveTaskLens(task);
-  const exclude = input.exclude ?? getResolvedConfig({ projectRoot: input.project.rootPath }).codegraph.excludePatterns;
+  const codegraphConfig = getResolvedConfig({ projectRoot: input.project.rootPath }).codegraph;
+  const exclude = input.exclude ?? codegraphConfig.excludePatterns;
+  const maxFileBytes = input.maxFileBytes ?? codegraphConfig.maxFileBytes;
   const store = new CodeGraphStore();
   await store.init(input.dataDir);
 
@@ -124,25 +132,44 @@ export async function buildAutoProjectContext(input: {
   };
 
   if (decision.performed) {
-    try {
-      const indexed = await indexProjectLite({
-        projectId: input.project.id,
-        projectRoot: input.project.rootPath,
-        exclude,
-      });
-      store.replaceProjectIndex(input.project.id, indexed);
-      const backfill = await backfillMissingObservationCodeRefs(
-        store,
-        activeProjectObservations(input.observations, input.project.id) as any,
-      );
-      refresh = { ...refresh, backfill };
-    } catch (error) {
-      refresh = {
-        mode: refreshMode,
-        performed: false,
-        reason: 'failed',
-        message: `Project scan failed: ${error instanceof Error ? error.message : String(error)}`,
-      };
+    if (input.enqueueRefresh) {
+      try {
+        await input.enqueueRefresh();
+        refresh = {
+          mode: refreshMode,
+          performed: false,
+          reason: 'queued',
+          message: 'Code Memory refresh queued; this brief uses the latest completed scan.',
+        };
+      } catch (error) {
+        refresh = {
+          mode: refreshMode,
+          performed: false,
+          reason: 'failed',
+          message: `Could not queue Code Memory refresh: ${error instanceof Error ? error.message : String(error)}`,
+        };
+      }
+    } else {
+      try {
+        await refreshProjectLite(store, {
+          projectId: input.project.id,
+          projectRoot: input.project.rootPath,
+          exclude,
+          maxFileBytes,
+        });
+        const backfill = await backfillMissingObservationCodeRefs(
+          store,
+          activeProjectObservations(input.observations, input.project.id) as any,
+        );
+        refresh = { ...refresh, backfill };
+      } catch (error) {
+        refresh = {
+          mode: refreshMode,
+          performed: false,
+          reason: 'failed',
+          message: `Project scan failed: ${error instanceof Error ? error.message : String(error)}`,
+        };
+      }
     }
   }
 

--- a/src/codegraph/exclude.ts
+++ b/src/codegraph/exclude.ts
@@ -9,6 +9,16 @@ export const DEFAULT_CODEGRAPH_EXCLUDES = [
   '.tmp/**',
   '.worktrees/**',
   '.claude/worktrees/**',
+  'vendor/**',
+  '.venv/**',
+  'venv/**',
+  '.tox/**',
+  'target/**',
+  '.gradle/**',
+  '.mvn/**',
+  'obj/**',
+  'Pods/**',
+  'DerivedData/**',
 ];
 
 export function normalizeCodeGraphExcludePatterns(exclude?: string[]): string[] {

--- a/src/codegraph/lite-provider.ts
+++ b/src/codegraph/lite-provider.ts
@@ -4,19 +4,36 @@ import { join, relative } from 'node:path';
 import type { CodeEdge, CodeFile, CodeSymbol } from './types.js';
 import { makeCodeEdgeId, makeCodeFileId, makeCodeSymbolId, normalizeCodePath } from './ids.js';
 import { isCodeGraphExcludedPath, normalizeCodeGraphExcludePatterns } from './exclude.js';
+import { CodeGraphStore, type CodeGraphFileDelta } from './store.js';
 
 export interface LiteIndexOptions {
   projectId: string;
   projectRoot: string;
   exclude?: string[];
   maxFiles?: number;
+  maxFileBytes?: number;
 }
 
 export interface LiteIndexResult {
   files: CodeFile[];
   symbols: CodeSymbol[];
   edges: CodeEdge[];
+  skippedOversizedFiles: number;
 }
+
+export interface LiteRefreshResult {
+  scannedFiles: number;
+  changedFiles: number;
+  unchangedFiles: number;
+  metadataOnlyFiles: number;
+  removedFiles: number;
+  indexedSymbols: number;
+  indexedEdges: number;
+  skippedOversizedFiles: number;
+  removalScanDeferred: boolean;
+}
+
+export const DEFAULT_CODEGRAPH_MAX_FILE_BYTES = 2 * 1024 * 1024;
 
 const LANGUAGE_BY_EXTENSION = new Map<string, string>([
   ['.ts', 'typescript'],
@@ -170,6 +187,11 @@ function languageForPath(path: string): string {
   return LANGUAGE_BY_EXTENSION.get(ext) ?? 'unknown';
 }
 
+function resolveMaxFileBytes(value: number | undefined): number {
+  if (!Number.isFinite(value)) return DEFAULT_CODEGRAPH_MAX_FILE_BYTES;
+  return Math.max(1, Math.floor(value!));
+}
+
 function walk(root: string, exclude: string[], maxFiles: number): string[] {
   const out: string[] = [];
   const visit = (dir: string) => {
@@ -277,39 +299,147 @@ function extractImportEdges(projectId: string, file: CodeFile, text: string, ind
   return edges;
 }
 
+function indexFileLite(
+  projectId: string,
+  projectRoot: string,
+  abs: string,
+  indexedAt: string,
+  fileStat?: ReturnType<typeof statSync>,
+): CodeGraphFileDelta | undefined {
+  const rel = normalizeCodePath(relative(projectRoot, abs));
+  try {
+    const text = readFileSync(abs, 'utf-8');
+    const stat = fileStat ?? statSync(abs);
+    const file: CodeFile = {
+      id: makeCodeFileId(projectId, rel),
+      projectId,
+      path: rel,
+      language: languageForPath(rel),
+      contentHash: hashText(text),
+      mtimeMs: Math.round(Number(stat.mtimeMs)),
+      sizeBytes: Number(stat.size),
+      indexedAt,
+    };
+    return {
+      file,
+      symbols: extractSymbols(projectId, file, text, indexedAt),
+      edges: extractImportEdges(projectId, file, text, indexedAt),
+    };
+  } catch {
+    return undefined;
+  }
+}
+
 export async function indexProjectLite(options: LiteIndexOptions): Promise<LiteIndexResult> {
   const exclude = normalizeCodeGraphExcludePatterns(options.exclude);
   const maxFiles = options.maxFiles ?? 5000;
+  const maxFileBytes = resolveMaxFileBytes(options.maxFileBytes);
   const indexedAt = new Date().toISOString();
   const paths = walk(options.projectRoot, exclude, maxFiles);
   const files: CodeFile[] = [];
   const symbols: CodeSymbol[] = [];
   const edges: CodeEdge[] = [];
+  let skippedOversizedFiles = 0;
 
   for (const abs of paths) {
-    const rel = normalizeCodePath(relative(options.projectRoot, abs));
-    let text: string;
     let stat: ReturnType<typeof statSync>;
     try {
-      text = readFileSync(abs, 'utf-8');
       stat = statSync(abs);
     } catch {
       continue;
     }
-    const file: CodeFile = {
-      id: makeCodeFileId(options.projectId, rel),
-      projectId: options.projectId,
-      path: rel,
-      language: languageForPath(rel),
-      contentHash: hashText(text),
-      mtimeMs: Math.round(stat.mtimeMs),
-      sizeBytes: stat.size,
-      indexedAt,
-    };
-    files.push(file);
-    symbols.push(...extractSymbols(options.projectId, file, text, indexedAt));
-    edges.push(...extractImportEdges(options.projectId, file, text, indexedAt));
+    if (Number(stat.size) > maxFileBytes) {
+      skippedOversizedFiles++;
+      continue;
+    }
+    const delta = indexFileLite(options.projectId, options.projectRoot, abs, indexedAt, stat);
+    if (!delta) continue;
+    files.push(delta.file);
+    symbols.push(...delta.symbols);
+    edges.push(...delta.edges);
   }
 
-  return { files, symbols, edges };
+  return { files, symbols, edges, skippedOversizedFiles };
+}
+
+/**
+ * Refresh the Lite graph incrementally. A directory walk is still necessary to
+ * discover deletes, but unchanged files are not read, hashed, or reparsed.
+ */
+export async function refreshProjectLite(
+  store: CodeGraphStore,
+  options: LiteIndexOptions,
+): Promise<LiteRefreshResult> {
+  const exclude = normalizeCodeGraphExcludePatterns(options.exclude);
+  const maxFiles = options.maxFiles ?? 5000;
+  const maxFileBytes = resolveMaxFileBytes(options.maxFileBytes);
+  const indexedAt = new Date().toISOString();
+  const paths = walk(options.projectRoot, exclude, maxFiles);
+  const existingByPath = new Map(store.listFiles(options.projectId).map((file) => [file.path, file]));
+  const changed: CodeGraphFileDelta[] = [];
+  const metadataOnly: CodeFile[] = [];
+  const seenPaths = new Set<string>();
+  const oversizedExistingFileIds = new Set<string>();
+  let unchangedFiles = 0;
+  let skippedOversizedFiles = 0;
+
+  for (const abs of paths) {
+    const rel = normalizeCodePath(relative(options.projectRoot, abs));
+    let stat: ReturnType<typeof statSync>;
+    try {
+      stat = statSync(abs);
+    } catch {
+      continue;
+    }
+    seenPaths.add(rel);
+    const existing = existingByPath.get(rel);
+    const roundedMtime = Math.round(Number(stat.mtimeMs));
+    const sizeBytes = Number(stat.size);
+    if (sizeBytes > maxFileBytes) {
+      skippedOversizedFiles++;
+      if (existing) oversizedExistingFileIds.add(existing.id);
+      continue;
+    }
+    if (existing && existing.mtimeMs === roundedMtime && existing.sizeBytes === sizeBytes) {
+      unchangedFiles++;
+      continue;
+    }
+
+    const delta = indexFileLite(options.projectId, options.projectRoot, abs, indexedAt, stat);
+    if (!delta) continue;
+    if (existing?.contentHash === delta.file.contentHash) {
+      metadataOnly.push(delta.file);
+      unchangedFiles++;
+    } else {
+      changed.push(delta);
+    }
+  }
+
+  // At the file cap, absence from this partial walk is not proof of deletion.
+  const removalScanDeferred = paths.length >= maxFiles;
+  const removedFileIds = [...new Set([
+    ...oversizedExistingFileIds,
+    ...(removalScanDeferred
+      ? []
+      : [...existingByPath.values()]
+        .filter((file) => !seenPaths.has(file.path))
+        .map((file) => file.id)),
+  ])];
+  store.applyFileDeltas(options.projectId, {
+    changed,
+    metadataOnly,
+    removedFileIds,
+  });
+
+  return {
+    scannedFiles: paths.length,
+    changedFiles: changed.length,
+    unchangedFiles,
+    metadataOnlyFiles: metadataOnly.length,
+    removedFiles: removedFileIds.length,
+    indexedSymbols: changed.reduce((total, delta) => total + delta.symbols.length, 0),
+    indexedEdges: changed.reduce((total, delta) => total + delta.edges.length, 0),
+    skippedOversizedFiles,
+    removalScanDeferred,
+  };
 }

--- a/src/codegraph/project-context.ts
+++ b/src/codegraph/project-context.ts
@@ -12,6 +12,8 @@ export interface ProjectContextObservation {
   status?: string;
   createdAt?: string;
   updatedAt?: string;
+  /** Explicit file paths recorded with a memory, used only before Code Memory exists. */
+  filesModified?: string[];
 }
 
 export interface LanguageSummary {
@@ -143,6 +145,27 @@ function collectGraph(
       status: result.status,
       reason: result.reason,
     });
+  }
+
+  // A cold project has no parsed graph yet. Do not make the first agent brief
+  // empty while a refresh is queued: surface only file paths the memory itself
+  // explicitly recorded, and label them unbound so callers know to verify.
+  if (files.length === 0) {
+    for (const observation of observations) {
+      for (const path of observation.filesModified ?? []) {
+        if (!path || isCodeGraphExcludedPath(path, exclude)) continue;
+        suggestedReads.push(path);
+        sources.push({
+          observationId: observation.id,
+          title: observation.title,
+          type: observation.type,
+          path,
+          status: 'unbound',
+          reason: 'Recorded file hint; Code Memory refresh is pending.',
+        });
+        freshness.unbound++;
+      }
+    }
   }
 
   return {

--- a/src/codegraph/store.ts
+++ b/src/codegraph/store.ts
@@ -2,6 +2,12 @@ import { getDatabase } from '../store/sqlite-db.js';
 import type { CodeEdge, CodeFile, CodeGraphStatus, CodeSymbol, ObservationCodeRef } from './types.js';
 import { normalizeCodePath } from './ids.js';
 
+export interface CodeGraphFileDelta {
+  file: CodeFile;
+  symbols: CodeSymbol[];
+  edges: CodeEdge[];
+}
+
 function rowToFile(row: any): CodeFile {
   return {
     id: row.id,
@@ -234,6 +240,123 @@ export class CodeGraphStore {
       }
     });
 
+    tx();
+  }
+
+  /**
+   * Reconcile only files whose source changed plus files that disappeared.
+   * Refs tied to replaced sources become stale instead of being silently kept.
+   */
+  applyFileDeltas(
+    projectId: string,
+    input: {
+      changed: CodeGraphFileDelta[];
+      metadataOnly?: CodeFile[];
+      removedFileIds?: string[];
+    },
+  ): void {
+    const changed = input.changed.filter((delta) => delta.file.projectId === projectId);
+    const metadataOnly = (input.metadataOnly ?? []).filter((file) => file.projectId === projectId);
+    const removedFileIds = input.removedFileIds ?? [];
+    if (changed.length === 0 && metadataOnly.length === 0 && removedFileIds.length === 0) return;
+
+    const staleRefsForFile = this.db.prepare(`
+      UPDATE observation_code_refs
+      SET status = 'stale', updatedAt = ?
+      WHERE projectId = ? AND (
+        fileId = ? OR symbolId IN (
+          SELECT id FROM code_symbols WHERE projectId = ? AND fileId = ?
+        )
+      )
+    `);
+    const deleteEdgesForFile = this.db.prepare(`
+      DELETE FROM code_edges
+      WHERE projectId = ? AND (fromFileId = ? OR toFileId = ?)
+    `);
+    const deleteSymbolsForFile = this.db.prepare(`DELETE FROM code_symbols WHERE projectId = ? AND fileId = ?`);
+    const deleteFile = this.db.prepare(`DELETE FROM code_files WHERE projectId = ? AND id = ?`);
+    const upsertFile = this.db.prepare(`
+      INSERT OR REPLACE INTO code_files
+        (id, projectId, path, language, contentHash, mtimeMs, sizeBytes, indexedAt, gitCommit)
+      VALUES
+        (@id, @projectId, @path, @language, @contentHash, @mtimeMs, @sizeBytes, @indexedAt, @gitCommit)
+    `);
+    const upsertSymbol = this.db.prepare(`
+      INSERT OR REPLACE INTO code_symbols
+        (id, projectId, fileId, path, name, qualifiedName, kind, startLine, endLine, signature, contentHash, indexedAt, stale)
+      VALUES
+        (@id, @projectId, @fileId, @path, @name, @qualifiedName, @kind, @startLine, @endLine, @signature, @contentHash, @indexedAt, @stale)
+    `);
+    const upsertEdge = this.db.prepare(`
+      INSERT OR REPLACE INTO code_edges
+        (id, projectId, fromSymbolId, toSymbolId, fromFileId, toFileId, type, confidence, evidence, indexedAt)
+      VALUES
+        (@id, @projectId, @fromSymbolId, @toSymbolId, @fromFileId, @toFileId, @type, @confidence, @evidence, @indexedAt)
+    `);
+    const writeFile = (file: CodeFile) => upsertFile.run({
+      id: file.id,
+      projectId: file.projectId,
+      path: normalizeCodePath(file.path),
+      language: file.language ?? null,
+      contentHash: file.contentHash,
+      mtimeMs: file.mtimeMs ?? null,
+      sizeBytes: file.sizeBytes ?? null,
+      indexedAt: file.indexedAt,
+      gitCommit: file.gitCommit ?? null,
+    });
+
+    const tx = this.db.transaction(() => {
+      const staleAt = new Date().toISOString();
+      for (const fileId of removedFileIds) {
+        staleRefsForFile.run(staleAt, projectId, fileId, projectId, fileId);
+        deleteEdgesForFile.run(projectId, fileId, fileId);
+        deleteSymbolsForFile.run(projectId, fileId);
+        deleteFile.run(projectId, fileId);
+      }
+
+      for (const delta of changed) {
+        const fileId = delta.file.id;
+        staleRefsForFile.run(staleAt, projectId, fileId, projectId, fileId);
+        deleteEdgesForFile.run(projectId, fileId, fileId);
+        deleteSymbolsForFile.run(projectId, fileId);
+        writeFile(delta.file);
+
+        for (const symbol of delta.symbols) {
+          upsertSymbol.run({
+            id: symbol.id,
+            projectId: symbol.projectId,
+            fileId: symbol.fileId,
+            path: normalizeCodePath(symbol.path),
+            name: symbol.name,
+            qualifiedName: symbol.qualifiedName,
+            kind: symbol.kind,
+            startLine: symbol.startLine ?? null,
+            endLine: symbol.endLine ?? null,
+            signature: symbol.signature ?? null,
+            contentHash: symbol.contentHash ?? null,
+            indexedAt: symbol.indexedAt,
+            stale: symbol.stale ? 1 : 0,
+          });
+        }
+
+        for (const edge of delta.edges) {
+          upsertEdge.run({
+            id: edge.id,
+            projectId: edge.projectId,
+            fromSymbolId: edge.fromSymbolId ?? null,
+            toSymbolId: edge.toSymbolId ?? null,
+            fromFileId: edge.fromFileId ?? null,
+            toFileId: edge.toFileId ?? null,
+            type: edge.type,
+            confidence: edge.confidence,
+            evidence: edge.evidence ?? null,
+            indexedAt: edge.indexedAt,
+          });
+        }
+      }
+
+      for (const file of metadataOnly) writeFile(file);
+    });
     tx();
   }
 

--- a/src/config/behavior.ts
+++ b/src/config/behavior.ts
@@ -1,19 +1,24 @@
 /**
- * Behavior Configuration Reader
- *
- * Reads behavior settings from ~/.memorix/config.json.
- * Falls back to sensible defaults if config is missing.
+ * Behavior configuration resolved through the same TOML/YAML/legacy chain as
+ * the rest of the runtime. Legacy config.json remains a fallback only.
  */
 
-import { readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
 import { homedir } from 'node:os';
+import { getLegacyConfigJsonPath } from './config-paths.js';
+import { getResolvedConfig } from './resolved-config.js';
+import { detectProject } from '../project/detector.js';
 
 export interface BehaviorConfig {
   sessionInject: 'full' | 'minimal' | 'silent';
   syncAdvisory: boolean;
   autoCleanup: boolean;
   formationMode: 'shadow' | 'active' | 'fallback';
+}
+
+export interface BehaviorConfigOptions {
+  projectRoot?: string | null;
+  homeDir?: string;
 }
 
 const DEFAULTS: BehaviorConfig = {
@@ -23,37 +28,70 @@ const DEFAULTS: BehaviorConfig = {
   formationMode: 'active',
 };
 
-let cached: BehaviorConfig | null = null;
+const cache = new Map<string, BehaviorConfig>();
 
-/**
- * Load behavior config from ~/.memorix/config.json.
- * Caches after first read. Returns defaults if file is missing.
- */
-export function getBehaviorConfig(): BehaviorConfig {
-  if (cached) return cached;
+function isSessionInject(value: unknown): value is BehaviorConfig['sessionInject'] {
+  return value === 'full' || value === 'minimal' || value === 'silent';
+}
 
+function isFormationMode(value: unknown): value is BehaviorConfig['formationMode'] {
+  return value === 'shadow' || value === 'active' || value === 'fallback';
+}
+
+function legacyBehavior(homeDir: string): Record<string, unknown> {
+  const configPath = getLegacyConfigJsonPath(homeDir);
   try {
-    const configPath = join(homedir(), '.memorix', 'config.json');
-    const raw = readFileSync(configPath, 'utf-8');
-    const config = JSON.parse(raw);
-    const behavior = config.behavior ?? {};
-
-    cached = {
-      sessionInject: behavior.sessionInject ?? DEFAULTS.sessionInject,
-      syncAdvisory: behavior.syncAdvisory ?? DEFAULTS.syncAdvisory,
-      autoCleanup: behavior.autoCleanup ?? DEFAULTS.autoCleanup,
-      formationMode: behavior.formationMode ?? DEFAULTS.formationMode,
-    };
+    if (!existsSync(configPath)) return {};
+    const parsed = JSON.parse(readFileSync(configPath, 'utf-8')) as { behavior?: unknown };
+    return parsed.behavior && typeof parsed.behavior === 'object' && !Array.isArray(parsed.behavior)
+      ? parsed.behavior as Record<string, unknown>
+      : {};
   } catch {
-    cached = { ...DEFAULTS };
+    return {};
   }
-
-  return cached;
 }
 
 /**
- * Reset cached config (for testing or after config change).
+ * Resolve behavior through project TOML/YAML first, then legacy config.json.
+ * Passing projectRoot is important for HTTP sessions whose process cwd belongs
+ * to a different project than the MCP session.
  */
+export function getBehaviorConfig(options: BehaviorConfigOptions = {}): BehaviorConfig {
+  const homeDir = options.homeDir ?? homedir();
+  const projectRoot = options.projectRoot === undefined
+    ? detectProject()?.rootPath ?? null
+    : options.projectRoot;
+  const cacheKey = `${homeDir}\0${projectRoot ?? ''}`;
+  const cached = cache.get(cacheKey);
+  if (cached) return cached;
+
+  const legacy = legacyBehavior(homeDir);
+  let resolved: Partial<ReturnType<typeof getResolvedConfig>['memory']> = {};
+  try {
+    resolved = getResolvedConfig({ projectRoot, homeDir }).memory;
+  } catch {
+    // Behavior settings must not make hooks or MCP startup unavailable when a
+    // user is in the middle of fixing a malformed TOML/YAML file.
+  }
+  const config: BehaviorConfig = {
+    sessionInject: isSessionInject(resolved.inject)
+      ? resolved.inject
+      : isSessionInject(legacy.sessionInject) ? legacy.sessionInject : DEFAULTS.sessionInject,
+    syncAdvisory: typeof resolved.syncAdvisory === 'boolean'
+      ? resolved.syncAdvisory
+      : typeof legacy.syncAdvisory === 'boolean' ? legacy.syncAdvisory : DEFAULTS.syncAdvisory,
+    autoCleanup: typeof resolved.autoCleanup === 'boolean'
+      ? resolved.autoCleanup
+      : typeof legacy.autoCleanup === 'boolean' ? legacy.autoCleanup : DEFAULTS.autoCleanup,
+    formationMode: isFormationMode(resolved.formation)
+      ? resolved.formation
+      : isFormationMode(legacy.formationMode) ? legacy.formationMode : DEFAULTS.formationMode,
+  };
+  cache.set(cacheKey, config);
+  return config;
+}
+
+/** Reset cached resolved behavior. Used after config changes and in tests. */
 export function resetBehaviorConfigCache(): void {
-  cached = null;
+  cache.clear();
 }

--- a/src/config/resolved-config.ts
+++ b/src/config/resolved-config.ts
@@ -29,6 +29,7 @@ export interface ResolvedMemorixConfig {
     inject?: 'full' | 'minimal' | 'silent';
     formation?: 'active' | 'shadow' | 'fallback';
     autoCleanup?: boolean;
+    syncAdvisory?: boolean;
     llm: {
       provider?: string;
       model?: string;
@@ -53,6 +54,7 @@ export interface ResolvedMemorixConfig {
   };
   codegraph: {
     excludePatterns?: string[];
+    maxFileBytes?: number;
   };
   server: {
     transport?: 'stdio' | 'http';
@@ -119,6 +121,7 @@ export function getResolvedConfig(options: ResolvedLaneOptions = {}): ResolvedMe
       inject: first(toml.memory?.inject, yaml.behavior?.sessionInject),
       formation: first(toml.memory?.formation, yaml.behavior?.formationMode),
       autoCleanup: firstBool(toml.memory?.auto_cleanup, yaml.behavior?.autoCleanup),
+      syncAdvisory: firstBool(toml.memory?.sync_advisory, yaml.behavior?.syncAdvisory),
       llm: {
         provider: first(process.env.MEMORIX_LLM_PROVIDER, toml.memory?.llm?.provider, yaml.llm?.provider, legacy.llm?.provider),
         model: first(process.env.MEMORIX_LLM_MODEL, toml.memory?.llm?.model, yaml.llm?.model, legacy.llm?.model),
@@ -152,6 +155,7 @@ export function getResolvedConfig(options: ResolvedLaneOptions = {}): ResolvedMe
     },
     codegraph: {
       excludePatterns: firstArray(toml.codegraph?.exclude_patterns, yaml.codegraph?.excludePatterns),
+      maxFileBytes: firstNumber(toml.codegraph?.max_file_bytes, yaml.codegraph?.maxFileBytes),
     },
     server: {
       transport: first(toml.server?.transport, yaml.server?.transport),

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -13,6 +13,7 @@ export interface MemorixTomlConfig {
     inject?: 'full' | 'minimal' | 'silent';
     formation?: 'active' | 'shadow' | 'fallback';
     auto_cleanup?: boolean;
+    sync_advisory?: boolean;
     llm?: {
       provider?: string;
       model?: string;
@@ -41,6 +42,7 @@ export interface MemorixTomlConfig {
   };
   codegraph?: {
     exclude_patterns?: string[];
+    max_file_bytes?: number;
   };
   server?: {
     transport?: 'stdio' | 'http';

--- a/src/config/yaml-loader.ts
+++ b/src/config/yaml-loader.ts
@@ -60,7 +60,7 @@ export interface MemorixYamlConfig {
     skipMergeCommits?: boolean;
     /** File patterns to exclude from git memory (glob) */
     excludePatterns?: string[];
-    /** Additional commit message patterns to treat as noise (regex strings) */
+    /** Additional commit message phrases to treat as noise (literal, case-insensitive) */
     noiseKeywords?: string[];
   };
 
@@ -68,6 +68,8 @@ export interface MemorixYamlConfig {
   codegraph?: {
     /** File patterns to exclude from CodeGraph indexing and context suggestions */
     excludePatterns?: string[];
+    /** Maximum source file size to parse into CodeGraph Memory */
+    maxFileBytes?: number;
   };
 
   /** Behavior settings */

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -40,7 +40,6 @@ const MIME_TYPES: Record<string, string> = {
 function sendJson(res: ServerResponse, data: unknown, status = 200) {
     res.writeHead(status, {
         'Content-Type': 'application/json; charset=utf-8',
-        'Access-Control-Allow-Origin': '*',
     });
     res.end(JSON.stringify(data));
 }
@@ -61,10 +60,6 @@ function filterByProject<T extends { projectId?: string }>(items: T[], projectId
 
 function isActiveStatus(status?: string): boolean {
     return (status ?? 'active') === 'active';
-}
-
-function filterActiveByProject<T extends { projectId?: string; status?: string }>(items: T[], projectId: string): T[] {
-    return items.filter(item => item.projectId === projectId && isActiveStatus(item.status));
 }
 
 /**
@@ -216,10 +211,10 @@ async function handleApi(
                 const gStore = getGraphStore();
                 const graph = { entities: gStore.loadEntities(), relations: gStore.loadRelations() };
                 // Project-scope the graph: only include entities that have observations in this project
-                const graphObs = await getObservationStore().loadAll() as Array<{ projectId?: string; entityName?: string; status?: string }>;
+                const graphObs = await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' }) as Array<{ entityName?: string }>;
                 const projectEntityNames = new Set(
                     graphObs
-                        .filter(o => o.projectId === effectiveProjectId && (o.status ?? 'active') === 'active' && o.entityName)
+                        .filter(o => o.entityName)
                         .map(o => o.entityName!),
                 );
                 const entities = graph.entities.filter((e: any) => projectEntityNames.has(e.name));
@@ -230,8 +225,7 @@ async function handleApi(
             }
 
             case '/observations': {
-                const allObs = await getObservationStore().loadAll();
-                const observations = filterActiveByProject(allObs as Array<{ projectId?: string; status?: string }>, effectiveProjectId);
+                const observations = await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' });
                 sendJson(res, observations);
                 break;
             }
@@ -246,11 +240,7 @@ async function handleApi(
             case '/stats': {
                 await initGraphStore(effectiveDataDir);
                 const graph = { entities: getGraphStore().loadEntities(), relations: getGraphStore().loadRelations() };
-                const allObs = await getObservationStore().loadAll();
-                const observations = filterActiveByProject(
-                    allObs as Array<{ projectId?: string; status?: string; type?: string; id?: number; createdAt?: string; title?: string; entityName?: string }>,
-                    effectiveProjectId,
-                );
+                const observations = await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' }) as Array<{ type?: string; id?: number; createdAt?: string; title?: string; entityName?: string; status?: string }>;
                 const nextId = await getObservationStore().loadIdCounter();
 
                 // Project-scoped graph counts (must match /api/graph and /api/export)
@@ -331,6 +321,12 @@ async function handleApi(
                     generation: store.getGeneration(),
                 };
 
+                let maintenance = { total: 0, pending: 0, running: 0, retrying: 0, completed: 0, failed: 0 };
+                try {
+                    const { MaintenanceJobStore } = await import('../runtime/maintenance-jobs.js');
+                    maintenance = new MaintenanceJobStore(effectiveDataDir).summary(effectiveProjectId);
+                } catch { /* optional maintenance diagnostics */ }
+
                 sendJson(res, {
                     entities: projectGraphCounts.entities,
                     relations: projectGraphCounts.relations,
@@ -341,6 +337,7 @@ async function handleApi(
                     recentObservations: sorted,
                     embedding: embeddingStatus,
                     storage: storageInfo,
+                    maintenance,
                     gitSummary: {
                         total: gitMemories.length,
                         recentWeek: recentGitCount,
@@ -351,8 +348,21 @@ async function handleApi(
                 break;
             }
 
+            case '/maintenance': {
+                const { MaintenanceJobStore } = await import('../runtime/maintenance-jobs.js');
+                const jobs = new MaintenanceJobStore(effectiveDataDir).list({
+                    projectId: effectiveProjectId,
+                    limit: 50,
+                });
+                sendJson(res, {
+                    summary: new MaintenanceJobStore(effectiveDataDir).summary(effectiveProjectId),
+                    jobs,
+                });
+                break;
+            }
+
             case '/retention': {
-                const allObs = await getObservationStore().loadAll() as Array<{
+                const observations = await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' }) as Array<{
                     id?: number;
                     title?: string;
                     type?: string;
@@ -361,10 +371,7 @@ async function handleApi(
                     lastAccessedAt?: string;
                     createdAt?: string;
                     entityName?: string;
-                    projectId?: string;
-                    status?: string;
                 }>;
-                const observations = filterActiveByProject(allObs, effectiveProjectId);
 
                 const now = Date.now();
                 // Exclude probe from retention display -- not durable knowledge
@@ -412,13 +419,11 @@ async function handleApi(
 
             case '/knowledge': {
                 const { generateKnowledgeBase } = await import('../wiki/generator.js');
-                const { initObservations, getAllObservations } = await import('../memory/observations.js');
                 const { initMiniSkillStore, getMiniSkillStore } = await import('../store/mini-skill-store.js');
 
-                await initObservations(effectiveDataDir);
                 await initMiniSkillStore(effectiveDataDir);
 
-                const allObs = getAllObservations();
+                const allObs = await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' });
                 const skills = await getMiniSkillStore().loadByProject(effectiveProjectId);
 
                 const overview = generateKnowledgeBase({
@@ -433,23 +438,21 @@ async function handleApi(
 
             case '/knowledge-graph': {
                 const { generateKnowledgeGraph } = await import('../wiki/knowledge-graph.js');
-                const { initObservations, getAllObservations } = await import('../memory/observations.js');
                 const { initMiniSkillStore, getMiniSkillStore } = await import('../store/mini-skill-store.js');
                 const { initGraphStore, getGraphStore } = await import('../store/graph-store.js');
 
-                await initObservations(effectiveDataDir);
                 await initMiniSkillStore(effectiveDataDir);
                 await initGraphStore(effectiveDataDir);
 
-                const allObs = getAllObservations();
+                const allObs = await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' });
                 const skills = await getMiniSkillStore().loadByProject(effectiveProjectId);
 
                 // Project-scope graph store (same logic as /api/graph)
                 const fullGraph = { entities: getGraphStore().loadEntities(), relations: getGraphStore().loadRelations() };
-                const graphObs = await getObservationStore().loadAll() as Array<{ projectId?: string; entityName?: string; status?: string }>;
+                const graphObs = await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' }) as Array<{ entityName?: string }>;
                 const projectEntityNames = new Set(
                     graphObs
-                        .filter(o => o.projectId === effectiveProjectId && (o.status ?? 'active') === 'active' && o.entityName)
+                        .filter(o => o.entityName)
                         .map(o => o.entityName!),
                 );
                 const scopedEntities = fullGraph.entities.filter((e: any) => projectEntityNames.has(e.name));
@@ -698,8 +701,7 @@ async function handleApi(
                 if (deleteMatch && req.method === 'DELETE') {
                     const obsId = parseInt(deleteMatch[1], 10);
                     const obsStore = getObservationStore();
-                    const allObs = await obsStore.loadAll();
-                    const matchObs = allObs.find(o => o.id === obsId);
+                    const matchObs = await obsStore.getById(obsId);
                     if (!matchObs) {
                         sendError(res, 'Observation not found', 404);
                     } else if (matchObs.projectId !== effectiveProjectId) {
@@ -729,8 +731,7 @@ async function handleApi(
                 if (apiPath === '/export') {
                     await initGraphStore(effectiveDataDir);
                     const fullGraph = { entities: getGraphStore().loadEntities(), relations: getGraphStore().loadRelations() };
-                    const allObs = await getObservationStore().loadAll();
-                    const observations = filterActiveByProject(allObs as Array<{ projectId?: string; entityName?: string; status?: string }>, effectiveProjectId);
+                    const observations = await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' });
                     const nextId = await getObservationStore().loadIdCounter();
                     // Project-scope the graph: only entities referenced by this project's observations
                     const exportEntityNames = new Set(

--- a/src/dashboard/static/app.js
+++ b/src/dashboard/static/app.js
@@ -220,6 +220,11 @@ const i18n = {
     providerUnavailable: 'Unavailable',
     providerDisabled: 'Disabled (BM25 only)',
     degradedHint: 'Search is degraded — no vector similarity',
+    maintenance: 'Maintenance',
+    maintenanceIdle: 'No work queued',
+    maintenanceQueued: 'queued',
+    maintenanceRunning: 'running',
+    maintenanceNeedsAttention: 'needs attention',
 
     // Project states
     noProjects: 'No projects',
@@ -642,6 +647,11 @@ const i18n = {
     providerUnavailable: '不可用',
     providerDisabled: '已禁用 (仅 BM25)',
     degradedHint: '搜索已降级 — 无向量相似性',
+    maintenance: '维护任务',
+    maintenanceIdle: '无待处理任务',
+    maintenanceQueued: '项排队',
+    maintenanceRunning: '项运行中',
+    maintenanceNeedsAttention: '项需要处理',
 
     // Project states
     noProjects: '无项目',
@@ -1320,6 +1330,17 @@ async function loadDashboard() {
   const totalObs = stats.observations || 0;
   const gs = stats.gitSummary || { total: 0, recentWeek: 0, recentMemories: [] };
   const rs = stats.retentionSummary || { active: 0, stale: 0, archive: 0, immune: 0 };
+  const maintenance = stats.maintenance || { pending: 0, running: 0, retrying: 0, failed: 0 };
+  const queuedMaintenance = (maintenance.pending || 0) + (maintenance.retrying || 0);
+  const activeMaintenance = maintenance.running || 0;
+  const failedMaintenance = maintenance.failed || 0;
+  const maintenanceState = failedMaintenance > 0
+    ? { color: 'var(--accent-red)', text: `${failedMaintenance} ${t('maintenanceNeedsAttention')}` }
+    : activeMaintenance > 0
+      ? { color: 'var(--accent-blue)', text: `${activeMaintenance} ${t('maintenanceRunning')}` }
+      : queuedMaintenance > 0
+        ? { color: 'var(--accent-amber)', text: `${queuedMaintenance} ${t('maintenanceQueued')}` }
+        : { color: 'var(--accent-green)', text: t('maintenanceIdle') };
 
   const typeIcons = {
     'session-request': '<span class="iconify" data-icon="lucide:target" style="color:#f87171;"></span>', gotcha: '<span class="iconify" data-icon="lucide:alert-octagon" style="color:#ef4444;"></span>', 'problem-solution': '<span class="iconify" data-icon="lucide:lightbulb" style="color:#fbbf24;"></span>',
@@ -1371,7 +1392,7 @@ async function loadDashboard() {
       <div class="panel" style="flex:1;">
         <div class="panel-header"><span class="panel-title">${t('systemStatus')}</span></div>
         <div class="panel-body">
-          <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:16px;">
+          <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:16px;">
             <div>
               <div style="font-size:11px;color:var(--text-muted);margin-bottom:4px;">${t('embeddingProvider')}</div>
               <div style="font-size:14px;font-weight:600;color:${stats.embedding?.enabled ? 'var(--accent-green)' : stats.embedding?.provider ? 'var(--accent-amber)' : 'var(--text-muted)'};">
@@ -1395,6 +1416,11 @@ async function loadDashboard() {
                 ${stats.searchMode || (stats.embedding?.enabled ? 'hybrid' : 'fulltext')}
               </div>
               ${stats.embeddingProviderState === 'temporarily_unavailable' ? `<div style="font-size:11px;color:var(--accent-amber);margin-top:2px;">${t('degradedHint')}</div>` : ''}
+            </div>
+            <div>
+              <div style="font-size:11px;color:var(--text-muted);margin-bottom:4px;">${t('maintenance')}</div>
+              <div style="font-size:14px;font-weight:600;color:${maintenanceState.color};">${maintenanceState.text}</div>
+              ${queuedMaintenance > 0 && activeMaintenance > 0 ? `<div style="font-size:11px;color:var(--text-secondary);margin-top:2px;">${queuedMaintenance} ${t('maintenanceQueued')}</div>` : ''}
             </div>
           </div>
         </div>
@@ -1440,9 +1466,9 @@ async function loadDashboard() {
         <div class="panel-header"><span class="panel-title">${t('observationTypes')}</span></div>
         <div class="panel-body">
           ${typeEntries.length > 0 ? `
-            <div style="display: flex; gap: 20px; align-items: flex-start;">
+            <div class="type-distribution" style="display: flex; gap: 20px; align-items: flex-start;">
               <canvas id="type-pie-chart" width="140" height="140" style="flex-shrink: 0;"></canvas>
-              <div style="flex: 1;">
+              <div class="type-distribution-list" style="flex: 1;">
                 ${typeEntries.map(([type, count]) => `
                   <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
                     <span style="width: 18px; text-align: center; font-size: 13px;">${typeIcons[type] || '[UNKNOWN]'}</span>

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -51,7 +51,7 @@
 
     <div class="sidebar-section-label" data-section="core">CORE</div>
     <div class="sidebar-nav">
-      <button class="nav-btn active" data-page="dashboard">
+      <button class="nav-btn active" data-page="dashboard" title="Overview" aria-label="Overview">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <rect x="3" y="3" width="7" height="7" rx="1"/>
           <rect x="14" y="3" width="7" height="7" rx="1"/>
@@ -60,7 +60,7 @@
         </svg>
         <span class="nav-label">Overview</span>
       </button>
-      <button class="nav-btn" data-page="git-memory">
+      <button class="nav-btn" data-page="git-memory" title="Git Memory" aria-label="Git Memory">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <circle cx="12" cy="12" r="4"/>
           <line x1="1.05" y1="12" x2="7" y2="12"/>
@@ -68,14 +68,14 @@
         </svg>
         <span class="nav-label">Git Memory</span>
       </button>
-      <button class="nav-btn" data-page="knowledge">
+      <button class="nav-btn" data-page="knowledge" title="Knowledge" aria-label="Knowledge">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/>
           <path d="M4 4.5A2.5 2.5 0 0 1 6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5z"/>
         </svg>
         <span class="nav-label">Knowledge</span>
       </button>
-      <button class="nav-btn" data-page="graph">
+      <button class="nav-btn" data-page="graph" title="Graph" aria-label="Graph">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <circle cx="12" cy="5" r="3"/>
           <circle cx="5" cy="19" r="3"/>
@@ -85,7 +85,7 @@
         </svg>
         <span class="nav-label">Graph</span>
       </button>
-      <button class="nav-btn" data-page="observations">
+      <button class="nav-btn" data-page="observations" title="Observations" aria-label="Observations">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
           <circle cx="12" cy="12" r="3"/>
@@ -95,20 +95,20 @@
     </div>
     <div class="sidebar-section-label" data-section="health">HEALTH</div>
     <div class="sidebar-nav">
-      <button class="nav-btn" data-page="retention">
+      <button class="nav-btn" data-page="retention" title="Retention" aria-label="Retention">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <polyline points="22,12 18,12 15,21 9,3 6,12 2,12"/>
         </svg>
         <span class="nav-label">Retention</span>
       </button>
-      <button class="nav-btn" data-page="config">
+      <button class="nav-btn" data-page="config" title="Config" aria-label="Config">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <circle cx="12" cy="12" r="3"/>
           <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/>
         </svg>
         <span class="nav-label">Config</span>
       </button>
-      <button class="nav-btn" data-page="identity">
+      <button class="nav-btn" data-page="identity" title="Identity" aria-label="Identity">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
         </svg>
@@ -117,7 +117,7 @@
     </div>
     <div class="sidebar-section-label" data-section="collaboration">AGENTS</div>
     <div class="sidebar-nav">
-      <button class="nav-btn" data-page="sessions">
+      <button class="nav-btn" data-page="sessions" title="Sessions" aria-label="Sessions">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
           <line x1="16" y1="2" x2="16" y2="6"/>
@@ -126,7 +126,7 @@
         </svg>
         <span class="nav-label">Sessions</span>
       </button>
-      <button class="nav-btn" data-page="team">
+      <button class="nav-btn" data-page="team" title="Coordination" aria-label="Coordination">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
           <circle cx="9" cy="7" r="4"/>

--- a/src/dashboard/static/style.css
+++ b/src/dashboard/static/style.css
@@ -3582,3 +3582,181 @@ mark {
 .stat-card[data-accent="red"]::before {
   background: var(--accent-red);
 }
+
+/* Mobile navigation keeps the app usable instead of squeezing the content
+ * beside a desktop-width sidebar. */
+@media (max-width: 768px) {
+  html,
+  body {
+    height: auto;
+    min-height: 100%;
+    overflow: auto;
+  }
+
+  body {
+    display: block;
+  }
+
+  #sidebar {
+    width: 100%;
+    height: auto;
+    min-height: 0;
+    padding: 10px 12px;
+    border-right: none;
+    border-bottom: 1px solid var(--border-subtle);
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    overflow: visible;
+  }
+
+  .sidebar-brand {
+    gap: 8px;
+    padding: 0;
+    margin: 0;
+  }
+
+  .brand-text {
+    font-size: 14px;
+  }
+
+  .mode-badge {
+    display: none !important;
+  }
+
+  .project-switcher {
+    flex: 1 1 150px;
+    min-width: 0;
+    padding: 0;
+  }
+
+  .project-trigger {
+    min-width: 0;
+    min-height: 38px;
+    padding: 8px 10px;
+  }
+
+  .sidebar-section-label,
+  .sidebar-spacer {
+    display: none;
+  }
+
+  .sidebar-nav {
+    display: contents;
+  }
+
+  .nav-btn {
+    width: 40px;
+    height: 40px;
+    flex: 0 0 40px;
+    justify-content: center;
+    padding: 0;
+    border-radius: var(--radius-sm);
+  }
+
+  .nav-label,
+  .action-label {
+    display: none;
+  }
+
+  .sidebar-footer {
+    display: contents;
+    padding: 0;
+  }
+
+  .sidebar-action-btn {
+    width: 40px;
+    height: 40px;
+    flex: 0 0 40px;
+    justify-content: center;
+    padding: 0;
+    border-radius: var(--radius-sm);
+  }
+
+  #app {
+    height: auto;
+    min-height: 0;
+    overflow: visible;
+    scrollbar-gutter: auto;
+  }
+
+  .page {
+    min-height: 0;
+    padding: 20px 16px;
+  }
+
+  .page-header {
+    margin-bottom: 20px;
+  }
+
+  .page-title {
+    font-size: 24px;
+    line-height: 1.2;
+    overflow-wrap: anywhere;
+  }
+
+  .page-subtitle {
+    line-height: 1.45;
+    overflow-wrap: anywhere;
+  }
+
+  .overview-row {
+    flex-direction: column;
+  }
+
+  .overview-row > .panel {
+    min-width: 0;
+  }
+
+  .type-distribution {
+    flex-direction: column;
+    align-items: stretch !important;
+    gap: 16px !important;
+  }
+
+  .type-distribution canvas {
+    align-self: center;
+  }
+
+  .type-distribution-list {
+    min-width: 0;
+    width: 100%;
+  }
+
+  .activity-item {
+    display: grid;
+    grid-template-columns: auto auto minmax(0, 1fr);
+    gap: 4px 8px;
+    align-items: start;
+    padding: 10px 0;
+  }
+
+  .activity-id {
+    grid-row: 1 / span 2;
+    align-self: center;
+  }
+
+  .activity-item .type-badge {
+    grid-column: 2;
+    grid-row: 1;
+  }
+
+  .activity-title,
+  .activity-entity {
+    grid-column: 3;
+    min-width: 0;
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  .activity-title {
+    grid-row: 1;
+  }
+
+  .activity-entity {
+    grid-row: 2;
+  }
+}

--- a/src/git/noise-filter.ts
+++ b/src/git/noise-filter.ts
@@ -22,7 +22,7 @@ export interface NoiseFilterConfig {
   skipMergeCommits?: boolean;
   /** File glob patterns to exclude (default: lockfiles, generated files) */
   excludePatterns?: string[];
-  /** Additional commit message patterns to skip (regex strings) */
+  /** Additional commit message phrases to skip (literal, case-insensitive) */
   noiseKeywords?: string[];
 }
 
@@ -112,23 +112,39 @@ function isMergeCommit(commit: CommitInfo): boolean {
 function isAllFilesNoise(files: string[], extraPatterns?: string[]): boolean {
   if (files.length === 0) return false;
 
-  const allPatterns = [...NOISE_FILE_PATTERNS];
-  if (extraPatterns) {
-    for (const p of extraPatterns) {
-      try {
-        // Convert glob-like patterns to regex: *.lock → \.lock$, dist/* → ^dist\/
-        const escaped = p
-          .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-          .replace(/\*/g, '.*')
-          .replace(/\?/g, '.');
-        allPatterns.push(new RegExp(escaped));
-      } catch { /* invalid pattern — skip */ }
-    }
-  }
-
-  return files.every(file =>
-    allPatterns.some(pattern => pattern.test(file)),
+  return files.every((file) =>
+    NOISE_FILE_PATTERNS.some((pattern) => pattern.test(file)) ||
+    (extraPatterns ?? []).some((pattern) => matchesGlob(file, pattern)),
   );
+}
+
+/**
+ * Glob matching without compiling user configuration into a JavaScript regex.
+ * `*` matches any sequence and `?` matches one character, including `/`, which
+ * preserves the old file-pattern semantics while bounding work to O(m*n).
+ */
+function matchesGlob(file: string, pattern: string): boolean {
+  const text = file.replace(/\\/g, '/');
+  const glob = pattern.replace(/\\/g, '/');
+  if (!glob) return false;
+
+  let previous = new Array<boolean>(text.length + 1).fill(false);
+  previous[0] = true;
+  for (const token of glob) {
+    const current = new Array<boolean>(text.length + 1).fill(false);
+    if (token === '*') {
+      current[0] = previous[0];
+      for (let index = 1; index <= text.length; index++) {
+        current[index] = previous[index] || current[index - 1];
+      }
+    } else {
+      for (let index = 1; index <= text.length; index++) {
+        current[index] = previous[index - 1] && (token === '?' || token === text[index - 1]);
+      }
+    }
+    previous = current;
+  }
+  return previous[text.length];
 }
 
 /**
@@ -156,15 +172,15 @@ export function shouldFilterCommit(
     }
   }
 
-  // 3. User-defined noise keywords from memorix.yml
+  // 3. User-defined literal noise keywords from memorix.yml
   if (config?.noiseKeywords) {
     for (const keyword of config.noiseKeywords) {
-      try {
-        const re = new RegExp(keyword, 'i');
-        if (re.test(commit.subject) || re.test(commit.body)) {
-          return { skip: true, reason: `user noise pattern: ${keyword}` };
-        }
-      } catch { /* invalid regex — skip */ }
+      const needle = keyword.trim().toLocaleLowerCase();
+      if (!needle) continue;
+      const message = `${commit.subject}\n${commit.body}`.toLocaleLowerCase();
+      if (message.includes(needle)) {
+        return { skip: true, reason: `user noise keyword: ${keyword}` };
+      }
     }
   }
 

--- a/src/hooks/handler.ts
+++ b/src/hooks/handler.ts
@@ -292,12 +292,20 @@ async function handleSessionStart(input: NormalizedHookInput): Promise<{
       await initObservationStore(dataDir);
       await initMiniSkillStore(dataDir);
       await initSessionStore(dataDir);
-      const allObs = await getStore().loadAll();
+      const activeObservations = await getStore().loadByProject(canonicalId, { status: 'active' });
       const context = await buildAutoProjectContext({
         project: { ...rawProject, id: canonicalId },
         dataDir,
-        observations: allObs,
+        observations: activeObservations,
         refresh: 'auto',
+        enqueueRefresh: () => import('../runtime/maintenance-jobs.js').then(({ MaintenanceJobStore }) => {
+            new MaintenanceJobStore(dataDir).enqueue({
+              projectId: canonicalId,
+              kind: 'codegraph-refresh',
+              dedupeKey: 'hook-codegraph-refresh',
+              payload: { maxFiles: 5_000 },
+            });
+          }),
       });
       contextSummary = `\n\n${formatAutoProjectContextPrompt(context)}`;
     } catch (sessErr) {

--- a/src/memory/consolidation.ts
+++ b/src/memory/consolidation.ts
@@ -88,6 +88,10 @@ export interface ConsolidationResult {
   observationsMerged: number;
   /** Number of observations after consolidation */
   observationsAfter: number;
+  /** Number of active project observations inspected in this bounded pass. */
+  scanned: number;
+  /** Present when another bounded pass is needed to cover this project. */
+  nextCursor?: number;
   /** Details of each merge */
   merges: Array<{
     clusterId: number;
@@ -97,65 +101,68 @@ export interface ConsolidationResult {
   }>;
 }
 
-/**
- * Find clusters of similar observations that could be consolidated.
- * Does NOT modify data — use this for preview / dry run.
- */
-export async function findConsolidationCandidates(
-  projectDir: string,
+interface ConsolidationPage {
+  observations: Observation[];
+  nextCursor?: number;
+}
+
+function clampBatchSize(limit: number | undefined): number {
+  if (!Number.isFinite(limit)) return MAX_BATCH_SIZE;
+  return Math.min(MAX_BATCH_SIZE, Math.max(1, Math.floor(limit!)));
+}
+
+function clampCursor(afterId: number | undefined): number {
+  if (!Number.isFinite(afterId)) return 0;
+  return Math.max(0, Math.floor(afterId!));
+}
+
+async function loadConsolidationPage(
   projectId: string,
-  opts?: { threshold?: number; limit?: number },
-): Promise<ConsolidationCluster[]> {
-  const threshold = opts?.threshold ?? DEFAULT_SIMILARITY_THRESHOLD;
-  const limit = opts?.limit ?? MAX_BATCH_SIZE;
+  options: { limit?: number; afterId?: number },
+): Promise<ConsolidationPage> {
+  const limit = clampBatchSize(options.limit);
+  const page = await getObservationStore().loadByProject(projectId, {
+    status: 'active',
+    afterId: clampCursor(options.afterId),
+    limit: limit + 1,
+  });
+  const hasMore = page.length > limit;
+  const observations = hasMore ? page.slice(0, limit) : page;
+  return hasMore && observations.length > 0
+    ? { observations, nextCursor: observations[observations.length - 1].id }
+    : { observations };
+}
 
-  const store = getObservationStore();
-  const allObs = await store.loadAll();
-  const projectObs = allObs
-    .filter(o => o.projectId === projectId)
-    .slice(0, limit);
+function findClusters(observations: Observation[], threshold: number): ConsolidationCluster[] {
+  if (observations.length < MIN_CLUSTER_SIZE) return [];
 
-  if (projectObs.length < MIN_CLUSTER_SIZE) return [];
-
-  // Group by entity + type
   const groups = new Map<string, Observation[]>();
-  for (const obs of projectObs) {
+  for (const obs of observations) {
     const key = `${obs.entityName}::${obs.type}`;
-    if (!groups.has(key)) groups.set(key, []);
-    groups.get(key)!.push(obs);
+    const group = groups.get(key) ?? [];
+    group.push(obs);
+    groups.set(key, group);
   }
 
   const clusters: ConsolidationCluster[] = [];
-
-  for (const [, group] of groups) {
+  for (const group of groups.values()) {
     if (group.length < MIN_CLUSTER_SIZE) continue;
 
-    // High-value types require much higher similarity to merge
     const groupType = group[0].type;
     const effectiveThreshold = HIGH_VALUE_TYPES.has(groupType)
       ? Math.max(threshold, HIGH_VALUE_SIMILARITY_THRESHOLD)
       : threshold;
-
-    // Pre-compute fingerprints
-    const fingerprints = group.map(obs => ({
-      obs,
-      tokens: tokenize(observationFingerprint(obs)),
-    }));
-
-    // Track which observations are already clustered
+    const fingerprints = group.map(obs => ({ obs, tokens: tokenize(observationFingerprint(obs)) }));
     const clustered = new Set<number>();
 
-    // Greedy clustering: for each unclustered obs, find similar ones
     for (let i = 0; i < fingerprints.length; i++) {
       if (clustered.has(fingerprints[i].obs.id)) continue;
 
       const cluster: Observation[] = [fingerprints[i].obs];
       let totalSim = 0;
       let simCount = 0;
-
       for (let j = i + 1; j < fingerprints.length; j++) {
         if (clustered.has(fingerprints[j].obs.id)) continue;
-
         const sim = jaccardSimilarity(fingerprints[i].tokens, fingerprints[j].tokens);
         if (sim >= effectiveThreshold) {
           cluster.push(fingerprints[j].obs);
@@ -181,6 +188,20 @@ export async function findConsolidationCandidates(
 }
 
 /**
+ * Find clusters of similar observations that could be consolidated.
+ * Does NOT modify data — use this for preview / dry run.
+ */
+export async function findConsolidationCandidates(
+  _projectDir: string,
+  projectId: string,
+  opts?: { threshold?: number; limit?: number; afterId?: number },
+): Promise<ConsolidationCluster[]> {
+  const threshold = opts?.threshold ?? DEFAULT_SIMILARITY_THRESHOLD;
+  const page = await loadConsolidationPage(projectId, opts ?? {});
+  return findClusters(page.observations, threshold);
+}
+
+/**
  * Execute consolidation — merge clusters into single observations.
  *
  * For each cluster:
@@ -190,20 +211,21 @@ export async function findConsolidationCandidates(
  * 4. Remove the other members
  */
 export async function executeConsolidation(
-  projectDir: string,
+  _projectDir: string,
   projectId: string,
-  opts?: { threshold?: number; limit?: number },
+  opts?: { threshold?: number; limit?: number; afterId?: number },
 ): Promise<ConsolidationResult> {
-  const clusters = await findConsolidationCandidates(projectDir, projectId, opts);
-
   const store = getObservationStore();
+  const page = await loadConsolidationPage(projectId, opts ?? {});
+  const clusters = findClusters(page.observations, opts?.threshold ?? DEFAULT_SIMILARITY_THRESHOLD);
 
   if (clusters.length === 0) {
-    const allObs = await store.loadAll();
     return {
       clustersFound: 0,
       observationsMerged: 0,
-      observationsAfter: allObs.filter(o => o.projectId === projectId).length,
+      observationsAfter: await store.countByProject(projectId),
+      scanned: page.observations.length,
+      ...(page.nextCursor === undefined ? {} : { nextCursor: page.nextCursor }),
       merges: [],
     };
   }
@@ -212,19 +234,23 @@ export async function executeConsolidation(
     clustersFound: clusters.length,
     observationsMerged: 0,
     observationsAfter: 0,
+    scanned: page.observations.length,
+    ...(page.nextCursor === undefined ? {} : { nextCursor: page.nextCursor }),
     merges: [],
   };
 
   await store.atomic(async (tx) => {
-    const allObs = await tx.loadAll();
-    const obsMap = new Map(allObs.map(o => [o.id, o]));
     const idsToRemove = new Set<number>();
+    const updated = new Map<number, Observation>();
 
     for (let ci = 0; ci < clusters.length; ci++) {
       const cluster = clusters[ci];
-      const members = cluster.ids
-        .map(id => obsMap.get(id))
-        .filter((o): o is Observation => o !== undefined);
+      const members = (await Promise.all(cluster.ids.map((id) => tx.getById(id))))
+        .filter((observation): observation is Observation => {
+          if (!observation) return false;
+          return observation.projectId === projectId
+            && (observation.status ?? 'active') === 'active';
+        });
 
       if (members.length < MIN_CLUSTER_SIZE) continue;
 
@@ -276,6 +302,7 @@ export async function executeConsolidation(
       primary.narrative = narrativeParts.join('\n\n');
       primary.updatedAt = new Date().toISOString();
       primary.revisionCount = (primary.revisionCount ?? 1) + others.length;
+      updated.set(primary.id, primary);
 
       // Mark others for removal
       for (const other of others) {
@@ -291,12 +318,11 @@ export async function executeConsolidation(
       });
     }
 
-    // Remove merged observations
-    const remaining = allObs.filter(o => !idsToRemove.has(o.id));
-    await tx.saveAll(remaining);
-
-    result.observationsAfter = remaining.filter(o => o.projectId === projectId).length;
+    await Promise.all([...updated.values()].map((observation) => tx.update(observation)));
+    await Promise.all([...idsToRemove].map((id) => tx.remove(id)));
   });
+
+  result.observationsAfter = await store.countByProject(projectId);
 
   return result;
 }

--- a/src/memory/export-import.ts
+++ b/src/memory/export-import.ts
@@ -167,6 +167,7 @@ export async function importFromJson(
         .filter(o => o.topicKey)
         .map(o => `${o.projectId}::${o.topicKey}`),
     );
+    const observationsToInsert: Observation[] = [];
 
     // Import observations
     for (const obs of data.observations) {
@@ -178,6 +179,7 @@ export async function importFromJson(
 
       const newObs = { ...obs, id: nextId++ };
       existingObs.push(newObs);
+      observationsToInsert.push(newObs);
       imported++;
     }
 
@@ -190,7 +192,7 @@ export async function importFromJson(
       }
     }
 
-    await tx.saveAll(existingObs);
+    await Promise.all(observationsToInsert.map((observation) => tx.insert(observation)));
     await tx.saveIdCounter(nextId);
     // Persist imported sessions via store
     for (const session of data.sessions) {

--- a/src/memory/observations.ts
+++ b/src/memory/observations.ts
@@ -86,6 +86,23 @@ function normalizeEmbeddingFailure(error: unknown): { key: string; message: stri
   };
 }
 
+function queueVectorBackfill(projectId: string): void {
+  const dataDir = projectDir;
+  if (!dataDir) return;
+  void import('../runtime/maintenance-jobs.js')
+    .then(({ MaintenanceJobStore }) => {
+      new MaintenanceJobStore(dataDir).enqueue({
+        projectId,
+        kind: 'vector-backfill',
+        dedupeKey: 'vector-backfill',
+        payload: { limit: 12 },
+      });
+    })
+    .catch(() => {
+      // Memory writes remain durable even when the optional maintenance queue is unavailable.
+    });
+}
+
 async function bindObservationCodeRefsBestEffort(observation: Observation): Promise<void> {
   if (!projectDir) return;
   try {
@@ -199,6 +216,10 @@ export async function storeObservation(input: {
   // Covers all write paths: hooks, git-ingest, CLI, reasoning, compact-on-write, etc.
   input = { ...input, title: sanitizeCredentials(input.title), narrative: sanitizeCredentials(input.narrative), facts: input.facts?.map(sanitizeCredentials) };
 
+  // Sync the local cache before using it as the topicKey fast path. This costs a
+  // generation read in the normal case and only reloads when another process wrote.
+  await ensureFreshObservations();
+
   // Topic key upsert: fast-path check in-memory (optimistic, may be stale).
   // A second authoritative check happens inside the file lock to prevent TOCTOU races
   // where two concurrent calls with the same topicKey both miss this check.
@@ -235,26 +256,29 @@ export async function storeObservation(input: {
   let doc!: MemorixDocument;
 
   let upsertedInsideLock = false;
+  let reloadCacheAfterCommit = false;
   const assignAndPersist = async () => {
     if (projectDir) {
       const store = getObservationStore();
+      const cachedGeneration = store.getGeneration();
       await store.atomic(async (tx) => {
-        // Re-read from store to get the authoritative nextId and observation list
-        const diskObs = await tx.loadAll();
+        const transactionGeneration = await tx.getGeneration();
         const diskNextId = await tx.loadIdCounter();
+
+        // A different writer committed after the cache freshness check but before
+        // this transaction acquired its lock. Keep the cache coherent after commit.
+        reloadCacheAfterCommit = transactionGeneration !== cachedGeneration;
 
         // ── Atomic topicKey re-check inside lock (prevents TOCTOU race) ──
         // Two concurrent calls with the same topicKey may both pass the fast-path
         // check above, but here we re-check against the authoritative disk state.
         if (input.topicKey) {
-          const diskExisting = diskObs.find(
-            o => o.topicKey === input.topicKey && o.projectId === input.projectId,
-          );
+          const diskExisting = await tx.findByTopicKey(input.projectId, input.topicKey);
           if (diskExisting) {
-            // Switch to upsert path — update the existing observation in-place
-            observations = diskObs;
+            // Switch to upsert path — update the existing observation after this
+            // short transaction has released its lock.
             upsertedInsideLock = true;
-            observation = diskExisting as Observation;
+            observation = diskExisting;
             return; // Exit atomic — upsert will be handled after assignAndPersist
           }
         }
@@ -287,21 +311,29 @@ export async function storeObservation(input: {
           sourceDetail: input.sourceDetail,
           valueCategory: input.valueCategory,
           createdByAgentId: input.createdByAgentId,
-          // Phase 4a: predict writeGeneration before saveAll so it gets persisted to SQLite.
+          // Predict the generation that atomic() will commit after this callback.
           // bumpGeneration() runs after fn(tx) returns, incrementing by 1.
-          writeGeneration: store.getGeneration() + 1,
+          writeGeneration: transactionGeneration + 1,
         };
 
-        diskObs.push(observation);
-        nextId = id + 1;
-        observations = diskObs;
-
-        await tx.saveAll(observations);
-        await tx.saveIdCounter(nextId);
+        await tx.insert(observation);
+        await tx.saveIdCounter(id + 1);
       });
 
       // Phase 4a: confirm writeGeneration matches actual post-bump value
       observation.writeGeneration = store.getGeneration();
+
+      if (upsertedInsideLock || reloadCacheAfterCommit) {
+        observations = await store.loadAll();
+        nextId = await store.loadIdCounter();
+        if (upsertedInsideLock) {
+          observation = observations.find((candidate) => candidate.id === observation.id)
+            ?? observation;
+        }
+      } else {
+        observations.push(observation);
+        nextId = observation.id + 1;
+      }
 
       // If the atomic block detected a topicKey duplicate, skip Orama insert — upsert handles it
       if (upsertedInsideLock) return;
@@ -384,6 +416,7 @@ export async function storeObservation(input: {
         console.error(
           `[memorix] Embedding dimension mismatch for obs-${obsId}: provider returned ${embedding.length}d, index expects ${vectorDimensions ?? 'unknown'}d (kept in backfill queue)`,
         );
+        queueVectorBackfill(input.projectId);
         return;
       }
       try {
@@ -393,16 +426,19 @@ export async function storeObservation(input: {
         vectorMissingIds.delete(obsId);
       } catch {
         console.error(`[memorix] Embedding index update failed for obs-${obsId} (kept in backfill queue)`);
+        queueVectorBackfill(input.projectId);
       }
     } else if (isEmbeddingExplicitlyDisabled()) {
       vectorMissingIds.delete(obsId);
     } else {
+      queueVectorBackfill(input.projectId);
       logEmbeddingFailureOnce(
         'provider-unavailable',
         `[memorix] Embedding provider unavailable (using BM25 until embedding recovers; queued obs-${obsId} for retry)`,
       );
     }
   }).catch((err) => {
+    queueVectorBackfill(input.projectId);
     const failure = normalizeEmbeddingFailure(err);
     logEmbeddingFailureOnce(
       failure.key,
@@ -522,17 +558,25 @@ async function upsertObservation(
   // Generate embedding async (fire-and-forget) — never blocks MCP response
   const searchableText = [input.title, input.narrative, ...(input.facts ?? [])].join(' ');
   const obsId = existing.id;
+  vectorMissingIds.add(obsId);
   generateEmbedding(searchableText).then(async (embedding) => {
     if (embedding) {
       try {
         const { removeObservation: removeObs } = await import('../store/orama-store.js');
         await removeObs(makeOramaObservationId(existing.projectId, obsId));
         await insertObservation(Object.assign({}, doc, { embedding }));
+        vectorMissingIds.delete(obsId);
       } catch {
         // Embedding index update failed — observation still persisted without vector
+        queueVectorBackfill(existing.projectId);
       }
+    } else if (isEmbeddingExplicitlyDisabled()) {
+      vectorMissingIds.delete(obsId);
+    } else {
+      queueVectorBackfill(existing.projectId);
     }
   }).catch((err) => {
+    queueVectorBackfill(existing.projectId);
     const failure = normalizeEmbeddingFailure(err);
     logEmbeddingFailureOnce(
       failure.key,
@@ -560,6 +604,7 @@ export async function resolveObservations(
 ): Promise<{ resolved: number[]; notFound: number[] }> {
   const resolved: number[] = [];
   const notFound: number[] = [];
+  const changed: Observation[] = [];
   const now = new Date().toISOString();
 
   for (const id of ids) {
@@ -574,6 +619,7 @@ export async function resolveObservations(
       obs.progress.status = status === 'resolved' ? 'completed' : obs.progress.status;
     }
     resolved.push(id);
+    changed.push(obs);
 
     // Update Orama index (without blocking on embedding)
     try {
@@ -616,7 +662,9 @@ export async function resolveObservations(
   // Persist via ObservationStore
   if (projectDir && resolved.length > 0) {
     const store = getObservationStore();
-    await store.bulkReplace(observations);
+    await store.atomic(async (tx) => {
+      await Promise.all(changed.map((observation) => tx.update(observation)));
+    });
   }
 
   return { resolved, notFound };
@@ -652,16 +700,20 @@ export async function migrateProjectIds(
   if (nonCanonical.size === 0) return 0;
 
   let migrated = 0;
+  const changed: Observation[] = [];
   for (const obs of observations) {
     if (nonCanonical.has(obs.projectId)) {
       obs.projectId = canonicalId;
       migrated++;
+      changed.push(obs);
     }
   }
 
   if (migrated > 0 && projectDir) {
     const store = getObservationStore();
-    await store.bulkReplace(observations);
+    await store.atomic(async (tx) => {
+      await Promise.all(changed.map((observation) => tx.update(observation)));
+    });
   }
 
   return migrated;
@@ -831,25 +883,28 @@ export async function prepareSearchIndex(): Promise<number> {
  * Get the current set of observation IDs that are missing vector embeddings.
  * Useful for dashboards, health checks, and monitoring search quality degradation.
  */
-export function getVectorMissingIds(): number[] {
-  return [...vectorMissingIds];
+export function getVectorMissingIds(projectId?: string): number[] {
+  if (!projectId) return [...vectorMissingIds];
+  const observationById = new Map(observations.map((observation) => [observation.id, observation]));
+  return [...vectorMissingIds].filter((id) => observationById.get(id)?.projectId === projectId);
 }
 
 /**
  * Get a summary of vector embedding status.
  * Returns total observations, how many have vectors, and how many are missing.
  */
-export function getVectorStatus(): {
+export function getVectorStatus(projectId?: string): {
   total: number;
   missing: number;
   missingIds: number[];
   backfillRunning: boolean;
   lastBackfill: typeof lastVectorBackfill;
 } {
+  const missingIds = getVectorMissingIds(projectId);
   return {
-    total: observations.length,
-    missing: vectorMissingIds.size,
-    missingIds: [...vectorMissingIds],
+    total: projectId ? observations.filter((observation) => observation.projectId === projectId).length : observations.length,
+    missing: missingIds.length,
+    missingIds,
     backfillRunning: vectorBackfillRunning,
     lastBackfill: lastVectorBackfill,
   };
@@ -896,7 +951,10 @@ export async function probeSearchIndex(projectId: string): Promise<string> {
  *
  * Safe to call concurrently — only one backfill runs at a time.
  */
-export async function backfillVectorEmbeddings(): Promise<{
+export async function backfillVectorEmbeddings(options: {
+  projectId?: string;
+  limit?: number;
+} = {}): Promise<{
   attempted: number;
   succeeded: number;
   failed: number;
@@ -906,14 +964,20 @@ export async function backfillVectorEmbeddings(): Promise<{
   }
   vectorBackfillRunning = true;
 
-  const ids = [...vectorMissingIds];
+  const observationById = new Map(observations.map((observation) => [observation.id, observation]));
+  const limit = Number.isFinite(options.limit)
+    ? Math.max(1, Math.floor(options.limit!))
+    : Number.POSITIVE_INFINITY;
+  const ids = [...vectorMissingIds]
+    .filter((id) => !options.projectId || observationById.get(id)?.projectId === options.projectId)
+    .slice(0, limit);
   let succeeded = 0;
   let failed = 0;
   let lastFailure: string | undefined;
 
   try {
     for (const id of ids) {
-      const obs = observations.find(o => o.id === id);
+      const obs = observationById.get(id);
       if (!obs) {
         vectorMissingIds.delete(id);
         continue;

--- a/src/memory/retention.ts
+++ b/src/memory/retention.ts
@@ -363,6 +363,89 @@ export function explainRetention(
 
 // ── Auto-Archive ────────────────────────────────────────────────────
 
+export interface ArchiveExpiredBatchOptions {
+  projectId: string;
+  afterId?: number;
+  limit?: number;
+  referenceTime?: Date;
+  accessMap?: Map<number, { accessCount: number; lastAccessedAt: string }>;
+}
+
+export interface ArchiveExpiredBatchResult {
+  archived: number;
+  scanned: number;
+  nextCursor?: number;
+}
+
+function toRetentionDocument(
+  obs: Observation,
+  accessMap?: Map<number, { accessCount: number; lastAccessedAt: string }>,
+): MemorixDocument {
+  const access = accessMap?.get(obs.id);
+  return {
+    id: `obs-${obs.id}`,
+    observationId: obs.id,
+    entityName: obs.entityName,
+    type: obs.type,
+    title: obs.title,
+    narrative: obs.narrative,
+    facts: obs.facts.join('\n'),
+    filesModified: obs.filesModified.join('\n'),
+    concepts: obs.concepts.join(', '),
+    tokens: obs.tokens,
+    createdAt: obs.createdAt,
+    projectId: obs.projectId,
+    accessCount: access?.accessCount ?? 0,
+    lastAccessedAt: access?.lastAccessedAt ?? '',
+    status: obs.status ?? 'active',
+    source: obs.source ?? 'agent',
+    sourceDetail: obs.sourceDetail ?? '',
+    valueCategory: obs.valueCategory ?? '',
+  };
+}
+
+/**
+ * Archive one bounded page of a project's active memories. The caller owns the
+ * cursor, which makes the operation safe to run from a durable maintenance job.
+ */
+export async function archiveExpiredBatch(
+  _projectDir: string,
+  options: ArchiveExpiredBatchOptions,
+): Promise<ArchiveExpiredBatchResult> {
+  const store = getObservationStore();
+  const limit = Math.min(500, Math.max(1, Math.floor(options.limit ?? 100)));
+  const afterId = Math.max(0, Math.floor(options.afterId ?? 0));
+  const page = await store.loadByProject(options.projectId, {
+    status: 'active',
+    afterId,
+    limit: limit + 1,
+  });
+  const hasMore = page.length > limit;
+  const scanned = hasMore ? page.slice(0, limit) : page;
+  const candidateIds = scanned
+    .filter((observation) => getRetentionZone(
+      toRetentionDocument(observation, options.accessMap),
+      options.referenceTime,
+    ) === 'archive-candidate')
+    .map((observation) => observation.id);
+
+  const archived = candidateIds.length === 0
+    ? 0
+    : await store.atomic(async (tx) => {
+      const updates = await Promise.all(
+        candidateIds.map((id) => tx.setStatus(id, 'archived', 'active')),
+      );
+      return updates.filter(Boolean).length;
+    });
+
+  const nextCursor = hasMore && scanned.length > 0
+    ? scanned[scanned.length - 1].id
+    : undefined;
+  return nextCursor === undefined
+    ? { archived, scanned: scanned.length }
+    : { archived, scanned: scanned.length, nextCursor };
+}
+
 /**
  * Archive expired observations by setting status='archived' in-place.
  *
@@ -377,57 +460,52 @@ export async function archiveExpired(
   projectDir: string,
   referenceTime?: Date,
   accessMap?: Map<number, { accessCount: number; lastAccessedAt: string }>,
+  projectId?: string,
 ): Promise<{ archived: number; remaining: number }> {
   const store = getObservationStore();
+  if (projectId) {
+    let afterId: number | undefined;
+    let archived = 0;
+    do {
+      const batch = await archiveExpiredBatch(projectDir, {
+        projectId,
+        afterId,
+        referenceTime,
+        accessMap,
+      });
+      archived += batch.archived;
+      afterId = batch.nextCursor;
+    } while (afterId !== undefined);
+
+    const remaining = await store.countByProject(projectId, { status: 'active' });
+    return { archived, remaining };
+  }
+
   return await store.atomic(async (tx) => {
     const allObs = await tx.loadAll();
 
-    // Convert to MemorixDocument-like shape for zone calculation
-    // Use accessMap (from Orama index) when available for accurate immunity checks
-    const toDoc = (obs: Observation): MemorixDocument => {
-      const access = accessMap?.get(obs.id);
-      return {
-        id: `obs-${obs.id}`,
-        observationId: obs.id,
-        entityName: obs.entityName,
-        type: obs.type,
-        title: obs.title,
-        narrative: obs.narrative,
-        facts: obs.facts.join('\n'),
-        filesModified: obs.filesModified.join('\n'),
-        concepts: obs.concepts.join(', '),
-        tokens: obs.tokens,
-        createdAt: obs.createdAt,
-        projectId: obs.projectId,
-        accessCount: access?.accessCount ?? 0,
-        lastAccessedAt: access?.lastAccessedAt ?? '',
-        status: obs.status ?? 'active',
-        source: obs.source ?? 'agent',
-        sourceDetail: obs.sourceDetail ?? '',
-        valueCategory: obs.valueCategory ?? '',
-      };
-    };
-
     // Only consider active observations for archiving
-    const activeObs = allObs.filter(o => (o.status ?? 'active') === 'active');
-    let archivedCount = 0;
+    const activeObs = allObs.filter((observation) =>
+      (observation.status ?? 'active') === 'active' &&
+      (!projectId || observation.projectId === projectId),
+    );
+    const archivedIds: number[] = [];
 
     for (const obs of activeObs) {
-      const doc = toDoc(obs);
+      const doc = toRetentionDocument(obs, accessMap);
       const zone = getRetentionZone(doc, referenceTime);
       if (zone === 'archive-candidate') {
-        obs.status = 'archived';
-        archivedCount++;
+        archivedIds.push(obs.id);
       }
     }
 
-    if (archivedCount === 0) {
+    if (archivedIds.length === 0) {
       return { archived: 0, remaining: activeObs.length };
     }
 
-    // Persist all observations with updated statuses
-    await tx.saveAll(allObs);
+    const updates = await Promise.all(archivedIds.map((id) => tx.setStatus(id, 'archived', 'active')));
+    const archived = updates.filter(Boolean).length;
 
-    return { archived: archivedCount, remaining: activeObs.length - archivedCount };
+    return { archived, remaining: activeObs.length - archived };
   });
 }

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -100,6 +100,26 @@ async function resolveProjectIds(projectId: string): Promise<Set<string>> {
   }
 }
 
+async function loadAliasSessions(projectIds: Set<string>): Promise<Session[]> {
+  const store = getSessionStore();
+  const groups = await Promise.all([...projectIds].map((projectId) => store.loadByProject(projectId)));
+  return groups.flat();
+}
+
+async function loadAliasActiveSessions(projectIds: Set<string>): Promise<Session[]> {
+  const store = getSessionStore();
+  const groups = await Promise.all([...projectIds].map((projectId) => store.loadActive(projectId)));
+  return groups.flat();
+}
+
+async function loadAliasActiveObservations(projectIds: Set<string>): Promise<Observation[]> {
+  const store = getObservationStore();
+  const groups = await Promise.all(
+    [...projectIds].map((projectId) => store.loadByProject(projectId, { status: 'active' })),
+  );
+  return groups.flat();
+}
+
 /**
  * Generate a unique session ID.
  */
@@ -262,8 +282,7 @@ export async function endSession(
   summary?: string,
 ): Promise<Session | null> {
   const sessionStore = getSessionStore();
-  const sessions = await sessionStore.loadAll();
-  const session = sessions.find((entry) => entry.id === sessionId);
+  const session = await sessionStore.getById(sessionId);
 
   if (!session) return null;
 
@@ -292,10 +311,11 @@ export async function getSessionContext(
   projectId: string,
   limit: number = 3,
 ): Promise<string> {
-  const sessions = await getSessionStore().loadAll();
-  const allObs = await getObservationStore().loadAll();
-
   const aliasSet = await resolveProjectIds(projectId);
+  const [sessions, allObs] = await Promise.all([
+    loadAliasSessions(aliasSet),
+    loadAliasActiveObservations(aliasSet),
+  ]);
   /** Check if a session summary contains noise/system-self content */
   const isNoisySummary = (summary: string | undefined): boolean => {
     if (!summary) return false;
@@ -303,7 +323,7 @@ export async function getSessionContext(
   };
 
   const projectSessions = sessions
-    .filter((session) => aliasSet.has(session.projectId) && session.status === 'completed')
+    .filter((session) => session.status === 'completed')
     .filter((session) => !isNoisySummary(session.summary))
     .sort((a, b) => new Date(b.endedAt || b.startedAt).getTime() - new Date(a.endedAt || a.startedAt).getTime())
     .slice(0, limit);
@@ -317,7 +337,6 @@ export async function getSessionContext(
 
   // ── Partition project observations by disclosure layer ─────────────
   const projectObs = allObs
-    .filter((obs) => aliasSet.has(obs.projectId) && (obs.status ?? 'active') === 'active')
     .filter((obs) => !isNoiseObservation(obs) && !isSystemSelfObservation(obs));
 
   // L2: durable working context (explicit/undefined/core), priority types only
@@ -503,8 +522,7 @@ export async function listSessions(
   const sessionStore = getSessionStore();
   if (projectId) {
     const aliasSet = await resolveProjectIds(projectId);
-    const all = await sessionStore.loadAll();
-    return all.filter((session) => aliasSet.has(session.projectId));
+    return loadAliasSessions(aliasSet);
   }
   return sessionStore.loadAll();
 }
@@ -516,8 +534,9 @@ export async function getActiveSession(
   projectDir: string,
   projectId: string,
 ): Promise<Session | null> {
-  const sessionStore = getSessionStore();
-  const sessions = await sessionStore.loadAll();
   const aliasSet = await resolveProjectIds(projectId);
-  return sessions.find((session) => aliasSet.has(session.projectId) && session.status === 'active') || null;
+  const sessions = await loadAliasActiveSessions(aliasSet);
+  return sessions
+    .sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime())[0]
+    ?? null;
 }

--- a/src/runtime/control-plane-maintenance.ts
+++ b/src/runtime/control-plane-maintenance.ts
@@ -1,0 +1,62 @@
+import {
+  MaintenanceJobStore,
+  MaintenanceJobWorker,
+  type MaintenanceJobHandler,
+  type MaintenanceJobKind,
+} from './maintenance-jobs.js';
+import { runMaintenanceInChildProcess } from './isolated-maintenance.js';
+import { MaintenanceTargetStore } from './maintenance-targets.js';
+
+export const CONTROL_PLANE_MAINTENANCE_KINDS: readonly MaintenanceJobKind[] = [
+  'retention-archive',
+  'consolidation',
+  'codegraph-refresh',
+];
+
+const TARGET_WAIT_RETRY_MS = 30_000;
+
+/**
+ * Resolve a durable job to an isolated runner without sharing a session's
+ * global config, observation cache, or Orama index with another HTTP client.
+ */
+export function createControlPlaneMaintenanceHandler(
+  dataDir: string,
+  isolatedRunner: typeof runMaintenanceInChildProcess = runMaintenanceInChildProcess,
+): MaintenanceJobHandler {
+  const targets = new MaintenanceTargetStore(dataDir);
+  return async (job) => {
+    if (!CONTROL_PLANE_MAINTENANCE_KINDS.includes(job.kind)) {
+      throw new Error(`Control-plane worker cannot process ${job.kind}`);
+    }
+    const target = targets.get(job.projectId);
+    if (!target) {
+      return { action: 'reschedule', delayMs: TARGET_WAIT_RETRY_MS };
+    }
+    return isolatedRunner({
+      job,
+      projectRoot: target.projectRoot,
+      dataDir: target.dataDir,
+    });
+  };
+}
+
+export function createControlPlaneMaintenanceWorker(
+  dataDir: string,
+  options: {
+    workerId?: string;
+    pollIntervalMs?: number;
+    leaseMs?: number;
+    isolatedRunner?: typeof runMaintenanceInChildProcess;
+  } = {},
+): MaintenanceJobWorker {
+  return new MaintenanceJobWorker(
+    new MaintenanceJobStore(dataDir),
+    createControlPlaneMaintenanceHandler(dataDir, options.isolatedRunner),
+    {
+      workerId: options.workerId,
+      pollIntervalMs: options.pollIntervalMs,
+      leaseMs: options.leaseMs,
+      kinds: CONTROL_PLANE_MAINTENANCE_KINDS,
+    },
+  );
+}

--- a/src/runtime/isolated-maintenance.ts
+++ b/src/runtime/isolated-maintenance.ts
@@ -1,0 +1,187 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import type { MaintenanceJob, MaintenanceJobKind, MaintenanceJobRunResult } from './maintenance-jobs.js';
+import { sanitizeCredentials } from '../memory/secret-filter.js';
+
+export const MAINTENANCE_RESULT_PREFIX = '__MEMORIX_MAINTENANCE_RESULT__';
+
+export const ISOLATED_MAINTENANCE_JOB_KINDS: readonly MaintenanceJobKind[] = [
+  'retention-archive',
+  'consolidation',
+  'codegraph-refresh',
+];
+const DEFAULT_TIMEOUT_MS = 5 * 60_000;
+const MAX_CHILD_OUTPUT_BYTES = 1_000_000;
+
+export interface IsolatedMaintenanceRequest {
+  job: MaintenanceJob;
+  projectRoot: string;
+  dataDir: string;
+}
+
+export interface IsolatedMaintenanceOptions {
+  runnerPath?: string;
+  timeoutMs?: number;
+  env?: NodeJS.ProcessEnv;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isMaintenanceResult(value: unknown): value is MaintenanceJobRunResult {
+  if (!isRecord(value)) return false;
+  if (value.action === 'complete') return true;
+  return value.action === 'reschedule' && typeof value.delayMs === 'number';
+}
+
+function childError(prefix: string, detail: string): Error {
+  const cleaned = sanitizeCredentials(detail.trim()).slice(0, 4_000);
+  return new Error(cleaned ? `${prefix}: ${cleaned}` : prefix);
+}
+
+/**
+ * Resolve the runner beside the compiled package entry. The CLI bundle lives
+ * in dist/cli while the library entry lives directly in dist.
+ */
+export function resolveMaintenanceRunnerPath(moduleUrl = import.meta.url): string {
+  const moduleDir = path.dirname(fileURLToPath(moduleUrl));
+  const distDir = path.basename(moduleDir) === 'cli'
+    ? path.dirname(moduleDir)
+    : path.basename(moduleDir) === 'runtime' && path.basename(path.dirname(moduleDir)) === 'src'
+      ? path.join(path.dirname(path.dirname(moduleDir)), 'dist')
+      : moduleDir;
+  return path.join(distDir, 'maintenance-runner.js');
+}
+
+export function parseMaintenanceRunnerOutput(output: string): MaintenanceJobRunResult {
+  const line = output
+    .split(/\r?\n/)
+    .reverse()
+    .find((candidate) => candidate.startsWith(MAINTENANCE_RESULT_PREFIX));
+  if (!line) {
+    throw childError('Maintenance runner did not return a result', output);
+  }
+
+  try {
+    const parsed = JSON.parse(line.slice(MAINTENANCE_RESULT_PREFIX.length));
+    if (!isMaintenanceResult(parsed)) {
+      throw new Error('result shape is invalid');
+    }
+    return parsed;
+  } catch (error) {
+    throw childError(
+      'Maintenance runner returned an invalid result',
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+}
+
+function validateRequest(request: IsolatedMaintenanceRequest): void {
+  if (!ISOLATED_MAINTENANCE_JOB_KINDS.includes(request.job.kind)) {
+    throw new Error(`Maintenance job ${request.job.kind} cannot run in an isolated worker`);
+  }
+  if (!path.isAbsolute(request.projectRoot)) {
+    throw new Error('Maintenance runner requires an absolute project root');
+  }
+  if (!path.isAbsolute(request.dataDir)) {
+    throw new Error('Maintenance runner requires an absolute data directory');
+  }
+}
+
+function collectOutput(
+  stream: NodeJS.ReadableStream,
+  limit: number,
+  onOverflow: () => void,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let value = '';
+    let size = 0;
+    stream.setEncoding('utf8');
+    stream.on('data', (chunk: string) => {
+      size += Buffer.byteLength(chunk);
+      if (size > limit) {
+        onOverflow();
+        reject(new Error('maintenance runner output exceeded its safety limit'));
+        return;
+      }
+      value += chunk;
+    });
+    stream.on('error', reject);
+    stream.on('end', () => resolve(value));
+  });
+}
+
+/**
+ * Runs CPU/disk-heavy maintenance out of the MCP process. The parent keeps
+ * the durable queue lease; the child gets only one job and returns one result.
+ */
+export async function runMaintenanceInChildProcess(
+  request: IsolatedMaintenanceRequest,
+  options: IsolatedMaintenanceOptions = {},
+): Promise<MaintenanceJobRunResult> {
+  validateRequest(request);
+  const runnerPath = options.runnerPath ?? resolveMaintenanceRunnerPath();
+  if (!existsSync(runnerPath)) {
+    throw new Error(`Maintenance runner is unavailable at ${runnerPath}. Reinstall or rebuild Memorix.`);
+  }
+
+  const timeoutMs = Number.isFinite(options.timeoutMs)
+    ? Math.max(1_000, Math.floor(options.timeoutMs!))
+    : DEFAULT_TIMEOUT_MS;
+  const env = { ...process.env, ...options.env };
+
+  return new Promise<MaintenanceJobRunResult>((resolve, reject) => {
+    let settled = false;
+    let child: ChildProcessWithoutNullStreams;
+    try {
+      child = spawn(process.execPath, [runnerPath], {
+        cwd: request.projectRoot,
+        env,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+      });
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
+    const settle = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      fn();
+    };
+    const terminateForOutput = (): void => {
+      child.kill();
+    };
+    const stdout = collectOutput(child.stdout, MAX_CHILD_OUTPUT_BYTES, terminateForOutput);
+    const stderr = collectOutput(child.stderr, MAX_CHILD_OUTPUT_BYTES, terminateForOutput);
+    const timeout = setTimeout(() => {
+      child.kill();
+      settle(() => reject(new Error(`Maintenance runner timed out after ${timeoutMs}ms`)));
+    }, timeoutMs);
+
+    child.once('error', (error) => settle(() => reject(error)));
+    child.once('close', async (code, signal) => {
+      try {
+        const [out, err] = await Promise.all([stdout, stderr]);
+        if (code !== 0) {
+          settle(() => reject(childError(
+            `Maintenance runner exited with ${signal ? `signal ${signal}` : `code ${code ?? 'unknown'}`}`,
+            err || out,
+          )));
+          return;
+        }
+        settle(() => resolve(parseMaintenanceRunnerOutput(out)));
+      } catch (error) {
+        settle(() => reject(error));
+      }
+    });
+
+    child.stdin.end(JSON.stringify(request));
+  });
+}

--- a/src/runtime/maintenance-jobs.ts
+++ b/src/runtime/maintenance-jobs.ts
@@ -1,0 +1,512 @@
+import { randomUUID } from 'node:crypto';
+
+import { getDatabase } from '../store/sqlite-db.js';
+import { sanitizeCredentials } from '../memory/secret-filter.js';
+
+export const MAINTENANCE_JOB_KINDS = [
+  'vector-backfill',
+  'retention-archive',
+  'consolidation',
+  'codegraph-refresh',
+] as const;
+
+export type MaintenanceJobKind = typeof MAINTENANCE_JOB_KINDS[number];
+export type MaintenanceJobStatus = 'pending' | 'running' | 'retry' | 'completed' | 'failed';
+
+export interface MaintenanceJob {
+  id: string;
+  projectId: string;
+  kind: MaintenanceJobKind;
+  dedupeKey: string;
+  payload: Record<string, unknown>;
+  status: MaintenanceJobStatus;
+  attempts: number;
+  maxAttempts: number;
+  runAfter: number;
+  leaseOwner?: string;
+  leaseExpiresAt?: number;
+  lastError?: string;
+  createdAt: number;
+  updatedAt: number;
+  completedAt?: number;
+}
+
+export interface EnqueueMaintenanceJobInput {
+  projectId: string;
+  kind: MaintenanceJobKind;
+  dedupeKey?: string;
+  payload?: Record<string, unknown>;
+  maxAttempts?: number;
+  runAfter?: number;
+  now?: number;
+}
+
+export interface ClaimMaintenanceJobOptions {
+  workerId: string;
+  projectId?: string;
+  /** Limit this worker to compatible job kinds without claiming other work. */
+  kinds?: readonly MaintenanceJobKind[];
+  leaseMs?: number;
+  now?: number;
+}
+
+export interface MaintenanceJobSummary {
+  total: number;
+  pending: number;
+  running: number;
+  retrying: number;
+  completed: number;
+  failed: number;
+}
+
+export type MaintenanceJobRunResult =
+  | { action: 'complete' }
+  | { action: 'reschedule'; delayMs: number; resetAttempts?: boolean; payload?: Record<string, unknown> };
+
+export type MaintenanceJobHandler = (
+  job: MaintenanceJob,
+) => Promise<MaintenanceJobRunResult | void>;
+
+const DEFAULT_MAX_ATTEMPTS = 8;
+const DEFAULT_LEASE_MS = 30_000;
+const DEFAULT_POLL_INTERVAL_MS = 2_000;
+const MAX_ERROR_LENGTH = 1_000;
+const DEFAULT_COMPLETED_HISTORY_RETENTION_MS = 7 * 24 * 60 * 60 * 1_000;
+
+function parsePayload(raw: unknown): Record<string, unknown> {
+  if (typeof raw !== 'string' || !raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function rowToJob(row: any): MaintenanceJob {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    kind: row.kind as MaintenanceJobKind,
+    dedupeKey: row.dedupe_key,
+    payload: parsePayload(row.payload_json),
+    status: row.status as MaintenanceJobStatus,
+    attempts: Number(row.attempts),
+    maxAttempts: Number(row.max_attempts),
+    runAfter: Number(row.run_after),
+    ...(row.lease_owner ? { leaseOwner: row.lease_owner } : {}),
+    ...(row.lease_expires_at != null ? { leaseExpiresAt: Number(row.lease_expires_at) } : {}),
+    ...(row.last_error ? { lastError: row.last_error } : {}),
+    createdAt: Number(row.created_at),
+    updatedAt: Number(row.updated_at),
+    ...(row.completed_at != null ? { completedAt: Number(row.completed_at) } : {}),
+  };
+}
+
+function clampPositiveInteger(value: number | undefined, fallback: number): number {
+  if (!Number.isFinite(value) || value == null) return fallback;
+  return Math.max(1, Math.floor(value));
+}
+
+function errorText(error: unknown): string {
+  const text = error instanceof Error ? error.message : String(error);
+  return sanitizeCredentials(text).slice(0, MAX_ERROR_LENGTH);
+}
+
+function normalizedKinds(kinds: readonly MaintenanceJobKind[] | undefined): MaintenanceJobKind[] | undefined {
+  if (!kinds) return undefined;
+  return [...new Set(kinds.filter((kind) => MAINTENANCE_JOB_KINDS.includes(kind)))];
+}
+
+/** Retry delay grows slowly enough for a local control plane but never spins. */
+export function getMaintenanceRetryDelayMs(attempts: number): number {
+  return Math.min(60_000, 1_000 * (2 ** Math.max(0, attempts - 1)));
+}
+
+/**
+ * Persistent queue for work that must never run inside an MCP tool handler.
+ * SQLite leases make recovery deterministic when a process exits mid-job.
+ */
+export class MaintenanceJobStore {
+  private readonly db: any;
+
+  constructor(dataDir: string) {
+    this.db = getDatabase(dataDir);
+  }
+
+  enqueue(input: EnqueueMaintenanceJobInput): MaintenanceJob {
+    const now = input.now ?? Date.now();
+    const dedupeKey = input.dedupeKey ?? input.kind;
+    const runAfter = input.runAfter ?? now;
+    const maxAttempts = clampPositiveInteger(input.maxAttempts, DEFAULT_MAX_ATTEMPTS);
+    const payloadJson = JSON.stringify(input.payload ?? {});
+
+    this.begin();
+    try {
+      this.pruneCompletedHistory({ now });
+      const existing = this.db.prepare(`
+        SELECT * FROM maintenance_jobs
+        WHERE project_id = ? AND kind = ? AND dedupe_key = ?
+          AND status IN ('pending', 'running', 'retry')
+        LIMIT 1
+      `).get(input.projectId, input.kind, dedupeKey);
+
+      if (existing) {
+        const nextRunAfter = Math.min(Number(existing.run_after), runAfter);
+        this.db.prepare(`
+          UPDATE maintenance_jobs
+          SET payload_json = ?, run_after = ?, updated_at = ?
+          WHERE id = ?
+        `).run(payloadJson, nextRunAfter, now, existing.id);
+        const updated = this.getRow(existing.id)!;
+        this.commit();
+        return rowToJob(updated);
+      }
+
+      const id = randomUUID();
+      this.db.prepare(`
+        INSERT INTO maintenance_jobs (
+          id, project_id, kind, dedupe_key, payload_json, status, attempts,
+          max_attempts, run_after, created_at, updated_at
+        ) VALUES (?, ?, ?, ?, ?, 'pending', 0, ?, ?, ?, ?)
+      `).run(id, input.projectId, input.kind, dedupeKey, payloadJson, maxAttempts, runAfter, now, now);
+      const created = this.getRow(id)!;
+      this.commit();
+      return rowToJob(created);
+    } catch (error) {
+      this.rollback();
+      throw error;
+    }
+  }
+
+  get(id: string): MaintenanceJob | undefined {
+    const row = this.getRow(id);
+    return row ? rowToJob(row) : undefined;
+  }
+
+  list(options: { projectId?: string; status?: MaintenanceJobStatus; limit?: number } = {}): MaintenanceJob[] {
+    const limit = Math.min(500, clampPositiveInteger(options.limit, 100));
+    const clauses: string[] = [];
+    const values: unknown[] = [];
+    if (options.projectId) {
+      clauses.push('project_id = ?');
+      values.push(options.projectId);
+    }
+    if (options.status) {
+      clauses.push('status = ?');
+      values.push(options.status);
+    }
+    const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
+    const rows = this.db.prepare(`
+      SELECT * FROM maintenance_jobs
+      ${where}
+      ORDER BY run_after ASC, created_at ASC
+      LIMIT ?
+    `).all(...values, limit);
+    return rows.map(rowToJob);
+  }
+
+  summary(projectId?: string): MaintenanceJobSummary {
+    const row = projectId
+      ? this.db.prepare(`
+          SELECT
+            COUNT(*) AS total,
+            SUM(status = 'pending') AS pending,
+            SUM(status = 'running') AS running,
+            SUM(status = 'retry') AS retrying,
+            SUM(status = 'completed') AS completed,
+            SUM(status = 'failed') AS failed
+          FROM maintenance_jobs WHERE project_id = ?
+        `).get(projectId)
+      : this.db.prepare(`
+          SELECT
+            COUNT(*) AS total,
+            SUM(status = 'pending') AS pending,
+            SUM(status = 'running') AS running,
+            SUM(status = 'retry') AS retrying,
+            SUM(status = 'completed') AS completed,
+            SUM(status = 'failed') AS failed
+          FROM maintenance_jobs
+        `).get();
+    return {
+      total: Number(row?.total ?? 0),
+      pending: Number(row?.pending ?? 0),
+      running: Number(row?.running ?? 0),
+      retrying: Number(row?.retrying ?? 0),
+      completed: Number(row?.completed ?? 0),
+      failed: Number(row?.failed ?? 0),
+    };
+  }
+
+  /**
+   * Completed jobs are useful recent operator history, not permanent data.
+   * Failed jobs stay available for diagnosis until an operator explicitly
+   * resolves them or clears the database.
+   */
+  pruneCompletedHistory(options: { now?: number; maxAgeMs?: number } = {}): number {
+    const now = options.now ?? Date.now();
+    const maxAgeMs = Number.isFinite(options.maxAgeMs)
+      ? Math.max(0, Math.floor(options.maxAgeMs!))
+      : DEFAULT_COMPLETED_HISTORY_RETENTION_MS;
+    const result = this.db.prepare(`
+      DELETE FROM maintenance_jobs
+      WHERE status = 'completed'
+        AND completed_at IS NOT NULL
+        AND completed_at < ?
+    `).run(now - maxAgeMs);
+    return Number(result.changes ?? 0);
+  }
+
+  claimNext(options: ClaimMaintenanceJobOptions): MaintenanceJob | undefined {
+    const now = options.now ?? Date.now();
+    const leaseMs = clampPositiveInteger(options.leaseMs, DEFAULT_LEASE_MS);
+    const kinds = normalizedKinds(options.kinds);
+
+    this.begin();
+    try {
+      // A dead worker leaves a leased row behind. Make it retryable before
+      // selecting the next candidate, while respecting its retry budget.
+      this.db.prepare(`
+        UPDATE maintenance_jobs
+        SET
+          status = CASE WHEN attempts >= max_attempts THEN 'failed' ELSE 'retry' END,
+          run_after = CASE WHEN attempts >= max_attempts THEN run_after ELSE ? END,
+          lease_owner = NULL,
+          lease_expires_at = NULL,
+          last_error = COALESCE(last_error, 'worker lease expired'),
+          updated_at = ?
+        WHERE status = 'running' AND lease_expires_at IS NOT NULL AND lease_expires_at <= ?
+      `).run(now, now, now);
+      this.db.prepare(`
+        UPDATE maintenance_jobs
+        SET status = 'failed', updated_at = ?
+        WHERE status IN ('pending', 'retry') AND attempts >= max_attempts
+      `).run(now);
+
+      if (options.kinds && kinds?.length === 0) {
+        this.commit();
+        return undefined;
+      }
+      const projectClause = options.projectId ? 'AND project_id = ?' : '';
+      const kindClause = kinds?.length
+        ? `AND kind IN (${kinds.map(() => '?').join(', ')})`
+        : '';
+      const values = [
+        now,
+        ...(kinds ?? []),
+        ...(options.projectId ? [options.projectId] : []),
+      ];
+      const candidate = this.db.prepare(`
+        SELECT * FROM maintenance_jobs
+        WHERE status IN ('pending', 'retry') AND run_after <= ?
+        ${kindClause}
+        ${projectClause}
+        ORDER BY run_after ASC, created_at ASC
+        LIMIT 1
+      `).get(...values);
+
+      if (!candidate) {
+        this.commit();
+        return undefined;
+      }
+
+      const leaseExpiresAt = now + leaseMs;
+      this.db.prepare(`
+        UPDATE maintenance_jobs
+        SET status = 'running', attempts = attempts + 1, lease_owner = ?,
+            lease_expires_at = ?, updated_at = ?
+        WHERE id = ?
+      `).run(options.workerId, leaseExpiresAt, now, candidate.id);
+      const claimed = this.getRow(candidate.id)!;
+      this.commit();
+      return rowToJob(claimed);
+    } catch (error) {
+      this.rollback();
+      throw error;
+    }
+  }
+
+  /**
+   * Extend a running job's lease. A worker may only renew its own lease, so a
+   * stale worker cannot reclaim work that was already recovered elsewhere.
+   */
+  renewLease(id: string, workerId: string, leaseMs = DEFAULT_LEASE_MS, now = Date.now()): boolean {
+    const expiresAt = now + clampPositiveInteger(leaseMs, DEFAULT_LEASE_MS);
+    const result = this.db.prepare(`
+      UPDATE maintenance_jobs
+      SET lease_expires_at = ?, updated_at = ?
+      WHERE id = ? AND status = 'running' AND lease_owner = ?
+    `).run(expiresAt, now, id, workerId);
+    return Number(result.changes) > 0;
+  }
+
+  complete(id: string, workerId: string, now = Date.now()): MaintenanceJob | undefined {
+    this.db.prepare(`
+      UPDATE maintenance_jobs
+      SET status = 'completed', lease_owner = NULL, lease_expires_at = NULL,
+          completed_at = ?, updated_at = ?
+      WHERE id = ? AND status = 'running' AND lease_owner = ?
+    `).run(now, now, id, workerId);
+    return this.get(id);
+  }
+
+  reschedule(
+    id: string,
+    workerId: string,
+    options: { delayMs: number; resetAttempts?: boolean; payload?: Record<string, unknown>; now?: number },
+  ): MaintenanceJob | undefined {
+    const now = options.now ?? Date.now();
+    const delayMs = Number.isFinite(options.delayMs) ? Math.max(0, Math.floor(options.delayMs)) : 0;
+    const payloadJson = options.payload === undefined ? null : JSON.stringify(options.payload);
+    this.db.prepare(`
+      UPDATE maintenance_jobs
+      SET status = 'pending', run_after = ?, attempts = CASE WHEN ? THEN 0 ELSE attempts END,
+          payload_json = COALESCE(?, payload_json),
+          lease_owner = NULL, lease_expires_at = NULL, updated_at = ?
+      WHERE id = ? AND status = 'running' AND lease_owner = ?
+    `).run(now + delayMs, options.resetAttempts ? 1 : 0, payloadJson, now, id, workerId);
+    return this.get(id);
+  }
+
+  fail(id: string, workerId: string, error: unknown, now = Date.now()): MaintenanceJob | undefined {
+    this.begin();
+    try {
+      const current = this.db.prepare(`
+        SELECT * FROM maintenance_jobs
+        WHERE id = ? AND status = 'running' AND lease_owner = ?
+      `).get(id, workerId);
+      if (!current) {
+        this.commit();
+        return undefined;
+      }
+
+      const attempts = Number(current.attempts);
+      const exhausted = attempts >= Number(current.max_attempts);
+      const status: MaintenanceJobStatus = exhausted ? 'failed' : 'retry';
+      const runAfter = exhausted ? Number(current.run_after) : now + getMaintenanceRetryDelayMs(attempts);
+      this.db.prepare(`
+        UPDATE maintenance_jobs
+        SET status = ?, run_after = ?, lease_owner = NULL, lease_expires_at = NULL,
+            last_error = ?, updated_at = ?
+        WHERE id = ?
+      `).run(status, runAfter, errorText(error), now, id);
+      const updated = this.getRow(id)!;
+      this.commit();
+      return rowToJob(updated);
+    } catch (caught) {
+      this.rollback();
+      throw caught;
+    }
+  }
+
+  private getRow(id: string): any {
+    return this.db.prepare(`SELECT * FROM maintenance_jobs WHERE id = ?`).get(id);
+  }
+
+  private begin(): void {
+    this.db.prepare('BEGIN IMMEDIATE').run();
+  }
+
+  private commit(): void {
+    this.db.prepare('COMMIT').run();
+  }
+
+  private rollback(): void {
+    try { this.db.prepare('ROLLBACK').run(); } catch { /* transaction already closed */ }
+  }
+}
+
+export class MaintenanceJobWorker {
+  private readonly workerId: string;
+  private readonly leaseMs: number;
+  private readonly pollIntervalMs: number;
+  private readonly projectId?: string;
+  private readonly kinds?: readonly MaintenanceJobKind[];
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private running = false;
+
+  constructor(
+    private readonly store: MaintenanceJobStore,
+    private readonly handler: MaintenanceJobHandler,
+    options: {
+      workerId?: string;
+      leaseMs?: number;
+      pollIntervalMs?: number;
+      projectId?: string;
+      kinds?: readonly MaintenanceJobKind[];
+    } = {},
+  ) {
+    this.workerId = options.workerId ?? `memorix-${process.pid}-${randomUUID().slice(0, 8)}`;
+    this.leaseMs = clampPositiveInteger(options.leaseMs, DEFAULT_LEASE_MS);
+    this.pollIntervalMs = clampPositiveInteger(options.pollIntervalMs, DEFAULT_POLL_INTERVAL_MS);
+    this.projectId = options.projectId;
+    this.kinds = options.kinds;
+  }
+
+  async runOnce(now = Date.now()): Promise<{ state: 'idle' | 'busy' | 'completed' | 'rescheduled' | 'failed'; job?: MaintenanceJob }> {
+    if (this.running) return { state: 'busy' };
+    this.running = true;
+    try {
+      const job = this.store.claimNext({
+        workerId: this.workerId,
+        projectId: this.projectId,
+        kinds: this.kinds,
+        now,
+        leaseMs: this.leaseMs,
+      });
+      if (!job) return { state: 'idle' };
+
+      const heartbeatMs = Math.max(10, Math.floor(this.leaseMs / 3));
+      let leaseLost = false;
+      const heartbeat = setInterval(() => {
+        try {
+          leaseLost = !this.store.renewLease(job.id, this.workerId, this.leaseMs);
+        } catch {
+          // The next heartbeat can recover from a transient SQLite error. The
+          // job itself still has its prior lease until it expires.
+        }
+      }, heartbeatMs);
+      heartbeat.unref?.();
+
+      try {
+        const result = await this.handler(job);
+        if (leaseLost) {
+          return { state: 'failed', job: this.store.get(job.id) };
+        }
+        if (result?.action === 'reschedule') {
+          const updated = this.store.reschedule(job.id, this.workerId, {
+            delayMs: result.delayMs,
+            resetAttempts: result.resetAttempts,
+            payload: result.payload,
+            now,
+          });
+          return { state: 'rescheduled', job: updated };
+        }
+        const updated = this.store.complete(job.id, this.workerId, now);
+        return { state: 'completed', job: updated };
+      } catch (error) {
+        const updated = this.store.fail(job.id, this.workerId, error, now);
+        return { state: 'failed', job: updated };
+      } finally {
+        clearInterval(heartbeat);
+      }
+    } finally {
+      this.running = false;
+    }
+  }
+
+  start(): void {
+    if (this.timer) return;
+    void this.runOnce().catch(() => {});
+    this.timer = setInterval(() => { void this.runOnce().catch(() => {}); }, this.pollIntervalMs);
+    this.timer.unref?.();
+  }
+
+  stop(): void {
+    if (!this.timer) return;
+    clearInterval(this.timer);
+    this.timer = null;
+  }
+}

--- a/src/runtime/maintenance-runner.ts
+++ b/src/runtime/maintenance-runner.ts
@@ -1,0 +1,96 @@
+import { closeAllDatabases } from '../store/sqlite-db.js';
+import { loadDotenv } from '../config/dotenv-loader.js';
+import { initProjectRoot } from '../config/yaml-loader.js';
+import { initLLM } from '../llm/provider.js';
+import { initObservationStore } from '../store/obs-store.js';
+import {
+  MAINTENANCE_JOB_KINDS,
+  type MaintenanceJob,
+  type MaintenanceJobRunResult,
+} from './maintenance-jobs.js';
+import {
+  ISOLATED_MAINTENANCE_JOB_KINDS,
+  MAINTENANCE_RESULT_PREFIX,
+  type IsolatedMaintenanceRequest,
+} from './isolated-maintenance.js';
+import { createProjectMaintenanceHandler } from './project-maintenance.js';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function isJob(value: unknown): value is MaintenanceJob {
+  if (!isRecord(value)) return false;
+  return typeof value.id === 'string'
+    && typeof value.projectId === 'string'
+    && typeof value.kind === 'string'
+    && MAINTENANCE_JOB_KINDS.includes(value.kind as MaintenanceJob['kind'])
+    && ISOLATED_MAINTENANCE_JOB_KINDS.includes(value.kind as MaintenanceJob['kind'])
+    && isRecord(value.payload);
+}
+
+export function parseMaintenanceRequest(raw: string): IsolatedMaintenanceRequest {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new Error('Maintenance runner received invalid JSON input');
+  }
+  if (!isRecord(value) || !isJob(value.job)) {
+    throw new Error('Maintenance runner received an invalid job payload');
+  }
+  if (typeof value.projectRoot !== 'string' || !value.projectRoot) {
+    throw new Error('Maintenance runner requires projectRoot');
+  }
+  if (typeof value.dataDir !== 'string' || !value.dataDir) {
+    throw new Error('Maintenance runner requires dataDir');
+  }
+  return {
+    job: value.job,
+    projectRoot: value.projectRoot,
+    dataDir: value.dataDir,
+  };
+}
+
+export async function executeMaintenanceRequest(
+  request: IsolatedMaintenanceRequest,
+): Promise<MaintenanceJobRunResult> {
+  initProjectRoot(request.projectRoot);
+  loadDotenv(request.projectRoot);
+  await initObservationStore(request.dataDir);
+  if (request.job.kind === 'consolidation') initLLM();
+
+  const handler = createProjectMaintenanceHandler(
+    request.job.projectId,
+    request.dataDir,
+    request.projectRoot,
+  );
+  return (await handler(request.job)) ?? { action: 'complete' };
+}
+
+function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let raw = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => { raw += chunk; });
+    process.stdin.once('error', reject);
+    process.stdin.once('end', () => resolve(raw));
+  });
+}
+
+export async function main(): Promise<void> {
+  try {
+    const request = parseMaintenanceRequest(await readStdin());
+    const result = await executeMaintenanceRequest(request);
+    process.stdout.write(`${MAINTENANCE_RESULT_PREFIX}${JSON.stringify(result)}\n`);
+  } catch (error) {
+    process.stderr.write(`[memorix] maintenance runner failed: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  } finally {
+    closeAllDatabases();
+  }
+}
+
+if (process.argv[1] && process.argv[1].endsWith('maintenance-runner.js')) {
+  void main();
+}

--- a/src/runtime/maintenance-targets.ts
+++ b/src/runtime/maintenance-targets.ts
@@ -1,0 +1,59 @@
+import { getDatabase } from '../store/sqlite-db.js';
+
+export interface MaintenanceTarget {
+  projectId: string;
+  projectRoot: string;
+  dataDir: string;
+  updatedAt: number;
+}
+
+export interface RegisterMaintenanceTargetInput {
+  projectId: string;
+  projectRoot: string;
+  dataDir: string;
+  now?: number;
+}
+
+function rowToTarget(row: any): MaintenanceTarget {
+  return {
+    projectId: row.project_id,
+    projectRoot: row.project_root,
+    dataDir: row.data_dir,
+    updatedAt: Number(row.updated_at),
+  };
+}
+
+/**
+ * A local registry for isolated maintenance jobs. It deliberately stores only
+ * project identity and local paths; it is never sent through MCP responses.
+ */
+export class MaintenanceTargetStore {
+  private readonly db: any;
+
+  constructor(dataDir: string) {
+    this.db = getDatabase(dataDir);
+  }
+
+  register(input: RegisterMaintenanceTargetInput): MaintenanceTarget {
+    if (!input.projectId.trim()) throw new Error('Maintenance target requires a project ID');
+    if (!input.projectRoot.trim()) throw new Error('Maintenance target requires a project root');
+    if (!input.dataDir.trim()) throw new Error('Maintenance target requires a data directory');
+    const now = input.now ?? Date.now();
+    this.db.prepare(`
+      INSERT INTO maintenance_targets (project_id, project_root, data_dir, updated_at)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT(project_id) DO UPDATE SET
+        project_root = excluded.project_root,
+        data_dir = excluded.data_dir,
+        updated_at = excluded.updated_at
+    `).run(input.projectId, input.projectRoot, input.dataDir, now);
+    return this.get(input.projectId)!;
+  }
+
+  get(projectId: string): MaintenanceTarget | undefined {
+    const row = this.db.prepare(`
+      SELECT * FROM maintenance_targets WHERE project_id = ?
+    `).get(projectId);
+    return row ? rowToTarget(row) : undefined;
+  }
+}

--- a/src/runtime/project-maintenance.ts
+++ b/src/runtime/project-maintenance.ts
@@ -1,0 +1,274 @@
+import type {
+  MaintenanceJobHandler,
+  MaintenanceJobRunResult,
+} from './maintenance-jobs.js';
+import { runMaintenanceInChildProcess } from './isolated-maintenance.js';
+
+const DEFAULT_VECTOR_BATCH_SIZE = 12;
+const DEFAULT_RETENTION_BATCH_SIZE = 100;
+const DEFAULT_CONSOLIDATION_BATCH_SIZE = 200;
+const DEFAULT_CODEGRAPH_MAX_FILES = 5_000;
+const VECTOR_RETRY_DELAY_MS = 5_000;
+const DEDUP_PER_PAIR_TIMEOUT_MS = 5_000;
+
+function vectorBatchSize(payload: Record<string, unknown>): number {
+  const value = payload.limit;
+  if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_VECTOR_BATCH_SIZE;
+  return Math.min(100, Math.max(1, Math.floor(value)));
+}
+
+function retentionBatchSize(payload: Record<string, unknown>): number {
+  const value = payload.limit;
+  if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_RETENTION_BATCH_SIZE;
+  return Math.min(500, Math.max(1, Math.floor(value)));
+}
+
+function retentionCursor(payload: Record<string, unknown>): number {
+  const value = payload.cursor;
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(0, Math.floor(value))
+    : 0;
+}
+
+function consolidationBatchSize(payload: Record<string, unknown>): number {
+  const value = payload.limit;
+  if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_CONSOLIDATION_BATCH_SIZE;
+  return Math.min(500, Math.max(1, Math.floor(value)));
+}
+
+function consolidationCursor(payload: Record<string, unknown>): number {
+  const value = payload.cursor;
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(0, Math.floor(value))
+    : 0;
+}
+
+function codeGraphMaxFiles(payload: Record<string, unknown>): number {
+  const value = payload.maxFiles;
+  if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_CODEGRAPH_MAX_FILES;
+  return Math.min(20_000, Math.max(1, Math.floor(value)));
+}
+
+/**
+ * Creates handlers for one initialized project runtime. The worker itself is
+ * project-scoped so it never claims a different project's queued work.
+ */
+function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+    promise.then(
+      (value) => { clearTimeout(timer); resolve(value); },
+      (error) => { clearTimeout(timer); reject(error); },
+    );
+  });
+}
+
+async function runAutomaticConsolidation(
+  projectId: string,
+  projectDir: string,
+  options: { afterId: number; limit: number },
+): Promise<{ nextCursor?: number }> {
+  const { isLLMEnabled } = await import('../llm/provider.js');
+  if (!isLLMEnabled()) {
+    const { executeConsolidation } = await import('../memory/consolidation.js');
+    const result = await executeConsolidation(projectDir, projectId, {
+      threshold: 0.55,
+      afterId: options.afterId,
+      limit: options.limit,
+    });
+    return result.nextCursor === undefined ? {} : { nextCursor: result.nextCursor };
+  }
+
+  const [{ getObservationStore }, { deduplicateMemory }] = await Promise.all([
+    import('../store/obs-store.js'),
+    import('../llm/memory-manager.js'),
+  ]);
+  const store = getObservationStore();
+  const page = await store.loadByProject(projectId, {
+    status: 'active',
+    afterId: options.afterId,
+    limit: options.limit + 1,
+  });
+  const hasMore = page.length > options.limit;
+  const allObservations = hasMore ? page.slice(0, options.limit) : page;
+  const nextCursor = hasMore && allObservations.length > 0
+    ? allObservations[allObservations.length - 1].id
+    : undefined;
+  if (allObservations.length <= 10) {
+    return nextCursor === undefined ? {} : { nextCursor };
+  }
+
+  const grouped = new Map<string, typeof allObservations>();
+  for (const observation of allObservations) {
+    const key = `${observation.entityName}::${observation.type}`;
+    const group = grouped.get(key) ?? [];
+    group.push(observation);
+    grouped.set(key, group);
+  }
+
+  const toResolve: number[] = [];
+  const maxDedupCalls = 15;
+  let dedupCalls = 0;
+  for (const group of grouped.values()) {
+    if (group.length < 2 || dedupCalls >= maxDedupCalls) continue;
+    group.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+    for (let index = 0; index < group.length - 1 && index < 3 && dedupCalls < maxDedupCalls; index++) {
+      try {
+        dedupCalls++;
+        const older = group[index];
+        const newer = group[index + 1];
+        const decision = await withTimeout(
+          deduplicateMemory(
+            { title: newer.title, narrative: newer.narrative, facts: newer.facts },
+            [{ id: older.id, title: older.title, narrative: older.narrative, facts: older.facts.join('\n') }],
+          ),
+          DEDUP_PER_PAIR_TIMEOUT_MS,
+          `Dedup pair #${older.id}<->#${newer.id}`,
+        );
+        if (decision && (decision.action === 'UPDATE' || decision.action === 'NONE')) {
+          toResolve.push(decision.action === 'UPDATE' ? older.id : newer.id);
+        } else if (decision?.action === 'DELETE' && decision.targetId) {
+          toResolve.push(decision.targetId);
+        }
+      } catch {
+        // One slow or malformed LLM decision must not abandon the maintenance job.
+      }
+    }
+  }
+  if (toResolve.length > 0) {
+    await store.atomic(async (tx) => {
+      await Promise.all(
+        [...new Set(toResolve)].map((id) => tx.setStatus(id, 'resolved', 'active')),
+      );
+    });
+  }
+  return nextCursor === undefined ? {} : { nextCursor };
+}
+
+export function createProjectMaintenanceHandler(
+  projectId: string,
+  projectDir: string,
+  projectRoot?: string,
+): MaintenanceJobHandler {
+  return async (job): Promise<MaintenanceJobRunResult> => {
+    if (job.projectId !== projectId) {
+      return { action: 'reschedule', delayMs: VECTOR_RETRY_DELAY_MS };
+    }
+
+    if (job.kind === 'retention-archive') {
+      const { archiveExpiredBatch } = await import('../memory/retention.js');
+      const limit = retentionBatchSize(job.payload);
+      const result = await archiveExpiredBatch(projectDir, {
+        projectId,
+        afterId: retentionCursor(job.payload),
+        limit,
+      });
+      if (result.nextCursor !== undefined) {
+        return {
+          action: 'reschedule',
+          delayMs: 0,
+          resetAttempts: true,
+          payload: { cursor: result.nextCursor, limit },
+        };
+      }
+      return { action: 'complete' };
+    }
+
+    if (job.kind === 'consolidation') {
+      const limit = consolidationBatchSize(job.payload);
+      const result = await runAutomaticConsolidation(projectId, projectDir, {
+        afterId: consolidationCursor(job.payload),
+        limit,
+      });
+      if (result.nextCursor !== undefined) {
+        return {
+          action: 'reschedule',
+          delayMs: 0,
+          resetAttempts: true,
+          payload: { cursor: result.nextCursor, limit },
+        };
+      }
+      return { action: 'complete' };
+    }
+
+    if (job.kind === 'codegraph-refresh') {
+      if (!projectRoot) {
+        throw new Error(`CodeGraph refresh requires a project root for ${projectId}`);
+      }
+      const [
+        { CodeGraphStore },
+        { refreshProjectLite },
+        { backfillMissingObservationCodeRefs },
+        { getObservationStore },
+        { getResolvedConfig },
+      ] = await Promise.all([
+        import('../codegraph/store.js'),
+        import('../codegraph/lite-provider.js'),
+        import('../codegraph/binder.js'),
+        import('../store/obs-store.js'),
+        import('../config/resolved-config.js'),
+      ]);
+      const store = new CodeGraphStore();
+      await store.init(projectDir);
+      const codegraphConfig = getResolvedConfig({ projectRoot }).codegraph;
+      await refreshProjectLite(store, {
+        projectId,
+        projectRoot,
+        exclude: codegraphConfig.excludePatterns,
+        maxFiles: codeGraphMaxFiles(job.payload),
+        maxFileBytes: codegraphConfig.maxFileBytes,
+      });
+      const activeObservations = await getObservationStore().loadByProject(projectId, { status: 'active' });
+      await backfillMissingObservationCodeRefs(store, activeObservations);
+      return { action: 'complete' };
+    }
+
+    if (job.kind !== 'vector-backfill') {
+      throw new Error(`No runtime handler is registered for maintenance job: ${job.kind}`);
+    }
+
+    const { isEmbeddingExplicitlyDisabled } = await import('../embedding/provider.js');
+    if (isEmbeddingExplicitlyDisabled()) return { action: 'complete' };
+
+    const { backfillVectorEmbeddings, getVectorStatus } = await import('../memory/observations.js');
+    const before = getVectorStatus(projectId);
+    if (before.missing === 0) return { action: 'complete' };
+
+    const result = await backfillVectorEmbeddings({
+      projectId,
+      limit: vectorBatchSize(job.payload),
+    });
+    const after = getVectorStatus(projectId);
+    if (after.missing === 0) return { action: 'complete' };
+
+    if (result.failed > 0 && result.succeeded === 0) {
+      throw new Error(`vector backfill made no progress (${result.failed}/${result.attempted} failed)`);
+    }
+
+    return {
+      action: 'reschedule',
+      delayMs: result.attempted === 0 ? VECTOR_RETRY_DELAY_MS : 0,
+      resetAttempts: result.succeeded > 0,
+    };
+  };
+}
+
+/**
+ * Keep vector writes with the active in-memory search index. Everything that
+ * can scan disk or consolidate a large corpus runs in a separate process so
+ * an MCP request never shares its event loop with maintenance work.
+ */
+export function createProjectMaintenanceDispatcher(
+  projectId: string,
+  projectDir: string,
+  projectRoot: string,
+  isolatedRunner: typeof runMaintenanceInChildProcess = runMaintenanceInChildProcess,
+): MaintenanceJobHandler {
+  const inProcessHandler = createProjectMaintenanceHandler(projectId, projectDir, projectRoot);
+  return async (job): Promise<MaintenanceJobRunResult> => {
+    if (job.kind === 'vector-backfill') {
+      return (await inProcessHandler(job)) ?? { action: 'complete' };
+    }
+    return isolatedRunner({ job, projectRoot, dataDir: projectDir });
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,14 +17,12 @@
  */
 
 import { createHash } from 'node:crypto';
-import { watchFile } from 'node:fs';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 import { KnowledgeGraphManager } from './memory/graph.js';
 import { initObservations, storeObservation, prepareSearchIndex, migrateProjectIds, getObservation, getAllObservations } from './memory/observations.js';
 import { withFreshIndex } from './memory/freshness.js';
 import { initObservationStore, getObservationStore } from './store/obs-store.js';
-import { resetDb } from './store/orama-store.js';
 import { initMiniSkillStore } from './store/mini-skill-store.js';
 import { initSessionStore } from './store/session-store.js';
 import { checkProjectAttribution, auditProjectObservations } from './memory/attribution-guard.js';
@@ -55,7 +53,6 @@ import { parseFormationTimeoutMs } from './server/formation-timeout.js';
 const FORMATION_TIMEOUT_MS = parseFormationTimeoutMs(process.env.MEMORIX_FORMATION_TIMEOUT_MS); // Formation pipeline (extract+resolve+evaluate)
 const COMPACT_ON_WRITE_TIMEOUT_MS = 12_000; // Legacy compact-on-write fallback path
 const COMPRESSION_TIMEOUT_MS = 5_000;  // Narrative compression
-const DEDUP_PER_PAIR_TIMEOUT_MS = 5_000; // Per-pair dedup LLM call
 
 /** Race a promise against a timeout. Rejects with a descriptive Error on timeout. */
 function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
@@ -75,10 +72,6 @@ function formatFormationStageDurations(stageDurationsMs: Partial<Record<Formatio
     .map(stage => `${stage}=${stageDurationsMs[stage]}ms`);
   return parts.join(', ');
 }
-
-/** Timestamp of last MCP-initiated write — hot-reload skips changes within 10s */
-let lastInternalWriteMs = 0;
-const markInternalWrite = () => { lastInternalWriteMs = Date.now(); };
 
 /** Valid observation types for input validation */
 const OBSERVATION_TYPES: [string, ...string[]] = [
@@ -220,6 +213,23 @@ export interface CreateMemorixServerOptions {
   toolProfile?: ToolProfile;
 }
 
+/**
+ * These read-only tools operate directly on the project-scoped SQLite stores.
+ * They are safe before the in-memory observation/Orama runtime is hydrated,
+ * which keeps the first MCP request from turning deferred initialization into
+ * a hidden synchronous barrier.
+ */
+export const BOOTSTRAP_SAFE_TOOL_NAMES = new Set([
+  'memorix_project_context',
+  'memorix_codegraph_status',
+  'memorix_graph_context',
+  'memorix_context_pack',
+]);
+
+export function shouldAwaitProjectRuntime(toolName: string): boolean {
+  return !BOOTSTRAP_SAFE_TOOL_NAMES.has(toolName);
+}
+
 export async function createMemorixServer(
   cwd?: string,
   existingServer?: McpServer,
@@ -294,6 +304,22 @@ export async function createMemorixServer(
       console.error(`[memorix] Alias resolved: ${rawProject.id} -> ${canonicalId}`);
     }
   }
+
+  const registerMaintenanceTarget = async (): Promise<void> => {
+    if (!projectResolved) return;
+    try {
+      const { MaintenanceTargetStore } = await import('./runtime/maintenance-targets.js');
+      new MaintenanceTargetStore(projectDir).register({
+        projectId: project.id,
+        projectRoot: project.rootPath,
+        dataDir: projectDir,
+      });
+    } catch {
+      // Maintenance target registration is optional until an isolated worker
+      // needs it; normal MCP tools must remain usable without it.
+    }
+  };
+  await registerMaintenanceTarget();
 
   // Initialize project root for YAML config resolution — ensures all config getters
   // (getLLMApiKey, getGitConfig, etc.) pick up project-level memorix.yml, not just user-level.
@@ -440,6 +466,78 @@ export async function createMemorixServer(
     await projectRuntimeInitPromise;
   };
 
+  let maintenanceWorker: { stop(): void } | null = null;
+  const startProjectMaintenanceWorker = async (autoCleanup = false): Promise<void> => {
+    maintenanceWorker?.stop();
+    const [{ MaintenanceJobStore, MaintenanceJobWorker }, maintenance, observations] = await Promise.all([
+      import('./runtime/maintenance-jobs.js'),
+      import('./runtime/project-maintenance.js'),
+      import('./memory/observations.js'),
+    ]);
+    const queue = new MaintenanceJobStore(projectDir);
+    const vectorStatus = observations.getVectorStatus(project.id);
+    if (vectorStatus.missing > 0) {
+      queue.enqueue({
+        projectId: project.id,
+        kind: 'vector-backfill',
+        dedupeKey: 'vector-backfill',
+        payload: { limit: 12 },
+      });
+    }
+    if (autoCleanup) {
+      queue.enqueue({
+        projectId: project.id,
+        kind: 'retention-archive',
+        dedupeKey: 'startup-retention',
+      });
+      queue.enqueue({
+        projectId: project.id,
+        kind: 'consolidation',
+        dedupeKey: 'startup-consolidation',
+      });
+    }
+
+    // This check is only a small SQLite metadata query. The actual directory
+    // walk runs in the isolated maintenance process below.
+    try {
+      const { CodeGraphStore } = await import('./codegraph/store.js');
+      const codeStore = new CodeGraphStore();
+      await codeStore.init(projectDir);
+      const status = codeStore.status(project.id);
+      const indexedAt = status.indexedAt ? Date.parse(status.indexedAt) : Number.NaN;
+      const needsRefresh = status.files === 0
+        || !Number.isFinite(indexedAt)
+        || Date.now() - indexedAt > 10 * 60_000;
+      if (needsRefresh) {
+        queue.enqueue({
+          projectId: project.id,
+          kind: 'codegraph-refresh',
+          dedupeKey: 'startup-codegraph-refresh',
+          payload: { maxFiles: 5_000 },
+        });
+      }
+    } catch {
+      // Code Memory is optional; a failed metadata probe must not affect MCP.
+    }
+
+    const worker = options.dashboardMode === 'control-plane'
+      // Vector embeddings live in this process's Orama index, so a control
+      // plane session may only run vector recovery for its own project. The
+      // shared HTTP worker handles the other job kinds in isolated processes.
+      ? new MaintenanceJobWorker(
+        queue,
+        maintenance.createProjectMaintenanceHandler(project.id, projectDir, project.rootPath),
+        { projectId: project.id, kinds: ['vector-backfill'], pollIntervalMs: 2_000 },
+      )
+      : new MaintenanceJobWorker(
+        queue,
+        maintenance.createProjectMaintenanceDispatcher(project.id, projectDir, project.rootPath),
+        { projectId: project.id, pollIntervalMs: 2_000 },
+      );
+    worker.start();
+    maintenanceWorker = worker;
+  };
+
   const requireResolvedProject = (action: string) => {
     if (projectResolved) return null;
     return {
@@ -467,11 +565,13 @@ export async function createMemorixServer(
     if (!isToolInProfile(name, toolProfile)) {
       return undefined as never;
     }
-    const maybeConfig = args[0];
-    const maybeHandler = args[1];
-    if (typeof maybeHandler === 'function' && typeof maybeConfig === 'object' && maybeConfig !== null) {
-      const wrappedHandler = async (...handlerArgs: unknown[]) => {
-        await ensureProjectRuntimeInitialized();
+      const maybeConfig = args[0];
+      const maybeHandler = args[1];
+      if (typeof maybeHandler === 'function' && typeof maybeConfig === 'object' && maybeConfig !== null) {
+        const wrappedHandler = async (...handlerArgs: unknown[]) => {
+        if (shouldAwaitProjectRuntime(name)) {
+          await ensureProjectRuntimeInitialized();
+        }
         return await maybeHandler(...handlerArgs);
       };
       return (originalRegisterTool as (...innerArgs: unknown[]) => unknown)(name, maybeConfig, wrappedHandler, ...args.slice(2)) as never;
@@ -547,7 +647,7 @@ export async function createMemorixServer(
       } else {
         try {
           const { getBehaviorConfig } = await import('./config/behavior.js');
-          formationMode = getBehaviorConfig().formationMode;
+          formationMode = getBehaviorConfig({ projectRoot: project.rootPath }).formationMode;
         } catch { /* default to active */ }
       }
       const useFormation = formationMode === 'active';
@@ -651,7 +751,6 @@ export async function createMemorixServer(
           // Merge into existing observation
           const targetObs = getObservation(targetId);
           if (targetObs) {
-            markInternalWrite();
             await storeObservation({
               entityName: targetObs.entityName,
               type: targetObs.type,
@@ -677,7 +776,6 @@ export async function createMemorixServer(
           // Evolve existing observation
           const targetObs = getObservation(targetId);
           if (targetObs) {
-            markInternalWrite();
             await storeObservation({
               entityName: targetObs.entityName,
               type: targetObs.type,
@@ -750,7 +848,6 @@ export async function createMemorixServer(
               // Merge into existing memory (Mem0-style UPDATE)
               const targetObs = getObservation(decision.targetId);
               if (targetObs) {
-                markInternalWrite();
                 await storeObservation({
                   entityName: targetObs.entityName,
                   type: targetObs.type,
@@ -872,7 +969,6 @@ export async function createMemorixServer(
       } catch { /* guard is best-effort — never blocks the write */ }
 
       // Store the observation (may upsert if topicKey matches existing)
-      markInternalWrite();
       const { observation: obs, upserted } = await storeObservation({
         entityName,
         type: type as ObservationType,
@@ -1179,25 +1275,25 @@ export async function createMemorixServer(
       const unresolved = requireResolvedProject('build graph context for the current project');
       if (unresolved) return unresolved;
 
-      return withFreshIndex(async () => {
-        const packet = buildGraphContextPacket(getAllObservations(), {
-          projectId: project.id,
-          query,
-          limit: limit != null ? coerceNumber(limit, 5) : undefined,
-        });
-        const text = format === 'summary'
-          ? [
-              `Graph context packet for ${project.name}`,
-              `- ${packet.summary}`,
-              '',
-              ...packet.entities.map((entity) => `* ${entity.name} (#${entity.observationIds.join(', #')})`),
-            ].join('\n')
-          : formatGraphContextPrompt(packet);
-
-        return {
-          content: [{ type: 'text' as const, text }],
-        };
+      const { getObservationStore } = await import('./store/obs-store.js');
+      const observations = await getObservationStore().loadByProject(project.id);
+      const packet = buildGraphContextPacket(observations, {
+        projectId: project.id,
+        query,
+        limit: limit != null ? coerceNumber(limit, 5) : undefined,
       });
+      const text = format === 'summary'
+        ? [
+            `Graph context packet for ${project.name}`,
+            `- ${packet.summary}`,
+            '',
+            ...packet.entities.map((entity) => `* ${entity.name} (#${entity.observationIds.join(', #')})`),
+          ].join('\n')
+        : formatGraphContextPrompt(packet);
+
+      return {
+        content: [{ type: 'text' as const, text }],
+      };
     },
   );
 
@@ -1207,7 +1303,7 @@ export async function createMemorixServer(
       title: 'Memory Autopilot Project Context',
       description:
         'Build a compact Memory Autopilot brief for the current coding task. ' +
-        'Automatically refreshes Code Memory when needed, includes Start here files, ' +
+        'Schedules Code Memory refresh when needed, includes Start here files, ' +
         'reliable code-bound memories, stale/suspect cautions, and verification hints. Use this at the start of a new coding turn or after switching tasks.',
       inputSchema: {
         task: z.string().optional().describe('Current coding task or question'),
@@ -1224,30 +1320,45 @@ export async function createMemorixServer(
       const unresolved = requireResolvedProject('build project context for the current project');
       if (unresolved) return unresolved;
 
-      return withFreshIndex(async () => {
-        const {
+      const [
+        {
           buildAutoProjectBrief,
           buildAutoProjectContext,
           formatAutoProjectContextPrompt,
           formatAutoProjectContextSummary,
-        } = await import('./codegraph/auto-context.js');
-        const context = await buildAutoProjectContext({
-          project,
-          dataDir: projectDir,
-          observations: getAllObservations(),
-          task,
-          refresh: refresh ?? 'auto',
-        });
-        const text = format === 'json'
-          ? JSON.stringify({ ...context, brief: buildAutoProjectBrief(context) }, null, 2)
-          : format === 'summary'
-            ? formatAutoProjectContextSummary(context)
-            : formatAutoProjectContextPrompt(context);
-
-        return {
-          content: [{ type: 'text' as const, text }],
-        };
+        },
+        { getObservationStore },
+        { MaintenanceJobStore },
+      ] = await Promise.all([
+        import('./codegraph/auto-context.js'),
+        import('./store/obs-store.js'),
+        import('./runtime/maintenance-jobs.js'),
+      ]);
+      const observations = await getObservationStore().loadByProject(project.id, { status: 'active' });
+      const context = await buildAutoProjectContext({
+        project,
+        dataDir: projectDir,
+        observations,
+        task,
+        refresh: refresh ?? 'auto',
+        enqueueRefresh: () => {
+          new MaintenanceJobStore(projectDir).enqueue({
+            projectId: project.id,
+            kind: 'codegraph-refresh',
+            dedupeKey: 'context-codegraph-refresh',
+            payload: { maxFiles: 5_000 },
+          });
+        },
       });
+      const text = format === 'json'
+        ? JSON.stringify({ ...context, brief: buildAutoProjectBrief(context) }, null, 2)
+        : format === 'summary'
+          ? formatAutoProjectContextSummary(context)
+          : formatAutoProjectContextPrompt(context);
+
+      return {
+        content: [{ type: 'text' as const, text }],
+      };
     },
   );
 
@@ -1292,31 +1403,35 @@ export async function createMemorixServer(
       const unresolved = requireResolvedProject('build a context pack for the current project');
       if (unresolved) return unresolved;
 
-      return withFreshIndex(async () => {
-        const { CodeGraphStore } = await import('./codegraph/store.js');
-        const { assembleContextPackForTask, buildContextPackPrompt } = await import('./codegraph/context-pack.js');
-        const { getResolvedConfig } = await import('./config/resolved-config.js');
-        const store = new CodeGraphStore();
-        await store.init(projectDir);
-        const exclude = getResolvedConfig({ projectRoot: project.rootPath }).codegraph.excludePatterns;
-
-        const observations = getAllObservations()
-          .filter(obs => obs.projectId === project.id && (obs.status ?? 'active') === 'active')
-          .reverse();
-        const pack = assembleContextPackForTask({
-          store,
-          projectId: project.id,
-          task,
-          observations,
-          limit: typeof limit === 'number' ? limit : 20,
-          exclude,
-        });
-        const text = buildContextPackPrompt(pack);
-
-        return {
-          content: [{ type: 'text' as const, text }],
-        };
+      const [
+        { CodeGraphStore },
+        { assembleContextPackForTask, buildContextPackPrompt },
+        { getResolvedConfig },
+        { getObservationStore },
+      ] = await Promise.all([
+        import('./codegraph/store.js'),
+        import('./codegraph/context-pack.js'),
+        import('./config/resolved-config.js'),
+        import('./store/obs-store.js'),
+      ]);
+      const store = new CodeGraphStore();
+      await store.init(projectDir);
+      const exclude = getResolvedConfig({ projectRoot: project.rootPath }).codegraph.excludePatterns;
+      const observations = await getObservationStore().loadByProject(project.id, { status: 'active' });
+      observations.reverse();
+      const pack = assembleContextPackForTask({
+        store,
+        projectId: project.id,
+        task,
+        observations,
+        limit: typeof limit === 'number' ? limit : 20,
+        exclude,
       });
+      const text = buildContextPackPrompt(pack);
+
+      return {
+        content: [{ type: 'text' as const, text }],
+      };
     },
   );
 
@@ -1435,7 +1550,6 @@ export async function createMemorixServer(
         }
       } catch { /* guard is best-effort — never blocks the write */ }
 
-      markInternalWrite();
       const { observation: obs } = await storeObservation({
         entityName,
         type: 'reasoning' as ObservationType,
@@ -1875,7 +1989,7 @@ export async function createMemorixServer(
 
       // Handle archive action
       if (action === 'archive') {
-        const result = await archiveExpired(projectDir, undefined, accessMap);
+        const result = await archiveExpired(projectDir, undefined, accessMap, project.id);
         if (result.archived === 0) {
           return {
             content: [{ type: 'text' as const, text: '[OK] No expired observations to archive. All memories are within their retention period.' }],
@@ -3984,7 +4098,6 @@ export async function createMemorixServer(
         const { analyzeImage } = await import('./multimodal/image-loader.js');
         const analysis = await analyzeImage(args);
         const entityName = args.filename?.replace(/\.[^.]+$/, '') ?? `image-${Date.now()}`;
-        markInternalWrite();
         const { observation } = await storeObservation({
           entityName,
           type: 'discovery',
@@ -4065,7 +4178,7 @@ export async function createMemorixServer(
     let behaviorConfig: { syncAdvisory: boolean; autoCleanup: boolean } = { syncAdvisory: true, autoCleanup: true };
     try {
       const { getBehaviorConfig } = await import('./config/behavior.js');
-      behaviorConfig = getBehaviorConfig();
+      behaviorConfig = getBehaviorConfig({ projectRoot: project.rootPath });
     } catch { /* defaults */ }
 
     // Sync advisory: compute for diagnostics only.
@@ -4085,153 +4198,18 @@ export async function createMemorixServer(
       console.error(`[memorix] Sync advisory: ${hasSyncTargets ? 'available' : 'nothing to sync'}`);
     } catch { /* sync scan is optional */ }
 
-    // ── Background retention cleanup ────────────────────────────────
-    // Archive expired memories automatically so users never need to run it manually.
-    // Respects behavior.autoCleanup config (defaults to true).
     if (!behaviorConfig.autoCleanup) {
       console.error('[memorix] Auto-cleanup disabled via config.');
-    } else {
-    try {
-      const { archiveExpired } = await import('./memory/retention.js');
-      const archiveResult = await archiveExpired(projectDir);
-      if (archiveResult.archived > 0) {
-        console.error(`[memorix] Auto-archived ${archiveResult.archived} expired observation(s)`);
-      }
-    } catch { /* retention cleanup is optional */ }
-
-    // ── Background consolidation ─────────────────────────────────────
-    // With LLM: semantic dedup (higher quality). Without: Jaccard similarity.
-    // Users who configure an API key want quality — each call is only ~500 tokens.
-    try {
-      if (isLLMEnabled()) {
-        const { getAllObservations, resolveObservations } = await import('./memory/observations.js');
-        const { deduplicateMemory } = await import('./llm/memory-manager.js');
-        const allObs = await withFreshIndex(() => getAllObservations().filter(o => (o.status ?? 'active') === 'active' && o.projectId === project.id));
-        if (allObs.length > 10) {
-          const grouped = new Map<string, typeof allObs>();
-          for (const obs of allObs) {
-            const key = `${obs.entityName}::${obs.type}`;
-            if (!grouped.has(key)) grouped.set(key, []);
-            grouped.get(key)!.push(obs);
-          }
-          const toResolve: number[] = [];
-          // Cap total LLM dedup calls per session to avoid runaway API usage
-          const MAX_DEDUP_CALLS = 15;
-          let dedupCalls = 0;
-          for (const [, group] of grouped) {
-            if (group.length < 2 || dedupCalls >= MAX_DEDUP_CALLS) continue;
-            group.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
-            for (let i = 0; i < group.length - 1 && i < 3 && dedupCalls < MAX_DEDUP_CALLS; i++) {
-              try {
-                dedupCalls++;
-                const older = group[i], newer = group[i + 1];
-                const decision = await withTimeout(
-                  deduplicateMemory(
-                    { title: newer.title, narrative: newer.narrative, facts: newer.facts },
-                    [{ id: older.id, title: older.title, narrative: older.narrative, facts: older.facts.join('\n') }],
-                  ),
-                  DEDUP_PER_PAIR_TIMEOUT_MS,
-                  `Dedup pair #${older.id}↔#${newer.id}`,
-                );
-                if (decision && (decision.action === 'UPDATE' || decision.action === 'NONE')) {
-                  toResolve.push(decision.action === 'UPDATE' ? older.id : newer.id);
-                } else if (decision?.action === 'DELETE' && decision.targetId) {
-                  toResolve.push(decision.targetId);
-                }
-              } catch { /* skip individual comparison errors or timeouts */ }
-            }
-          }
-          if (toResolve.length > 0) {
-            await resolveObservations([...new Set(toResolve)], 'resolved');
-            console.error(`[memorix] Auto-dedup (LLM): resolved ${toResolve.length} redundant observation(s)`);
-          }
-        }
-      } else {
-        const { executeConsolidation } = await import('./memory/consolidation.js');
-        const result = await executeConsolidation(projectDir, project.id, { threshold: 0.55 });
-        if (result.observationsMerged > 0) {
-          console.error(`[memorix] Auto-consolidated: merged ${result.observationsMerged} duplicate(s) across ${result.clustersFound} cluster(s)`);
-        }
-      }
-    } catch { /* consolidation is optional */ }
-    } // end autoCleanup
-
-    // ── Vector-missing observability & background backfill ──────────
-    // Log how many observations are missing embeddings (search quality degradation).
-    // If any are missing and embedding is available, attempt background backfill.
-    // A periodic timer retries every 60s so provider recovery actually helps.
-    try {
-      const { getVectorStatus, backfillVectorEmbeddings } = await import('./memory/observations.js');
-      const { isEmbeddingExplicitlyDisabled } = await import('./embedding/provider.js');
-
-      const runBackfill = async (label: string) => {
-        const vs = getVectorStatus();
-        if (vs.missing === 0 || isEmbeddingExplicitlyDisabled()) return;
-        if (label === 'init') {
-          console.error(`[memorix] Vector status: ${vs.missing}/${vs.total} observations missing embeddings`);
-        }
-        try {
-          const result = await backfillVectorEmbeddings();
-          if (result.succeeded > 0) {
-            console.error(`[memorix] Vector backfill (${label}): ${result.succeeded}/${result.attempted} embeddings recovered`);
-          }
-          if (result.failed > 0 && label === 'init') {
-            console.error(`[memorix] Vector backfill: ${result.failed} failed (periodic retry active)`);
-          }
-        } catch { /* best-effort */ }
-      };
-
-      // Initial backfill attempt (non-blocking)
-      runBackfill('init');
-
-      // Periodic retry: every 60s, check if there are still missing vectors
-      // Stops automatically when all vectors are backfilled or embedding is disabled
-      const BACKFILL_INTERVAL_MS = 60_000;
-      const backfillTimer = setInterval(async () => {
-        const vs = getVectorStatus();
-        if (vs.missing === 0 || isEmbeddingExplicitlyDisabled()) {
-          clearInterval(backfillTimer);
-          return;
-        }
-        await runBackfill('periodic');
-      }, BACKFILL_INTERVAL_MS);
-      // Don't keep the process alive just for backfill
-      if (backfillTimer.unref) backfillTimer.unref();
-    } catch { /* vector observability is optional */ }
-
-    // Watch for external writes (e.g., from hook processes) and hot-reload.
-    // Uses watchFile (polling) instead of watch because atomicWriteFile uses
-    // rename(), which changes the file inode — fs.watch loses track on Windows.
-    const observationsFile = projectDir + '/observations.json';
-    let reloadDebounce: ReturnType<typeof setTimeout> | null = null;
-    let reloading = false; // guard: skip if a reload is already in progress
-    // lastInternalWriteMs + markInternalWrite are module-level (see top of file)
-    try {
-      watchFile(observationsFile, { interval: 5000 }, (curr, prev) => {
-        if (curr.mtimeMs === prev.mtimeMs) return; // no actual change
-        // Skip reload if a MCP tool wrote recently — data is already in memory
-        if (Date.now() - lastInternalWriteMs < 10_000) return;
-        if (reloading) return; // skip — previous reload still running
-        if (reloadDebounce) clearTimeout(reloadDebounce);
-        reloadDebounce = setTimeout(async () => {
-          if (reloading) return;
-          reloading = true;
-          try {
-            await resetDb();
-            await initObservationStore(projectDir);
-            await initObservations(projectDir);
-            const count = await prepareSearchIndex();
-            if (count > 0) {
-              console.error(`[memorix] Hot-reloaded search index for ${count} observations (external write detected)`);
-            }
-          } catch { /* silent */ }
-          reloading = false;
-        }, 3000);
-      });
-      console.error(`[memorix] Watching for external writes (hooks hot-reload enabled)`);
-    } catch {
-      console.error(`[memorix] Warning: could not watch observations file for hot-reload`);
     }
+
+    // Maintenance is durable and leased: retention, consolidation, and vector
+    // recovery run outside the MCP request path and survive process restarts.
+    try {
+      await startProjectMaintenanceWorker(behaviorConfig.autoCleanup);
+    } catch {
+      // Lexical memory remains available when optional maintenance cannot start.
+    }
+
   };
 
   // Runtime project switch — called when MCP roots change, projectRoot binding, or new workspace detected.
@@ -4246,6 +4224,8 @@ export async function createMemorixServer(
       return false;
     }
     const newDetected = result.project;
+    maintenanceWorker?.stop();
+    maintenanceWorker = null;
 
     // Resolve data dir FIRST (was buggy: used before declaration)
     const newProjectDir = await getProjectDataDir(newDetected.id);
@@ -4270,6 +4250,7 @@ export async function createMemorixServer(
     projectResolutionError = null;
     project = { ...newDetected, id: newCanonicalId };
     projectDir = canonicalProjectDir;
+    await registerMaintenanceTarget();
 
     // Update YAML config root and reload .env for the new project
     try {
@@ -4301,10 +4282,17 @@ export async function createMemorixServer(
     } catch { /* best-effort - coordination features degrade gracefully */ }
 
     await initializeProjectRuntime('switch');
+    try {
+      await startProjectMaintenanceWorker();
+    } catch {
+      // Switching projects must not fail because optional maintenance is unavailable.
+    }
     return true;
   };
 
   const handleTransportClose = (): void => {
+    maintenanceWorker?.stop();
+    maintenanceWorker = null;
     const agentId = currentAgentId;
     currentAgentId = undefined;
     if (!teamFeaturesEnabled || !agentId) return;

--- a/src/store/obs-store.ts
+++ b/src/store/obs-store.ts
@@ -23,12 +23,26 @@ import type { Observation } from '../types.js';
 export interface StoreTransaction {
   /** Load all observations (raw, no lock). */
   loadAll(): Promise<Observation[]>;
+  /** Load one observation by its globally unique ID (raw, no lock). */
+  getById(id: number): Promise<Observation | undefined>;
+  /** Find one observation by its project-scoped topic key (raw, no lock). */
+  findByTopicKey(projectId: string, topicKey: string): Promise<Observation | undefined>;
   /** Load the ID counter (raw, no lock). */
   loadIdCounter(): Promise<number>;
+  /** Insert one observation without independently acquiring a lock. */
+  insert(obs: Observation): Promise<void>;
+  /** Update one observation without independently acquiring a lock. */
+  update(obs: Observation): Promise<void>;
+  /** Change only an observation's lifecycle status without replacing its other fields. */
+  setStatus(id: number, status: string, expectedStatus?: string): Promise<boolean>;
+  /** Remove one observation without independently acquiring a lock. */
+  remove(id: number): Promise<void>;
   /** Save all observations (raw, no lock). */
   saveAll(obs: Observation[]): Promise<void>;
   /** Save the ID counter (raw, no lock). */
   saveIdCounter(nextId: number): Promise<void>;
+  /** Read the storage generation visible to this transaction. */
+  getGeneration(): Promise<number>;
 }
 
 export interface ObservationStore {
@@ -41,6 +55,18 @@ export interface ObservationStore {
 
   /** Load all observations into memory. Called at startup after init(). */
   loadAll(): Promise<Observation[]>;
+
+  /** Load one project's observations without scanning the shared flat store. */
+  loadByProject(
+    projectId: string,
+    options?: { status?: string; limit?: number; offset?: number; afterId?: number },
+  ): Promise<Observation[]>;
+
+  /** Count one project's observations without materializing the rows. */
+  countByProject(projectId: string, options?: { status?: string }): Promise<number>;
+
+  /** Load one observation by its globally unique ID. */
+  getById(id: number): Promise<Observation | undefined>;
 
   /** Load the current next-ID counter value. */
   loadIdCounter(): Promise<number>;
@@ -60,7 +86,7 @@ export interface ObservationStore {
 
   /**
    * Replace the entire observation set atomically.
-   * Used by consolidation, cleanup, and project-ID migration.
+   * Reserved for explicit full-state imports or recovery operations.
    */
   bulkReplace(obs: Observation[]): Promise<void>;
 
@@ -203,6 +229,18 @@ export class DegradedBackend implements ObservationStore {
 
   async loadAll(): Promise<Observation[]> {
     return [];
+  }
+
+  async loadByProject(_projectId: string, _options?: { status?: string; limit?: number; offset?: number; afterId?: number }): Promise<Observation[]> {
+    return [];
+  }
+
+  async countByProject(_projectId: string, _options?: { status?: string }): Promise<number> {
+    return 0;
+  }
+
+  async getById(_id: number): Promise<Observation | undefined> {
+    return undefined;
   }
 
   async loadIdCounter(): Promise<number> {

--- a/src/store/session-store.ts
+++ b/src/store/session-store.ts
@@ -20,6 +20,7 @@ import fs from 'node:fs';
 export interface SessionStoreInterface {
   init(dataDir: string): Promise<void>;
   loadAll(): Promise<Session[]>;
+  getById(id: string): Promise<Session | undefined>;
   loadByProject(projectId: string): Promise<Session[]>;
   loadActive(projectId: string): Promise<Session[]>;
   insert(session: Session): Promise<void>;
@@ -68,6 +69,7 @@ export class SessionSqliteStore implements SessionStoreInterface {
 
   private stmtInsert: any = null;
   private stmtSelectAll: any = null;
+  private stmtSelectById: any = null;
   private stmtSelectByProject: any = null;
   private stmtSelectActive: any = null;
   private _stmtCompleteActive: any = null;
@@ -84,6 +86,7 @@ export class SessionSqliteStore implements SessionStoreInterface {
         (@id, @projectId, @startedAt, @endedAt, @status, @summary, @agent)
     `);
     this.stmtSelectAll = this.db.prepare(`SELECT * FROM sessions ORDER BY startedAt DESC`);
+    this.stmtSelectById = this.db.prepare(`SELECT * FROM sessions WHERE id = ?`);
     this.stmtSelectByProject = this.db.prepare(`SELECT * FROM sessions WHERE projectId = ? ORDER BY startedAt DESC`);
     this.stmtSelectActive = this.db.prepare(`SELECT * FROM sessions WHERE projectId = ? AND status = 'active' ORDER BY startedAt DESC`);
 
@@ -124,6 +127,11 @@ export class SessionSqliteStore implements SessionStoreInterface {
 
   async loadAll(): Promise<Session[]> {
     return this.stmtSelectAll.all().map(rowToSession);
+  }
+
+  async getById(id: string): Promise<Session | undefined> {
+    const row = this.stmtSelectById.get(id);
+    return row ? rowToSession(row) : undefined;
   }
 
   async loadByProject(projectId: string): Promise<Session[]> {
@@ -205,6 +213,7 @@ export class SessionGracefulDegrade implements SessionStoreInterface {
   }
 
   async loadAll(): Promise<Session[]> { return []; }
+  async getById(_id: string): Promise<Session | undefined> { return undefined; }
   async loadByProject(_projectId: string): Promise<Session[]> { return []; }
   async loadActive(_projectId: string): Promise<Session[]> { return []; }
 

--- a/src/store/sqlite-db.ts
+++ b/src/store/sqlite-db.ts
@@ -293,10 +293,42 @@ CREATE TABLE IF NOT EXISTS observation_code_refs (
 );
 `;
 
+// ── Runtime maintenance jobs ───────────────────────────────────────
+
+const CREATE_MAINTENANCE_JOBS_TABLE = `
+CREATE TABLE IF NOT EXISTS maintenance_jobs (
+  id               TEXT PRIMARY KEY,
+  project_id       TEXT NOT NULL,
+  kind             TEXT NOT NULL,
+  dedupe_key       TEXT NOT NULL,
+  payload_json     TEXT NOT NULL DEFAULT '{}',
+  status           TEXT NOT NULL DEFAULT 'pending',
+  attempts         INTEGER NOT NULL DEFAULT 0,
+  max_attempts     INTEGER NOT NULL DEFAULT 8,
+  run_after        INTEGER NOT NULL,
+  lease_owner      TEXT,
+  lease_expires_at INTEGER,
+  last_error       TEXT,
+  created_at       INTEGER NOT NULL,
+  updated_at       INTEGER NOT NULL,
+  completed_at     INTEGER
+);
+`;
+
+const CREATE_MAINTENANCE_TARGETS_TABLE = `
+CREATE TABLE IF NOT EXISTS maintenance_targets (
+  project_id   TEXT PRIMARY KEY,
+  project_root TEXT NOT NULL,
+  data_dir     TEXT NOT NULL,
+  updated_at   INTEGER NOT NULL
+);
+`;
+
 const CREATE_INDEXES = `
 CREATE INDEX IF NOT EXISTS idx_observations_projectId ON observations(projectId);
 CREATE INDEX IF NOT EXISTS idx_observations_topicKey ON observations(projectId, topicKey);
 CREATE INDEX IF NOT EXISTS idx_observations_status ON observations(status);
+CREATE INDEX IF NOT EXISTS idx_observations_project_status_id ON observations(projectId, status, id);
 CREATE INDEX IF NOT EXISTS idx_mini_skills_projectId ON mini_skills(projectId);
 CREATE INDEX IF NOT EXISTS idx_sessions_projectId ON sessions(projectId);
 CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(projectId, status);
@@ -318,6 +350,12 @@ CREATE INDEX IF NOT EXISTS idx_code_symbols_file ON code_symbols(fileId);
 CREATE INDEX IF NOT EXISTS idx_code_edges_project ON code_edges(projectId, type);
 CREATE INDEX IF NOT EXISTS idx_observation_code_refs_obs ON observation_code_refs(projectId, observationId);
 CREATE INDEX IF NOT EXISTS idx_observation_code_refs_status ON observation_code_refs(projectId, status);
+CREATE INDEX IF NOT EXISTS idx_maintenance_jobs_ready ON maintenance_jobs(status, run_after);
+CREATE INDEX IF NOT EXISTS idx_maintenance_jobs_project ON maintenance_jobs(project_id, status, run_after);
+CREATE INDEX IF NOT EXISTS idx_maintenance_targets_updated ON maintenance_targets(updated_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_maintenance_jobs_active_dedupe
+  ON maintenance_jobs(project_id, kind, dedupe_key)
+  WHERE status IN ('pending', 'running', 'retry');
 `;
 
 // ── Singleton cache ─────────────────────────────────────────────────
@@ -367,6 +405,8 @@ export function getDatabase(dataDir: string): any {
   db.exec(CREATE_CODE_SYMBOLS_TABLE);
   db.exec(CREATE_CODE_EDGES_TABLE);
   db.exec(CREATE_OBSERVATION_CODE_REFS_TABLE);
+  db.exec(CREATE_MAINTENANCE_JOBS_TABLE);
+  db.exec(CREATE_MAINTENANCE_TARGETS_TABLE);
 
   // Phase 3a migration: add sourceSnapshot + updatedAt to mini_skills
   // Idempotent — ALTER TABLE ADD COLUMN throws if column already exists

--- a/src/store/sqlite-store.ts
+++ b/src/store/sqlite-store.ts
@@ -103,8 +103,18 @@ export class SqliteBackend implements ObservationStore {
   // Prepared statements (lazy-initialized after db open)
   private stmtInsert: any = null;
   private stmtUpdate: any = null;
+  private stmtSetStatus: any = null;
+  private stmtSetStatusIfCurrent: any = null;
   private stmtDelete: any = null;
   private stmtSelectAll: any = null;
+  private stmtSelectById: any = null;
+  private stmtSelectByProject: any = null;
+  private stmtSelectByProjectStatus: any = null;
+  private stmtSelectByProjectAfterId: any = null;
+  private stmtSelectByProjectStatusAfterId: any = null;
+  private stmtCountByProject: any = null;
+  private stmtCountByProjectStatus: any = null;
+  private stmtSelectByTopicKey: any = null;
   private stmtSelectGeneration: any = null;
   private stmtBumpGeneration: any = null;
   private stmtGetMeta: any = null;
@@ -130,8 +140,38 @@ export class SqliteBackend implements ObservationStore {
          @sourceDetail, @valueCategory, @createdByAgentId, @writeGeneration)
     `);
     this.stmtUpdate = this.stmtInsert; // INSERT OR REPLACE works for both
+    this.stmtSetStatus = this.db.prepare(`UPDATE observations SET status = ? WHERE id = ?`);
+    this.stmtSetStatusIfCurrent = this.db.prepare(
+      `UPDATE observations SET status = ? WHERE id = ? AND status = ?`,
+    );
     this.stmtDelete = this.db.prepare(`DELETE FROM observations WHERE id = ?`);
     this.stmtSelectAll = this.db.prepare(`SELECT * FROM observations`);
+    this.stmtSelectById = this.db.prepare(`SELECT * FROM observations WHERE id = ?`);
+    this.stmtSelectByProject = this.db.prepare(`
+      SELECT * FROM observations WHERE projectId = ?
+      ORDER BY id ASC LIMIT ? OFFSET ?
+    `);
+    this.stmtSelectByProjectStatus = this.db.prepare(`
+      SELECT * FROM observations WHERE projectId = ? AND status = ?
+      ORDER BY id ASC LIMIT ? OFFSET ?
+    `);
+    this.stmtSelectByProjectAfterId = this.db.prepare(`
+      SELECT * FROM observations WHERE projectId = ? AND id > ?
+      ORDER BY id ASC LIMIT ?
+    `);
+    this.stmtSelectByProjectStatusAfterId = this.db.prepare(`
+      SELECT * FROM observations WHERE projectId = ? AND status = ? AND id > ?
+      ORDER BY id ASC LIMIT ?
+    `);
+    this.stmtCountByProject = this.db.prepare(
+      `SELECT COUNT(*) AS count FROM observations WHERE projectId = ?`,
+    );
+    this.stmtCountByProjectStatus = this.db.prepare(
+      `SELECT COUNT(*) AS count FROM observations WHERE projectId = ? AND status = ?`,
+    );
+    this.stmtSelectByTopicKey = this.db.prepare(
+      `SELECT * FROM observations WHERE projectId = ? AND topicKey = ? ORDER BY id ASC LIMIT 1`,
+    );
     this.stmtSelectGeneration = this.db.prepare(`SELECT value FROM meta WHERE key = 'storage_generation'`);
     this.stmtBumpGeneration = this.db.prepare(`UPDATE meta SET value = CAST(CAST(value AS INTEGER) + 1 AS TEXT) WHERE key = 'storage_generation'`);
     this.stmtGetMeta = this.db.prepare(`SELECT value FROM meta WHERE key = ?`);
@@ -159,6 +199,16 @@ export class SqliteBackend implements ObservationStore {
   private rawLoadAll(): Observation[] {
     const rows = this.stmtSelectAll.all();
     return rows.map(rowToObs);
+  }
+
+  private rawGetById(id: number): Observation | undefined {
+    const row = this.stmtSelectById.get(id);
+    return row ? rowToObs(row) : undefined;
+  }
+
+  private rawFindByTopicKey(projectId: string, topicKey: string): Observation | undefined {
+    const row = this.stmtSelectByTopicKey.get(projectId, topicKey);
+    return row ? rowToObs(row) : undefined;
   }
 
   private rawLoadIdCounter(): number {
@@ -224,6 +274,34 @@ export class SqliteBackend implements ObservationStore {
     return this.rawLoadAll();
   }
 
+  async loadByProject(
+    projectId: string,
+    options: { status?: string; limit?: number; offset?: number; afterId?: number } = {},
+  ): Promise<Observation[]> {
+    const limit = options.limit == null ? -1 : Math.max(1, Math.floor(options.limit));
+    const offset = options.offset == null ? 0 : Math.max(0, Math.floor(options.offset));
+    const afterId = options.afterId == null ? null : Math.max(0, Math.floor(options.afterId));
+    const rows = afterId === null
+      ? (options.status
+        ? this.stmtSelectByProjectStatus.all(projectId, options.status, limit, offset)
+        : this.stmtSelectByProject.all(projectId, limit, offset))
+      : (options.status
+        ? this.stmtSelectByProjectStatusAfterId.all(projectId, options.status, afterId, limit)
+        : this.stmtSelectByProjectAfterId.all(projectId, afterId, limit));
+    return rows.map(rowToObs);
+  }
+
+  async getById(id: number): Promise<Observation | undefined> {
+    return this.rawGetById(id);
+  }
+
+  async countByProject(projectId: string, options: { status?: string } = {}): Promise<number> {
+    const row = options.status
+      ? this.stmtCountByProjectStatus.get(projectId, options.status)
+      : this.stmtCountByProject.get(projectId);
+    return Number(row?.count ?? 0);
+  }
+
   async loadIdCounter(): Promise<number> {
     return this.rawLoadIdCounter();
   }
@@ -284,7 +362,18 @@ export class SqliteBackend implements ObservationStore {
         try {
           const tx: StoreTransaction = {
             loadAll: async () => this.rawLoadAll(),
+            getById: async (id) => this.rawGetById(id),
+            findByTopicKey: async (projectId, topicKey) => this.rawFindByTopicKey(projectId, topicKey),
             loadIdCounter: async () => this.rawLoadIdCounter(),
+            insert: async (obs) => { this.stmtInsert.run(obsToRow(obs)); },
+            update: async (obs) => { this.stmtUpdate.run(obsToRow(obs)); },
+            setStatus: async (id, status, expectedStatus) => {
+              const result = expectedStatus === undefined
+                ? this.stmtSetStatus.run(status, id)
+                : this.stmtSetStatusIfCurrent.run(status, id, expectedStatus);
+              return Number(result.changes) > 0;
+            },
+            remove: async (id) => { this.stmtDelete.run(id); },
             saveAll: async (obs) => {
               this.db.prepare(`DELETE FROM observations`).run();
               for (const o of obs) {
@@ -292,6 +381,7 @@ export class SqliteBackend implements ObservationStore {
               }
             },
             saveIdCounter: async (nextId) => this.rawSaveIdCounter(nextId),
+            getGeneration: async () => this.readGeneration(),
           };
           const result = await fn(tx);
           this.bumpGeneration();

--- a/tests/cli/cleanup-mutations.test.ts
+++ b/tests/cli/cleanup-mutations.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import type { Observation } from '../../src/types.js';
+import { applyCleanupMutations } from '../../src/cli/commands/cleanup.js';
+import { SqliteBackend } from '../../src/store/sqlite-store.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+
+function makeObservation(overrides: Partial<Observation> & { id: number; projectId: string }): Observation {
+  return {
+    entityName: `entity-${overrides.id}`,
+    type: 'discovery',
+    title: `Observation ${overrides.id}`,
+    narrative: '',
+    facts: [],
+    filesModified: [],
+    concepts: [],
+    tokens: 10,
+    createdAt: new Date().toISOString(),
+    status: 'active',
+    source: 'agent',
+    ...overrides,
+  } as Observation;
+}
+
+describe('cleanup persistence', () => {
+  let dataDir: string;
+  let store: SqliteBackend;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-cleanup-test-'));
+    store = new SqliteBackend();
+    await store.init(dataDir);
+  });
+
+  afterEach(async () => {
+    store.close();
+    closeAllDatabases();
+    await fs.rm(dataDir, { recursive: true, force: true });
+  });
+
+  it('archives and deletes selected IDs without a table replacement or stale-field overwrite', async () => {
+    const remove = makeObservation({ id: 1, projectId: 'project-a', title: 'remove me' });
+    const currentArchive = makeObservation({ id: 2, projectId: 'project-a', title: 'current title' });
+    const otherProject = makeObservation({ id: 3, projectId: 'project-b', title: 'keep other project' });
+    await store.insert(remove);
+    await store.insert(currentArchive);
+    await store.insert(otherProject);
+
+    const rawLoadAll = vi.spyOn(store as any, 'rawLoadAll');
+    const bulkReplace = vi.spyOn(store, 'bulkReplace');
+    const staleArchiveSnapshot = { ...currentArchive, title: 'stale title from preview' };
+
+    const result = await applyCleanupMutations(store, [staleArchiveSnapshot], [remove]);
+
+    expect(result).toEqual({ archived: 1, removed: 1 });
+    expect(rawLoadAll).not.toHaveBeenCalled();
+    expect(bulkReplace).not.toHaveBeenCalled();
+
+    expect(await store.getById(1)).toBeUndefined();
+    expect(await store.getById(2)).toMatchObject({
+      status: 'archived',
+      title: 'current title',
+      projectId: 'project-a',
+    });
+    expect(await store.getById(3)).toMatchObject({
+      status: 'active',
+      title: 'keep other project',
+      projectId: 'project-b',
+    });
+  });
+});

--- a/tests/cli/docker-deployment.test.ts
+++ b/tests/cli/docker-deployment.test.ts
@@ -15,6 +15,7 @@ describe('official Docker deployment artifacts', () => {
     expect(dockerfile).toContain('serve-http');
     expect(dockerfile).toContain('0.0.0.0');
     expect(dockerfile).toContain('3211');
+    expect(dockerfile).toMatch(/^USER\s+node\s*$/m);
   });
 
   it('ships a compose file with port 3211 and a healthcheck', () => {

--- a/tests/cli/serve-mode.test.ts
+++ b/tests/cli/serve-mode.test.ts
@@ -31,6 +31,8 @@ const mkdirSyncMock = vi.fn();
 const createServerMock = vi.fn();
 const httpServerListenMock = vi.fn();
 const httpServerCloseMock = vi.fn();
+const createControlPlaneMaintenanceWorkerMock = vi.fn();
+const maintenanceWorkerStartMock = vi.fn();
 
 let capturedHttpHandler: ((req: any, res: any) => Promise<void>) | undefined;
 
@@ -113,6 +115,10 @@ vi.mock('node:fs', async () => {
 
 vi.mock('../../src/server.js', () => ({
   createMemorixServer: createMemorixServerMock,
+}));
+
+vi.mock('../../src/runtime/control-plane-maintenance.js', () => ({
+  createControlPlaneMaintenanceWorker: createControlPlaneMaintenanceWorkerMock,
 }));
 
 vi.mock('../../src/cli/commands/serve-shared.js', () => ({
@@ -333,6 +339,7 @@ describe('serve-http command mode support', () => {
     initTeamStoreMock.mockResolvedValue({});
     getProjectDataDirMock.mockResolvedValue('E:/memorix-data');
     getBaseDataDirMock.mockReturnValue('E:/memorix-base');
+    createControlPlaneMaintenanceWorkerMock.mockReturnValue({ start: maintenanceWorkerStartMock });
     createMemorixServerMock.mockResolvedValue(makeServerResult());
     createServerMock.mockImplementation((handler: any) => {
       capturedHttpHandler = handler;
@@ -396,6 +403,8 @@ describe('serve-http command mode support', () => {
 
     expect(createMemorixServerMock).toHaveBeenCalledTimes(1);
     expect(createMemorixServerMock.mock.calls[0]?.[3]).toMatchObject({ toolProfile: 'full' });
+    expect(createControlPlaneMaintenanceWorkerMock).toHaveBeenCalledWith('E:/memorix-data', { pollIntervalMs: 2_000 });
+    expect(maintenanceWorkerStartMock).toHaveBeenCalledTimes(1);
   });
 
   it('uses MEMORIX_MODE as the HTTP fallback when mode is omitted', async () => {

--- a/tests/codegraph/auto-context.test.ts
+++ b/tests/codegraph/auto-context.test.ts
@@ -94,6 +94,36 @@ describe('auto project context', () => {
     expect(text).not.toContain('SQLite');
   });
 
+  it('queues an MCP-style refresh instead of scanning code inside the request', async () => {
+    await storeObservation({
+      entityName: 'auth',
+      type: 'decision',
+      title: 'auth memory has a file hint',
+      narrative: 'Start from src/auth.ts.',
+      filesModified: ['src/auth.ts'],
+      projectId: 'local/repo',
+    });
+    const enqueueRefresh = vi.fn();
+
+    const context = await buildAutoProjectContext({
+      project: { id: 'local/repo', name: 'repo', rootPath: repoDir },
+      dataDir,
+      observations: getAllObservations(),
+      refresh: 'auto',
+      enqueueRefresh,
+      task: 'inspect the cold project without blocking on indexing',
+    });
+
+    expect(enqueueRefresh).toHaveBeenCalledTimes(1);
+    expect(context.refresh).toMatchObject({ performed: false, reason: 'queued' });
+    expect(context.overview.code.files).toBe(0);
+    expect(context.overview.suggestedReads).toContain('src/auth.ts');
+    expect(context.explain.sources[0]).toMatchObject({
+      path: 'src/auth.ts',
+      status: 'unbound',
+    });
+  });
+
   it('collects the project graph once per context request', async () => {
     const store = new CodeGraphStore();
     await store.init(dataDir);

--- a/tests/codegraph/lite-provider.test.ts
+++ b/tests/codegraph/lite-provider.test.ts
@@ -2,7 +2,9 @@ import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { indexProjectLite } from '../../src/codegraph/lite-provider.js';
+import { indexProjectLite, refreshProjectLite } from '../../src/codegraph/lite-provider.js';
+import { CodeGraphStore } from '../../src/codegraph/store.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
 
 let root: string | null = null;
 
@@ -13,11 +15,35 @@ function makeRoot(): string {
 }
 
 afterEach(() => {
+  closeAllDatabases();
   if (root) rmSync(root, { recursive: true, force: true });
   root = null;
 });
 
 describe('CodeGraph Lite provider', () => {
+  it('refreshes only changed files and removes deleted files without replacing the project graph', async () => {
+    const dir = makeRoot();
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(join(dir, 'src', 'stable.ts'), 'export function stable() { return 1; }\n');
+    writeFileSync(join(dir, 'src', 'changed.ts'), 'export function beforeChange() {}\n');
+
+    const store = new CodeGraphStore();
+    await store.init(dir);
+    const first = await refreshProjectLite(store, { projectId: 'org/repo', projectRoot: dir });
+    expect(first.changedFiles).toBe(2);
+    expect(store.findSymbols('org/repo', 'beforeChange')).toHaveLength(1);
+
+    writeFileSync(join(dir, 'src', 'changed.ts'), 'export function afterChangeWithMoreBytes() { return true; }\n');
+    rmSync(join(dir, 'src', 'stable.ts'));
+
+    const second = await refreshProjectLite(store, { projectId: 'org/repo', projectRoot: dir });
+    expect(second.changedFiles).toBe(1);
+    expect(second.removedFiles).toBe(1);
+    expect(store.findSymbols('org/repo', 'beforeChange')).toHaveLength(0);
+    expect(store.findSymbols('org/repo', 'afterChangeWithMoreBytes')).toHaveLength(1);
+    expect(store.getFile('org/repo', 'src/stable.ts')).toBeNull();
+  });
+
   it('indexes TS files, imports, exports, and top-level symbols', async () => {
     const dir = makeRoot();
     mkdirSync(join(dir, 'src'), { recursive: true });
@@ -153,7 +179,10 @@ describe('CodeGraph Lite provider', () => {
     mkdirSync(join(dir, 'src'), { recursive: true });
     writeFileSync(join(dir, 'src', 'main.ts'), 'export function main() {}\n');
 
-    for (const generatedDir of ['dist', 'build', 'coverage', '.next', '.turbo', 'node_modules', '.git', '.tmp', '.worktrees']) {
+    for (const generatedDir of [
+      'dist', 'build', 'coverage', '.next', '.turbo', 'node_modules', '.git', '.tmp', '.worktrees',
+      'vendor', '.venv', 'venv', '.tox', 'target', '.gradle', '.mvn', 'obj', 'Pods', 'DerivedData',
+    ]) {
       mkdirSync(join(dir, generatedDir), { recursive: true });
       writeFileSync(join(dir, generatedDir, 'generated.ts'), 'export function generated() {}\n');
     }
@@ -185,6 +214,49 @@ describe('CodeGraph Lite provider', () => {
 
     expect(result.files.map(file => file.path)).toEqual(['src/main.ts']);
     expect(result.symbols.map(symbol => symbol.name)).toEqual(['main']);
+  });
+
+  it('skips oversized source files instead of parsing unbounded generated content', async () => {
+    const dir = makeRoot();
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(join(dir, 'src', 'small.ts'), 'export function small() {}\n');
+    writeFileSync(join(dir, 'src', 'large.ts'), `export const payload = '${'x'.repeat(4_096)}';\n`);
+
+    const result = await indexProjectLite({
+      projectId: 'org/repo',
+      projectRoot: dir,
+      maxFileBytes: 1_024,
+    });
+
+    expect(result.files.map(file => file.path)).toEqual(['src/small.ts']);
+    expect(result.skippedOversizedFiles).toBe(1);
+  });
+
+  it('removes an existing graph entry when a source file grows beyond the safety limit', async () => {
+    const dir = makeRoot();
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    const file = join(dir, 'src', 'worker.ts');
+    writeFileSync(file, 'export function worker() {}\n');
+
+    const store = new CodeGraphStore();
+    await store.init(dir);
+    await refreshProjectLite(store, {
+      projectId: 'org/repo',
+      projectRoot: dir,
+      maxFileBytes: 1_024,
+    });
+    expect(store.getFile('org/repo', 'src/worker.ts')).not.toBeNull();
+
+    writeFileSync(file, `export const generated = '${'x'.repeat(4_096)}';\n`);
+    const refresh = await refreshProjectLite(store, {
+      projectId: 'org/repo',
+      projectRoot: dir,
+      maxFileBytes: 1_024,
+    });
+
+    expect(refresh.skippedOversizedFiles).toBe(1);
+    expect(refresh.removedFiles).toBe(1);
+    expect(store.getFile('org/repo', 'src/worker.ts')).toBeNull();
   });
 
   it('continues indexing when a discovered file cannot be read', async () => {

--- a/tests/config/behavior.test.ts
+++ b/tests/config/behavior.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { getBehaviorConfig, resetBehaviorConfigCache } from '../../src/config/behavior.js';
+import { resetResolvedConfigCache } from '../../src/config/resolved-config.js';
+import { resetTomlConfigCache } from '../../src/config/toml-loader.js';
+import { resetYamlConfigCache } from '../../src/config/yaml-loader.js';
+
+const TEMP_ROOT = join(process.cwd(), '.tmp-behavior-config-test');
+const HOME = join(TEMP_ROOT, 'home');
+const PROJECT = join(TEMP_ROOT, 'project');
+
+beforeEach(() => {
+  rmSync(TEMP_ROOT, { recursive: true, force: true });
+  mkdirSync(join(HOME, '.memorix'), { recursive: true });
+  mkdirSync(PROJECT, { recursive: true });
+  resetBehaviorConfigCache();
+  resetResolvedConfigCache();
+  resetTomlConfigCache();
+  resetYamlConfigCache();
+});
+
+afterEach(() => {
+  rmSync(TEMP_ROOT, { recursive: true, force: true });
+  resetBehaviorConfigCache();
+  resetResolvedConfigCache();
+  resetTomlConfigCache();
+  resetYamlConfigCache();
+});
+
+describe('behavior config resolution', () => {
+  it('uses resolved TOML behavior settings instead of only legacy config.json', () => {
+    writeFileSync(join(HOME, '.memorix', 'config.toml'), [
+      '[memory]',
+      'inject = "silent"',
+      'formation = "shadow"',
+      'auto_cleanup = false',
+      'sync_advisory = false',
+    ].join('\n'), 'utf8');
+
+    expect(getBehaviorConfig({ projectRoot: PROJECT, homeDir: HOME })).toEqual({
+      sessionInject: 'silent',
+      formationMode: 'shadow',
+      autoCleanup: false,
+      syncAdvisory: false,
+    });
+  });
+
+  it('uses project YAML behavior settings when TOML is absent', () => {
+    writeFileSync(join(PROJECT, 'memorix.yml'), [
+      'behavior:',
+      '  sessionInject: full',
+      '  formationMode: fallback',
+      '  autoCleanup: false',
+      '  syncAdvisory: false',
+    ].join('\n'), 'utf8');
+
+    expect(getBehaviorConfig({ projectRoot: PROJECT, homeDir: HOME })).toEqual({
+      sessionInject: 'full',
+      formationMode: 'fallback',
+      autoCleanup: false,
+      syncAdvisory: false,
+    });
+  });
+
+  it('falls back to legacy behavior when resolved config is temporarily malformed', () => {
+    writeFileSync(join(HOME, '.memorix', 'config.toml'), '[memory\n', 'utf8');
+    writeFileSync(join(HOME, '.memorix', 'config.json'), JSON.stringify({
+      behavior: {
+        sessionInject: 'silent',
+        formationMode: 'shadow',
+        autoCleanup: false,
+        syncAdvisory: false,
+      },
+    }), 'utf8');
+
+    expect(getBehaviorConfig({ projectRoot: PROJECT, homeDir: HOME })).toEqual({
+      sessionInject: 'silent',
+      formationMode: 'shadow',
+      autoCleanup: false,
+      syncAdvisory: false,
+    });
+  });
+});

--- a/tests/config/resolved-config.test.ts
+++ b/tests/config/resolved-config.test.ts
@@ -164,20 +164,23 @@ describe('resolved config', () => {
     expect(cfg.git.excludePatterns).toEqual(['dist/**', '*.lock']);
   });
 
-  it('resolves CodeGraph exclude patterns from TOML above legacy YAML', () => {
+  it('resolves CodeGraph scan limits from TOML above legacy YAML', () => {
     writeFileSync(join(HOME, '.memorix', 'config.toml'), [
       '[codegraph]',
       'exclude_patterns = ["vendor/**", "**/generated/**"]',
+      'max_file_bytes = 524288',
     ].join('\n'), 'utf8');
     writeFileSync(join(HOME, '.memorix', 'memorix.yml'), [
       'codegraph:',
       '  excludePatterns:',
       '    - ignored-from-yaml/**',
+      '  maxFileBytes: 123',
     ].join('\n'), 'utf8');
 
     const cfg = getResolvedConfig({ projectRoot: null, homeDir: HOME });
 
     expect(cfg.codegraph.excludePatterns).toEqual(['vendor/**', '**/generated/**']);
+    expect(cfg.codegraph.maxFileBytes).toBe(524288);
   });
 
   it('uses git TOML settings in runtime getGitConfig after project root detection', () => {

--- a/tests/git/noise-filter.test.ts
+++ b/tests/git/noise-filter.test.ts
@@ -136,15 +136,21 @@ describe('shouldFilterCommit', () => {
       { noiseKeywords: ['auto-deploy'] },
     );
     expect(result.skip).toBe(true);
-    expect(result.reason).toContain('user noise pattern');
+    expect(result.reason).toContain('user noise keyword');
   });
 
-  it('should handle regex in noiseKeywords', () => {
-    const result = shouldFilterCommit(
+  it('treats noiseKeywords as literal text instead of executable regex', () => {
+    const regexLike = shouldFilterCommit(
       makeCommit({ subject: 'BOT: automated PR merge #42' }),
       { noiseKeywords: ['^BOT:'] },
     );
-    expect(result.skip).toBe(true);
+    expect(regexLike.skip).toBe(false);
+
+    const literal = shouldFilterCommit(
+      makeCommit({ subject: '^BOT: automated PR merge #42' }),
+      { noiseKeywords: ['^BOT:'] },
+    );
+    expect(literal.skip).toBe(true);
   });
 
   // ─── excludePatterns for files ───

--- a/tests/hooks/handler-e2e.test.ts
+++ b/tests/hooks/handler-e2e.test.ts
@@ -253,7 +253,7 @@ export function verifyToken(token: string) {
       expect(output.systemMessage).toContain('Memorix Autopilot Brief for repo');
       expect(output.systemMessage).toContain('Start here');
       expect(output.systemMessage).toContain('src/auth.ts');
-      expect(output.systemMessage).toContain('python 1');
+      expect(output.systemMessage).toContain('Code Memory refresh queued');
       expect(output.systemMessage).not.toContain('SQLite');
     } finally {
       process.chdir(originalCwd);

--- a/tests/integration/dashboard-project-scope.test.ts
+++ b/tests/integration/dashboard-project-scope.test.ts
@@ -183,12 +183,29 @@ describe('Standalone Dashboard Project Scope', () => {
     expect(ids).toEqual([1, 2]);
   });
 
+  it('does not expose standalone dashboard JSON to arbitrary origins', async () => {
+    const response = await fetch(`${DASH_BASE}/api/project`, {
+      headers: { Origin: 'https://evil.example' },
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get('access-control-allow-origin')).toBeNull();
+  });
+
   it('GET /api/stats counts only active project observations', async () => {
     const { status, body } = await fetchJson('/api/stats');
     expect(status).toBe(200);
 
     expect(body.observations).toBe(2);
     expect(body.nextId).toBe(7);
+  });
+
+  it('GET /api/maintenance exposes project-scoped background work state', async () => {
+    const { status, body } = await fetchJson('/api/maintenance');
+
+    expect(status).toBe(200);
+    expect(body.summary).toMatchObject({ total: 0, pending: 0, running: 0 });
+    expect(body.jobs).toEqual([]);
   });
 
   it('GET /api/knowledge returns project-scoped Knowledge Base overview', async () => {

--- a/tests/memory/consolidation.test.ts
+++ b/tests/memory/consolidation.test.ts
@@ -16,6 +16,7 @@ import path from 'node:path';
 import os from 'node:os';
 import { findConsolidationCandidates, executeConsolidation } from '../../src/memory/consolidation.js';
 import { storeObservation, initObservations, getObservationCount } from '../../src/memory/observations.js';
+import { getObservationStore } from '../../src/store/obs-store.js';
 import { resetDb } from '../../src/store/orama-store.js';
 
 let testDir: string;
@@ -127,6 +128,41 @@ describe('Memory Consolidation', () => {
   });
 
   describe('executeConsolidation', () => {
+    it('scans a bounded active project page without reading the shared observation table', async () => {
+      for (const title of ['First isolated note', 'Second isolated note', 'Third isolated note']) {
+        await storeObservation({
+          entityName: 'bounded',
+          type: 'discovery',
+          title,
+          narrative: `${title} has distinct content.`,
+          projectId: PROJECT_ID,
+        });
+      }
+      await storeObservation({
+        entityName: 'other-project',
+        type: 'discovery',
+        title: 'Other project must not be scanned',
+        narrative: 'This is unrelated.',
+        projectId: 'other/project',
+      });
+
+      const store = getObservationStore();
+      const loadAll = vi.spyOn(store, 'loadAll');
+      const loadByProject = vi.spyOn(store, 'loadByProject');
+
+      const result = await executeConsolidation(testDir, PROJECT_ID, { limit: 2, threshold: 0.99 });
+
+      expect(loadAll).not.toHaveBeenCalled();
+      expect(loadByProject).toHaveBeenCalledWith(PROJECT_ID, {
+        status: 'active',
+        afterId: 0,
+        limit: 3,
+      });
+      expect(result.scanned).toBe(2);
+      expect(result.nextCursor).toBe(2);
+      expect(result.observationsAfter).toBe(3);
+    });
+
     it('should merge similar observations and reduce count', async () => {
       // Uses 'discovery' type — high-value types (gotcha/decision) require 0.85 similarity
       await storeObservation({

--- a/tests/memory/retention.test.ts
+++ b/tests/memory/retention.test.ts
@@ -5,7 +5,7 @@
  * Patterns from mcp-memory-service + MemCP.
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
@@ -18,6 +18,7 @@ import {
   getRetentionSummary,
   getImportanceLevel,
   archiveExpired,
+  archiveExpiredBatch,
 } from '../../src/memory/retention.js';
 import { initObservationStore, resetObservationStore, getObservationStore } from '../../src/store/obs-store.js';
 import { closeAllDatabases } from '../../src/store/sqlite-db.js';
@@ -325,6 +326,75 @@ describe('Retention & Decay', () => {
       const result = await archiveExpired(tmpDir, now, accessMap);
       expect(result.archived).toBe(0);
       expect(result.remaining).toBe(1);
+    });
+
+    it('archives only the requested project in a shared flat store', async () => {
+      const now = new Date();
+      const expiredDate = new Date(now.getTime() - 60 * 24 * 60 * 60 * 1000).toISOString();
+      const observations = [
+        { id: 1, entityName: 'a', type: 'session-request', title: 'A expired', narrative: '', facts: [], filesModified: [], concepts: [], tokens: 10, createdAt: expiredDate, projectId: 'project-a' },
+        { id: 2, entityName: 'b', type: 'session-request', title: 'B expired', narrative: '', facts: [], filesModified: [], concepts: [], tokens: 10, createdAt: expiredDate, projectId: 'project-b' },
+      ];
+      await fs.writeFile(path.join(tmpDir, 'observations.json'), JSON.stringify(observations));
+      await initObservationStore(tmpDir);
+
+      const result = await archiveExpired(tmpDir, now, undefined, 'project-a');
+
+      expect(result).toEqual({ archived: 1, remaining: 0 });
+      const all = await getObservationStore().loadAll();
+      expect(all.find((observation) => observation.id === 1)?.status).toBe('archived');
+      expect(all.find((observation) => observation.id === 2)?.status ?? 'active').toBe('active');
+    });
+
+    it('archives a project in bounded ID-cursor batches without loading the shared table', async () => {
+      const now = new Date();
+      const expiredDate = new Date(now.getTime() - 60 * 24 * 60 * 60 * 1000).toISOString();
+      const observations = [
+        { id: 1, entityName: 'a', type: 'decision', title: 'Recent A', narrative: '', facts: [], filesModified: [], concepts: [], tokens: 10, createdAt: now.toISOString(), projectId: 'project-a' },
+        { id: 2, entityName: 'b', type: 'session-request', title: 'Expired A one', narrative: '', facts: [], filesModified: [], concepts: [], tokens: 10, createdAt: expiredDate, projectId: 'project-a' },
+        { id: 3, entityName: 'c', type: 'decision', title: 'Recent A two', narrative: '', facts: [], filesModified: [], concepts: [], tokens: 10, createdAt: now.toISOString(), projectId: 'project-a' },
+        { id: 4, entityName: 'd', type: 'session-request', title: 'Expired A two', narrative: '', facts: [], filesModified: [], concepts: [], tokens: 10, createdAt: expiredDate, projectId: 'project-a' },
+        { id: 5, entityName: 'e', type: 'session-request', title: 'Expired B', narrative: '', facts: [], filesModified: [], concepts: [], tokens: 10, createdAt: expiredDate, projectId: 'project-b' },
+      ];
+      await fs.writeFile(path.join(tmpDir, 'observations.json'), JSON.stringify(observations));
+      await initObservationStore(tmpDir);
+
+      const rawLoadAll = vi.spyOn(getObservationStore() as any, 'rawLoadAll');
+      const first = await archiveExpiredBatch(tmpDir, {
+        projectId: 'project-a',
+        limit: 2,
+        referenceTime: now,
+      });
+      const second = await archiveExpiredBatch(tmpDir, {
+        projectId: 'project-a',
+        limit: 2,
+        afterId: first.nextCursor,
+        referenceTime: now,
+      });
+
+      expect(first).toEqual({ archived: 1, scanned: 2, nextCursor: 2 });
+      expect(second).toEqual({ archived: 1, scanned: 2 });
+      expect(rawLoadAll).not.toHaveBeenCalled();
+
+      const all = await getObservationStore().loadAll();
+      expect(all.find((observation) => observation.id === 2)?.status).toBe('archived');
+      expect(all.find((observation) => observation.id === 4)?.status).toBe('archived');
+      expect(all.find((observation) => observation.id === 5)?.status ?? 'active').toBe('active');
+    });
+
+    it('does not advance storage generation for a scanned page with no archive candidates', async () => {
+      const now = new Date();
+      const observations = [
+        { id: 1, entityName: 'a', type: 'decision', title: 'Recent', narrative: '', facts: [], filesModified: [], concepts: [], tokens: 10, createdAt: now.toISOString(), projectId: 'project-a' },
+      ];
+      await fs.writeFile(path.join(tmpDir, 'observations.json'), JSON.stringify(observations));
+      await initObservationStore(tmpDir);
+
+      const generationBefore = getObservationStore().getGeneration();
+      const result = await archiveExpiredBatch(tmpDir, { projectId: 'project-a', referenceTime: now });
+
+      expect(result).toEqual({ archived: 0, scanned: 1 });
+      expect(getObservationStore().getGeneration()).toBe(generationBefore);
     });
   });
 });

--- a/tests/memory/session.test.ts
+++ b/tests/memory/session.test.ts
@@ -20,8 +20,8 @@ import os from 'node:os';
 import { startSession, endSession, getSessionContext, listSessions, getActiveSession } from '../../src/memory/session.js';
 import { storeObservation, initObservations, resolveObservations } from '../../src/memory/observations.js';
 import { resetDb } from '../../src/store/orama-store.js';
-import { initObservationStore, resetObservationStore } from '../../src/store/obs-store.js';
-import { initSessionStore, resetSessionStore } from '../../src/store/session-store.js';
+import { getObservationStore, initObservationStore, resetObservationStore } from '../../src/store/obs-store.js';
+import { getSessionStore, initSessionStore, resetSessionStore } from '../../src/store/session-store.js';
 
 let testDir: string;
 const PROJECT_ID = 'test/session-lifecycle';
@@ -115,6 +115,34 @@ describe('Session Lifecycle', () => {
   });
 
   describe('getSessionContext', () => {
+    it('loads only the current project aliases instead of scanning global sessions and observations', async () => {
+      await storeObservation({
+        entityName: 'current',
+        type: 'decision',
+        title: 'Current project decision',
+        narrative: 'Keep this in the current session context.',
+        projectId: PROJECT_ID,
+      });
+      await storeObservation({
+        entityName: 'other',
+        type: 'decision',
+        title: 'Other project decision',
+        narrative: 'Do not load this for the current project.',
+        projectId: 'other-project',
+      });
+      await startSession(testDir, 'other-project', { sessionId: 'other-session' });
+      await endSession(testDir, 'other-session', 'Other project handoff');
+
+      const observationLoadAll = vi.spyOn(getObservationStore(), 'loadAll');
+      const sessionLoadAll = vi.spyOn(getSessionStore(), 'loadAll');
+      const context = await getSessionContext(testDir, PROJECT_ID);
+
+      expect(context).toContain('Current project decision');
+      expect(context).not.toContain('Other project decision');
+      expect(observationLoadAll).not.toHaveBeenCalled();
+      expect(sessionLoadAll).not.toHaveBeenCalled();
+    });
+
     it('should return previous session summary in context', async () => {
       // Create and end a session with summary
       await startSession(testDir, PROJECT_ID, { sessionId: 'ctx-test', agent: 'cursor' });

--- a/tests/memory/topic-upsert.test.ts
+++ b/tests/memory/topic-upsert.test.ts
@@ -18,6 +18,7 @@ import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { storeObservation, initObservations, getObservation, getObservationCount, suggestTopicKey } from '../../src/memory/observations.js';
+import { getObservationStore } from '../../src/store/obs-store.js';
 import { resetDb } from '../../src/store/orama-store.js';
 
 let testDir: string;
@@ -30,6 +31,22 @@ beforeEach(async () => {
 });
 
 describe('Topic Key Upsert', () => {
+  it('stores a new topic without loading all persisted observations', async () => {
+    const store = getObservationStore();
+    const rawLoadAll = vi.spyOn(store as any, 'rawLoadAll');
+
+    await storeObservation({
+      entityName: 'runtime',
+      type: 'decision',
+      title: 'Keep normal writes targeted',
+      narrative: 'A new observation should not rewrite the whole SQLite table.',
+      topicKey: 'runtime/targeted-write',
+      projectId: PROJECT_ID,
+    });
+
+    expect(rawLoadAll).not.toHaveBeenCalled();
+  });
+
   it('should create new observation when topicKey is new', async () => {
     const { observation, upserted } = await storeObservation({
       entityName: 'auth',
@@ -74,6 +91,26 @@ describe('Topic Key Upsert', () => {
     expect(second.revisionCount).toBe(2);
     expect(second.updatedAt).toBeTruthy();
     expect(getObservationCount()).toBe(1); // no duplicate created
+  });
+
+  it('serializes concurrent writes for the same new topicKey', async () => {
+    const input = {
+      entityName: 'runtime',
+      type: 'decision' as const,
+      narrative: 'Only one canonical runtime decision should remain.',
+      topicKey: 'runtime/concurrent-topic',
+      projectId: PROJECT_ID,
+    };
+
+    const [first, second] = await Promise.all([
+      storeObservation({ ...input, title: 'Runtime decision v1' }),
+      storeObservation({ ...input, title: 'Runtime decision v2' }),
+    ]);
+
+    expect(first.observation.id).toBe(second.observation.id);
+    expect([first.upserted, second.upserted].filter(Boolean)).toHaveLength(1);
+    expect(getObservationCount()).toBe(1);
+    expect(getObservation(first.observation.id, PROJECT_ID)?.revisionCount).toBe(2);
   });
 
   it('should increment revisionCount on each upsert', async () => {

--- a/tests/runtime/control-plane-maintenance.test.ts
+++ b/tests/runtime/control-plane-maintenance.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  CONTROL_PLANE_MAINTENANCE_KINDS,
+  createControlPlaneMaintenanceHandler,
+  createControlPlaneMaintenanceWorker,
+} from '../../src/runtime/control-plane-maintenance.js';
+import { MaintenanceJobStore, type MaintenanceJob } from '../../src/runtime/maintenance-jobs.js';
+import { MaintenanceTargetStore } from '../../src/runtime/maintenance-targets.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+
+let dataDir: string;
+
+beforeEach(async () => {
+  dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-control-plane-'));
+});
+
+afterEach(async () => {
+  closeAllDatabases();
+  await fs.rm(dataDir, { recursive: true, force: true });
+});
+
+function makeJob(overrides: Partial<MaintenanceJob> = {}): MaintenanceJob {
+  return {
+    id: 'job-1',
+    projectId: 'project-a',
+    kind: 'codegraph-refresh',
+    dedupeKey: 'graph',
+    payload: { maxFiles: 100 },
+    status: 'running',
+    attempts: 1,
+    maxAttempts: 8,
+    runAfter: 0,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+describe('control-plane maintenance', () => {
+  it('stores the latest local target without exposing it through the job payload', () => {
+    const targets = new MaintenanceTargetStore(dataDir);
+    targets.register({
+      projectId: 'project-a',
+      projectRoot: 'C:/workspace/old',
+      dataDir,
+      now: 1_000,
+    });
+    const registered = targets.register({
+      projectId: 'project-a',
+      projectRoot: 'C:/workspace/current',
+      dataDir,
+      now: 2_000,
+    });
+
+    expect(registered).toEqual({
+      projectId: 'project-a',
+      projectRoot: 'C:/workspace/current',
+      dataDir,
+      updatedAt: 2_000,
+    });
+    expect(targets.get('project-a')).toEqual(registered);
+  });
+
+  it('uses a registered target for isolated work and reschedules unknown projects', async () => {
+    const targets = new MaintenanceTargetStore(dataDir);
+    targets.register({ projectId: 'project-a', projectRoot: 'C:/workspace/project-a', dataDir });
+    const runner = vi.fn().mockResolvedValue({ action: 'complete' as const });
+    const handler = createControlPlaneMaintenanceHandler(dataDir, runner);
+
+    await expect(handler(makeJob())).resolves.toEqual({ action: 'complete' });
+    expect(runner).toHaveBeenCalledWith({
+      job: makeJob(),
+      projectRoot: 'C:/workspace/project-a',
+      dataDir,
+    });
+
+    await expect(handler(makeJob({ projectId: 'missing-project' }))).resolves.toEqual({
+      action: 'reschedule',
+      delayMs: 30_000,
+    });
+  });
+
+  it('claims only isolated job kinds and leaves vector work for the live MCP runtime', async () => {
+    expect(CONTROL_PLANE_MAINTENANCE_KINDS).not.toContain('vector-backfill');
+    const targets = new MaintenanceTargetStore(dataDir);
+    targets.register({ projectId: 'project-a', projectRoot: 'C:/workspace/project-a', dataDir });
+    const queue = new MaintenanceJobStore(dataDir);
+    const vector = queue.enqueue({
+      projectId: 'project-a',
+      kind: 'vector-backfill',
+      dedupeKey: 'vectors',
+      now: 1_000,
+    });
+    const graph = queue.enqueue({
+      projectId: 'project-a',
+      kind: 'codegraph-refresh',
+      dedupeKey: 'graph',
+      now: 1_000,
+    });
+    const runner = vi.fn().mockResolvedValue({ action: 'complete' as const });
+    const worker = createControlPlaneMaintenanceWorker(dataDir, {
+      workerId: 'control-plane-test',
+      isolatedRunner: runner,
+    });
+
+    await worker.runOnce(1_000);
+
+    expect(queue.get(graph.id)?.status).toBe('completed');
+    expect(queue.get(vector.id)?.status).toBe('pending');
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/runtime/isolated-maintenance.test.ts
+++ b/tests/runtime/isolated-maintenance.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 import {
   MAINTENANCE_RESULT_PREFIX,
@@ -44,8 +45,11 @@ async function createRunner(source: string): Promise<string> {
 
 describe('isolated maintenance runner', () => {
   it('resolves the compiled runner from both library and CLI bundles', () => {
-    expect(resolveMaintenanceRunnerPath('file:///C:/pkg/dist/index.js')).toBe('C:\\pkg\\dist\\maintenance-runner.js');
-    expect(resolveMaintenanceRunnerPath('file:///C:/pkg/dist/cli/index.js')).toBe('C:\\pkg\\dist\\maintenance-runner.js');
+    const distDir = path.resolve('pkg', 'dist');
+    const expected = path.join(distDir, 'maintenance-runner.js');
+
+    expect(resolveMaintenanceRunnerPath(pathToFileURL(path.join(distDir, 'index.js')).href)).toBe(expected);
+    expect(resolveMaintenanceRunnerPath(pathToFileURL(path.join(distDir, 'cli', 'index.js')).href)).toBe(expected);
   });
 
   it('parses only the explicit runner result line, ignoring ordinary child output', () => {

--- a/tests/runtime/isolated-maintenance.test.ts
+++ b/tests/runtime/isolated-maintenance.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  MAINTENANCE_RESULT_PREFIX,
+  parseMaintenanceRunnerOutput,
+  resolveMaintenanceRunnerPath,
+  runMaintenanceInChildProcess,
+} from '../../src/runtime/isolated-maintenance.js';
+import type { MaintenanceJob } from '../../src/runtime/maintenance-jobs.js';
+
+const temporaryPaths: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryPaths.splice(0).map((filePath) => fs.rm(filePath, { recursive: true, force: true })));
+});
+
+function makeJob(overrides: Partial<MaintenanceJob> = {}): MaintenanceJob {
+  return {
+    id: 'job-1',
+    projectId: 'project-a',
+    kind: 'codegraph-refresh',
+    dedupeKey: 'graph',
+    payload: {},
+    status: 'running',
+    attempts: 1,
+    maxAttempts: 8,
+    runAfter: 0,
+    createdAt: 0,
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+async function createRunner(source: string): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-maintenance-runner-'));
+  temporaryPaths.push(dir);
+  const runner = path.join(dir, 'runner.mjs');
+  await fs.writeFile(runner, source, 'utf8');
+  return runner;
+}
+
+describe('isolated maintenance runner', () => {
+  it('resolves the compiled runner from both library and CLI bundles', () => {
+    expect(resolveMaintenanceRunnerPath('file:///C:/pkg/dist/index.js')).toBe('C:\\pkg\\dist\\maintenance-runner.js');
+    expect(resolveMaintenanceRunnerPath('file:///C:/pkg/dist/cli/index.js')).toBe('C:\\pkg\\dist\\maintenance-runner.js');
+  });
+
+  it('parses only the explicit runner result line, ignoring ordinary child output', () => {
+    const output = [
+      'refreshing 12 files',
+      `${MAINTENANCE_RESULT_PREFIX}{"action":"reschedule","delayMs":0,"resetAttempts":true}`,
+    ].join('\n');
+    expect(parseMaintenanceRunnerOutput(output)).toEqual({
+      action: 'reschedule',
+      delayMs: 0,
+      resetAttempts: true,
+    });
+  });
+
+  it('does not expose a child credential in a malformed result error', () => {
+    expect(() => parseMaintenanceRunnerOutput('api_key=sk-abcdefghijklmnopqrstuvwxyz123456')).toThrow('[REDACTED]');
+  });
+
+  it('runs a heavy job in a separate Node process and returns its structured result', async () => {
+    const runner = await createRunner([
+      'let input = "";',
+      'process.stdin.on("data", (chunk) => { input += chunk; });',
+      'process.stdin.on("end", () => {',
+      '  const request = JSON.parse(input);',
+      '  if (request.job.kind !== "codegraph-refresh") process.exit(2);',
+      `  process.stdout.write("${MAINTENANCE_RESULT_PREFIX}{\\\"action\\\":\\\"complete\\\"}\\n");`,
+      '});',
+    ].join('\n'));
+
+    await expect(runMaintenanceInChildProcess({
+      job: makeJob(),
+      projectRoot: process.cwd(),
+      dataDir: process.cwd(),
+    }, { runnerPath: runner, timeoutMs: 5_000 })).resolves.toEqual({ action: 'complete' });
+  });
+
+  it('refuses vector backfill because it must update the active process index', async () => {
+    await expect(runMaintenanceInChildProcess({
+      job: makeJob({ kind: 'vector-backfill' }),
+      projectRoot: process.cwd(),
+      dataDir: process.cwd(),
+    }, { runnerPath: 'does-not-matter' })).rejects.toThrow('cannot run in an isolated worker');
+  });
+});

--- a/tests/runtime/maintenance-jobs.test.ts
+++ b/tests/runtime/maintenance-jobs.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  MaintenanceJobStore,
+  MaintenanceJobWorker,
+} from '../../src/runtime/maintenance-jobs.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+
+let dataDir: string;
+
+beforeEach(async () => {
+  dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-maintenance-jobs-'));
+});
+
+afterEach(async () => {
+  closeAllDatabases();
+  await fs.rm(dataDir, { recursive: true, force: true });
+});
+
+describe('MaintenanceJobStore', () => {
+  it('deduplicates active work for the same project and key', () => {
+    const store = new MaintenanceJobStore(dataDir);
+    const first = store.enqueue({
+      projectId: 'project-a',
+      kind: 'vector-backfill',
+      dedupeKey: 'vectors',
+      now: 1_000,
+    });
+    const duplicate = store.enqueue({
+      projectId: 'project-a',
+      kind: 'vector-backfill',
+      dedupeKey: 'vectors',
+      now: 2_000,
+    });
+
+    expect(duplicate.id).toBe(first.id);
+    expect(store.summary('project-a').pending).toBe(1);
+  });
+
+  it('leases one job at a time and recovers work after an expired lease', () => {
+    const store = new MaintenanceJobStore(dataDir);
+    const job = store.enqueue({
+      projectId: 'project-a',
+      kind: 'vector-backfill',
+      dedupeKey: 'vectors',
+      now: 1_000,
+    });
+
+    const firstClaim = store.claimNext({ workerId: 'worker-a', now: 1_000, leaseMs: 100 });
+    expect(firstClaim?.id).toBe(job.id);
+    expect(firstClaim?.attempts).toBe(1);
+    expect(store.claimNext({ workerId: 'worker-b', now: 1_050, leaseMs: 100 })).toBeUndefined();
+
+    const recovered = store.claimNext({ workerId: 'worker-b', now: 1_101, leaseMs: 100 });
+    expect(recovered?.id).toBe(job.id);
+    expect(recovered?.attempts).toBe(2);
+    expect(recovered?.leaseOwner).toBe('worker-b');
+  });
+
+  it('renews an active lease so a long-running job cannot be reclaimed mid-run', () => {
+    const store = new MaintenanceJobStore(dataDir);
+    const job = store.enqueue({
+      projectId: 'project-a',
+      kind: 'codegraph-refresh',
+      dedupeKey: 'graph',
+      now: 1_000,
+    });
+    const claimed = store.claimNext({ workerId: 'worker-a', now: 1_000, leaseMs: 100 });
+    expect(claimed?.id).toBe(job.id);
+
+    expect(store.renewLease(job.id, 'worker-a', 100, 1_050)).toBe(true);
+    expect(store.get(job.id)?.leaseExpiresAt).toBe(1_150);
+    expect(store.claimNext({ workerId: 'worker-b', now: 1_101, leaseMs: 100 })).toBeUndefined();
+
+    const recovered = store.claimNext({ workerId: 'worker-b', now: 1_151, leaseMs: 100 });
+    expect(recovered?.id).toBe(job.id);
+    expect(store.renewLease(job.id, 'worker-a', 100, 1_152)).toBe(false);
+  });
+
+  it('backs off transient failures and retains the error for operators', () => {
+    const store = new MaintenanceJobStore(dataDir);
+    const job = store.enqueue({
+      projectId: 'project-a',
+      kind: 'vector-backfill',
+      dedupeKey: 'vectors',
+      now: 10_000,
+    });
+    store.claimNext({ workerId: 'worker-a', now: 10_000, leaseMs: 500 });
+
+    const retried = store.fail(job.id, 'worker-a', new Error('provider unavailable'), 10_100);
+    expect(retried?.status).toBe('retry');
+    expect(retried?.lastError).toContain('provider unavailable');
+    expect(retried?.runAfter).toBeGreaterThan(10_100);
+    expect(store.claimNext({ workerId: 'worker-b', now: 10_500, leaseMs: 500 })).toBeUndefined();
+
+    const retriedClaim = store.claimNext({ workerId: 'worker-b', now: retried!.runAfter, leaseMs: 500 });
+    expect(retriedClaim?.id).toBe(job.id);
+  });
+
+  it('redacts credentials before persisting a maintenance failure for operators', () => {
+    const store = new MaintenanceJobStore(dataDir);
+    const job = store.enqueue({
+      projectId: 'project-a',
+      kind: 'vector-backfill',
+      now: 1_000,
+    });
+    store.claimNext({ workerId: 'worker-a', now: 1_000, leaseMs: 500 });
+
+    const failed = store.fail(
+      job.id,
+      'worker-a',
+      new Error('provider rejected api_key=sk-abcdefghijklmnopqrstuvwxyz123456'),
+      1_100,
+    );
+
+    expect(failed?.lastError).toContain('[REDACTED]');
+    expect(failed?.lastError).not.toContain('sk-abcdefghijklmnopqrstuvwxyz123456');
+  });
+
+  it('prunes completed history after its retention window without deleting failed diagnostics', () => {
+    const store = new MaintenanceJobStore(dataDir);
+    const completed = store.enqueue({
+      projectId: 'project-a',
+      kind: 'retention-archive',
+      now: 1_000,
+    });
+    store.claimNext({ workerId: 'worker-a', now: 1_000, leaseMs: 500 });
+    store.complete(completed.id, 'worker-a', 2_000);
+
+    const failed = store.enqueue({
+      projectId: 'project-a',
+      kind: 'codegraph-refresh',
+      now: 1_000,
+      maxAttempts: 1,
+    });
+    store.claimNext({ workerId: 'worker-b', now: 1_000, leaseMs: 500 });
+    store.fail(failed.id, 'worker-b', new Error('scan failed'), 2_000);
+
+    const pruned = store.pruneCompletedHistory({ now: 8 * 24 * 60 * 60 * 1_000 });
+
+    expect(pruned).toBe(1);
+    expect(store.get(completed.id)).toBeUndefined();
+    expect(store.get(failed.id)?.status).toBe('failed');
+  });
+
+  it('does not prune completed history when enqueue cannot begin its transaction', () => {
+    const store = new MaintenanceJobStore(dataDir);
+    const completed = store.enqueue({
+      projectId: 'project-a',
+      kind: 'retention-archive',
+      now: 1_000,
+    });
+    store.claimNext({ workerId: 'worker-a', now: 1_000, leaseMs: 500 });
+    store.complete(completed.id, 'worker-a', 2_000);
+
+    const begin = vi.spyOn(store as any, 'begin').mockImplementationOnce(() => {
+      throw new Error('database busy');
+    });
+
+    expect(() => store.enqueue({
+      projectId: 'project-a',
+      kind: 'codegraph-refresh',
+      now: 8 * 24 * 60 * 60 * 1_000,
+    })).toThrow('database busy');
+    expect(store.get(completed.id)?.status).toBe('completed');
+
+    begin.mockRestore();
+  });
+});
+
+describe('MaintenanceJobWorker', () => {
+  it('reschedules incremental work without treating successful progress as a failure', async () => {
+    const store = new MaintenanceJobStore(dataDir);
+    const job = store.enqueue({
+      projectId: 'project-a',
+      kind: 'vector-backfill',
+      dedupeKey: 'vectors',
+      now: 1_000,
+    });
+    let calls = 0;
+    const worker = new MaintenanceJobWorker(store, async () => {
+      calls++;
+      return calls === 1
+        ? { action: 'reschedule' as const, delayMs: 0, resetAttempts: true }
+        : { action: 'complete' as const };
+    }, { workerId: 'test-worker', leaseMs: 100 });
+
+    await worker.runOnce(1_000);
+    expect(store.get(job.id)?.status).toBe('pending');
+    expect(store.get(job.id)?.attempts).toBe(0);
+
+    await worker.runOnce(1_001);
+    expect(store.get(job.id)?.status).toBe('completed');
+    expect(calls).toBe(2);
+  });
+
+  it('persists a replacement payload when a bounded job advances its cursor', async () => {
+    const store = new MaintenanceJobStore(dataDir);
+    const job = store.enqueue({
+      projectId: 'project-a',
+      kind: 'retention-archive',
+      dedupeKey: 'retention',
+      payload: { cursor: 0, limit: 100 },
+      now: 1_000,
+    });
+    const worker = new MaintenanceJobWorker(store, async () => ({
+      action: 'reschedule' as const,
+      delayMs: 0,
+      resetAttempts: true,
+      payload: { cursor: 100, limit: 100 },
+    }), { workerId: 'cursor-worker', leaseMs: 100 });
+
+    await worker.runOnce(1_000);
+
+    expect(store.get(job.id)).toMatchObject({
+      status: 'pending',
+      attempts: 0,
+      payload: { cursor: 100, limit: 100 },
+    });
+  });
+
+  it('keeps a lease alive while an asynchronous handler is still running', async () => {
+    const store = new MaintenanceJobStore(dataDir);
+    const job = store.enqueue({
+      projectId: 'project-a',
+      kind: 'codegraph-refresh',
+      dedupeKey: 'graph',
+      now: Date.now(),
+    });
+    let competingClaim: unknown;
+    const worker = new MaintenanceJobWorker(store, async () => {
+      await new Promise((resolve) => setTimeout(resolve, 140));
+      competingClaim = store.claimNext({ workerId: 'worker-b', now: Date.now(), leaseMs: 100 });
+      return { action: 'complete' as const };
+    }, { workerId: 'worker-a', leaseMs: 100 });
+
+    await worker.runOnce(Date.now());
+
+    expect(competingClaim).toBeUndefined();
+    expect(store.get(job.id)?.status).toBe('completed');
+  });
+
+  it('claims ready work immediately when the worker starts', async () => {
+    const store = new MaintenanceJobStore(dataDir);
+    const job = store.enqueue({
+      projectId: 'project-a',
+      kind: 'retention-archive',
+      now: Date.now(),
+    });
+    let finishHandler: (() => void) | undefined;
+    const handled = new Promise<void>((resolve) => { finishHandler = resolve; });
+    const worker = new MaintenanceJobWorker(store, async () => {
+      finishHandler?.();
+      return { action: 'complete' as const };
+    }, { workerId: 'immediate-worker', pollIntervalMs: 60_000 });
+
+    worker.start();
+    await handled;
+    worker.stop();
+
+    expect(store.get(job.id)?.status).toBe('completed');
+  });
+});

--- a/tests/runtime/project-maintenance.test.ts
+++ b/tests/runtime/project-maintenance.test.ts
@@ -1,0 +1,162 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { runMaintenanceInChildProcess } = vi.hoisted(() => ({
+  runMaintenanceInChildProcess: vi.fn(),
+}));
+
+const isEmbeddingExplicitlyDisabled = vi.fn();
+const backfillVectorEmbeddings = vi.fn();
+const getVectorStatus = vi.fn();
+const archiveExpiredBatch = vi.fn();
+const codeStoreInit = vi.fn();
+const CodeGraphStore = vi.fn(function CodeGraphStoreMock() {
+  return { init: codeStoreInit };
+});
+const refreshProjectLite = vi.fn();
+const backfillMissingObservationCodeRefs = vi.fn();
+const getResolvedConfig = vi.fn();
+const loadByProject = vi.fn();
+const getObservationStore = vi.fn(() => ({ loadByProject }));
+
+vi.mock('../../src/embedding/provider.js', () => ({
+  isEmbeddingExplicitlyDisabled,
+}));
+
+vi.mock('../../src/memory/observations.js', () => ({
+  backfillVectorEmbeddings,
+  getVectorStatus,
+}));
+
+vi.mock('../../src/memory/retention.js', () => ({
+  archiveExpiredBatch,
+}));
+
+vi.mock('../../src/codegraph/store.js', () => ({ CodeGraphStore }));
+vi.mock('../../src/codegraph/lite-provider.js', () => ({ refreshProjectLite }));
+vi.mock('../../src/codegraph/binder.js', () => ({ backfillMissingObservationCodeRefs }));
+vi.mock('../../src/store/obs-store.js', () => ({ getObservationStore }));
+vi.mock('../../src/config/resolved-config.js', () => ({ getResolvedConfig }));
+vi.mock('../../src/runtime/isolated-maintenance.js', () => ({ runMaintenanceInChildProcess }));
+
+import { createProjectMaintenanceDispatcher, createProjectMaintenanceHandler } from '../../src/runtime/project-maintenance.js';
+import type { MaintenanceJob } from '../../src/runtime/maintenance-jobs.js';
+
+function makeJob(overrides: Partial<MaintenanceJob> = {}): MaintenanceJob {
+  return {
+    id: 'job-1',
+    projectId: 'project-a',
+    kind: 'vector-backfill',
+    dedupeKey: 'vectors',
+    payload: { limit: 2 },
+    status: 'running',
+    attempts: 1,
+    maxAttempts: 8,
+    runAfter: 1_000,
+    createdAt: 1_000,
+    updatedAt: 1_000,
+    ...overrides,
+  };
+}
+
+describe('createProjectMaintenanceHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    isEmbeddingExplicitlyDisabled.mockReturnValue(false);
+    getResolvedConfig.mockReturnValue({ codegraph: { excludePatterns: ['generated/**'] } });
+    getObservationStore.mockReturnValue({ loadByProject });
+  });
+
+  it('processes vector work in the requested bounded batch and reschedules remaining work', async () => {
+    getVectorStatus
+      .mockReturnValueOnce({ missing: 3 })
+      .mockReturnValueOnce({ missing: 1 });
+    backfillVectorEmbeddings.mockResolvedValue({ attempted: 2, succeeded: 2, failed: 0 });
+
+    const result = await createProjectMaintenanceHandler('project-a', 'C:/memorix-data')(makeJob());
+
+    expect(backfillVectorEmbeddings).toHaveBeenCalledWith({ projectId: 'project-a', limit: 2 });
+    expect(result).toEqual({ action: 'reschedule', delayMs: 0, resetAttempts: true });
+  });
+
+  it('completes vector work immediately when embeddings are explicitly disabled', async () => {
+    isEmbeddingExplicitlyDisabled.mockReturnValue(true);
+
+    const result = await createProjectMaintenanceHandler('project-a', 'C:/memorix-data')(makeJob());
+
+    expect(result).toEqual({ action: 'complete' });
+    expect(backfillVectorEmbeddings).not.toHaveBeenCalled();
+  });
+
+  it('continues retention through a durable cursor instead of scanning from the beginning', async () => {
+    archiveExpiredBatch.mockResolvedValue({ archived: 1, scanned: 25, nextCursor: 50 });
+
+    const result = await createProjectMaintenanceHandler('project-a', 'C:/memorix-data')(
+      makeJob({
+        kind: 'retention-archive',
+        payload: { cursor: 25, limit: 25 },
+      }),
+    );
+
+    expect(archiveExpiredBatch).toHaveBeenCalledWith('C:/memorix-data', {
+      projectId: 'project-a',
+      afterId: 25,
+      limit: 25,
+    });
+    expect(result).toEqual({
+      action: 'reschedule',
+      delayMs: 0,
+      resetAttempts: true,
+      payload: { cursor: 50, limit: 25 },
+    });
+  });
+
+  it('refreshes and binds Code Memory through the registered maintenance handler', async () => {
+    const observations = [
+      { id: 1, projectId: 'project-a', title: 'Current', narrative: '', createdAt: '2026-01-01T00:00:00.000Z', status: 'active' },
+      { id: 2, projectId: 'project-b', title: 'Other project', narrative: '', createdAt: '2026-01-01T00:00:00.000Z', status: 'active' },
+      { id: 3, projectId: 'project-a', title: 'Archived', narrative: '', createdAt: '2026-01-01T00:00:00.000Z', status: 'archived' },
+    ];
+    loadByProject.mockResolvedValue([observations[0]]);
+    refreshProjectLite.mockResolvedValue({ changedFiles: 1 });
+    backfillMissingObservationCodeRefs.mockResolvedValue({ observationsBackfilled: 1, refsBackfilled: 2 });
+
+    const result = await createProjectMaintenanceHandler(
+      'project-a',
+      'C:/memorix-data',
+      'C:/workspace/project-a',
+    )(makeJob({ kind: 'codegraph-refresh', payload: { maxFiles: 250 } }));
+
+    expect(codeStoreInit).toHaveBeenCalledWith('C:/memorix-data');
+    expect(refreshProjectLite).toHaveBeenCalledWith(expect.anything(), {
+      projectId: 'project-a',
+      projectRoot: 'C:/workspace/project-a',
+      exclude: ['generated/**'],
+      maxFiles: 250,
+    });
+    expect(backfillMissingObservationCodeRefs).toHaveBeenCalledWith(
+      expect.anything(),
+      [observations[0]],
+    );
+    expect(loadByProject).toHaveBeenCalledWith('project-a', { status: 'active' });
+    expect(result).toEqual({ action: 'complete' });
+  });
+
+  it('keeps vector backfill in the live process and moves disk-heavy work into an isolated runner', async () => {
+    runMaintenanceInChildProcess.mockResolvedValue({ action: 'complete' });
+    const dispatcher = createProjectMaintenanceDispatcher(
+      'project-a',
+      'C:/memorix-data',
+      'C:/workspace/project-a',
+    );
+
+    const result = await dispatcher(makeJob({ kind: 'codegraph-refresh' }));
+
+    expect(result).toEqual({ action: 'complete' });
+    expect(runMaintenanceInChildProcess).toHaveBeenCalledWith({
+      job: makeJob({ kind: 'codegraph-refresh' }),
+      projectRoot: 'C:/workspace/project-a',
+      dataDir: 'C:/memorix-data',
+    });
+    expect(refreshProjectLite).not.toHaveBeenCalled();
+  });
+});

--- a/tests/server/bootstrap-tools.test.ts
+++ b/tests/server/bootstrap-tools.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { BOOTSTRAP_SAFE_TOOL_NAMES, shouldAwaitProjectRuntime } from '../../src/server.js';
+
+describe('MCP bootstrap-safe tools', () => {
+  it('allows only project-scoped read tools before full memory hydration', () => {
+    expect([...BOOTSTRAP_SAFE_TOOL_NAMES].sort()).toEqual([
+      'memorix_codegraph_status',
+      'memorix_context_pack',
+      'memorix_graph_context',
+      'memorix_project_context',
+    ]);
+    expect(shouldAwaitProjectRuntime('memorix_project_context')).toBe(false);
+    expect(shouldAwaitProjectRuntime('memorix_codegraph_status')).toBe(false);
+    expect(shouldAwaitProjectRuntime('memorix_graph_context')).toBe(false);
+    expect(shouldAwaitProjectRuntime('memorix_context_pack')).toBe(false);
+  });
+
+  it('keeps search, writes, and session operations behind full runtime initialization', () => {
+    for (const tool of ['memorix_search', 'memorix_store', 'memorix_session_start']) {
+      expect(shouldAwaitProjectRuntime(tool)).toBe(true);
+    }
+  });
+});

--- a/tests/store/sqlite-store.test.ts
+++ b/tests/store/sqlite-store.test.ts
@@ -172,6 +172,21 @@ describe('SqliteBackend CRUD', () => {
     expect(loaded.sourceDetail).toBe('git-ingest');
     expect(loaded.valueCategory).toBe('core');
   });
+
+  it('loads one project without scanning observations from other projects', async () => {
+    await store.insert(makeObs({ id: 1, entityName: 'a-active', projectId: 'project-a', status: 'active' }));
+    await store.insert(makeObs({ id: 2, entityName: 'a-archived', projectId: 'project-a', status: 'archived' }));
+    await store.insert(makeObs({ id: 3, entityName: 'b-active', projectId: 'project-b', status: 'active' }));
+
+    const rawLoadAll = vi.spyOn(store as any, 'rawLoadAll');
+    const active = await store.loadByProject('project-a', { status: 'active' });
+
+    expect(rawLoadAll).not.toHaveBeenCalled();
+    expect(active.map((observation) => observation.id)).toEqual([1]);
+    expect(await store.getById(3)).toMatchObject({ projectId: 'project-b' });
+    expect(await store.countByProject('project-a', { status: 'active' })).toBe(1);
+    expect(await store.countByProject('project-a')).toBe(2);
+  });
 });
 
 // ── Atomic transactions ───────────────────────────────────────────
@@ -205,6 +220,48 @@ describe('SqliteBackend atomic()', () => {
     const all = await store.loadAll();
     expect(all).toHaveLength(2);
     expect(await store.loadIdCounter()).toBe(3);
+  });
+
+  it('supports targeted writes without loading or replacing all observations', async () => {
+    await store.insert(makeObs({ id: 1, entityName: 'auth', projectId: 'p', topicKey: 'decision/auth' }));
+    await store.insert(makeObs({ id: 2, entityName: 'cache', projectId: 'p', topicKey: 'decision/cache' }));
+    await store.saveIdCounter(3);
+
+    const rawLoadAll = vi.spyOn(store as any, 'rawLoadAll');
+    const generationBeforeWrite = await store.atomic(async (tx) => {
+      const existing = await tx.findByTopicKey('p', 'decision/auth');
+      expect(existing?.id).toBe(1);
+      expect(await tx.getGeneration()).toBe(2);
+
+      await tx.insert(makeObs({ id: 3, entityName: 'queue', projectId: 'p', topicKey: 'decision/jobs' }));
+      await tx.saveIdCounter(4);
+      return await tx.getGeneration();
+    });
+
+    expect(generationBeforeWrite).toBe(2);
+    expect(rawLoadAll).not.toHaveBeenCalled();
+
+    const all = await store.loadAll();
+    expect(all.map((obs) => obs.id).sort()).toEqual([1, 2, 3]);
+    expect(await store.loadIdCounter()).toBe(4);
+  });
+
+  it('updates and removes selected observations without loading all rows', async () => {
+    await store.insert(makeObs({ id: 1, entityName: 'keep-updated', projectId: 'p', title: 'before' }));
+    await store.insert(makeObs({ id: 2, entityName: 'remove', projectId: 'p' }));
+    await store.insert(makeObs({ id: 3, entityName: 'keep-untouched', projectId: 'p' }));
+
+    const rawLoadAll = vi.spyOn(store as any, 'rawLoadAll');
+    await store.atomic(async (tx) => {
+      await tx.update(makeObs({ id: 1, entityName: 'keep-updated', projectId: 'p', title: 'after' }));
+      await tx.remove(2);
+    });
+
+    expect(rawLoadAll).not.toHaveBeenCalled();
+    const all = await store.loadAll();
+    expect(all.map((obs) => obs.id).sort()).toEqual([1, 3]);
+    expect(all.find((obs) => obs.id === 1)?.title).toBe('after');
+    expect(all.find((obs) => obs.id === 3)?.entityName).toBe('keep-untouched');
   });
 
   it('atomic rolls back on error', async () => {

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -8,7 +8,15 @@ export default defineConfig([
   {
     // Phase 4b: types entry added for memorix/types SDK subpath export
     // SDK entry added for memorix/sdk programmatic API
-    entry: { index: 'src/index.ts', types: 'src/types.ts', sdk: 'src/sdk.ts' },
+    entry: {
+      index: 'src/index.ts',
+      types: 'src/types.ts',
+      sdk: 'src/sdk.ts',
+      // Hidden process entry used by the durable maintenance queue. Keeping it
+      // separate from the MCP host prevents graph scans and consolidation from
+      // blocking an agent request on the main event loop.
+      'maintenance-runner': 'src/runtime/maintenance-runner.ts',
+    },
     format: ['esm'],
     target: 'node20',
     dts: true,
@@ -83,4 +91,3 @@ export default defineConfig([
     },
   },
 ]);
-


### PR DESCRIPTION
## 1.1.11 runtime integrity

- Move lifecycle work into durable, leased SQLite maintenance jobs and isolate non-vector maintenance from MCP request handling.
- Make CodeGraph Lite incremental and bounded for large repositories.
- Keep first-turn context tools responsive from project-scoped SQLite before Orama hydration.
- Align runtime behavior configuration, project-scoped dashboard reads, and mobile dashboard layout.
- Add regression coverage for queue atomicity, cross-process maintenance, scoped persistence, and bootstrap MCP tools.

Verification: `npm test`, `npm run lint`, `npm run build`, production dependency audit, package dry-run, clean-install smoke, and built stdio MCP smoke all pass.