### PR TITLE
feat(embedding): multimodal inputs and query/document intent

### DIFF
--- a/src/compact/engine.ts
+++ b/src/compact/engine.ts
@@ -392,6 +392,12 @@ function observationToDocument(obs: ReturnType<typeof getAllObservations>[number
     facts: obs.facts.join('\n'),
     filesModified: obs.filesModified.join('\n'),
     concepts: obs.concepts.join(', '),
+    attachments: (obs.attachments ?? []).map((attachment) => [
+      attachment.name,
+      attachment.modality,
+      attachment.mimeType,
+      attachment.url,
+    ].filter(Boolean).join(' ')).join('\n'),
     tokens: obs.tokens,
     createdAt: obs.createdAt,
     projectId: obs.projectId,

--- a/src/compact/index-format.ts
+++ b/src/compact/index-format.ts
@@ -174,6 +174,7 @@ export function formatObservationDetail(doc: {
   facts: string;
   filesModified: string;
   concepts: string;
+  attachments?: string;
   createdAt: string;
   projectId: string;
   entityName: string;
@@ -223,6 +224,13 @@ export function formatObservationDetail(doc: {
   if (doc.concepts) {
     lines.push('');
     lines.push(`Concepts: ${doc.concepts}`);
+  }
+
+  const attachments = doc.attachments?.split('\n').filter(Boolean) ?? [];
+  if (attachments.length > 0) {
+    lines.push('');
+    lines.push('Attachments (provenance/BM25 metadata; URL content is not fetched):');
+    for (const attachment of attachments) lines.push(`- ${attachment}`);
   }
 
   return lines.join('\n');

--- a/src/embedding/api-provider.ts
+++ b/src/embedding/api-provider.ts
@@ -10,6 +10,7 @@ import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import {
+  EmbeddingInputError,
   UnsupportedEmbeddingModalityError,
   validateEmbeddingInput,
   type EmbeddingInput,
@@ -78,6 +79,44 @@ function isJinaEndpoint(baseUrl: string): boolean {
 
 function isGoogleEmbeddingEndpoint(baseUrl: string): boolean {
   return /generativelanguage\.googleapis\.com/i.test(baseUrl);
+}
+
+function isNativeGeminiEndpoint(baseUrl: string): boolean {
+  if (!isGoogleEmbeddingEndpoint(baseUrl)) return false;
+  return !new URL(baseUrl).pathname.split('/').includes('openai');
+}
+
+function geminiModelName(model: string): string {
+  return model.replace(/^models\//, '');
+}
+
+function geminiBody(
+  input: EmbeddingInput,
+  model: string,
+  requestedDimensions: number | null,
+  options: EmbeddingOptions = {},
+): Record<string, unknown> {
+  if (options.instruction) {
+    throw new EmbeddingInputError(`Gemini native ${model} does not support embedding instructions`);
+  }
+  if (input.modality !== 'text' && !('data' in input && input.data !== undefined)) {
+    throw new UnsupportedEmbeddingModalityError(`Gemini native ${model}`, input.modality);
+  }
+  const part = input.modality === 'text'
+    ? { text: input.text }
+    : { inlineData: { mimeType: input.mimeType, data: input.data } };
+  const body: Record<string, unknown> = {
+    content: { parts: [part] },
+  };
+  if (requestedDimensions) body.outputDimensionality = requestedDimensions;
+  if (!/^gemini-embedding-2(?:-|$)/i.test(geminiModelName(model))) {
+    body.taskType = (options.intent ?? 'document') === 'query' ? 'RETRIEVAL_QUERY' : 'RETRIEVAL_DOCUMENT';
+  }
+  return body;
+}
+
+function geminiUrl(baseUrl: string, model: string): string {
+  return `${baseUrl}/models/${geminiModelName(model)}:embedContent`;
 }
 
 function mapIntentTask(baseUrl: string, model: string, options: EmbeddingOptions = {}): Record<string, unknown> {
@@ -344,7 +383,8 @@ function cacheSet(hash: string, value: number[]): void {
 }
 
 interface EmbeddingAPIResponse {
-  object: string;
+  object?: string;
+  embedding?: { values: number[] };
   data: Array<{
     object: string;
     index: number;
@@ -495,29 +535,31 @@ export class APIEmbeddingProvider implements EmbeddingProvider {
   }
 
   private static async probeAPI(config: APIEmbeddingConfig): Promise<number> {
-    const body: Record<string, unknown> = {
-      model: config.model,
-      input: 'dimension probe',
-    };
-    if (config.requestedDimensions) {
-      body.dimensions = config.requestedDimensions;
+    if (isNativeGeminiEndpoint(config.baseUrl)) {
+      const response = await fetchWithRetry(
+        geminiUrl(config.baseUrl, config.model),
+        config.apiKey,
+        geminiBody({ modality: 'text', text: 'dimension probe' }, config.model, config.requestedDimensions),
+        0,
+        true,
+      );
+      const embedding = response.embedding?.values;
+      if (!embedding) throw new Error('API probe returned no embeddings; check model name and API key');
+      return embedding.length;
     }
-
-    const response = await fetchWithRetry(
-      `${config.baseUrl}/embeddings`,
-      config.apiKey,
-      body,
-    );
-
-    if (response.data.length === 0 || !response.data[0].embedding) {
-      throw new Error('API probe returned no embeddings; check model name and API key');
-    }
-
-    return response.data[0].embedding.length;
+    const body: Record<string, unknown> = { model: config.model, input: 'dimension probe' };
+    if (config.requestedDimensions) body.dimensions = config.requestedDimensions;
+    const response = await fetchWithRetry(`${config.baseUrl}/embeddings`, config.apiKey, body);
+    const embedding = response.data?.[0]?.embedding;
+    if (!embedding) throw new Error('API probe returned no embeddings; check model name and API key');
+    return embedding.length;
   }
 
   async embed(text: string): Promise<number[]> {
     const normalized = normalizeText(text);
+    if (isNativeGeminiEndpoint(this.config.baseUrl)) {
+      return this.embedInput({ modality: 'text', text: normalized }, { intent: 'document' });
+    }
     const hash = textHash(normalized, this.cacheKeyNamespace);
 
     // Fast path: cache already loaded (warm process) — instant lookup
@@ -586,6 +628,9 @@ export class APIEmbeddingProvider implements EmbeddingProvider {
   }
 
   async embedBatch(texts: string[]): Promise<number[][]> {
+    if (isNativeGeminiEndpoint(this.config.baseUrl)) {
+      return Promise.all(texts.map((text) => this.embedInput({ modality: 'text', text }, { intent: 'document' })));
+    }
     await ensureDiskCacheLoaded();
     const normalizedTexts = texts.map(normalizeText);
     const results: number[][] = new Array(texts.length);
@@ -685,7 +730,7 @@ export class APIEmbeddingProvider implements EmbeddingProvider {
   private supportsModality(modality: EmbeddingInput['modality']): boolean {
     if (modality === 'text') return true;
     if (isJinaEndpoint(this.config.baseUrl)) return true;
-    if (isGoogleEmbeddingEndpoint(this.config.baseUrl) && /embedding-2/i.test(this.config.model)) return true;
+    if (isNativeGeminiEndpoint(this.config.baseUrl) && /embedding-2/i.test(this.config.model)) return true;
     return false;
   }
 
@@ -704,21 +749,26 @@ export class APIEmbeddingProvider implements EmbeddingProvider {
     const cached = cache.get(hash);
     if (cached) return cached;
 
-    const body: Record<string, unknown> = {
-      model: this.config.model,
-      input: input.modality === 'text' && !isJinaEndpoint(this.config.baseUrl)
-        ? input.text
-        : [toProviderInput(input, this.config.baseUrl)],
-      ...mapIntentTask(this.config.baseUrl, this.config.model, options),
-    };
-    if (this.config.requestedDimensions) body.dimensions = this.config.requestedDimensions;
+    const nativeGemini = isNativeGeminiEndpoint(this.config.baseUrl);
+    const body: Record<string, unknown> = nativeGemini
+      ? geminiBody(input, this.config.model, this.config.requestedDimensions, options)
+      : {
+          model: this.config.model,
+          input: input.modality === 'text' && !isJinaEndpoint(this.config.baseUrl)
+            ? input.text
+            : [toProviderInput(input, this.config.baseUrl)],
+          ...mapIntentTask(this.config.baseUrl, this.config.model, options),
+          ...(this.config.requestedDimensions ? { dimensions: this.config.requestedDimensions } : {}),
+        };
 
     const response = await fetchWithRetry(
-      `${this.config.baseUrl}/embeddings`,
+      nativeGemini ? geminiUrl(this.config.baseUrl, this.config.model) : `${this.config.baseUrl}/embeddings`,
       this.config.apiKey,
       body,
+      0,
+      nativeGemini,
     );
-    const embedding = response.data[0]?.embedding;
+    const embedding = nativeGemini ? response.embedding?.values : response.data[0]?.embedding;
     if (!embedding) throw new Error('Embedding API returned no vectors');
     if (embedding.length !== this.dimensions) {
       throw new Error(`Expected ${this.dimensions}d, got ${embedding.length}d; dimension mismatch`);
@@ -756,6 +806,7 @@ async function fetchWithRetry(
   apiKey: string,
   body: Record<string, unknown>,
   attempt = 0,
+  nativeGemini = false,
 ): Promise<EmbeddingAPIResponse> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 10_000);
@@ -763,10 +814,9 @@ async function fetchWithRetry(
   try {
     response = await fetch(url, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`,
-      },
+      headers: nativeGemini
+        ? { 'Content-Type': 'application/json', 'x-goog-api-key': apiKey }
+        : { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` },
       body: JSON.stringify(body),
       signal: controller.signal,
     });
@@ -789,7 +839,7 @@ async function fetchWithRetry(
     const waitMs = retryAfter ? parseInt(retryAfter, 10) * 1000 : delay;
     console.error(`[memorix] Embedding API ${response.status}, retry ${attempt + 1}/${MAX_RETRIES} in ${waitMs}ms`);
     await new Promise(resolve => setTimeout(resolve, waitMs));
-    return fetchWithRetry(url, apiKey, body, attempt + 1);
+    return fetchWithRetry(url, apiKey, body, attempt + 1, nativeGemini);
   }
 
   const errorText = await response.text().catch(() => 'unknown error');

--- a/src/embedding/api-provider.ts
+++ b/src/embedding/api-provider.ts
@@ -9,12 +9,26 @@ import { createHash } from 'node:crypto';
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import type { EmbeddingProvider } from './provider.js';
+import {
+  UnsupportedEmbeddingModalityError,
+  validateEmbeddingInput,
+  type EmbeddingInput,
+  type EmbeddingOptions,
+  type EmbeddingProvider,
+} from './provider.js';
 
-const CACHE_DIR = process.env.MEMORIX_DATA_DIR || join(homedir(), '.memorix', 'data');
-const CACHE_FILE = join(CACHE_DIR, '.embedding-api-cache.json');
-const DIMS_CACHE_FILE = join(CACHE_DIR, '.embedding-dims-cache.json');
-const CACHE_META_FILE = join(CACHE_DIR, '.embedding-api-cache-meta.json');
+function cacheDir(): string {
+  return process.env.MEMORIX_DATA_DIR || join(homedir(), '.memorix', 'data');
+}
+function cacheFile(): string {
+  return join(cacheDir(), '.embedding-api-cache.json');
+}
+function dimsCacheFile(): string {
+  return join(cacheDir(), '.embedding-dims-cache.json');
+}
+function cacheMetaFile(): string {
+  return join(cacheDir(), '.embedding-api-cache-meta.json');
+}
 
 const cache = new Map<string, number[]>();
 const MAX_CACHE_SIZE = 10000;
@@ -49,10 +63,60 @@ function textHash(text: string, namespace: string): string {
   return createHash('sha256').update(`${namespace}\u0000${text}`).digest('hex').slice(0, 16);
 }
 
+function inputIdentity(input: EmbeddingInput, options: EmbeddingOptions = {}): string {
+  return JSON.stringify({
+    modality: input.modality,
+    input,
+    intent: options.intent ?? 'document',
+    instruction: options.instruction ?? '',
+  });
+}
+
+function isJinaEndpoint(baseUrl: string): boolean {
+  return /jina\.ai/i.test(baseUrl);
+}
+
+function isGoogleEmbeddingEndpoint(baseUrl: string): boolean {
+  return /generativelanguage\.googleapis\.com/i.test(baseUrl);
+}
+
+function mapIntentTask(baseUrl: string, model: string, options: EmbeddingOptions = {}): Record<string, unknown> {
+  const intent = options.intent ?? 'document';
+  if (isJinaEndpoint(baseUrl)) {
+    return { task: intent === 'query' ? 'retrieval.query' : 'retrieval.passage' };
+  }
+  if (isGoogleEmbeddingEndpoint(baseUrl)) {
+    const out: Record<string, unknown> = {
+      task_type: intent === 'query' ? 'RETRIEVAL_QUERY' : 'RETRIEVAL_DOCUMENT',
+    };
+    if (options.instruction) out.instruction = options.instruction;
+    return out;
+  }
+  return options.instruction ? { instruction: options.instruction } : {};
+}
+
+function toProviderInput(input: EmbeddingInput, baseUrl: string): unknown {
+  if (input.modality === 'text') {
+    return isJinaEndpoint(baseUrl) ? { text: input.text } : input.text;
+  }
+  if (isJinaEndpoint(baseUrl)) {
+    const key = input.modality === 'document' ? 'pdf' : input.modality;
+    if ('data' in input && input.data !== undefined) {
+      return { [key]: `data:${input.mimeType};base64,${input.data}` };
+    }
+    return { [key]: input.url };
+  }
+  // Generic OpenAI-compatible multimodal transport for capable Google-style endpoints.
+  if ('data' in input && input.data !== undefined) {
+    return { type: input.modality, data: input.data, media_type: input.mimeType };
+  }
+  return { type: input.modality, url: input.url };
+}
+
 async function loadDiskCache(): Promise<void> {
   if (diskCacheLoaded) return;
   try {
-    const raw = await readFile(CACHE_FILE, 'utf-8');
+    const raw = await readFile(cacheFile(), 'utf-8');
     const entries: [string, number[]][] = JSON.parse(raw);
     for (const [k, v] of entries) cache.set(k, v);
     console.error(`[memorix] Loaded ${entries.length} cached API embeddings from disk`);
@@ -101,7 +165,7 @@ async function loadCachedVectorDimensions(
   config: Pick<APIEmbeddingConfig, 'baseUrl' | 'model' | 'requestedDimensions'>,
 ): Promise<number | null> {
   try {
-    const raw = await readFile(CACHE_META_FILE, 'utf-8');
+    const raw = await readFile(cacheMetaFile(), 'utf-8');
     const data = JSON.parse(raw);
     const namespace = cacheNamespace(config);
     if (!Array.isArray(data?.entries)) return null;
@@ -123,10 +187,10 @@ async function saveCachedVectorDimensions(
 ): Promise<void> {
   if (!isValidDimension(dimensions)) return;
   try {
-    await mkdir(CACHE_DIR, { recursive: true });
+    await mkdir(cacheDir(), { recursive: true });
     let entries: CacheMetadataEntry[] = [];
     try {
-      const raw = await readFile(CACHE_META_FILE, 'utf-8');
+      const raw = await readFile(cacheMetaFile(), 'utf-8');
       const data = JSON.parse(raw);
       if (Array.isArray(data?.entries)) {
         entries = data.entries.filter((candidate: unknown): candidate is CacheMetadataEntry =>
@@ -144,7 +208,7 @@ async function saveCachedVectorDimensions(
     const namespace = cacheNamespace(config);
     entries = entries.filter((entry) => entry.namespace !== namespace);
     entries.push({ namespace, dimensions, ts: Date.now() });
-    await writeFile(CACHE_META_FILE, JSON.stringify({ version: 1, entries }));
+    await writeFile(cacheMetaFile(), JSON.stringify({ version: 1, entries }));
   } catch {
     // A missing or read-only cache must never block embedding requests.
   }
@@ -153,7 +217,7 @@ async function saveCachedVectorDimensions(
 /** Load cached probe dimensions from disk. Returns null if not cached. */
 async function loadCachedDims(config: Pick<APIEmbeddingConfig, 'baseUrl' | 'model' | 'requestedDimensions'>): Promise<number | null> {
   try {
-    const raw = await readFile(DIMS_CACHE_FILE, 'utf-8');
+    const raw = await readFile(dimsCacheFile(), 'utf-8');
     const data = JSON.parse(raw);
 
     const key = dimsCacheKey(config);
@@ -195,12 +259,12 @@ async function loadCachedDims(config: Pick<APIEmbeddingConfig, 'baseUrl' | 'mode
 /** Persist probe dimensions for fast subsequent starts. */
 async function saveCachedDims(config: Pick<APIEmbeddingConfig, 'baseUrl' | 'model' | 'requestedDimensions'>, dimensions: number): Promise<void> {
   try {
-    await mkdir(CACHE_DIR, { recursive: true });
+    await mkdir(cacheDir(), { recursive: true });
     const key = dimsCacheKey(config);
     let entries: Array<{ key: string; baseUrl: string; model: string; requestedDimensions: number | null; dimensions: number; ts: number }> = [];
 
     try {
-      const raw = await readFile(DIMS_CACHE_FILE, 'utf-8');
+      const raw = await readFile(dimsCacheFile(), 'utf-8');
       const data = JSON.parse(raw);
       if (Array.isArray(data.entries)) {
         entries = data.entries.filter((entry: unknown) =>
@@ -245,7 +309,7 @@ async function saveCachedDims(config: Pick<APIEmbeddingConfig, 'baseUrl' | 'mode
     entries = entries.filter((entry) => entry.key !== key);
     entries.push(nextEntry);
 
-    await writeFile(DIMS_CACHE_FILE, JSON.stringify({ entries }));
+    await writeFile(dimsCacheFile(), JSON.stringify({ entries }));
   } catch { /* best-effort */ }
   await saveCachedVectorDimensions(config, dimensions);
 }
@@ -253,9 +317,9 @@ async function saveCachedDims(config: Pick<APIEmbeddingConfig, 'baseUrl' | 'mode
 async function saveDiskCacheNow(): Promise<void> {
   if (!diskCacheDirty) return;
   try {
-    await mkdir(CACHE_DIR, { recursive: true });
+    await mkdir(cacheDir(), { recursive: true });
     const entries = Array.from(cache.entries());
-    await writeFile(CACHE_FILE, JSON.stringify(entries));
+    await writeFile(cacheFile(), JSON.stringify(entries));
     diskCacheDirty = false;
   } catch {
     // Cache persistence is best-effort only.
@@ -616,6 +680,59 @@ export class APIEmbeddingProvider implements EmbeddingProvider {
       const hash = textHash(normalizeText(text), this.cacheKeyNamespace);
       return cache.get(hash) ?? null;
     });
+  }
+
+  private supportsModality(modality: EmbeddingInput['modality']): boolean {
+    if (modality === 'text') return true;
+    if (isJinaEndpoint(this.config.baseUrl)) return true;
+    if (isGoogleEmbeddingEndpoint(this.config.baseUrl) && /embedding-2/i.test(this.config.model)) return true;
+    return false;
+  }
+
+  async embedInput(input: EmbeddingInput, options: EmbeddingOptions = {}): Promise<number[]> {
+    validateEmbeddingInput(input);
+    if (!this.supportsModality(input.modality)) {
+      throw new UnsupportedEmbeddingModalityError(this.name, input.modality);
+    }
+    if (input.modality === 'text' && !options.intent && !options.instruction && !isJinaEndpoint(this.config.baseUrl) && !isGoogleEmbeddingEndpoint(this.config.baseUrl)) {
+      return this.embed(input.text);
+    }
+
+    await ensureDiskCacheLoaded();
+    const identity = inputIdentity(input, options);
+    const hash = textHash(identity, this.cacheKeyNamespace);
+    const cached = cache.get(hash);
+    if (cached) return cached;
+
+    const body: Record<string, unknown> = {
+      model: this.config.model,
+      input: input.modality === 'text' && !isJinaEndpoint(this.config.baseUrl)
+        ? input.text
+        : [toProviderInput(input, this.config.baseUrl)],
+      ...mapIntentTask(this.config.baseUrl, this.config.model, options),
+    };
+    if (this.config.requestedDimensions) body.dimensions = this.config.requestedDimensions;
+
+    const response = await fetchWithRetry(
+      `${this.config.baseUrl}/embeddings`,
+      this.config.apiKey,
+      body,
+    );
+    const embedding = response.data[0]?.embedding;
+    if (!embedding) throw new Error('Embedding API returned no vectors');
+    if (embedding.length !== this.dimensions) {
+      throw new Error(`Expected ${this.dimensions}d, got ${embedding.length}d; dimension mismatch`);
+    }
+    this.trackUsage(response);
+    cacheSet(hash, embedding);
+    scheduleDiskSave();
+    return embedding;
+  }
+
+  async embedInputs(inputs: EmbeddingInput[], options: EmbeddingOptions = {}): Promise<number[][]> {
+    const out: number[][] = [];
+    for (const input of inputs) out.push(await this.embedInput(input, options));
+    return out;
   }
 
   getStats(): { totalTokens: number; totalApiCalls: number; cacheSize: number } {

--- a/src/embedding/fastembed-provider.ts
+++ b/src/embedding/fastembed-provider.ts
@@ -15,7 +15,13 @@ import { createHash } from 'node:crypto';
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import type { EmbeddingProvider } from './provider.js';
+import {
+  UnsupportedEmbeddingModalityError,
+  validateEmbeddingInput,
+  type EmbeddingInput,
+  type EmbeddingOptions,
+  type EmbeddingProvider,
+} from './provider.js';
 
 const CACHE_DIR = process.env.MEMORIX_DATA_DIR || join(homedir(), '.memorix', 'data');
 const CACHE_FILE = join(CACHE_DIR, '.embedding-cache.json');
@@ -76,6 +82,18 @@ export class FastEmbedProvider implements EmbeddingProvider {
     // Load disk cache before returning — subsequent embedBatch calls will hit cache
     await loadDiskCache();
     return new FastEmbedProvider(model);
+  }
+
+  async embedInput(input: EmbeddingInput, _options: EmbeddingOptions = {}): Promise<number[]> {
+    validateEmbeddingInput(input);
+    if (input.modality !== 'text') {
+      throw new UnsupportedEmbeddingModalityError(this.name, input.modality);
+    }
+    return this.embed(input.text);
+  }
+
+  async embedInputs(inputs: EmbeddingInput[], options: EmbeddingOptions = {}): Promise<number[][]> {
+    return Promise.all(inputs.map((input) => this.embedInput(input, options)));
   }
 
   async embed(text: string): Promise<number[]> {

--- a/src/embedding/provider.ts
+++ b/src/embedding/provider.ts
@@ -27,6 +27,8 @@
  * Architecture inspired by Mem0's multi-provider embedding design.
  */
 
+import { isIP } from 'node:net';
+
 export type EmbeddingModality = 'text' | 'image' | 'audio' | 'video' | 'document';
 export type EmbeddingIntent = 'query' | 'document';
 
@@ -64,15 +66,40 @@ export class UnsupportedEmbeddingModalityError extends EmbeddingInputError {
 /** Maximum encoded inline media accepted by the public API (5 MiB). */
 export const MAX_INLINE_EMBEDDING_BYTES = 5 * 1024 * 1024;
 
-function isPrivateHost(hostname: string): boolean {
-  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
-  if (host === 'localhost' || host === '::1' || host === '0.0.0.0' || host.endsWith('.localhost')) return true;
+function isNonGlobalIPv4(host: string): boolean {
   const parts = host.split('.').map(Number);
-  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return false;
-  return parts[0] === 10 || parts[0] === 127 || parts[0] === 0 ||
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return true;
+  return parts[0] === 0 || parts[0] === 10 || parts[0] === 127 || parts[0] >= 224 ||
+    (parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127) ||
     (parts[0] === 169 && parts[1] === 254) ||
     (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
-    (parts[0] === 192 && parts[1] === 168);
+    (parts[0] === 192 && parts[1] === 0 && parts[2] === 0) ||
+    (parts[0] === 192 && parts[1] === 0 && parts[2] === 2) ||
+    (parts[0] === 192 && parts[1] === 168) ||
+    (parts[0] === 198 && (parts[1] === 18 || parts[1] === 19 || parts[1] === 51 && parts[2] === 100)) ||
+    (parts[0] === 203 && parts[1] === 0 && parts[2] === 113);
+}
+
+function isPrivateHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (host === 'localhost' || host.endsWith('.localhost')) return true;
+  if (isIP(host) === 4) return isNonGlobalIPv4(host);
+  if (isIP(host) !== 6) return false;
+
+  // URL canonicalizes IPv4-mapped addresses to hexadecimal (for example
+  // ::ffff:127.0.0.1 becomes ::ffff:7f00:1), so classify the mapped payload.
+  if (host.startsWith('::ffff:')) {
+    const groups = host.slice(7).split(':');
+    if (groups.length === 2) {
+      const high = parseInt(groups[0], 16);
+      const low = parseInt(groups[1], 16);
+      return isNonGlobalIPv4(`${high >> 8}.${high & 255}.${low >> 8}.${low & 255}`);
+    }
+  }
+  const first = parseInt(host.split(':')[0] || '0', 16);
+  return host === '::' || host === '::1' || (first & 0xfe00) === 0xfc00 ||
+    (first & 0xffc0) === 0xfe80 || (first & 0xff00) === 0xff00 ||
+    host.startsWith('2001:db8:');
 }
 
 /** Validate without reading or fetching the media. Returns the original typed input. */
@@ -95,7 +122,11 @@ export function validateEmbeddingInput(input: EmbeddingInput): EmbeddingInput {
     throw new EmbeddingInputError(`Invalid ${input.modality} URL`);
   }
   if (url.protocol !== 'https:') throw new EmbeddingInputError('Unsafe media URL scheme: only https is allowed');
-  if (url.username || url.password) throw new EmbeddingInputError('Media URLs must not contain credentials');
+  // Hostnames are not resolved here: the remote embedding provider performs the
+  // fetch, so local DNS checks cannot prevent provider-side DNS rebinding.
+  if (url.username || url.password || url.search || url.hash) {
+    throw new EmbeddingInputError('Media URLs must not contain credentials, query parameters, or fragments');
+  }
   if (isPrivateHost(url.hostname)) throw new EmbeddingInputError('Private or local media URLs are not allowed');
   return input;
 }

--- a/src/embedding/provider.ts
+++ b/src/embedding/provider.ts
@@ -27,15 +27,94 @@
  * Architecture inspired by Mem0's multi-provider embedding design.
  */
 
+export type EmbeddingModality = 'text' | 'image' | 'audio' | 'video' | 'document';
+export type EmbeddingIntent = 'query' | 'document';
+
+export type EmbeddingInput =
+  | { modality: 'text'; text: string }
+  | { modality: Exclude<EmbeddingModality, 'text'>; url: string; data?: never; mimeType?: string }
+  | { modality: Exclude<EmbeddingModality, 'text'>; data: string; url?: never; mimeType: string };
+
+export interface EmbeddingOptions {
+  /** Retrieval role. Providers may use asymmetric query/document models or tasks. */
+  intent?: EmbeddingIntent;
+  /** Optional provider-specific retrieval instruction. Never persisted by the embedding cache. */
+  instruction?: string;
+}
+
+export class EmbeddingInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EmbeddingInputError';
+  }
+}
+
+export class UnsupportedEmbeddingModalityError extends EmbeddingInputError {
+  readonly modality: EmbeddingModality;
+  readonly provider: string;
+
+  constructor(provider: string, modality: EmbeddingModality) {
+    super(`Embedding provider ${provider} does not support ${modality} input`);
+    this.name = 'UnsupportedEmbeddingModalityError';
+    this.provider = provider;
+    this.modality = modality;
+  }
+}
+
+/** Maximum encoded inline media accepted by the public API (5 MiB). */
+export const MAX_INLINE_EMBEDDING_BYTES = 5 * 1024 * 1024;
+
+function isPrivateHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (host === 'localhost' || host === '::1' || host === '0.0.0.0' || host.endsWith('.localhost')) return true;
+  const parts = host.split('.').map(Number);
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return false;
+  return parts[0] === 10 || parts[0] === 127 || parts[0] === 0 ||
+    (parts[0] === 169 && parts[1] === 254) ||
+    (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
+    (parts[0] === 192 && parts[1] === 168);
+}
+
+/** Validate without reading or fetching the media. Returns the original typed input. */
+export function validateEmbeddingInput(input: EmbeddingInput): EmbeddingInput {
+  if (input.modality === 'text') {
+    if (!input.text.trim()) throw new EmbeddingInputError('Embedding text must not be empty');
+    return input;
+  }
+  if ('data' in input && input.data !== undefined) {
+    if (!input.mimeType?.trim()) throw new EmbeddingInputError('Inline media requires a MIME type');
+    if (Buffer.byteLength(input.data, 'utf8') > MAX_INLINE_EMBEDDING_BYTES) {
+      throw new EmbeddingInputError(`Inline ${input.modality} payload is too large (maximum 5 MiB)`);
+    }
+    return input;
+  }
+  let url: URL;
+  try {
+    url = new URL(input.url);
+  } catch {
+    throw new EmbeddingInputError(`Invalid ${input.modality} URL`);
+  }
+  if (url.protocol !== 'https:') throw new EmbeddingInputError('Unsafe media URL scheme: only https is allowed');
+  if (url.username || url.password) throw new EmbeddingInputError('Media URLs must not contain credentials');
+  if (isPrivateHost(url.hostname)) throw new EmbeddingInputError('Private or local media URLs are not allowed');
+  return input;
+}
+
 export interface EmbeddingProvider {
   /** Provider name for logging/cache keys */
   readonly name: string;
   /** Vector dimensions (e.g., 384 for bge-small) */
   readonly dimensions: number;
-  /** Generate embedding for a single text */
+  /** Modalities accepted by the provider. Omitted means text-only. */
+  readonly supportedModalities?: readonly EmbeddingModality[];
+  /** Generate embedding for a single text (backward compatible). */
   embed(text: string): Promise<number[]>;
-  /** Generate embeddings for multiple texts (batch) */
+  /** Generate embeddings for multiple texts (backward compatible). */
   embedBatch(texts: string[]): Promise<number[][]>;
+  /** Generate an embedding for typed text or media input. */
+  embedInput?(input: EmbeddingInput, options?: EmbeddingOptions): Promise<number[]>;
+  /** Generate embeddings for typed inputs. */
+  embedInputs?(inputs: EmbeddingInput[], options?: EmbeddingOptions): Promise<number[][]>;
   /** Return already-persisted embeddings without generating new vectors. */
   getCachedEmbeddings?(texts: string[]): Promise<(number[] | null)[]>;
 }

--- a/src/embedding/transformers-provider.ts
+++ b/src/embedding/transformers-provider.ts
@@ -15,7 +15,13 @@
  * Inspired by Mem0's multi-provider embedding architecture.
  */
 
-import type { EmbeddingProvider } from './provider.js';
+import {
+  UnsupportedEmbeddingModalityError,
+  validateEmbeddingInput,
+  type EmbeddingInput,
+  type EmbeddingOptions,
+  type EmbeddingProvider,
+} from './provider.js';
 
 // In-memory LRU cache
 const cache = new Map<string, number[]>();
@@ -44,6 +50,18 @@ export class TransformersProvider implements EmbeddingProvider {
             { dtype: 'q8' }, // Quantized for small footprint
         );
         return new TransformersProvider(extractor);
+    }
+
+    async embedInput(input: EmbeddingInput, _options: EmbeddingOptions = {}): Promise<number[]> {
+        validateEmbeddingInput(input);
+        if (input.modality !== 'text') {
+            throw new UnsupportedEmbeddingModalityError(this.name, input.modality);
+        }
+        return this.embed(input.text);
+    }
+
+    async embedInputs(inputs: EmbeddingInput[], options: EmbeddingOptions = {}): Promise<number[][]> {
+        return Promise.all(inputs.map((input) => this.embedInput(input, options)));
     }
 
     async embed(text: string): Promise<number[]> {

--- a/src/memory/observations.ts
+++ b/src/memory/observations.ts
@@ -8,7 +8,7 @@
  * and in the Orama search index (for full-text + vector search).
  */
 
-import type { Observation, ObservationType, ObservationStatus, MemorixDocument, ProgressInfo } from '../types.js';
+import type { Observation, ObservationAttachment, ObservationType, ObservationStatus, MemorixDocument, ProgressInfo } from '../types.js';
 import { TOPIC_KEY_FAMILIES } from '../types.js';
 import {
   insertObservation,
@@ -29,7 +29,7 @@ import {
 import { getObservationStore, initObservationStore } from '../store/obs-store.js';
 import { countTextTokens } from '../compact/token-budget.js';
 import { extractEntities, enrichConcepts } from './entity-extractor.js';
-import { getEmbeddingProvider, isEmbeddingExplicitlyDisabled } from '../embedding/provider.js';
+import { getEmbeddingProvider, isEmbeddingExplicitlyDisabled, validateEmbeddingInput } from '../embedding/provider.js';
 import { sanitizeCredentials } from './secret-filter.js';
 import { enqueueClaimDerivation } from '../runtime/lifecycle.js';
 
@@ -251,6 +251,8 @@ export async function storeObservation(input: {
   commitHash?: string;
   relatedCommits?: string[];
   relatedEntities?: string[];
+  /** Safe HTTPS media references only; inline media is rejected. */
+  attachments?: ObservationAttachment[];
   sourceDetail?: 'explicit' | 'hook' | 'git-ingest';
   valueCategory?: 'core' | 'contextual' | 'ephemeral';
   createdByAgentId?: string;
@@ -260,6 +262,18 @@ export async function storeObservation(input: {
   // ── Central secret sanitization — strip credential values before any persistence ──
   // Covers all write paths: hooks, git-ingest, CLI, reasoning, compact-on-write, etc.
   input = { ...input, title: sanitizeCredentials(input.title), narrative: sanitizeCredentials(input.narrative), facts: input.facts?.map(sanitizeCredentials) };
+
+  const safeAttachments = input.attachments?.map((attachment) => {
+    validateEmbeddingInput({ modality: attachment.modality, url: attachment.url });
+    return {
+      modality: attachment.modality,
+      url: attachment.url,
+      ...(attachment.mimeType ? { mimeType: attachment.mimeType } : {}),
+      ...(attachment.name ? { name: attachment.name } : {}),
+    } satisfies ObservationAttachment;
+  });
+  if (safeAttachments) input = { ...input, attachments: safeAttachments };
+
 
   // Sync the local cache before using it as the topicKey fast path. This costs a
   // generation read in the normal case and only reloads when another process wrote.
@@ -353,6 +367,7 @@ export async function storeObservation(input: {
           commitHash: input.commitHash,
           relatedCommits: input.relatedCommits,
           relatedEntities: input.relatedEntities,
+          attachments: input.attachments,
           sourceDetail: input.sourceDetail,
           valueCategory: input.valueCategory,
           createdByAgentId: input.createdByAgentId,
@@ -407,6 +422,7 @@ export async function storeObservation(input: {
         commitHash: input.commitHash,
         relatedCommits: input.relatedCommits,
         relatedEntities: input.relatedEntities,
+      attachments: input.attachments,
         sourceDetail: input.sourceDetail,
         valueCategory: input.valueCategory,
         createdByAgentId: input.createdByAgentId,

--- a/src/memory/observations.ts
+++ b/src/memory/observations.ts
@@ -235,6 +235,15 @@ export async function withFreshObservations<T>(fn: () => T | Promise<T>): Promis
  *   3. Inserts into Orama for full-text search
  *   4. Persists to disk
  */
+function formatAttachmentProvenance(attachments?: ObservationAttachment[]): string {
+  return (attachments ?? []).map((attachment) => [
+    attachment.name,
+    attachment.modality,
+    attachment.mimeType,
+    attachment.url,
+  ].filter(Boolean).join(' ')).join('\n');
+}
+
 export async function storeObservation(input: {
   entityName: string;
   type: ObservationType;
@@ -442,6 +451,7 @@ export async function storeObservation(input: {
       facts: (input.facts ?? []).join('\n'),
       filesModified: enrichedFiles.join('\n'),
       concepts: enrichedConcepts.map(c => c.replace(/-/g, ' ')).join(', '),
+      attachments: formatAttachmentProvenance(input.attachments),
       tokens,
       createdAt: now,
       projectId: input.projectId,
@@ -471,6 +481,9 @@ export async function storeObservation(input: {
   const obsId = observation.id;
   vectorMissingIds.add(obsId);
   const searchableText = [input.title, input.narrative, ...(input.facts ?? [])].join(' ');
+  // URL attachments are durable provenance and BM25 metadata. The observation's
+  // semantic vector remains text-only because providers cannot jointly embed
+  // arbitrary remote URLs with the title/narrative/facts contract.
   generateEmbedding(searchableText).then(async (embedding) => {
     if (embedding) {
       if (!isVectorCompatibleWithCurrentIndex(embedding)) {
@@ -532,6 +545,7 @@ async function upsertObservation(
     topicKey?: string;
     sessionId?: string;
     progress?: ProgressInfo;
+    attachments?: ObservationAttachment[];
     sourceDetail?: 'explicit' | 'hook' | 'git-ingest';
     valueCategory?: 'core' | 'contextual' | 'ephemeral';
   },
@@ -561,6 +575,7 @@ async function upsertObservation(
   existing.title = input.title;
   existing.narrative = input.narrative;
   existing.facts = input.facts ?? [];
+  existing.attachments = input.attachments;
   existing.filesModified = enrichedFiles;
   existing.concepts = enrichedConcepts;
   existing.tokens = tokens;
@@ -584,6 +599,7 @@ async function upsertObservation(
     facts: existing.facts.join('\n'),
     filesModified: enrichedFiles.join('\n'),
     concepts: enrichedConcepts.map(c => c.replace(/-/g, ' ')).join(', '),
+    attachments: formatAttachmentProvenance(existing.attachments),
     tokens,
     createdAt: existing.createdAt,
     projectId: existing.projectId,
@@ -708,6 +724,7 @@ export async function resolveObservations(
         facts: obs.facts.join('\n'),
         filesModified: obs.filesModified.join('\n'),
         concepts: obs.concepts.map(c => c.replace(/-/g, ' ')).join(', '),
+        attachments: formatAttachmentProvenance(obs.attachments),
         tokens: obs.tokens,
         createdAt: obs.createdAt,
         projectId: obs.projectId,
@@ -911,6 +928,7 @@ export async function reindexObservations(): Promise<number> {
         facts: obs.facts.join('\n'),
         filesModified: obs.filesModified.join('\n'),
         concepts: obs.concepts.map((c: string) => c.replace(/-/g, ' ')).join(', '),
+        attachments: formatAttachmentProvenance(obs.attachments),
         tokens: obs.tokens,
         createdAt: obs.createdAt,
         projectId: obs.projectId,
@@ -1121,6 +1139,7 @@ export async function backfillVectorEmbeddings(options: {
             facts: obs.facts.join('\n'),
             filesModified: obs.filesModified.join('\n'),
             concepts: obs.concepts.map(c => c.replace(/-/g, ' ')).join(', '),
+            attachments: formatAttachmentProvenance(obs.attachments),
             tokens: obs.tokens,
             createdAt: obs.createdAt,
             projectId: obs.projectId,

--- a/src/server.ts
+++ b/src/server.ts
@@ -623,9 +623,18 @@ export async function createMemorixServer(
         }).optional().describe('Progress tracking for task/feature observations'),
         relatedCommits: z.array(z.string()).optional().describe('Git commit hashes this memory relates to (links ground truth ↔ reasoning)'),
         relatedEntities: z.array(z.string()).optional().describe('Other entity names this memory cross-references'),
+        attachments: z.array(z.object({
+          modality: z.enum(['image', 'audio', 'video', 'document']),
+          url: z.string().describe(
+            'Public HTTPS provenance reference without query parameters or fragments. ' +
+            'Memorix does not fetch this URL: attachment metadata is persisted and BM25-searchable, while observation vectors remain text-only.',
+          ),
+          mimeType: z.string().optional(),
+          name: z.string().optional(),
+        })).optional().describe('Safe media references to persist and embed; raw inline media is never stored'),
       },
     },
-    async ({ entityName: rawEntityName, type: rawType, title: rawTitle, narrative, facts, filesModified, concepts, topicKey, progress, relatedCommits, relatedEntities }) => {
+    async ({ entityName: rawEntityName, type: rawType, title: rawTitle, narrative, facts, filesModified, concepts, topicKey, progress, relatedCommits, relatedEntities, attachments }) => {
       const unresolved = requireResolvedProject('store memory in the current project');
       if (unresolved) return unresolved;
       return withFreshIndex(async () => {
@@ -986,6 +995,7 @@ export async function createMemorixServer(
         progress: progress as import('./types.js').ProgressInfo | undefined,
         relatedCommits,
         relatedEntities,
+        attachments,
         sourceDetail: 'explicit',
         valueCategory: formationResult?.evaluation.category,
         createdByAgentId: currentAgentId,

--- a/src/store/orama-store.ts
+++ b/src/store/orama-store.ts
@@ -12,7 +12,13 @@ import { create, insert, search, remove, update, count, getByID, type AnyOrama }
 import type { MemorixDocument, SearchOptions, IndexEntry, KnowledgeLayer } from '../types.js';
 import { OBSERVATION_ICONS, type ObservationType } from '../types.js';
 import { resolveKnowledgeLayer } from '../skills/mini-skills.js';
-import { getEmbeddingProvider, type EmbeddingProvider } from '../embedding/provider.js';
+import {
+  getEmbeddingProvider,
+  UnsupportedEmbeddingModalityError,
+  type EmbeddingInput,
+  type EmbeddingOptions,
+  type EmbeddingProvider,
+} from '../embedding/provider.js';
 import { calculateProjectAffinity, extractProjectKeywords, type AffinityContext, type MemoryContent } from './project-affinity.js';
 import { detectQueryIntent, applyIntentBoost } from '../search/intent-detector.js';
 import { maybeExpandSearchQuery } from '../search/query-expansion.js';
@@ -254,7 +260,26 @@ export function getVectorDimensions(): number | null {
 export async function generateEmbedding(text: string): Promise<number[] | null> {
   const provider = await getEmbeddingProvider();
   if (!provider) return null;
-  return provider.embed(text);
+  return provider.embedInput
+    ? provider.embedInput({ modality: 'text', text }, { intent: 'document' })
+    : provider.embed(text);
+}
+
+/** Generate a typed embedding; unsupported media returns null so callers retain BM25. */
+export async function generateEmbeddingInput(
+  input: EmbeddingInput,
+  options: EmbeddingOptions = {},
+): Promise<number[] | null> {
+  const provider = await getEmbeddingProvider();
+  if (!provider) return null;
+  try {
+    if (provider.embedInput) return await provider.embedInput(input, options);
+    if (input.modality === 'text') return provider.embed(input.text);
+    return null;
+  } catch (error) {
+    if (error instanceof UnsupportedEmbeddingModalityError) return null;
+    throw error;
+  }
 }
 
 /**
@@ -561,7 +586,9 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
         } else {
           // Embedding timeout: 15 seconds
           const EMBEDDING_TIMEOUT_MS = 15000;
-          const embedPromise = provider.embed(expandedEmbeddingQuery!);
+          const embedPromise = provider.embedInput
+            ? provider.embedInput({ modality: 'text', text: expandedEmbeddingQuery! }, { intent: 'query' })
+            : provider.embed(expandedEmbeddingQuery!);
           const timeoutPromise = new Promise<never>((_, reject) =>
             setTimeout(() => reject(new Error(`Embedding timeout after ${EMBEDDING_TIMEOUT_MS}ms`)), EMBEDDING_TIMEOUT_MS)
           );

--- a/src/store/orama-store.ts
+++ b/src/store/orama-store.ts
@@ -172,6 +172,7 @@ async function initializeDb(
     facts: 'string' as const,
     filesModified: 'string' as const,
     concepts: 'string' as const,
+    attachments: 'string' as const,
     tokens: 'number' as const,
     createdAt: 'string' as const,
     projectId: 'string' as const,
@@ -560,7 +561,7 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
     includeVectors: true,
     ...(Object.keys(filters).length > 0 ? { where: filters } : {}),
     // Search specific fields (not tokens, accessCount, etc.)
-    properties: ['title', 'entityName', 'narrative', 'facts', 'concepts', 'filesModified'],
+    properties: ['title', 'entityName', 'narrative', 'facts', 'concepts', 'filesModified', 'attachments'],
     // Field boosting: intent-aware or default
     boost: fieldBoost,
     // Fuzzy tolerance: allow 1-char typos for short queries, 2 for longer

--- a/src/store/sqlite-db.ts
+++ b/src/store/sqlite-db.ts
@@ -643,6 +643,12 @@ const SCHEMA_MIGRATIONS: SchemaMigration[] = [
       db.exec('CREATE INDEX IF NOT EXISTS idx_knowledge_workflow_runs_project_workflow ON knowledge_workflow_runs(projectId, workflowId, startedAt DESC)');
     },
   },
+  {
+    id: '1.2-observation-attachments',
+    apply: (db) => {
+      try { db.exec('ALTER TABLE observations ADD COLUMN attachments TEXT'); } catch { /* already exists */ }
+    },
+  },
 ];
 
 function applySchemaMigrations(db: any): void {

--- a/src/store/sqlite-store.ts
+++ b/src/store/sqlite-store.ts
@@ -47,6 +47,7 @@ function obsToRow(obs: Observation): Record<string, unknown> {
     commitHash: obs.commitHash ?? null,
     relatedCommits: obs.relatedCommits ? JSON.stringify(obs.relatedCommits) : null,
     relatedEntities: obs.relatedEntities ? JSON.stringify(obs.relatedEntities) : null,
+    attachments: obs.attachments ? JSON.stringify(obs.attachments) : null,
     sourceDetail: obs.sourceDetail ?? null,
     valueCategory: obs.valueCategory ?? null,
     createdByAgentId: obs.createdByAgentId ?? null,
@@ -78,6 +79,7 @@ function rowToObs(row: any): Observation {
     ...(row.commitHash ? { commitHash: row.commitHash } : {}),
     ...(row.relatedCommits ? { relatedCommits: safeJsonParse(row.relatedCommits, []) } : {}),
     ...(row.relatedEntities ? { relatedEntities: safeJsonParse(row.relatedEntities, []) } : {}),
+    ...(row.attachments ? { attachments: safeJsonParse(row.attachments, []) } : {}),
     ...(row.sourceDetail ? { sourceDetail: row.sourceDetail } : {}),
     ...(row.valueCategory ? { valueCategory: row.valueCategory } : {}),
     ...(row.createdByAgentId ? { createdByAgentId: row.createdByAgentId } : {}),
@@ -132,12 +134,12 @@ export class SqliteBackend implements ObservationStore {
         (id, entityName, type, title, narrative, facts, filesModified, concepts, tokens,
          createdAt, updatedAt, projectId, hasCausalLanguage, topicKey, revisionCount,
          sessionId, status, progress, source, commitHash, relatedCommits, relatedEntities,
-         sourceDetail, valueCategory, createdByAgentId, writeGeneration)
+         attachments, sourceDetail, valueCategory, createdByAgentId, writeGeneration)
       VALUES
         (@id, @entityName, @type, @title, @narrative, @facts, @filesModified, @concepts, @tokens,
          @createdAt, @updatedAt, @projectId, @hasCausalLanguage, @topicKey, @revisionCount,
          @sessionId, @status, @progress, @source, @commitHash, @relatedCommits, @relatedEntities,
-         @sourceDetail, @valueCategory, @createdByAgentId, @writeGeneration)
+         @attachments, @sourceDetail, @valueCategory, @createdByAgentId, @writeGeneration)
     `);
     this.stmtUpdate = this.stmtInsert; // INSERT OR REPLACE works for both
     this.stmtSetStatus = this.db.prepare(`UPDATE observations SET status = ? WHERE id = ?`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -254,6 +254,8 @@ export interface MemorixDocument {
   facts: string;
   filesModified: string;
   concepts: string;
+  /** Searchable, display-safe attachment provenance (one entry per line). */
+  attachments?: string;
   tokens: number;
   createdAt: string;
   projectId: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,6 +92,15 @@ export interface ProgressInfo {
   completion?: number;
 }
 
+/** Safe media reference for an observation. Raw inline media is never persisted. */
+export interface ObservationAttachment {
+  modality: 'image' | 'audio' | 'video' | 'document';
+  /** Public HTTPS reference. Local paths, private hosts, and credentials are rejected. */
+  url: string;
+  mimeType?: string;
+  name?: string;
+}
+
 /** A rich observation record attached to an entity */
 export interface Observation {
   id: number;
@@ -128,6 +137,8 @@ export interface Observation {
   relatedCommits?: string[];
   /** Related entity names — explicit cross-references to other memory entities */
   relatedEntities?: string[];
+  /** Safe media references and metadata; never contains inline payloads or credentials. */
+  attachments?: ObservationAttachment[];
   /** Provenance detail: how this observation entered the system */
   sourceDetail?: 'explicit' | 'hook' | 'git-ingest';
   /** Value category from formation pipeline evaluation */

--- a/tests/embedding/multimodal-input.test.ts
+++ b/tests/embedding/multimodal-input.test.ts
@@ -74,6 +74,26 @@ describe('typed embedding inputs', () => {
     ).toThrow(/too large/i);
   });
 
+  it('rejects credential-bearing and private IPv6 media URLs', () => {
+    for (const url of [
+      'https://example.com/a?X-Amz-Signature=secret',
+      'https://example.com/a#token',
+      'https://[::]/a',
+      'https://[fe80::1]/a',
+      'https://[fd00::1]/a',
+      'https://[::ffff:127.0.0.1]/a',
+      'https://[::ffff:10.0.0.1]/a',
+      'https://100.64.0.1/a',
+      'https://198.18.0.1/a',
+      'https://224.0.0.1/a',
+      'https://[ff02::1]/a',
+      'https://[2001:db8::1]/a',
+    ]) {
+      expect(() => validateEmbeddingInput({ modality: 'image', url })).toThrow(EmbeddingInputError);
+    }
+    expect(validateEmbeddingInput({ modality: 'image', url: 'https://[2606:4700:4700::1111]/a' })).toBeTruthy();
+  });
+
   it('reads the cache directory environment at provider creation time', async () => {
     await withEmbeddingEnv({
       MEMORIX_DATA_DIR: '/tmp/memorix-runtime-cache-dir',
@@ -158,32 +178,60 @@ describe('API multimodal mapping', () => {
     });
   });
 
-  it('maps Google retrieval task types and instructions', async () => {
+  it('uses the native Gemini embedContent contract and omits task type for Gemini 2', async () => {
     await withEmbeddingEnv({
       MEMORIX_DATA_DIR: `/tmp/memorix-google-${Date.now()}`,
       MEMORIX_EMBEDDING_API_KEY: 'test-key',
-      MEMORIX_EMBEDDING_BASE_URL: 'https://generativelanguage.googleapis.com/v1beta/openai',
+      MEMORIX_EMBEDDING_BASE_URL: 'https://generativelanguage.googleapis.com/v1beta',
       MEMORIX_EMBEDDING_MODEL: 'gemini-embedding-2-preview',
       MEMORIX_EMBEDDING_DIMENSIONS: '3',
     }, async () => {
       const fetchMock = vi.fn().mockResolvedValue({
         ok: true,
-        json: async () => ({ data: [{ embedding: [1, 2, 3] }] }),
+        json: async () => ({ embedding: { values: [1, 2, 3] } }),
         headers: { get: () => null },
       });
       vi.stubGlobal('fetch', fetchMock);
       const provider = await APIEmbeddingProvider.create();
       await provider!.embedInput(
-        { modality: 'text', text: 'needle' },
-        { intent: 'query', instruction: 'Find code' },
+        { modality: 'image', data: 'aW1hZ2U=', mimeType: 'image/png' },
+        { intent: 'query' },
       );
-      const body = fetchMock.mock.calls
-        .map((call) => JSON.parse(String(call[1].body)))
-        .find((candidate) => candidate.input !== 'dimension probe');
+      const [, options] = fetchMock.mock.calls.at(-1)!;
+      expect(fetchMock.mock.calls.at(-1)![0]).toBe(
+        'https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2-preview:embedContent',
+      );
+      expect(options.headers).toMatchObject({ 'x-goog-api-key': 'test-key' });
+      const body = JSON.parse(String(options.body));
       expect(body).toMatchObject({
-        task_type: 'RETRIEVAL_QUERY',
-        instruction: 'Find code',
+        content: { parts: [{ inlineData: { mimeType: 'image/png', data: 'aW1hZ2U=' } }] },
+        outputDimensionality: 3,
       });
+      expect(body).not.toHaveProperty('taskType');
+      expect(body).not.toHaveProperty('task_type');
+    });
+  });
+
+  it('keeps Google OpenAI compatibility routing separate', async () => {
+    await withEmbeddingEnv({
+      MEMORIX_DATA_DIR: `/tmp/memorix-google-openai-${Date.now()}`,
+      MEMORIX_EMBEDDING_API_KEY: 'test-key',
+      MEMORIX_EMBEDDING_BASE_URL: 'https://generativelanguage.googleapis.com/v1beta/openai',
+      MEMORIX_EMBEDDING_MODEL: 'text-embedding-004',
+      MEMORIX_EMBEDDING_DIMENSIONS: '3',
+    }, async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [{ index: 0, embedding: [1, 2, 3] }] }),
+        headers: { get: () => null },
+      });
+      vi.stubGlobal('fetch', fetchMock);
+      const provider = await APIEmbeddingProvider.create();
+      await provider!.embedInput({ modality: 'text', text: 'needle' }, { intent: 'query' });
+      expect(fetchMock.mock.calls.at(-1)![0]).toBe(
+        'https://generativelanguage.googleapis.com/v1beta/openai/embeddings',
+      );
+      expect(fetchMock.mock.calls.at(-1)![1].headers).toMatchObject({ Authorization: 'Bearer test-key' });
     });
   });
 });

--- a/tests/embedding/multimodal-input.test.ts
+++ b/tests/embedding/multimodal-input.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  EmbeddingInputError,
+  UnsupportedEmbeddingModalityError,
+  validateEmbeddingInput,
+  type EmbeddingProvider,
+} from '../../src/embedding/provider.ts';
+import { APIEmbeddingProvider } from '../../src/embedding/api-provider.ts';
+
+function withEmbeddingEnv(env: Record<string, string>, fn: () => Promise<void>): Promise<void> {
+  const previous = new Map<string, string | undefined>();
+  for (const key of Object.keys(env)) {
+    previous.set(key, process.env[key]);
+    process.env[key] = env[key];
+  }
+  return fn().finally(() => {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('typed embedding inputs', () => {
+  it('preserves string APIs while exposing query/document intent', async () => {
+    const provider: EmbeddingProvider = {
+      name: 'test',
+      dimensions: 2,
+      embed: vi.fn(async () => [1, 2]),
+      embedBatch: vi.fn(async (texts) => texts.map(() => [1, 2])),
+      embedInput: vi.fn(async () => [1, 2]),
+      embedInputs: vi.fn(async (inputs) => inputs.map(() => [1, 2])),
+    };
+
+    await provider.embed('legacy');
+    await provider.embedInput!(
+      { modality: 'text', text: 'query' },
+      { intent: 'query' },
+    );
+    expect(provider.embed).toHaveBeenCalledWith('legacy');
+    expect(provider.embedInput).toHaveBeenCalledWith(
+      { modality: 'text', text: 'query' },
+      { intent: 'query' },
+    );
+  });
+
+  it('rejects unsafe media references and oversized inline payloads', () => {
+    expect(() =>
+      validateEmbeddingInput({ modality: 'image', url: 'file:///etc/passwd' }),
+    ).toThrow(EmbeddingInputError);
+    expect(() =>
+      validateEmbeddingInput({
+        modality: 'document',
+        url: 'http://127.0.0.1/private',
+      }),
+    ).toThrow(/private|scheme/i);
+    expect(() =>
+      validateEmbeddingInput({
+        modality: 'image',
+        url: 'https://user:secret@example.com/a.png',
+      }),
+    ).toThrow(/credentials/i);
+    expect(() =>
+      validateEmbeddingInput({
+        modality: 'audio',
+        data: 'A'.repeat(5 * 1024 * 1024 + 1),
+        mimeType: 'audio/wav',
+      }),
+    ).toThrow(/too large/i);
+  });
+
+  it('reads the cache directory environment at provider creation time', async () => {
+    await withEmbeddingEnv({
+      MEMORIX_DATA_DIR: '/tmp/memorix-runtime-cache-dir',
+      MEMORIX_EMBEDDING_API_KEY: 'test-key',
+      MEMORIX_EMBEDDING_BASE_URL: 'https://api.openai.com/v1',
+      MEMORIX_EMBEDDING_MODEL: 'text-embedding-3-small',
+      MEMORIX_EMBEDDING_DIMENSIONS: '2',
+    }, async () => {
+      const provider = await APIEmbeddingProvider.create({ allowNetworkProbe: false });
+      // Without a dims cache this may return null; creation path must not throw on env resolution.
+      expect(provider === null || provider.dimensions === 2).toBe(true);
+    });
+  });
+
+  it('reports unsupported modality as a typed capability error', async () => {
+    await withEmbeddingEnv({
+      MEMORIX_EMBEDDING_API_KEY: 'test-key',
+      MEMORIX_EMBEDDING_BASE_URL: 'https://api.openai.com/v1',
+      MEMORIX_EMBEDDING_MODEL: 'text-embedding-3-small',
+      MEMORIX_EMBEDDING_DIMENSIONS: '2',
+    }, async () => {
+      // Seed dims metadata path by probing through network-allowed create with mocked fetch
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [{ embedding: [0.1, 0.2] }] }),
+        headers: { get: () => null },
+      });
+      vi.stubGlobal('fetch', fetchMock);
+      const provider = await APIEmbeddingProvider.create();
+      await expect(
+        provider!.embedInput({
+          modality: 'image',
+          url: 'https://example.com/a.png',
+        }),
+      ).rejects.toBeInstanceOf(UnsupportedEmbeddingModalityError);
+    });
+  });
+});
+
+describe('API multimodal mapping', () => {
+  it('maps Jina query/document intent and includes modality in cache identity', async () => {
+    await withEmbeddingEnv({
+      MEMORIX_DATA_DIR: `/tmp/memorix-jina-${Date.now()}`,
+      MEMORIX_EMBEDDING_API_KEY: 'test-key',
+      MEMORIX_EMBEDDING_BASE_URL: 'https://api.jina.ai/v1',
+      MEMORIX_EMBEDDING_MODEL: 'jina-embeddings-v4',
+      MEMORIX_EMBEDDING_DIMENSIONS: '3',
+    }, async () => {
+      const fetchMock = vi.fn().mockImplementation(async (_url, init) => {
+        const body = JSON.parse(String(init.body));
+        const isProbe = body.input === 'dimension probe';
+        return {
+          ok: true,
+          json: async () => ({
+            data: [{ embedding: isProbe || body.task === 'retrieval.query' ? [1, 2, 3] : [3, 2, 1] }],
+          }),
+          headers: { get: () => null },
+        };
+      });
+      vi.stubGlobal('fetch', fetchMock);
+      const provider = await APIEmbeddingProvider.create();
+
+      await provider!.embedInput(
+        { modality: 'image', url: 'https://example.com/a.png' },
+        { intent: 'query' },
+      );
+      await provider!.embedInput(
+        { modality: 'image', url: 'https://example.com/a.png' },
+        { intent: 'document' },
+      );
+
+      const bodies = fetchMock.mock.calls
+        .map((call) => JSON.parse(String(call[1].body)))
+        .filter((body) => body.input !== 'dimension probe');
+      const queryBody = bodies.find((body) => body.task === 'retrieval.query');
+      const documentBody = bodies.find((body) => body.task === 'retrieval.passage');
+      expect(queryBody).toMatchObject({
+        task: 'retrieval.query',
+        input: [{ image: 'https://example.com/a.png' }],
+      });
+      expect(documentBody.task).toBe('retrieval.passage');
+    });
+  });
+
+  it('maps Google retrieval task types and instructions', async () => {
+    await withEmbeddingEnv({
+      MEMORIX_DATA_DIR: `/tmp/memorix-google-${Date.now()}`,
+      MEMORIX_EMBEDDING_API_KEY: 'test-key',
+      MEMORIX_EMBEDDING_BASE_URL: 'https://generativelanguage.googleapis.com/v1beta/openai',
+      MEMORIX_EMBEDDING_MODEL: 'gemini-embedding-2-preview',
+      MEMORIX_EMBEDDING_DIMENSIONS: '3',
+    }, async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [{ embedding: [1, 2, 3] }] }),
+        headers: { get: () => null },
+      });
+      vi.stubGlobal('fetch', fetchMock);
+      const provider = await APIEmbeddingProvider.create();
+      await provider!.embedInput(
+        { modality: 'text', text: 'needle' },
+        { intent: 'query', instruction: 'Find code' },
+      );
+      const body = fetchMock.mock.calls
+        .map((call) => JSON.parse(String(call[1].body)))
+        .find((candidate) => candidate.input !== 'dimension probe');
+      expect(body).toMatchObject({
+        task_type: 'RETRIEVAL_QUERY',
+        instruction: 'Find code',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements a safe, backward-compatible foundation for typed embedding inputs and query/document intent, plus an agent-facing provenance path for media references.

- Preserves `embed(string)` / `embedBatch(string[])`
- Adds typed text/image/audio/video/document provider inputs and query/document intent
- Splits native Gemini `:embedContent` from Google's OpenAI-compatible route
- Uses the official native Gemini request/auth/response contract and omits `taskType` for Gemini Embedding 2
- Rejects credential-bearing URLs, query strings, fragments, and non-global IP literals
- Adds `memorix_store.attachments` for safe HTTPS provenance references
- Persists attachment metadata through topic upserts, indexing, hydration, and detail output
- Keeps observation semantic vectors text-based; attachment metadata is BM25-searchable and never fetched by Memorix
- Preserves BM25 fallback when semantic embedding is unavailable

## Scope

This PR is intentionally a **foundation layer**, not full remote-media semantic ingestion. URL attachments are durable provenance and BM25 metadata. Memorix does not fetch arbitrary URLs, and native Gemini only embeds inline media supplied through the typed provider API. This avoids credential forwarding, DNS-rebinding claims, local-file ingestion, media lifecycle machinery, and undocumented vector fusion.

Issue #133 remains open for a future controlled media ingestion/upload lifecycle if full media semantic indexing is desired.

## Validation

- `npm test -- tests/embedding/multimodal-input.test.ts tests/embedding/api-provider.test.ts tests/memory/embedding-failure-log.test.ts` — 33 passed
- `npm run lint` — passed
- `npm run build` — passed
- `git diff --check` — passed

The broader MCP integration suite remains environment-blocked where native `better-sqlite3` bindings are unavailable; focused changed-path tests, typecheck, and production build pass.