### PR TITLE
feat(hooks): add sessionHandoff to auto-inject prior-session handoff at SessionStart

### DIFF
--- a/src/config/behavior.ts
+++ b/src/config/behavior.ts
@@ -11,6 +11,8 @@ import { detectProject } from '../project/detector.js';
 
 export interface BehaviorConfig {
   sessionInject: 'full' | 'minimal' | 'silent';
+  /** When true, SessionStart also injects the prior-session handoff (Recent Handoff / last session summary). */
+  sessionHandoff: boolean;
   syncAdvisory: boolean;
   autoCleanup: boolean;
   formationMode: 'shadow' | 'active' | 'fallback';
@@ -23,6 +25,7 @@ export interface BehaviorConfigOptions {
 
 const DEFAULTS: BehaviorConfig = {
   sessionInject: 'minimal',
+  sessionHandoff: false,
   syncAdvisory: true,
   autoCleanup: true,
   formationMode: 'active',
@@ -77,6 +80,9 @@ export function getBehaviorConfig(options: BehaviorConfigOptions = {}): Behavior
     sessionInject: isSessionInject(resolved.inject)
       ? resolved.inject
       : isSessionInject(legacy.sessionInject) ? legacy.sessionInject : DEFAULTS.sessionInject,
+    sessionHandoff: typeof resolved.handoff === 'boolean'
+      ? resolved.handoff
+      : typeof legacy.sessionHandoff === 'boolean' ? legacy.sessionHandoff : DEFAULTS.sessionHandoff,
     syncAdvisory: typeof resolved.syncAdvisory === 'boolean'
       ? resolved.syncAdvisory
       : typeof legacy.syncAdvisory === 'boolean' ? legacy.syncAdvisory : DEFAULTS.syncAdvisory,

--- a/src/config/resolved-config.ts
+++ b/src/config/resolved-config.ts
@@ -27,6 +27,7 @@ export interface ResolvedMemorixConfig {
   };
   memory: {
     inject?: 'full' | 'minimal' | 'silent';
+    handoff?: boolean;
     formation?: 'active' | 'shadow' | 'fallback';
     autoCleanup?: boolean;
     syncAdvisory?: boolean;
@@ -122,6 +123,7 @@ export function getResolvedConfig(options: ResolvedLaneOptions = {}): ResolvedMe
     },
     memory: {
       inject: first(toml.memory?.inject, yaml.behavior?.sessionInject),
+      handoff: firstBool(toml.memory?.handoff, yaml.behavior?.sessionHandoff),
       formation: first(toml.memory?.formation, yaml.behavior?.formationMode),
       autoCleanup: firstBool(toml.memory?.auto_cleanup, yaml.behavior?.autoCleanup),
       syncAdvisory: firstBool(toml.memory?.sync_advisory, yaml.behavior?.syncAdvisory),

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -11,6 +11,7 @@ export interface MemorixTomlConfig {
   };
   memory?: {
     inject?: 'full' | 'minimal' | 'silent';
+    handoff?: boolean;
     formation?: 'active' | 'shadow' | 'fallback';
     auto_cleanup?: boolean;
     sync_advisory?: boolean;

--- a/src/config/yaml-loader.ts
+++ b/src/config/yaml-loader.ts
@@ -82,6 +82,8 @@ export interface MemorixYamlConfig {
   behavior?: {
     /** Session start injection mode */
     sessionInject?: 'full' | 'minimal' | 'silent';
+    /** Also inject prior-session handoff (Recent Handoff / last session summary) at session start */
+    sessionHandoff?: boolean;
     /** Show sync advisory on first search */
     syncAdvisory?: boolean;
     /** Auto-archive expired memories on startup */

--- a/src/hooks/handler.ts
+++ b/src/hooks/handler.ts
@@ -261,19 +261,25 @@ async function handleSessionStart(input: NormalizedHookInput): Promise<{
   observation: ReturnType<typeof buildObservation> | null;
   output: HookOutput;
 }> {
-  // Check behavior config for session injection level
+  // Check behavior config for session injection level + handoff
   let injectMode: 'full' | 'minimal' | 'silent' = 'minimal';
+  let injectHandoff = false;
   try {
     const { getBehaviorConfig } = await import('../config/behavior.js');
-    injectMode = getBehaviorConfig().sessionInject;
-  } catch { /* default to minimal */ }
+    const behavior = getBehaviorConfig();
+    injectMode = behavior.sessionInject;
+    injectHandoff = behavior.sessionHandoff;
+  } catch { /* default to minimal, no handoff */ }
 
   if (injectMode === 'silent') {
     return { observation: null, output: { continue: true } };
   }
 
   let contextSummary = '';
-  if (injectMode === 'full') {
+  let handoffSummary = '';
+  // Resolve project + stores once when either the full project-context brief or
+  // the prior-session handoff needs them.
+  if (injectMode === 'full' || injectHandoff) {
     try {
       const { detectProject } = await import('../project/detector.js');
       const { getProjectDataDir } = await import('../store/persistence.js');
@@ -281,7 +287,6 @@ async function handleSessionStart(input: NormalizedHookInput): Promise<{
       const { initMiniSkillStore } = await import('../store/mini-skill-store.js');
       const { initSessionStore } = await import('../store/session-store.js');
       const { initAliasRegistry, registerAlias } = await import('../project/aliases.js');
-      const { buildAutoProjectContext, formatAutoProjectContextPrompt } = await import('../codegraph/auto-context.js');
 
       const rawProject = detectProject(input.cwd || process.cwd());
       if (!rawProject) throw new Error('No .git found');
@@ -292,32 +297,46 @@ async function handleSessionStart(input: NormalizedHookInput): Promise<{
       await initObservationStore(dataDir);
       await initMiniSkillStore(dataDir);
       await initSessionStore(dataDir);
-      const activeObservations = await getStore().loadByProject(canonicalId, { status: 'active' });
-      const context = await buildAutoProjectContext({
-        project: { ...rawProject, id: canonicalId },
-        dataDir,
-        observations: activeObservations,
-        refresh: 'auto',
-        enqueueRefresh: () => import('../runtime/lifecycle.js').then(({ enqueueCodegraphRefresh }) => {
-            enqueueCodegraphRefresh({
-              dataDir,
-              projectId: canonicalId,
-              source: 'hook-session-start',
-              maxFiles: 5_000,
-            });
-          }),
-      });
-      contextSummary = `\n\n${formatAutoProjectContextPrompt(context)}`;
+
+      if (injectMode === 'full') {
+        const { buildAutoProjectContext, formatAutoProjectContextPrompt } = await import('../codegraph/auto-context.js');
+        const activeObservations = await getStore().loadByProject(canonicalId, { status: 'active' });
+        const context = await buildAutoProjectContext({
+          project: { ...rawProject, id: canonicalId },
+          dataDir,
+          observations: activeObservations,
+          refresh: 'auto',
+          enqueueRefresh: () => import('../runtime/lifecycle.js').then(({ enqueueCodegraphRefresh }) => {
+              enqueueCodegraphRefresh({
+                dataDir,
+                projectId: canonicalId,
+                source: 'hook-session-start',
+                maxFiles: 5_000,
+              });
+            }),
+        });
+        contextSummary = `\n\n${formatAutoProjectContextPrompt(context)}`;
+      }
+
+      // Prior-session handoff (Recent Handoff / last session summary + key memories).
+      // Independent of inject level so `minimal + handoff` works for pure task handoff.
+      if (injectHandoff) {
+        const { getSessionContext } = await import('../memory/session.js');
+        const handoff = await getSessionContext(dataDir, canonicalId);
+        if (handoff && handoff.trim()) {
+          handoffSummary = `\n\n${handoff}`;
+        }
+      }
     } catch (sessErr) {
       // Diagnostic log — session start context injection failed
       console.error('[memorix] session start context failed:', (sessErr as Error)?.message ?? sessErr);
     }
   }
 
-  // Build system message based on inject mode
+  // Build system message: base hint, plus project-context brief (full) and/or handoff.
   let systemMessage: string;
-  if (injectMode === 'full' && contextSummary) {
-    systemMessage = `Previous session context may be available. Use memorix_search when prior project context would materially help. If search reports a fresh project with no Memorix memories yet, treat that as a cold-start signal and do not repeat the search in the same turn.${contextSummary}`;
+  if (contextSummary || handoffSummary) {
+    systemMessage = `Previous session context may be available. Use memorix_search when prior project context would materially help. If search reports a fresh project with no Memorix memories yet, treat that as a cold-start signal and do not repeat the search in the same turn.${contextSummary}${handoffSummary}`;
   } else {
     // minimal: one-line hint, no memory content
     systemMessage = 'Previous session context may be available. Use memorix_search when prior project context would materially help. If search reports a fresh project with no Memorix memories yet, do not repeat the search in the same turn.';

--- a/tests/config/behavior.test.ts
+++ b/tests/config/behavior.test.ts
@@ -41,6 +41,7 @@ describe('behavior config resolution', () => {
 
     expect(getBehaviorConfig({ projectRoot: PROJECT, homeDir: HOME })).toEqual({
       sessionInject: 'silent',
+      sessionHandoff: false,
       formationMode: 'shadow',
       autoCleanup: false,
       syncAdvisory: false,
@@ -58,6 +59,7 @@ describe('behavior config resolution', () => {
 
     expect(getBehaviorConfig({ projectRoot: PROJECT, homeDir: HOME })).toEqual({
       sessionInject: 'full',
+      sessionHandoff: false,
       formationMode: 'fallback',
       autoCleanup: false,
       syncAdvisory: false,
@@ -77,9 +79,40 @@ describe('behavior config resolution', () => {
 
     expect(getBehaviorConfig({ projectRoot: PROJECT, homeDir: HOME })).toEqual({
       sessionInject: 'silent',
+      sessionHandoff: false,
       formationMode: 'shadow',
       autoCleanup: false,
       syncAdvisory: false,
     });
+  });
+
+  it('defaults sessionHandoff to false when unset', () => {
+    expect(getBehaviorConfig({ projectRoot: PROJECT, homeDir: HOME }).sessionHandoff).toBe(false);
+  });
+
+  it('reads sessionHandoff from TOML [memory] handoff', () => {
+    writeFileSync(join(HOME, '.memorix', 'config.toml'), [
+      '[memory]',
+      'handoff = true',
+    ].join('\n'), 'utf8');
+
+    expect(getBehaviorConfig({ projectRoot: PROJECT, homeDir: HOME }).sessionHandoff).toBe(true);
+  });
+
+  it('reads sessionHandoff from project YAML behavior.sessionHandoff', () => {
+    writeFileSync(join(PROJECT, 'memorix.yml'), [
+      'behavior:',
+      '  sessionHandoff: true',
+    ].join('\n'), 'utf8');
+
+    expect(getBehaviorConfig({ projectRoot: PROJECT, homeDir: HOME }).sessionHandoff).toBe(true);
+  });
+
+  it('falls back to legacy config.json behavior.sessionHandoff', () => {
+    writeFileSync(join(HOME, '.memorix', 'config.json'), JSON.stringify({
+      behavior: { sessionHandoff: true },
+    }), 'utf8');
+
+    expect(getBehaviorConfig({ projectRoot: PROJECT, homeDir: HOME }).sessionHandoff).toBe(true);
   });
 });


### PR DESCRIPTION
## Problem

At SessionStart, the memorix hook injects at most the **codegraph project-context brief** (`sessionInject: full`) plus a one-line hint to run `memorix_search`. It never surfaces the **narrative handoff** — the last session's summary: what the task is, progress, plan, pitfalls hit, next steps. That content already exists (it's what `memorix_session_start` returns via `getSessionContext`), but it is **pull-only**: an agent gets it only if it proactively calls the session tool.

For multi-agent / cross-tool task handoff this means every new session starts cold unless the host's rules explicitly tell the agent to pull the handoff. Wiring that per-project (e.g. an `AGENTS.md` rule for each project) doesn't scale.

## Change

Add an orthogonal boolean behavior config **`sessionHandoff`** (default `false`). When enabled, `handleSessionStart` also injects `getSessionContext()` — the Recent Handoff / Key Memories / Session History packet — **independently of the inject level**, so `minimal + handoff` works for pure task handoff without the full project brief.

Config resolves through the existing chain:
- TOML: `[memory] handoff = true`
- YAML: `behavior.sessionHandoff: true`
- legacy `config.json`: `behavior.sessionHandoff`

One global toggle then applies to every agent that runs the hook (Claude Code, Codex, Pi, …) — no per-project rule files.

### Files
- `src/config/behavior.ts` — `BehaviorConfig.sessionHandoff` (+ default `false` + resolution)
- `src/config/resolved-config.ts`, `toml-loader.ts`, `yaml-loader.ts` — `memory.handoff` type + mapping
- `src/hooks/handler.ts` — resolve project/stores once for `full || handoff`; append handoff to the injected system message
- `tests/config/behavior.test.ts` — resolution from TOML / YAML / legacy / default

## Backwards compatibility

With `sessionHandoff: false` (the default), SessionStart output is unchanged — the `full`/`minimal`/`silent` behavior is byte-for-byte identical. `silent` still suppresses everything.

## Verification

- `npm run build` clean; `tsc --noEmit` clean on touched files.
- New + updated `tests/config/behavior.test.ts` pass (TOML/YAML/legacy/default resolution).
- End-to-end: running the SessionStart hook with `sessionHandoff: true` now emits a system message containing the Recent Handoff packet in addition to the project brief.
