### PR TITLE
feat: complete 1.2.2 memory control plane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.2] - 2026-07-25
+
+### Added
+- **Direct CLI control plane** -- Added a consistent terminal surface for memory, context, Code State, knowledge, coordination, audit, and transfer work. `--cwd` selects the Git project from any shell, `memorix workbench` explicitly opens the interactive terminal UI, and every action group now has task-oriented help.
+- **Explicit local CLI identity** -- Added `memorix identity status|join|use|clear`. A user can deliberately activate one project coordination identity for personal/team memory and task, message, lock, handoff, and poll commands without needing an MCP connection.
+- **Automation-friendly transfer** -- Memory exports can write directly to a file, and imports accept `--file` or `--stdin` as well as existing inline JSON.
+
+### Changed
+- **One visibility reader across terminal surfaces** -- CLI commands, Workbench search, recents, health, graph, knowledge, and chat now resolve the same project/actor reader. An unbound terminal remains project-scoped by default.
+- **CLI ergonomics** -- Root `search`, `remember`, and `recent` aliases now use the canonical memory commands; kebab-case flags are accepted alongside the existing camelCase forms.
+
+### Fixed
+- **Private evidence cannot become public indirectly** -- Personal and team observations are rejected when promoting shared skills or generating project skills.
+- **TUI visibility mismatch** -- The interactive terminal UI no longer falls back to an unbound reader after an explicit local identity has been activated.
+- **Transfer visibility bypass** -- CLI and MCP exports now include only observations readable by the current caller, rather than exporting personal/team records from the same project by default.
+
 ## [1.2.1] - 2026-07-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -317,13 +317,24 @@ npm uninstall -g memorix
 ### Work from the CLI
 
 ```bash
-memorix context --task "continue release blocker"
+memorix --cwd /path/to/repo context --task "continue release blocker"
 memorix memory search --query "release blocker"
+memorix memory --help
+
+# Optional: activate one local agent identity for personal/team records and coordination.
+memorix identity join --agent-type codex --name codex-main
+memorix memory store --text "private investigation note" --visibility personal
+memorix task create --description "verify the release package"
+
+memorix transfer export --format json --out ./.memorix-export.json
+memorix transfer import --file ./.memorix-export.json
 memorix reasoning search --query "why sqlite"
 memorix git-hook --force
 memorix ingest log --count 20
-memorix dashboard
+memorix workbench
 ```
+
+The CLI is direct and does not depend on an MCP session. It binds to the current Git project, or to the project supplied with `--cwd`. Without an active identity it reads, writes, and exports project-visible memory only. Use `memorix identity join` or `memorix identity use --agent-id <id>` only when you intentionally need personal/team memory or coordinated task actions; `memorix identity clear` returns the terminal to project scope. `--as <active-agent-id>` is the one-command alternative for scripts. Both camelCase and kebab-case flags are accepted.
 
 ### Use the bundled terminal agent
 
@@ -358,6 +369,7 @@ Search is project-scoped by default. `scope="global"` searches across projects. 
 | Run shared HTTP MCP plus dashboard | `memorix background start` |
 | Debug HTTP MCP in the foreground | `memorix serve-http --port 3211` |
 | Inspect or manage memory directly | `memorix memory`, `memorix reasoning`, `memorix session`, `memorix ingest` |
+| Use the interactive terminal memory control plane | `memorix workbench` |
 | Use the bundled terminal agent | `memorix` or `memcode` |
 | Run orchestrated subagent work | `memorix orchestrate --goal "..."` |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -317,13 +317,24 @@ npm uninstall -g memorix
 ### 从 CLI 管理记忆
 
 ```bash
-memorix context --task "continue release blocker"
+memorix --cwd /path/to/repo context --task "继续处理发布阻塞问题"
 memorix memory search --query "release blocker"
+memorix memory --help
+
+# 可选：只在需要个人/团队记忆或协同时激活本地身份。
+memorix identity join --agent-type codex --name codex-main
+memorix memory store --text "个人排查笔记" --visibility personal
+memorix task create --description "验证发布包"
+
+memorix transfer export --format json --out ./.memorix-export.json
+memorix transfer import --file ./.memorix-export.json
 memorix reasoning search --query "why sqlite"
 memorix git-hook --force
 memorix ingest log --count 20
-memorix dashboard
+memorix workbench
 ```
+
+CLI 是直接入口，不依赖 MCP 会话。它默认绑定当前 Git 项目，也可以用 `--cwd` 指定项目。没有激活身份时，只会读写和导出项目公开记忆；只有明确需要个人/团队记忆或协同任务时，才运行 `memorix identity join` 或 `memorix identity use --agent-id <id>`。`memorix identity clear` 会回到项目公开范围；脚本可用一次性的 `--as <active-agent-id>`。已有 camelCase 参数仍兼容，kebab-case 也可直接使用。
 
 ### 使用内置终端 Agent
 
@@ -358,6 +369,7 @@ memcode
 | 启动共享 HTTP MCP 和 Dashboard | `memorix background start` |
 | 前台调试 HTTP MCP | `memorix serve-http --port 3211` |
 | 直接检查或管理记忆 | `memorix memory`、`memorix reasoning`、`memorix session`、`memorix ingest` |
+| 使用交互式终端记忆控制台 | `memorix workbench` |
 | 使用内置终端 Agent | `memorix` 或 `memcode` |
 | 运行编排式 subagent 工作 | `memorix orchestrate --goal "..."` |
 

--- a/docs/1.2.2-MEMORY-CONTROL-PLANE.md
+++ b/docs/1.2.2-MEMORY-CONTROL-PLANE.md
@@ -55,6 +55,47 @@ default until a capability is implemented end to end.
 - The `micro` MCP profile. It remains the normal coding-agent surface; 1.2.2
   must not answer an internal architecture problem by adding more default tools.
 
+## What To Borrow From AgentMemory
+
+AgentMemory is a useful reference implementation, not a template to copy. Its
+[architecture guide](https://github.com/rohitg00/agentmemory/blob/main/plugin/skills/agentmemory-architecture/SKILL.md),
+[context function](https://github.com/rohitg00/agentmemory/blob/main/src/functions/context.ts),
+and [hybrid search](https://github.com/rohitg00/agentmemory/blob/main/src/state/hybrid-search.ts)
+show a coherent capture, compression, lifecycle, and retrieval system.
+
+The parts worth adopting are product disciplines:
+
+| AgentMemory pattern | Memorix adoption | Important adaptation |
+| --- | --- | --- |
+| Automatic hook capture | Keep capture effortless, but record a small event/evidence record first. | Reading a file, repeated shell output, or agent chatter is not durable project knowledge by default. |
+| Raw observation, compressed fact, session summary, lesson/profile layers | Make evidence stages explicit: ephemeral event -> candidate -> qualified durable memory/claim -> reviewable wiki/workflow artifact. | Do not create a second opaque transcript database. Existing observations and source refs remain the base. |
+| Decay, access tracking, consolidation, forget | Apply lifecycle policy by evidence kind and source validity. | A code fact becomes suspect when its source changes; a release decision is superseded by evidence, not merely aged out. |
+| BM25 + vector + graph RRF | Use multiple retrieval lanes and bounded fusion. | Code State is a currentness gate, not one more fuzzy graph score. Task lens and provenance must outrank generic recency. |
+| Agent id and fail-closed isolated scope | Add uniform actor/source/visibility policy to every automatic write and delivery path. | Project facts can be shared deliberately; personal notes and private handoffs never leak because an agent id was absent. |
+
+The resulting Memorix lifecycle is intentionally narrower than "remember
+everything":
+
+```text
+Ephemeral event/evidence
+  -> candidate (deduplicated, sanitized, not injected)
+  -> qualified durable memory or claim (source-backed, task-addressable)
+  -> approved knowledge/workflow artifact (reviewable)
+  -> temporary TaskWorkset or HandoffPacket (bounded delivery only)
+```
+
+This is not a new storage stack. The first implementation adds lifecycle and
+provenance semantics to existing observations, claims, sessions, and
+maintenance jobs before considering any new table.
+
+AgentMemory's retrieval and delivery paths are also deliberately separated in
+its implementation: its hybrid search uses BM25, vector, and graph signals,
+while its automatic context builder assembles profile/lesson/recent-session
+blocks under a token budget. Memorix should keep that separation but improve
+the final choice: task relevance, current code state, source confidence, and
+workflow applicability must decide delivery. Recent text is a tie-breaker, not
+the primary truth signal.
+
 ## Non-Negotiable Invariants
 
 - **Current source wins.** Historical text, handoffs, derived claims, and
@@ -173,6 +214,23 @@ ephemeral activity. Reuse existing retention and consolidation logic, but make
 admission state, conflicts, requalification, maintenance actions, and reasons
 visible to the assembly layer.
 
+Start with a conservative automatic-write policy:
+
+- explicit user/agent saves, Git facts, focused test outcomes, verified tool
+  failures, and source-linked decisions can become candidates;
+- repeated reads, routine successful commands, raw conversation filler, and
+  unqualified tool output stay ephemeral or are dropped;
+- background consolidation may summarize compatible candidates, but it never
+  promotes them into an approved claim without provenance and policy;
+- every automatically captured record carries capture path, actor/session,
+  project, source reference, and visibility (`personal`, `project`, or `team`)
+  before it can be retrieved by another agent.
+
+The initial multi-agent read policy is fail-closed for private scopes. A
+missing actor id must not silently mean "read every agent's handoff". Project
+shared evidence remains possible only through an explicit project visibility
+rule and keeps the original actor in its receipt.
+
 Acceptance gate:
 
 - repeated low-value hook activity does not crowd out source-backed decisions;
@@ -180,7 +238,10 @@ Acceptance gate:
 - duplicate lifecycle signals enqueue one recoverable job;
 - failed or deferred maintenance appears as a concise caution/receipt, not a
   blocking foreground error;
-- consolidation never destroys a source reference needed for drill-down.
+- consolidation never destroys a source reference needed for drill-down;
+- a private handoff cannot cross an agent boundary without an explicit shared
+  visibility rule, while project-level verified facts remain available to the
+  agents that need them.
 
 ### Phase 4: Embedding Capability Foundation
 

--- a/docs/1.2.2-MEMORY-CONTROL-PLANE.md
+++ b/docs/1.2.2-MEMORY-CONTROL-PLANE.md
@@ -1,0 +1,292 @@
+# Memorix 1.2.2 Memory Control Plane
+
+Status: active development
+Branch: `codex/1.2.2-memory-control-plane`
+Baseline: `memorix@1.2.1`, tag `v1.2.1`
+Start: 2026-07-24
+
+## Product Promise
+
+Memorix 1.2.1 can already build a bounded task Workset from code state, Git
+facts, durable memories, claims, wiki pages, workflows, and verification
+hints. 1.2.2 makes that useful behavior consistent across the product.
+
+For a normal agent request such as "continue the login timeout fix", the agent
+should not need to remember a Memorix command or understand storage layers.
+When Memorix has useful evidence, it should quietly deliver a short, current,
+source-backed brief. When it does not, it should stay small and let the agent
+read the code normally.
+
+This is a control-plane release, not a new collection of memory types. Its job
+is to make existing evidence flow through one controlled path:
+
+```text
+capture -> qualify -> maintain -> assemble -> deliver -> receipt -> improve
+```
+
+The result must be less prompt ballast, not more.
+
+## Why This Release Exists
+
+The 1.2.1 foundation is real, but it has three seams that matter to users:
+
+1. `TaskWorkset` has a budget and provenance, while session handoff and legacy
+   graph-context paths can still form their own output outside the same
+   admission and receipt rules.
+2. A previous-session summary is valuable for a handoff, but a raw summary or
+   a scan of every active observation is unsafe to inject at SessionStart. It
+   can be slow, noisy, and consume the next agent's limited attention.
+3. Memory retention, consolidation, claims, workspace compilation, and
+   background jobs exist, but the product does not yet expose one answer to
+   "why was this included, why was this withheld, and what will be refreshed?"
+
+The open embedding request also identifies a separate boundary: Memorix needs
+a provider capability contract before it can honestly support query/document
+intent or media inputs. Text-only OpenRouter embedding remains the supported
+default until a capability is implemented end to end.
+
+## Existing Foundations To Reuse
+
+- `TaskWorkset` and the bounded Workset renderer in `src/knowledge/workset.ts`.
+- Auto Project Context and Context Pack adapters in `src/codegraph`.
+- Code State snapshots, Claim Ledger, Knowledge Workspace, canonical workflows,
+  evaluation fixtures, and durable maintenance jobs from 1.2.1.
+- Existing retention, deduplication, consolidation, and secret filtering.
+- The `micro` MCP profile. It remains the normal coding-agent surface; 1.2.2
+  must not answer an internal architecture problem by adding more default tools.
+
+## Non-Negotiable Invariants
+
+- **Current source wins.** Historical text, handoffs, derived claims, and
+  external code intelligence are evidence, never executable instruction.
+- **Every automatic delivery has a budget.** Context is selected as whole,
+  traceable items. It is not cut from an arbitrary raw corpus.
+- **No foreground corpus work.** MCP initialize, tools/list, SessionStart, and
+  Project Context may schedule maintenance, but do not wait for a broad scan,
+  model call, or remote embedding request.
+- **Silence is a valid result.** When evidence has no material advantage for
+  the task, Memorix returns a compact cold/fresh-project result instead of
+  manufacturing a narrative.
+- **Historical content is untrusted.** Injected handoffs and stored text are
+  clearly delimited as historical evidence and cannot override host or project
+  instructions.
+- **Source and recipient are explicit.** Every selected item carries source
+  references, freshness/trust state, selection reason, and a target surface.
+- **One model/vector family is one index identity.** Changing provider, model,
+  dimensions, modality, or embedding intent never mixes incompatible vectors;
+  it requires an explicit reindex policy.
+- **No automatic project writes.** Wiki/workflow proposals and agent adapters
+  remain reviewable. 1.2.2 does not mutate users' global agent configuration
+  to make an integration work.
+
+## Control-Plane Contract
+
+`TaskWorkset` remains the public task-shaped result. 1.2.2 introduces a
+shared internal assembly contract rather than a competing memory store:
+
+```text
+ContextCandidate
+  id / kind                 handoff, current-fact, code-state, claim,
+                            knowledge-page, workflow, verification, caution
+  sourceRefs / sourceHash
+  trust                     source-backed, derived, historical
+  freshness                 current, suspect, stale, unknown
+  relevance / importance
+  estimatedTokens
+  delivery                  task, hook-handoff, explicit-pull
+
+ContextAssembly
+  task / target surface / budget
+  selected candidates / omitted candidates with reasons
+  cautions / refresh actions
+  receipt
+```
+
+The Workset renderer, compact SessionStart handoff, Context Pack, and legacy
+graph-summary compatibility path must become views of this contract. They may
+have different budgets, but not different safety rules.
+
+The receipt is privacy-safe metadata, not another prompt section. It records
+at least selected source kinds and ids, reason, freshness, token counts,
+omissions, truncation, scheduled refreshes, and elapsed assembly time. It must
+not contain credentials, raw private source, or signed URLs.
+
+## Delivery Phases
+
+### Phase 0: Baseline And Failure Fixtures
+
+Record the present behavior before changing it. Add deterministic fixtures for:
+
+- a fresh project with no useful history;
+- a mature project with many active observations;
+- a long previous-session summary containing a secret-shaped value;
+- a stale/dirty/incomplete Code State result;
+- multiple workflows where generic words such as "verify" must not select the
+  release workflow;
+- an unavailable embedding provider and a changed vector identity.
+
+The fixtures measure output budget, selected evidence, omissions, and whether
+the foreground path scheduled rather than awaited maintenance. No performance
+number is claimed before it is measured on the supported Windows setup.
+
+### Phase 1: Shared Context Assembly
+
+Build the small `ContextCandidate` and `ContextAssembly` core around the
+existing Workset selector. Route Auto Project Context, Context Pack, and
+hook-delivered context through it without changing the default MCP profile.
+
+Acceptance gate:
+
+- same evidence produces stable selected/omitted reasons across each surface;
+- every rendered result remains inside its surface budget;
+- legacy prompt and JSON compatibility remain intact where documented;
+- an empty or irrelevant memory corpus produces a small answer;
+- `memorix explain` and JSON consumers can inspect a receipt without reading
+  storage internals.
+
+### Phase 2: Compact, Safe Session Handoff
+
+Introduce a dedicated `HandoffPacket`, not a call to the old broad
+`getSessionContext()` formatter. It reads the most recent eligible completed
+session and a bounded set of task-relevant durable evidence. Storage and
+delivery both have explicit character/token limits, redaction, a truncation
+marker, and a strict time budget.
+
+Full session history remains an explicit pull through the existing session
+surface. SessionStart only receives the small historical packet when the
+project's behavior setting enables it and the packet earns delivery.
+
+Acceptance gate:
+
+- `minimal + handoff`, `full + handoff`, disabled, and `silent` behavior have
+  positive hook integration coverage;
+- large summaries cannot block startup or exceed the injection budget;
+- config resolves from the hook input project root, never accidental process
+  cwd;
+- historical packet delimiters and redaction are visible in host output;
+- users can inspect a receipt and explicitly pull the full context.
+
+### Phase 3: Admission, Lifecycle, And Refresh Discipline
+
+Make the control loop decide what becomes durable evidence and what stays
+ephemeral activity. Reuse existing retention and consolidation logic, but make
+admission state, conflicts, requalification, maintenance actions, and reasons
+visible to the assembly layer.
+
+Acceptance gate:
+
+- repeated low-value hook activity does not crowd out source-backed decisions;
+- changed/deleted code downgrades related evidence deterministically;
+- duplicate lifecycle signals enqueue one recoverable job;
+- failed or deferred maintenance appears as a concise caution/receipt, not a
+  blocking foreground error;
+- consolidation never destroys a source reference needed for drill-down.
+
+### Phase 4: Embedding Capability Foundation
+
+Define provider capabilities before extending the public input surface:
+
+```text
+EmbeddingCapabilities
+  supportedModalities
+  supportedIntents
+  transport / endpoint family
+  maxInlineBytes / safe-reference policy
+  model / dimensions / vectorFamily
+  reindex requirement
+```
+
+The existing OpenRouter `qwen/qwen3-embedding-8b` text path remains unchanged
+and tested. Provider adapters must use their official protocol; a Google-native
+embedding request is not treated as a generic OpenAI `/embeddings` request.
+
+Media support only ships when an agent can safely complete the whole path:
+validated input -> durable provenance -> supported embedding/extraction ->
+index -> retrieval -> receipt. A typed internal foundation is allowed to land
+on its own only if its docs and issue linkage say exactly that; it cannot claim
+to close media retrieval before the end-to-end path exists.
+
+Acceptance gate:
+
+- capability and vector identity participate in cache/index identity;
+- unsupported modality/intent degrades predictably to lexical search with a
+  receipt rather than silently fabricating a vector;
+- reference validation rejects credentials in URLs and private, loopback,
+  link-local, and unsafe IPv6 targets, with DNS/rebinding policy documented;
+- provider request-shape tests derive from official contracts, not mocked
+  generic paths;
+- model/dimension/vector-family change requests or performs an explicit,
+  observable reindex.
+
+### Phase 5: Product Surface And Diagnostics
+
+Keep the normal interaction simple: a supported agent uses the user's task and
+gets Project Context when it helps. Operators can ask for a concise answer to
+"what did Memorix use?" through existing context/explain/doctor paths.
+
+Acceptance gate:
+
+- default tool count stays at the current micro profile level;
+- receipt explains inclusion, omission, freshness, and scheduled work in plain
+  language;
+- dashboard/CLI empty, unavailable, stale, and refresh-queued states are
+  distinguishable;
+- user-facing docs do not call a deterministic memory map a semantic graph or
+  describe a provider foundation as full multimodal retrieval.
+
+### Phase 6: Evaluation, Contribution Review, And Release
+
+Run the existing Workset evaluation harness plus new control-plane fixtures,
+full test/build/lint, package inspection, isolated Windows install, stdio MCP
+smoke, and supported-agent integration smoke. Release evidence must include
+the new budgets and no-foreground-wait behavior.
+
+## Open Contributions And Issue Boundaries
+
+### #135: Session Handoff
+
+The contributor identified the right product gap. Their branch remains the
+authoritative contribution and is invited to revise against Phase 2. It can be
+merged with full contributor credit when it uses the bounded handoff contract,
+target-project config resolution, explicit historical-data delimiters, and
+positive E2E coverage. Memorix will not reimplement it privately and label it
+as original work.
+
+### #133 / #134: Multimodal Embedding Inputs
+
+The contributor's typed input and cache-identity direction is useful. The PR
+cannot close #133 in its current form because its Google routing is not the
+official native protocol, safe URL storage is incomplete, and no MCP media
+input reaches index/retrieval. The contributor can either complete the
+end-to-end path or narrow the PR to a validated capability foundation; both
+remain eligible for review and credit. This phase deliberately separates that
+work from an unsupported promise of "any media in, semantic memory out".
+
+### #136: MemorixBench-Transfer
+
+The research artifact stays a draft research track. It is not bundled into a
+product patch merely because its CI is green.
+
+## Explicit Non-Goals
+
+- Capture every conversation, terminal output, or hook event by default.
+- Invent a 53-tool management surface to expose internal machinery.
+- Let a session handoff override project instructions or current code.
+- Claim universal multimodal embedding through one OpenAI-compatible endpoint.
+- Merge unrelated historical PRs or rewrite contributor work without credit.
+- Turn Memorix into a cloud knowledge graph service; local-first evidence and
+optional project artifacts remain the product boundary.
+
+## Definition Of Done
+
+1. All automatic context surfaces use the shared assembly/receipt policy.
+2. Session handoff is bounded, redacted, project-root-correct, and proven by
+   hook E2E tests.
+3. Lifecycle decisions can be explained and foreground requests do not await
+   corpus maintenance.
+4. Embedding capabilities make text behavior honest and leave no false media
+   retrieval claim.
+5. Existing MCP clients retain a compact default profile and documented
+   compatibility.
+6. Evaluation, clean-package smoke, supported-agent smoke, docs, changelog,
+   tag, npm package, and release evidence agree before publication.

--- a/docs/1.2.2-MEMORY-CONTROL-PLANE.md
+++ b/docs/1.2.2-MEMORY-CONTROL-PLANE.md
@@ -243,6 +243,47 @@ Acceptance gate:
   visibility rule, while project-level verified facts remain available to the
   agents that need them.
 
+### Phase 3 Implementation Status: Admission And Qualification
+
+The first Phase 3 slice is implemented. It adds a small admission state to the
+existing observation record instead of creating a second transcript store:
+
+| State | Meaning | Automatic delivery |
+| --- | --- | --- |
+| `ephemeral` | Routine automatic activity retained only as a short-lived trace. | Never selected. |
+| `candidate` | Sanitized automatic evidence worth retaining, but not yet current/source-backed. | Never selected. |
+| `qualified` | A candidate that a Code Memory scan completed after capture and linked to one or more current code references. | Eligible, subject to ordinary task relevance and budget. |
+
+Automatic hooks and orchestration writes now use this policy. File mutations,
+concrete failures, decisions, verified fixes, and pipeline summaries start as
+`candidate`; routine command success and task-completion telemetry are
+`ephemeral`; low-signal activity is dropped. Automatic capture is silent in
+the host agent rather than adding a stream of "saved memory" status messages.
+
+`observation-qualify` is a deduplicated maintenance job. It runs only after a
+CodeGraph refresh, rejects a snapshot older than the capture, binds the
+observation to the current scan, and upgrades only candidates with current
+code references. It never creates a Claim; claim derivation remains limited to
+explicit saves and Git evidence.
+
+The real hook path persists a candidate before it schedules Code Memory work,
+so a fast background worker cannot scan an earlier project state and strand a
+new candidate. CLI, hook, and foreground-refresh paths register their local
+project target before they enqueue isolated maintenance, letting the control
+plane locate the correct project root without placing a path in an MCP job
+payload.
+
+Auto Project Context, automatic session L1 context, Wiki/Knowledge Graph
+compilation, and graph-context packets exclude `candidate` and `ephemeral`
+records. Explicit retrieval still permits inspection, while ordinary search
+prefers qualified material and falls back only when no qualified result exists.
+
+Pending candidates are deliberately excluded from automatic consolidation so
+their evidence grain remains inspectable. Still pending in Phase 3:
+actor/visibility enforcement for cross-agent reads, a richer consolidation
+policy for qualified evidence, deterministic source-change demotion for all
+non-code evidence, and receipt-level lifecycle cautions.
+
 ### Phase 4: Embedding Capability Foundation
 
 Define provider capabilities before extending the public input surface:

--- a/docs/1.2.2-MEMORY-CONTROL-PLANE.md
+++ b/docs/1.2.2-MEMORY-CONTROL-PLANE.md
@@ -309,11 +309,14 @@ Topic-key upserts check write scope before a write, so guessing a private key
 does not disclose or modify the record. The project-attribution guard also
 receives only records visible to the current reader.
 
-The embedded SDK and unbound local TUI deliberately use the same
-project-visible reader. They are useful for ordinary project memory, but they
-cannot retrieve, resolve, or topic-key-update personal/team records. Private
-coordination remains an identity-bound MCP operation rather than an ambient
-local-database privilege.
+The embedded SDK remains an unbound project-visible reader. The CLI and local
+TUI also default to that reader, but an operator may explicitly select an
+active local identity with `memorix identity join|use` or one command of
+`--as <agent-id>`. That identity receives only its own personal/team access;
+it does not turn the local database into ambient access to another agent's
+records. Clearing the identity returns the terminal to project scope. CLI and
+MCP transfer exports also use this reader, so an unbound backup cannot include
+personal/team observations merely because they share a project database.
 
 Explicit full-purge commands remain local operator maintenance commands behind
 their existing confirmations; they are intentionally outside ordinary agent

--- a/docs/1.2.2-MEMORY-CONTROL-PLANE.md
+++ b/docs/1.2.2-MEMORY-CONTROL-PLANE.md
@@ -279,9 +279,46 @@ records. Explicit retrieval still permits inspection, while ordinary search
 prefers qualified material and falls back only when no qualified result exists.
 
 Pending candidates are deliberately excluded from automatic consolidation so
-their evidence grain remains inspectable. Still pending in Phase 3:
-actor/visibility enforcement for cross-agent reads, a richer consolidation
-policy for qualified evidence, deterministic source-change demotion for all
+their evidence grain remains inspectable.
+
+### Phase 3 Implementation Status: Actor And Visibility Boundaries
+
+The second Phase 3 slice gives the existing observation record a small,
+uniform access policy instead of creating a parallel private-memory store:
+
+| Visibility | Reader rule | Write rule |
+| --- | --- | --- |
+| `project` | Any caller bound to that project. This is also the legacy default. | A caller bound to that project. |
+| `team` | An active coordination member of that project. | An active coordination member of that project. |
+| `personal` | The creator or an explicit recipient in that project. | The creator only. |
+
+SQLite and Orama retain the visibility, creator, and explicit recipient list.
+Records created before this control-plane slice remain `project` visible so an
+upgrade cannot hide existing project knowledge. Automatic hook and
+orchestrator traces begin personal; only a later source-backed qualification
+may promote a hook record to project evidence. A targeted handoff is personal
+to its sender and recipient, while an untargeted handoff is team-visible.
+Automatic orchestration lesson retrieval is an unbound project reader, so it
+cannot inject personal or team-scoped records into another agent's prompt.
+
+The same reader policy is applied to MCP search/detail/timeline/context,
+automatic context, session packets, the regular CLI and TUI, both dashboards,
+knowledge compilation, graph context, retention, consolidation, and scoped
+maintenance. A recipient may read a targeted handoff but cannot mutate it.
+Topic-key upserts check write scope before a write, so guessing a private key
+does not disclose or modify the record. The project-attribution guard also
+receives only records visible to the current reader.
+
+The embedded SDK and unbound local TUI deliberately use the same
+project-visible reader. They are useful for ordinary project memory, but they
+cannot retrieve, resolve, or topic-key-update personal/team records. Private
+coordination remains an identity-bound MCP operation rather than an ambient
+local-database privilege.
+
+Explicit full-purge commands remain local operator maintenance commands behind
+their existing confirmations; they are intentionally outside ordinary agent
+delivery and mutation paths. Remaining Phase 3 work is limited to richer
+qualified-evidence consolidation, deterministic source-change demotion for
 non-code evidence, and receipt-level lifecycle cautions.
 
 ### Phase 4: Embedding Capability Foundation

--- a/docs/AGENT_OPERATOR_PLAYBOOK.md
+++ b/docs/AGENT_OPERATOR_PLAYBOOK.md
@@ -54,6 +54,10 @@ For direct use, prefer `memorix ...` commands first. In the 1.2 line, the CLI co
 
 Do not ask memory-only users to join coordination state. A lightweight session is enough for memory, retrieval, reasoning, and continuation. Use `joinTeam` / `team_manage(join)` only for explicit task/message/lock coordination or for CLI-agent work managed by `memorix orchestrate`.
 
+An unbound terminal is intentionally project-scoped: it reads and writes project-visible memory only. Use `memorix identity join --agent-type <agent>` or `memorix identity use --agent-id <id>` only when an operator explicitly needs personal/team memory or coordinated task actions. `memorix identity clear` removes that local selection; `--as <agent-id>` is the one-command script form and still requires an active member of the current project.
+
+`--cwd <git-project>` is the canonical way to run direct CLI work from outside a repository. It changes the command's project anchor only; Git remains the source of truth for final project identity.
+
 Use MCP when:
 
 - an IDE or agent needs tool calls

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -35,6 +35,7 @@ Use the **CLI** when:
 The current CLI namespaces are:
 
 - `memorix session`
+- `memorix identity`
 - `memorix memory`
 - `memorix codegraph`
 - `memorix knowledge`
@@ -53,13 +54,16 @@ The current CLI namespaces are:
 - `memorix receipt`
 - `memorix sync`
 - `memorix ingest`
+- `memorix workbench`
 
 Typical examples:
 
 ```bash
-memorix session start --agent codex-main --agentType codex
+memorix --cwd /path/to/repo context --task "continue auth bug"
+memorix identity join --agent-type codex --name codex-main
+memorix session start --agent codex-main --agent-type codex --join-team --use
 memorix memory search --query "release blocker"
-memorix context --task "continue auth bug"
+memorix memory store --text "private triage note" --visibility personal
 memorix codegraph refresh
 memorix codegraph status --json
 memorix knowledge status
@@ -70,7 +74,7 @@ memorix task claim --taskId <id> --agentId <agent-id>
 memorix message inbox --agentId <agent-id>
 memorix lock status --file src/cli/index.ts
 memorix audit project
-memorix transfer export --format markdown
+memorix transfer export --format markdown --out ./memorix-export.md
 memorix skills show --name auth-pattern
 memorix sync workspace --action scan
 memorix ingest image --path ./diagram.png
@@ -78,7 +82,7 @@ memorix poll --agentId <agent-id>
 memorix receipt --json --probe "release blocker"
 ```
 
-The CLI is for direct terminal use, not a 1:1 mirror of MCP tool names. The only MCP-only area is the optional graph-compatibility tools (`create_entities`, `read_graph`, and related tools) for workflows that expect the official memory-server style graph API.
+The CLI is for direct terminal use, not a 1:1 mirror of MCP tool names. It does not require an MCP connection. `--cwd` selects a Git project from any shell; an unbound terminal has project-visible access only, including transfer exports. `memorix identity join|use|clear` makes personal/team access and coordination explicit, while `--as <agent-id>` is the one-command equivalent for scripts. The only MCP-only area is the optional graph-compatibility tools (`create_entities`, `read_graph`, and related tools) for workflows that expect the official memory-server style graph API.
 
 ### Memory Autopilot, Code State, and Context Packs
 
@@ -463,6 +467,10 @@ Important inputs:
 ### `memorix_transfer`
 
 Export or import project memory.
+
+Exports contain only observations visible to the calling agent. An unbound
+agent receives project-visible observations only; personal and team records
+require its explicit active identity.
 
 Important inputs:
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -208,6 +208,13 @@ Important inputs:
 - optional `source`
 - optional `relatedCommits`
 - optional `relatedEntities`
+- optional `visibility`: `project` (default), `personal`, or `team`
+
+Visibility controls who can retrieve a record through agent-facing memory
+tools. Normal memories default to `project`. `personal` and `team` writes
+require a joined coordination identity; a personal record is readable only by
+its creator and explicitly named recipients. Supplying a `topicKey` never
+lets an agent overwrite a record outside its write scope.
 
 Example:
 
@@ -665,6 +672,11 @@ Important inputs:
 - optional `context`
 
 Use it when work should survive agent/session boundaries without relying on an IDE chat window staying alive.
+
+A targeted handoff is private to its sender and recipient. A handoff without
+`toAgentId` is visible only to active members of that project's team. Reading a
+targeted handoff does not give its recipient permission to rewrite or resolve
+it on behalf of the sender.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -87,7 +87,7 @@ The public docs are organized by user intent:
 | 1.2 task-shaped evidence selection | [1.2 Workset Retrieval](1.2.0-WORKSET-RETRIEVAL.md) |
 | 1.2 non-blocking refresh and maintenance contract | [1.2 Dynamic Lifecycle](1.2.0-DYNAMIC-LIFECYCLE.md) |
 | 1.2 honest Lite and optional semantic CodeGraph provider contract | [1.2 Provider Quality](1.2.0-PROVIDER-QUALITY.md) |
-| Active 1.2 multi-dimensional memory work | [1.2.0 Development Charter](1.2.0-DEVELOPMENT-CHARTER.md) |
+| Active context-control work | [1.2.2 Memory Control Plane](1.2.2-MEMORY-CONTROL-PLANE.md) |
 | Historical cloud sync and multi-agent research | [CLOUD_SYNC_AND_MULTI_AGENT_RESEARCH.md](CLOUD_SYNC_AND_MULTI_AGENT_RESEARCH.md) |
 | Known issues and old roadmap notes | [KNOWN_ISSUES_AND_ROADMAP.md](KNOWN_ISSUES_AND_ROADMAP.md) |
 

--- a/docs/dev-log/progress.txt
+++ b/docs/dev-log/progress.txt
@@ -4,15 +4,15 @@
 > older notes when they conflict.
 
 ## Current State
-- Phase: 1.2 release validation and publication
-- Branch: `codex/1.2.0-multidimensional-memory`
-- Last updated: 2026-07-18
-- Released baseline: `memorix@1.1.13`, tag `v1.1.13`, PR #129 merged as
-  `7e8077f`.
-- Goal: turn Memorix from a useful narrative-memory layer into a task-ready
-  working-context layer where code state, change evidence, verification,
-  source-backed project knowledge, workflows, and durable decisions are ranked
-  together.
+- Phase: 1.2.2 memory-control-plane definition and baseline fixtures
+- Branch: `codex/1.2.2-memory-control-plane`
+- Last updated: 2026-07-24
+- Released baseline: `memorix@1.2.1`, tag `v1.2.1`, `origin/main` at
+  `1b5bf7f`.
+- Goal: make the 1.2 multi-dimensional evidence layer behave as one bounded,
+  explainable control plane. A task Workset, hook handoff, lifecycle refresh,
+  and provider capability result must share evidence qualification, delivery
+  budgets, and privacy-safe receipts.
 
 ## 1.1.13 Closeout
 - Codex setup now stamps plugin versions and doctor distinguishes bundle,
@@ -102,7 +102,7 @@
 - The compiled CLI was smoke-tested in an isolated Git project through init,
   compile, apply, and lint with a source-backed claim.
 
-## 1.2 Delivery Complete, Release Checks In Progress
+## 1.2 Delivery Complete, Released As 1.2.1
 - Phase 4 added canonical Markdown workflows, safe adapter preview/apply, import,
   selection, and verification receipts. Agent instruction files are render
   targets, not the workflow source of truth.
@@ -123,4 +123,19 @@
 - Release audit also incorporated #130 before publication: the optional SQLite
   runtime now uses the Node-26-compatible `better-sqlite3` 12.x line, with a
   dedicated Node 26 CI smoke that opens an in-memory database.
-- Remaining remote gates: GitHub CI, npm publish, tag, and GitHub release.
+- The release was completed as `memorix@1.2.1`. Its next development line is
+  [1.2.2 Memory Control Plane](../1.2.2-MEMORY-CONTROL-PLANE.md), which
+  consolidates these capabilities instead of adding another disconnected
+  memory feature.
+
+## 1.2.2 Control Plane
+- `TaskWorkset` already has bounded rendering and source-aware claims, but
+  SessionStart handoff and legacy context surfaces need one shared admission,
+  budget, and receipt contract.
+- #135 remains a contributor-owned session-handoff candidate for the bounded
+  `HandoffPacket` phase. It is not copied or silently replaced.
+- #133/#134 remain open pending an official provider-capability layer and a
+  safe agent-facing media path. The existing OpenRouter text embedding path is
+  the supported baseline.
+- See [1.2.2 Memory Control Plane](../1.2.2-MEMORY-CONTROL-PLANE.md) for
+  phases, acceptance gates, non-goals, and release criteria.

--- a/docs/dev-log/progress.txt
+++ b/docs/dev-log/progress.txt
@@ -132,6 +132,15 @@
 - `TaskWorkset` already has bounded rendering and source-aware claims, but
   SessionStart handoff and legacy context surfaces need one shared admission,
   budget, and receipt contract.
+- First implementation slice complete: the shared `ContextReceipt` records
+  delivery target, selected source ids/kinds, trust/freshness, exact budget
+  omissions, queued refreshes, and Workset selection time without entering the
+  agent prompt. Project Context, Context Pack, and full SessionStart injection
+  now carry the same delivery-target semantics; `memorix explain` exposes the
+  receipt in text and JSON.
+- Budget selection now keeps a knowledge page dependent on a Claim out of the
+  prompt when its qualifying Claim could not fit. The receipt records both as
+  withheld instead of presenting an orphaned page path as usable knowledge.
 - #135 remains a contributor-owned session-handoff candidate for the bounded
   `HandoffPacket` phase. It is not copied or silently replaced.
 - #133/#134 remain open pending an official provider-capability layer and a

--- a/docs/dev-log/progress.txt
+++ b/docs/dev-log/progress.txt
@@ -141,6 +141,34 @@
 - Budget selection now keeps a knowledge page dependent on a Claim out of the
   prompt when its qualifying Claim could not fit. The receipt records both as
   withheld instead of presenting an orphaned page path as usable knowledge.
+- Phase 3 admission slice complete: automatic observations now persist an
+  `ephemeral`, `candidate`, or `qualified` state and a reason. Hooks and the
+  internal orchestrator capture concrete evidence as candidates, keep routine
+  success/telemetry ephemeral, and drop low-signal activity without writing it.
+  Automatic capture stays quiet in the host agent.
+- A deduplicated `observation-qualify` maintenance job runs after CodeGraph
+  refresh. It requires a scan no older than the capture and at least one
+  current code reference before upgrading a candidate. Qualification does not
+  create a Claim; explicit saves and Git remain the Claim boundary.
+- Auto Project Context, automatic session L1 delivery, Wiki/Knowledge Graph
+  compilation, and graph-context packets exclude candidates and ephemeral
+  traces. Ordinary search prefers qualified material, while explicit lookup
+  can still inspect pending evidence.
+- Pending automatic evidence is also excluded from automatic consolidation so
+  a later qualification can still inspect its original source grain. Retention
+  explanations no longer describe an unqualified `core` candidate as immune.
+- Direct CLI and foreground Code Memory refreshes now enqueue qualification as
+  well as claim requalification, and they register the local project target
+  needed by the isolated control-plane worker. The host hook path persists its
+  candidate before scheduling a refresh, avoiding a fast-worker race where a
+  scan could predate the capture.
+- Compiled-artifact smoke: an isolated Codex `PostToolUse` hook returned only
+  `continue: true`, stored a `candidate`, and the isolated background control
+  plane upgraded it to `qualified` after a real Code Memory scan with one
+  current reference. Embeddings were deliberately disabled for this
+  deterministic local smoke. The full test suite, TypeScript check, and
+  production build also passed after the admission policy was reconciled with
+  OpenCode's concise technical response events.
 - #135 remains a contributor-owned session-handoff candidate for the bounded
   `HandoffPacket` phase. It is not copied or silently replaced.
 - #133/#134 remain open pending an official provider-capability layer and a

--- a/docs/dev-log/progress.txt
+++ b/docs/dev-log/progress.txt
@@ -173,10 +173,18 @@
   project-attribution guard receives only memories visible to its current
   reader. This closes both guessed-key overwrite and cross-project existence
   hints without hiding historical project knowledge after upgrade.
-- The embedded SDK and unbound local TUI now use that same project-visible
-  reader. They cannot retrieve, resolve, or topic-key-update private/team
-  observations; identity-bound MCP remains the coordination path for those
-  records.
+- The embedded SDK remains project-visible when unbound. CLI and the local TUI
+  now share the same explicit actor reader: an unbound terminal sees project
+  memory only, while `memorix identity join|use` (or one-shot `--as`) grants
+  only that active project member's personal/team visibility and coordination
+  ergonomics. `identity clear` returns to project scope; private evidence
+  cannot be promoted into shared skills or generated project skills.
+- CLI control-plane ergonomics now include `--cwd`, kebab-case flag aliases,
+  action-oriented namespace help, explicit `memorix workbench`, and
+  file/stdin transfer import/export. Root memory aliases use the same
+  canonical command paths as `memorix memory`; CLI and MCP exports are filtered
+  by the same active reader so an unbound backup cannot contain private/team
+  observations.
 - Direct CLI and foreground Code Memory refreshes now enqueue qualification as
   well as claim requalification, and they register the local project target
   needed by the isolated control-plane worker. The host hook path persists its

--- a/docs/dev-log/progress.txt
+++ b/docs/dev-log/progress.txt
@@ -4,9 +4,9 @@
 > older notes when they conflict.
 
 ## Current State
-- Phase: 1.2.2 memory-control-plane definition and baseline fixtures
+- Phase: 1.2.2 memory-control-plane admission and visibility implementation
 - Branch: `codex/1.2.2-memory-control-plane`
-- Last updated: 2026-07-24
+- Last updated: 2026-07-25
 - Released baseline: `memorix@1.2.1`, tag `v1.2.1`, `origin/main` at
   `1b5bf7f`.
 - Goal: make the 1.2 multi-dimensional evidence layer behave as one bounded,
@@ -157,6 +157,26 @@
 - Pending automatic evidence is also excluded from automatic consolidation so
   a later qualification can still inspect its original source grain. Retention
   explanations no longer describe an unqualified `core` candidate as immune.
+- Actor and visibility enforcement is now one policy shared by MCP retrieval,
+  auto context, CLI/TUI, dashboards, knowledge/graph projections, and scoped
+  maintenance. Legacy observations remain project-visible; new records may be
+  `project`, `team`, or `personal` with an explicit creator and recipients.
+  Missing identity never grants private or team visibility.
+- Automatic hooks and orchestrator traces begin personal. A verified hook
+  candidate may become project evidence only when qualification proves a
+  current code reference. Targeted handoffs are readable by sender and
+  recipient but writable only by sender; broadcasts require an active project
+  team member.
+- Automatic orchestration lesson lookup is explicitly project-scoped, so its
+  prompt injection cannot read personal or team-scoped records.
+- Topic-key writes now check mutation scope before storage, and the
+  project-attribution guard receives only memories visible to its current
+  reader. This closes both guessed-key overwrite and cross-project existence
+  hints without hiding historical project knowledge after upgrade.
+- The embedded SDK and unbound local TUI now use that same project-visible
+  reader. They cannot retrieve, resolve, or topic-key-update private/team
+  observations; identity-bound MCP remains the coordination path for those
+  records.
 - Direct CLI and foreground Code Memory refreshes now enqueue qualification as
   well as claim requalification, and they register the local project target
   needed by the isolated control-plane worker. The host hook path persists its

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/src/cli/command-guide.ts
+++ b/src/cli/command-guide.ts
@@ -1,0 +1,192 @@
+export interface CliCommandGuide {
+  summary: string;
+  usage: string[];
+  notes?: string[];
+}
+
+const GUIDES: Record<string, CliCommandGuide> = {
+  memory: {
+    summary: 'Store, search, inspect, resolve, consolidate, and promote project memory.',
+    usage: [
+      'memorix memory search --query "timeout regression" [--limit 10]',
+      'memorix memory store --text "..." [--title "..."] [--visibility project|personal|team]',
+      'memorix memory detail --id 42',
+      'memorix memory recent [--limit 10]',
+      'memorix memory resolve --ids 42,43 [--status resolved|archived]',
+      'memorix memory consolidate --action preview|execute',
+      'memorix memory promote --ids 42,43 [--trigger "..."] [--instruction "..."]',
+    ],
+    notes: ['Personal and team visibility require `memorix identity join` or `memorix identity use` first.'],
+  },
+  identity: {
+    summary: 'Select the active local actor for private memory and coordination commands.',
+    usage: [
+      'memorix identity status',
+      'memorix identity join --agent-type codex [--name codex-main --instance-id local]',
+      'memorix identity use --agent-id <id>',
+      'memorix identity clear',
+    ],
+    notes: ['Without an identity, CLI reads and writes only project-visible memory.'],
+  },
+  session: {
+    summary: 'Start, end, and inspect coding sessions. Coordination remains opt-in.',
+    usage: [
+      'memorix session start --agent codex',
+      'memorix session start --agent codex --agent-type codex --join-team --use',
+      'memorix session end --session-id <id> [--summary "..."]',
+      'memorix session context [--limit 3]',
+    ],
+  },
+  context: {
+    summary: 'Build the bounded task Workset used to resume or begin real work.',
+    usage: ['memorix context --task "continue the release fix" [--refresh auto|always|never]'],
+  },
+  explain: {
+    summary: 'Show why a task context contains its current facts and memory evidence.',
+    usage: ['memorix explain [--refresh auto|always|never]'],
+  },
+  codegraph: {
+    summary: 'Refresh local code-state snapshots and assemble task-specific code context.',
+    usage: [
+      'memorix codegraph status',
+      'memorix codegraph refresh',
+      'memorix codegraph context-pack --task "trace the auth flow" [--limit 20]',
+    ],
+  },
+  knowledge: {
+    summary: 'Manage the reviewed, source-backed Knowledge Workspace and project workflows.',
+    usage: [
+      'memorix knowledge init [--mode local|versioned]',
+      'memorix knowledge status',
+      'memorix knowledge compile',
+      'memorix knowledge lint',
+      'memorix knowledge workflow list',
+    ],
+  },
+  reasoning: {
+    summary: 'Capture and retrieve engineering decision rationale.',
+    usage: [
+      'memorix reasoning store --entity auth --decision "Use SQLite" --rationale "..."',
+      'memorix reasoning search --query "why sqlite" [--scope project|global]',
+    ],
+  },
+  retention: {
+    summary: 'Inspect retention state and archive records that are eligible under the current scope.',
+    usage: [
+      'memorix retention status',
+      'memorix retention stale',
+      'memorix retention archive',
+    ],
+  },
+  transfer: {
+    summary: 'Create or restore explicit project memory snapshots for backup and automation.',
+    usage: [
+      'memorix transfer export --format json --out ./.memorix-export.json',
+      'memorix transfer import --file ./.memorix-export.json',
+      'memorix transfer import --stdin',
+    ],
+  },
+  team: {
+    summary: 'Manage explicit multi-agent coordination state for the current project.',
+    usage: [
+      'memorix team join --agent-type codex [--name codex-main]',
+      'memorix team status [--all]',
+      'memorix team leave [--agent-id <id>]',
+    ],
+  },
+  task: {
+    summary: 'Create and progress coordination tasks. An active CLI identity fills agentId automatically.',
+    usage: [
+      'memorix task create --description "Review release evidence"',
+      'memorix task claim --task-id <id>',
+      'memorix task complete --task-id <id> --result "Verified"',
+      'memorix task list [--available]',
+    ],
+  },
+  message: {
+    summary: 'Send and read coordination messages. An active CLI identity fills the sender automatically.',
+    usage: [
+      'memorix message send --to <agent-id> --type info --content "..."',
+      'memorix message broadcast --type announcement --content "..."',
+      'memorix message inbox [--mark-read]',
+    ],
+  },
+  lock: {
+    summary: 'Use advisory file locks to reduce overlapping edits between agents.',
+    usage: [
+      'memorix lock lock --file src/server.ts',
+      'memorix lock unlock --file src/server.ts',
+      'memorix lock status [--file src/server.ts]',
+    ],
+  },
+  handoff: {
+    summary: 'Create durable, targeted or team-visible handoff artifacts.',
+    usage: ['memorix handoff send --summary "..." --context "..." [--to-agent-id <id>]'],
+  },
+  poll: {
+    summary: 'Return a compact coordination snapshot for the active CLI identity.',
+    usage: ['memorix poll [--mark-inbox-read]'],
+  },
+  audit: {
+    summary: 'Inspect quality, attribution, and recorded audit evidence.',
+    usage: ['memorix audit memory', 'memorix audit project [--threshold 2]', 'memorix audit list'],
+  },
+  skills: {
+    summary: 'Inspect and generate project skills from project-visible memory evidence.',
+    usage: ['memorix skills list', 'memorix skills generate [--write --target codex]', 'memorix skills show --name <skill>'],
+  },
+  sync: {
+    summary: 'Synchronize agent rules and workspace artifacts through explicit routes.',
+    usage: ['memorix sync rules --action status', 'memorix sync workspace --action scan'],
+  },
+  ingest: {
+    summary: 'Ingest Git and image evidence into project memory.',
+    usage: ['memorix ingest commit [--ref HEAD]', 'memorix ingest log [--count 10]', 'memorix ingest image --path ./diagram.png'],
+  },
+  workbench: {
+    summary: 'Open the interactive terminal memory control plane.',
+    usage: ['memorix workbench'],
+  },
+};
+
+export function commandGuideNames(): string[] {
+  return Object.keys(GUIDES).sort();
+}
+
+export function renderCliGuide(command?: string): string {
+  const normalized = command?.trim().toLowerCase();
+  if (normalized && GUIDES[normalized]) {
+    const guide = GUIDES[normalized];
+    return [
+      `Memorix ${normalized}`,
+      '',
+      guide.summary,
+      '',
+      'Usage:',
+      ...guide.usage.map((line) => `  ${line}`),
+      ...(guide.notes?.length ? ['', ...guide.notes.map((line) => `Note: ${line}`)] : []),
+      '',
+      'Project/actor options: --cwd <git-project>  --as <active-agent-id>. Operator commands accept --json.',
+    ].join('\n');
+  }
+
+  return [
+    'Memorix CLI',
+    '',
+    'Use `memorix <command> --help` for an action-oriented guide.',
+    '',
+    `Command groups: ${commandGuideNames().join(', ')}`,
+    '',
+    'Global options: --cwd <git-project>  --as <active-agent-id>',
+    'Compatibility: camelCase flags remain supported; kebab-case flags are accepted too.',
+  ].join('\n');
+}
+
+/** Render manual action help before Citty consumes `--help` as flag metadata. */
+export function printCliGuideForHelp(argv: string[] = process.argv.slice(2)): boolean {
+  const [command, ...rest] = argv;
+  if (!command || !GUIDES[command.toLowerCase()]) return false;
+  if (!rest.includes('--help') && !rest.includes('-h')) return false;
+  console.log(renderCliGuide(command));
+  return true;
+}

--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -23,8 +23,8 @@ export default defineCommand({
     try {
       switch (action) {
         case 'memory': {
-          const { project } = await getCliProjectContext();
-          const report = auditMemoryQuality(filterReadableObservations(getAllObservations(), { projectId: project.id }), {
+          const { project, reader } = await getCliProjectContext();
+          const report = auditMemoryQuality(filterReadableObservations(getAllObservations(), reader), {
             projectId: project.id,
           });
           emitResult(
@@ -69,11 +69,11 @@ export default defineCommand({
         }
 
         case 'project': {
-          const { project } = await getCliProjectContext();
+          const { project, reader } = await getCliProjectContext();
           const threshold = Number.parseInt(String(args.threshold ?? '2'), 10) || 2;
           const entries = await auditProjectObservations(
             project.id,
-            filterReadableObservations(getAllObservations(), { projectId: project.id }),
+            filterReadableObservations(getAllObservations(), reader),
             threshold,
           );
           emitResult(

--- a/src/cli/commands/audit.ts
+++ b/src/cli/commands/audit.ts
@@ -3,6 +3,7 @@ import { getAllAuditEntries, getProjectId } from '../../audit/index.js';
 import { auditProjectObservations } from '../../memory/attribution-guard.js';
 import { getAllObservations } from '../../memory/observations.js';
 import { auditMemoryQuality } from '../../memory/quality-audit.js';
+import { filterReadableObservations } from '../../memory/visibility.js';
 import { emitError, emitResult, getCliProjectContext } from './operator-shared.js';
 
 export default defineCommand({
@@ -23,7 +24,7 @@ export default defineCommand({
       switch (action) {
         case 'memory': {
           const { project } = await getCliProjectContext();
-          const report = auditMemoryQuality(getAllObservations(), {
+          const report = auditMemoryQuality(filterReadableObservations(getAllObservations(), { projectId: project.id }), {
             projectId: project.id,
           });
           emitResult(
@@ -70,7 +71,11 @@ export default defineCommand({
         case 'project': {
           const { project } = await getCliProjectContext();
           const threshold = Number.parseInt(String(args.threshold ?? '2'), 10) || 2;
-          const entries = await auditProjectObservations(project.id, getAllObservations(), threshold);
+          const entries = await auditProjectObservations(
+            project.id,
+            filterReadableObservations(getAllObservations(), { projectId: project.id }),
+            threshold,
+          );
           emitResult(
             { project, entries, threshold },
             entries.length === 0

--- a/src/cli/commands/cleanup.ts
+++ b/src/cli/commands/cleanup.ts
@@ -19,6 +19,7 @@ import { detectProject } from '../../project/detector.js';
 import { getProjectDataDir } from '../../store/persistence.js';
 import type { ObservationStore } from '../../store/obs-store.js';
 import { getObservationStore, initObservationStore } from '../../store/obs-store.js';
+import { filterReadableObservations } from '../../memory/visibility.js';
 
 /** Patterns that indicate auto-generated, low-value observations */
 const LOW_QUALITY_PATTERNS = [
@@ -148,7 +149,10 @@ export default defineCommand({
         const dataDir = await getProjectDataDir(projectId);
         await initObservationStore(dataDir);
         const store = getObservationStore();
-        const projectObs = await store.loadByProject(projectId, { status: 'active' }) as Array<{
+        const projectObs = filterReadableObservations(
+            await store.loadByProject(projectId, { status: 'active' }),
+            { projectId },
+        ) as Array<{
             id?: number;
             type?: string;
             title?: string;

--- a/src/cli/commands/codegraph.ts
+++ b/src/cli/commands/codegraph.ts
@@ -125,12 +125,20 @@ export default defineCommand({
           const activeObservations = getAllObservations()
             .filter(obs => obs.projectId === project.id && (obs.status ?? 'active') === 'active');
           const backfill = await backfillMissingObservationCodeRefs(store, activeObservations);
-          const { enqueueClaimRequalification } = await import('../../runtime/lifecycle.js');
+          const {
+            enqueueClaimRequalification,
+            enqueueObservationQualification,
+          } = await import('../../runtime/lifecycle.js');
           enqueueClaimRequalification({
             dataDir,
             projectId: project.id,
             source: 'manual-codegraph-refresh',
             snapshotId: refresh.snapshot.id,
+          });
+          enqueueObservationQualification({
+            dataDir,
+            projectId: project.id,
+            source: 'manual-codegraph-refresh',
           });
           const status = store.status(project.id);
           const providerQuality = await inspectExternalCodeGraph({

--- a/src/cli/commands/codegraph.ts
+++ b/src/cli/commands/codegraph.ts
@@ -93,7 +93,7 @@ export default defineCommand({
     const asJson = !!args.json;
 
     try {
-      const { project, dataDir } = await getCliProjectContext();
+      const { project, dataDir, reader } = await getCliProjectContext();
       const store = new CodeGraphStore();
       await store.init(dataDir);
       const explicitAction = Boolean(positional[0] || (args.action as string | undefined));
@@ -171,7 +171,7 @@ export default defineCommand({
           const limit = parsePositiveInt(args.limit as string | undefined, 20);
           const observations = filterReadableObservations(
             getAllObservations().filter(obs => obs.projectId === project.id && (obs.status ?? 'active') === 'active'),
-            { projectId: project.id },
+            reader,
           ).reverse();
           const basePack = assembleContextPackForTask({
             store,

--- a/src/cli/commands/codegraph.ts
+++ b/src/cli/commands/codegraph.ts
@@ -9,6 +9,7 @@ import { getExternalCodeGraphContext, inspectExternalCodeGraph } from '../../cod
 import type { CodeGraphProviderQuality } from '../../codegraph/types.js';
 import { getResolvedConfig } from '../../config/resolved-config.js';
 import { getAllObservations } from '../../memory/observations.js';
+import { filterReadableObservations } from '../../memory/visibility.js';
 import { emitError, emitResult, getCliProjectContext, parsePositiveInt } from './operator-shared.js';
 
 function formatSnapshotStatus(status: ReturnType<CodeGraphStore['status']>): string[] {
@@ -168,9 +169,10 @@ export default defineCommand({
             return;
           }
           const limit = parsePositiveInt(args.limit as string | undefined, 20);
-          const observations = getAllObservations()
-            .filter(obs => obs.projectId === project.id && (obs.status ?? 'active') === 'active')
-            .reverse();
+          const observations = filterReadableObservations(
+            getAllObservations().filter(obs => obs.projectId === project.id && (obs.status ?? 'active') === 'active'),
+            { projectId: project.id },
+          ).reverse();
           const basePack = assembleContextPackForTask({
             store,
             projectId: project.id,

--- a/src/cli/commands/context.ts
+++ b/src/cli/commands/context.ts
@@ -6,6 +6,7 @@ import {
   type AutoContextRefreshMode,
 } from '../../codegraph/auto-context.js';
 import { getAllObservations } from '../../memory/observations.js';
+import { filterReadableObservations } from '../../memory/visibility.js';
 import { emitError, emitResult, getCliProjectContext } from './operator-shared.js';
 
 function coerceRefreshMode(input?: string): AutoContextRefreshMode {
@@ -32,7 +33,7 @@ export default defineCommand({
       const context = await buildAutoProjectContext({
         project,
         dataDir,
-        observations: getAllObservations(),
+        observations: filterReadableObservations(getAllObservations(), { projectId: project.id }),
         task: args.task as string | undefined,
         refresh: coerceRefreshMode(args.refresh as string | undefined),
       });

--- a/src/cli/commands/context.ts
+++ b/src/cli/commands/context.ts
@@ -29,11 +29,11 @@ export default defineCommand({
     const asJson = !!args.json;
 
     try {
-      const { project, dataDir } = await getCliProjectContext();
+      const { project, dataDir, reader } = await getCliProjectContext();
       const context = await buildAutoProjectContext({
         project,
         dataDir,
-        observations: filterReadableObservations(getAllObservations(), { projectId: project.id }),
+        observations: filterReadableObservations(getAllObservations(), reader),
         task: args.task as string | undefined,
         refresh: coerceRefreshMode(args.refresh as string | undefined),
       });

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -257,8 +257,10 @@ export default defineCommand({
         await initObservationStore(dataDir);
         const store = getObservationStore();
         backendName = store.getBackendName();
-        const obs = await store.loadAll();
-        projectObservations = obs.filter((o: any) => o.projectId === projectId);
+        const { filterReadableObservations } = await import('../../memory/visibility.js');
+        projectObservations = projectId
+          ? filterReadableObservations(await store.loadAll(), { projectId })
+          : [];
         obsCount = projectObservations.length;
         activeCount = projectObservations.filter((o: any) => (o.status ?? 'active') === 'active').length;
         ranCount = projectObservations.filter((o: any) => /^Ran:\s/i.test(o.title ?? '')).length;

--- a/src/cli/commands/explain.ts
+++ b/src/cli/commands/explain.ts
@@ -1,6 +1,7 @@
 import { defineCommand } from 'citty';
 import { buildAutoProjectContext, type AutoContextRefreshMode } from '../../codegraph/auto-context.js';
 import { formatProjectContextExplain } from '../../codegraph/project-context.js';
+import { formatContextReceipt } from '../../knowledge/context-assembly.js';
 import { getAllObservations } from '../../memory/observations.js';
 import { emitError, emitResult, getCliProjectContext } from './operator-shared.js';
 
@@ -31,7 +32,11 @@ export default defineCommand({
         refresh: coerceRefreshMode(args.refresh as string | undefined),
       });
 
-      emitResult({ project, explain: context.explain, refresh: context.refresh }, formatProjectContextExplain(context.explain), asJson);
+      emitResult(
+        { project, explain: context.explain, receipt: context.workset.receipt, refresh: context.refresh },
+        formatProjectContextExplain(context.explain) + '\n\n' + formatContextReceipt(context.workset.receipt),
+        asJson,
+      );
     } catch (error) {
       emitError(error instanceof Error ? error.message : String(error), asJson);
     }

--- a/src/cli/commands/explain.ts
+++ b/src/cli/commands/explain.ts
@@ -25,11 +25,11 @@ export default defineCommand({
     const asJson = !!args.json;
 
     try {
-      const { project, dataDir } = await getCliProjectContext();
+      const { project, dataDir, reader } = await getCliProjectContext();
       const context = await buildAutoProjectContext({
         project,
         dataDir,
-        observations: filterReadableObservations(getAllObservations(), { projectId: project.id }),
+        observations: filterReadableObservations(getAllObservations(), reader),
         refresh: coerceRefreshMode(args.refresh as string | undefined),
       });
 

--- a/src/cli/commands/explain.ts
+++ b/src/cli/commands/explain.ts
@@ -3,6 +3,7 @@ import { buildAutoProjectContext, type AutoContextRefreshMode } from '../../code
 import { formatProjectContextExplain } from '../../codegraph/project-context.js';
 import { formatContextReceipt } from '../../knowledge/context-assembly.js';
 import { getAllObservations } from '../../memory/observations.js';
+import { filterReadableObservations } from '../../memory/visibility.js';
 import { emitError, emitResult, getCliProjectContext } from './operator-shared.js';
 
 function coerceRefreshMode(input?: string): AutoContextRefreshMode {
@@ -28,7 +29,7 @@ export default defineCommand({
       const context = await buildAutoProjectContext({
         project,
         dataDir,
-        observations: getAllObservations(),
+        observations: filterReadableObservations(getAllObservations(), { projectId: project.id }),
         refresh: coerceRefreshMode(args.refresh as string | undefined),
       });
 

--- a/src/cli/commands/handoff.ts
+++ b/src/cli/commands/handoff.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from 'citty';
 import { storeObservation } from '../../memory/observations.js';
 import { createHandoffArtifact } from '../../team/handoff.js';
-import { emitError, emitResult, getCliProjectContext, parseCsvList, shortId } from './operator-shared.js';
+import { emitError, emitResult, getCliProjectContext, parseCsvList, resolveCliActorId, shortId } from './operator-shared.js';
 
 export default defineCommand({
   meta: {
@@ -23,19 +23,33 @@ export default defineCommand({
     const asJson = !!args.json;
 
     try {
-      const { project, teamStore } = await getCliProjectContext();
+      const { project, teamStore, identity } = await getCliProjectContext();
+      const fromAgentId = resolveCliActorId(args.fromAgentId, identity, 'fromAgentId');
 
       switch (action) {
         case 'send': {
-          if (!args.fromAgentId || !args.summary || !args.context) {
-            emitError('fromAgentId, summary, and context are required for "memorix handoff send"', asJson);
+          if (!fromAgentId || !args.summary || !args.context) {
+            emitError('summary, context, and an active CLI identity or fromAgentId are required for "memorix handoff send"', asJson);
             return;
+          }
+          const sender = teamStore.getAgent(fromAgentId);
+          if (!sender || sender.project_id !== project.id || sender.status !== 'active') {
+            emitError('The handoff sender must be an active coordination member of this project.', asJson);
+            return;
+          }
+          const toAgentId = (args.toAgentId as string | undefined)?.trim();
+          if (toAgentId) {
+            const recipient = teamStore.getAgent(toAgentId);
+            if (!recipient || recipient.project_id !== project.id || recipient.status !== 'active') {
+              emitError('The handoff recipient must be an active coordination member of this project.', asJson);
+              return;
+            }
           }
           const result = await createHandoffArtifact(
             {
               projectId: project.id,
-              fromAgentId: args.fromAgentId as string,
-              toAgentId: args.toAgentId as string | undefined,
+              fromAgentId,
+              toAgentId,
               taskId: args.taskId as string | undefined,
               summary: args.summary as string,
               context: args.context as string,
@@ -57,7 +71,7 @@ export default defineCommand({
           console.log('Memorix Handoff Commands');
           console.log('');
           console.log('Usage:');
-          console.log('  memorix handoff send --fromAgentId <id> --summary "..." --context "..." [--toAgentId <id>] [--taskId <id>]');
+          console.log('  memorix handoff send --summary "..." --context "..." [--fromAgentId <id>] [--toAgentId <id>] [--taskId <id>]');
       }
     } catch (error) {
       emitError(error instanceof Error ? error.message : String(error), asJson);

--- a/src/cli/commands/identity.ts
+++ b/src/cli/commands/identity.ts
@@ -1,0 +1,116 @@
+import { defineCommand } from 'citty';
+import { AGENT_TYPE_ROLE_MAP } from '../../team/team-store.js';
+import { clearCliIdentity, loadCliIdentity, saveCliIdentity } from '../identity.js';
+import { emitError, emitResult, getCliProjectContext, parseCsvList } from './operator-shared.js';
+
+function requiredText(value: unknown, label: string): string {
+  const text = typeof value === 'string' ? value.trim() : '';
+  if (!text) throw new Error(`${label} is required`);
+  return text;
+}
+
+export default defineCommand({
+  meta: {
+    name: 'identity',
+    description: 'Select the explicit CLI actor used for private or team-scoped operations',
+  },
+  args: {
+    agentId: { type: 'string', description: 'Existing active coordination agent ID' },
+    agentType: { type: 'string', description: 'Agent type when joining (for example codex)' },
+    instanceId: { type: 'string', description: 'Stable instance identity when joining' },
+    name: { type: 'string', description: 'Optional display name when joining' },
+    role: { type: 'string', description: 'Optional coordination role when joining' },
+    capabilities: { type: 'string', description: 'Comma-separated capability list when joining' },
+    json: { type: 'boolean', description: 'Emit machine-readable JSON output' },
+  },
+  run: async ({ args }) => {
+    const action = ((args._ as string[])?.[0] || 'status').toLowerCase();
+    const asJson = !!args.json;
+
+    try {
+      const { project, dataDir, teamStore, identity, reader, identityWarning } = await getCliProjectContext();
+
+      switch (action) {
+        case 'status': {
+          const saved = await loadCliIdentity(dataDir, project.id);
+          const agent = saved ? teamStore.getAgent(saved.agentId) : undefined;
+          emitResult(
+            {
+              project,
+              identity,
+              savedIdentity: saved,
+              agent: agent ?? null,
+              reader,
+              ...(identityWarning ? { warning: identityWarning } : {}),
+            },
+            identity
+              ? `CLI identity: ${agent?.name ?? identity.agentId} (${identity.agentId})`
+              : identityWarning ?? 'CLI identity: project-scoped only. Use "memorix identity join" or "memorix identity use --agent-id <id>" for private/team operations.',
+            asJson,
+          );
+          return;
+        }
+
+        case 'join': {
+          const agentType = requiredText(args.agentType, 'agentType');
+          const agent = teamStore.registerAgent({
+            projectId: project.id,
+            agentType,
+            instanceId: args.instanceId as string | undefined,
+            name: args.name as string | undefined,
+            role: (args.role as string | undefined) || AGENT_TYPE_ROLE_MAP[agentType] || 'engineer',
+            capabilities: parseCsvList(args.capabilities as string | undefined),
+          });
+          const nextIdentity = {
+            agentId: agent.agent_id,
+            projectId: project.id,
+            activatedAt: new Date().toISOString(),
+          };
+          await saveCliIdentity(dataDir, nextIdentity);
+          emitResult(
+            { project, identity: nextIdentity, agent },
+            `CLI identity activated: ${agent.name} (${agent.agent_id})`,
+            asJson,
+          );
+          return;
+        }
+
+        case 'use': {
+          const agentId = requiredText(args.agentId, 'agentId');
+          const agent = teamStore.getAgent(agentId);
+          if (!agent || agent.project_id !== project.id || agent.status !== 'active') {
+            emitError('agentId must identify an active coordination member of this project.', asJson);
+            return;
+          }
+          const nextIdentity = {
+            agentId: agent.agent_id,
+            projectId: project.id,
+            activatedAt: new Date().toISOString(),
+          };
+          await saveCliIdentity(dataDir, nextIdentity);
+          emitResult(
+            { project, identity: nextIdentity, agent },
+            `CLI identity activated: ${agent.name} (${agent.agent_id})`,
+            asJson,
+          );
+          return;
+        }
+
+        case 'clear': {
+          await clearCliIdentity(dataDir);
+          emitResult(
+            { project, cleared: true },
+            'CLI identity cleared. Subsequent commands use project-scoped access only.',
+            asJson,
+          );
+          return;
+        }
+
+        default:
+          emitError(`unknown identity action "${action}". Use "status", "join", "use", or "clear".`, asJson);
+      }
+    } catch (error) {
+      emitError(error instanceof Error ? error.message : String(error), asJson);
+    }
+  },
+});

--- a/src/cli/commands/ingest-image.ts
+++ b/src/cli/commands/ingest-image.ts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { analyzeImage } from '../../multimodal/image-loader.js';
 import { storeObservation } from '../../memory/observations.js';
-import { emitError, emitResult, getCliProjectContext } from './operator-shared.js';
+import { emitError, emitResult, getCliProjectContext, resolveCliWriteScope } from './operator-shared.js';
 
 function inferMimeType(filePath: string): string {
   const ext = path.extname(filePath).toLowerCase();
@@ -29,6 +29,7 @@ export default defineCommand({
     path: { type: 'string', description: 'Path to the image file' },
     prompt: { type: 'string', description: 'Custom analysis prompt' },
     mimeType: { type: 'string', description: 'Explicit MIME type override' },
+    visibility: { type: 'string', description: 'Memory visibility: project (default), personal, or team' },
     json: { type: 'boolean', description: 'Emit machine-readable JSON output' },
   },
   run: async ({ args }) => {
@@ -39,8 +40,8 @@ export default defineCommand({
         emitError('path is required for "memorix ingest image"', asJson);
         return;
       }
-      const { project } = await getCliProjectContext();
-      const resolvedPath = path.resolve(process.cwd(), imagePath);
+      const { project, reader, identity } = await getCliProjectContext();
+      const resolvedPath = path.resolve(project.rootPath, imagePath);
       const base64 = readFileSync(resolvedPath).toString('base64');
       const filename = path.basename(resolvedPath);
       const analysis = await analyzeImage({
@@ -59,6 +60,7 @@ export default defineCommand({
         facts: analysis.entities,
         projectId: project.id,
         source: 'manual',
+        ...resolveCliWriteScope({ reader, identity }, args.visibility as string | undefined),
       });
 
       emitResult(

--- a/src/cli/commands/lock.ts
+++ b/src/cli/commands/lock.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from 'citty';
-import { emitError, emitResult, getCliProjectContext, shortId } from './operator-shared.js';
+import { emitError, emitResult, getCliProjectContext, resolveCliActorId, shortId } from './operator-shared.js';
 
 export default defineCommand({
   meta: {
@@ -16,21 +16,22 @@ export default defineCommand({
     const asJson = !!args.json;
 
     try {
-      const { project, teamStore } = await getCliProjectContext();
+      const { project, teamStore, identity } = await getCliProjectContext();
+      const agentId = resolveCliActorId(args.agentId, identity);
 
       switch (action) {
         case 'lock': {
-          if (!args.file || !args.agentId) {
-            emitError('file and agentId are required for "memorix lock lock"', asJson);
+          if (!args.file || !agentId) {
+            emitError('file and an active CLI identity or agentId are required for "memorix lock lock"', asJson);
             return;
           }
-          const result = teamStore.acquireLock(project.id, args.file as string, args.agentId as string);
+          const result = teamStore.acquireLock(project.id, args.file as string, agentId);
           if (!result.success) {
             emitError(`File is already locked by ${shortId(result.lockedBy)}`, asJson);
             return;
           }
           emitResult(
-            { project, file: args.file, lockedBy: args.agentId },
+            { project, file: args.file, lockedBy: agentId },
             `Locked: ${args.file as string}`,
             asJson,
           );
@@ -38,11 +39,11 @@ export default defineCommand({
         }
 
         case 'unlock': {
-          if (!args.file || !args.agentId) {
-            emitError('file and agentId are required for "memorix lock unlock"', asJson);
+          if (!args.file || !agentId) {
+            emitError('file and an active CLI identity or agentId are required for "memorix lock unlock"', asJson);
             return;
           }
-          const released = teamStore.releaseLock(project.id, args.file as string, args.agentId as string);
+          const released = teamStore.releaseLock(project.id, args.file as string, agentId);
           if (!released) {
             emitError('Cannot unlock: not the owner or the file is not locked', asJson);
             return;
@@ -68,7 +69,7 @@ export default defineCommand({
             return;
           }
 
-          const locks = teamStore.listLocks(project.id, args.agentId as string | undefined);
+          const locks = teamStore.listLocks(project.id, agentId);
           emitResult(
             { project, locks },
             locks.length === 0

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -1,8 +1,9 @@
 import { defineCommand } from 'citty';
 import { compactDetail, compactSearch, compactTimeline } from '../../compact/engine.js';
 import { withFreshIndex } from '../../memory/freshness.js';
-import { getAllObservations, getProjectObservations, resolveObservations, storeObservation, suggestTopicKey } from '../../memory/observations.js';
+import { getAllObservations, getObservation, getProjectObservations, resolveObservations, storeObservation, suggestTopicKey } from '../../memory/observations.js';
 import { buildGraphContextPacket, formatGraphContextPrompt } from '../../memory/graph-context.js';
+import { canManageObservation, filterReadableObservations } from '../../memory/visibility.js';
 import { emitError, emitResult, getCliProjectContext, parseCsvList, parsePositiveInt, coerceObservationStatus, coerceObservationType } from './operator-shared.js';
 
 export default defineCommand({
@@ -45,6 +46,7 @@ export default defineCommand({
 
     try {
       const { project } = await getCliProjectContext({ searchIndex: true });
+      const reader = { projectId: project.id };
 
       switch (action) {
         case 'search': {
@@ -54,7 +56,7 @@ export default defineCommand({
             return;
           }
           const limit = parsePositiveInt(args.limit as string | undefined, 10);
-          const result = await compactSearch({ query, limit, projectId: project.id });
+          const result = await compactSearch({ query, limit, projectId: project.id, reader });
           emitResult({ project, entries: result.entries }, result.formatted, asJson);
           return;
         }
@@ -67,7 +69,7 @@ export default defineCommand({
             emitError('query is required for "memorix memory graph-context"', asJson);
             return;
           }
-          const observations = getAllObservations();
+          const observations = filterReadableObservations(getAllObservations(), reader);
           const packet = buildGraphContextPacket(observations, {
             projectId: project.id,
             query,
@@ -92,7 +94,7 @@ export default defineCommand({
 
         case 'recent': {
           const limit = parsePositiveInt(args.limit as string | undefined, 10);
-          const observations = getProjectObservations(project.id)
+          const observations = filterReadableObservations(getProjectObservations(project.id), reader)
             .filter((obs) => (obs.status ?? 'active') === 'active')
             .slice(-limit)
             .reverse();
@@ -129,6 +131,7 @@ export default defineCommand({
             projectId: project.id,
             topicKey,
             source: 'manual',
+            visibilityReader: reader,
           });
           emitResult(
             { project, observation: result.observation, upserted: result.upserted },
@@ -166,7 +169,7 @@ export default defineCommand({
               ? `obs:${numericId}@${project.id}`
               : ref;
           });
-          const result = await compactDetail(scopedRefs);
+          const result = await compactDetail(scopedRefs, { reader });
           emitResult({ project, documents: result.documents }, result.formatted, asJson);
           return;
         }
@@ -182,6 +185,7 @@ export default defineCommand({
             project.id,
             parsePositiveInt(args.before as string | undefined, 3),
             parsePositiveInt(args.after as string | undefined, 3),
+            reader,
           );
           emitResult({ project, timeline: result.timeline }, result.formatted, asJson);
           return;
@@ -196,7 +200,15 @@ export default defineCommand({
             return;
           }
           const status = coerceObservationStatus(args.status as string | undefined);
-          const result = await resolveObservations(ids, status);
+          const authorizedIds = ids.filter((id) => {
+            const observation = getObservation(id, project.id);
+            return observation ? canManageObservation(observation, reader) : false;
+          });
+          if (authorizedIds.length === 0) {
+            emitError('No requested observations are manageable from the unbound CLI.', asJson);
+            return;
+          }
+          const result = await resolveObservations(authorizedIds, status);
           emitResult(
             { project, result, status },
             `Resolved ${result.resolved.length} observation(s) to ${status}${result.notFound.length > 0 ? `; not found: ${result.notFound.join(', ')}` : ''}`,
@@ -220,7 +232,10 @@ export default defineCommand({
 
           const { deduplicateMemory } = await import('../../llm/memory-manager.js');
           const allObs = await withFreshIndex(() =>
-            getAllObservations().filter((obs) => (obs.status ?? 'active') === 'active' && obs.projectId === project.id),
+            filterReadableObservations(
+              getAllObservations().filter((obs) => (obs.status ?? 'active') === 'active' && obs.projectId === project.id),
+              reader,
+            ),
           );
 
           if (allObs.length < 2) {
@@ -230,7 +245,7 @@ export default defineCommand({
 
           let candidates = allObs;
           if (query) {
-            const searchResult = await compactSearch({ query, limit: 20, projectId: project.id, status: 'active' });
+            const searchResult = await compactSearch({ query, limit: 20, projectId: project.id, status: 'active', reader });
             const ids = new Set(searchResult.entries.map((entry) => entry.id));
             candidates = allObs.filter((obs) => ids.has(obs.id));
           } else {
@@ -277,7 +292,13 @@ export default defineCommand({
             return;
           }
 
-          const result = await resolveObservations([...new Set(toResolve)], 'resolved');
+          const result = await resolveObservations(
+            [...new Set(toResolve)].filter((id) => {
+              const observation = getObservation(id, project.id);
+              return observation ? canManageObservation(observation, reader) : false;
+            }),
+            'resolved',
+          );
           emitResult(
             { project, actions, resolved: result.resolved, notFound: result.notFound, dryRun: false },
             `Resolved ${result.resolved.length} duplicate observation(s).`,
@@ -361,7 +382,10 @@ export default defineCommand({
             return;
           }
           const observations = await withFreshIndex(() => getAllObservations());
-          const matched = observations.filter((obs) => ids.includes(obs.id));
+          const matched = filterReadableObservations(
+            observations.filter((obs) => obs.projectId === project.id && ids.includes(obs.id)),
+            reader,
+          );
           if (matched.length === 0) {
             emitError(`No observations found for IDs: ${ids.join(', ')}`, asJson);
             return;

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -3,8 +3,17 @@ import { compactDetail, compactSearch, compactTimeline } from '../../compact/eng
 import { withFreshIndex } from '../../memory/freshness.js';
 import { getAllObservations, getObservation, getProjectObservations, resolveObservations, storeObservation, suggestTopicKey } from '../../memory/observations.js';
 import { buildGraphContextPacket, formatGraphContextPrompt } from '../../memory/graph-context.js';
-import { canManageObservation, filterReadableObservations } from '../../memory/visibility.js';
-import { emitError, emitResult, getCliProjectContext, parseCsvList, parsePositiveInt, coerceObservationStatus, coerceObservationType } from './operator-shared.js';
+import { canManageObservation, filterReadableObservations, resolveObservationVisibility } from '../../memory/visibility.js';
+import {
+  coerceObservationStatus,
+  coerceObservationType,
+  emitError,
+  emitResult,
+  getCliProjectContext,
+  parseCsvList,
+  parsePositiveInt,
+  resolveCliWriteScope,
+} from './operator-shared.js';
 
 export default defineCommand({
   meta: {
@@ -20,6 +29,7 @@ export default defineCommand({
     facts: { type: 'string', description: 'Comma-separated facts' },
     files: { type: 'string', description: 'Comma-separated file list' },
     concepts: { type: 'string', description: 'Comma-separated concept list' },
+    visibility: { type: 'string', description: 'Memory visibility: project (default), personal, or team' },
     ids: { type: 'string', description: 'Comma-separated observation IDs' },
     id: { type: 'string', description: 'Single observation ID' },
     status: { type: 'string', description: 'Resolved or archived' },
@@ -33,6 +43,7 @@ export default defineCommand({
     after: { type: 'string', description: 'Timeline depth after anchor' },
     threshold: { type: 'string', description: 'Similarity threshold for consolidate' },
     dryRun: { type: 'boolean', description: 'Preview changes without mutating data' },
+    'dry-run': { type: 'boolean', description: 'Kebab-case alias for --dryRun' },
     trigger: { type: 'string', description: 'Custom trigger text for promoted mini-skills' },
     instruction: { type: 'string', description: 'Custom instruction for promoted mini-skills' },
     tags: { type: 'string', description: 'Comma-separated extra tags for promoted mini-skills' },
@@ -45,8 +56,7 @@ export default defineCommand({
     const asJson = !!args.json;
 
     try {
-      const { project } = await getCliProjectContext({ searchIndex: true });
-      const reader = { projectId: project.id };
+      const { project, dataDir, reader, identity } = await getCliProjectContext({ searchIndex: true });
 
       switch (action) {
         case 'search': {
@@ -120,6 +130,10 @@ export default defineCommand({
             (args.topicKey as string | undefined)?.trim() ||
             suggestTopicKey(type, title) ||
             undefined;
+          const writeScope = resolveCliWriteScope(
+            { reader, identity },
+            args.visibility as string | undefined,
+          );
           const result = await storeObservation({
             entityName: (args.entity as string | undefined)?.trim() || 'general',
             type,
@@ -131,7 +145,7 @@ export default defineCommand({
             projectId: project.id,
             topicKey,
             source: 'manual',
-            visibilityReader: reader,
+            ...writeScope,
           });
           emitResult(
             { project, observation: result.observation, upserted: result.upserted },
@@ -205,7 +219,7 @@ export default defineCommand({
             return observation ? canManageObservation(observation, reader) : false;
           });
           if (authorizedIds.length === 0) {
-            emitError('No requested observations are manageable from the unbound CLI.', asJson);
+            emitError('No requested observations are manageable with the active CLI scope.', asJson);
             return;
           }
           const result = await resolveObservations(authorizedIds, status);
@@ -219,7 +233,7 @@ export default defineCommand({
 
         case 'deduplicate': {
           const query = (args.query as string | undefined)?.trim();
-          const dryRun = !!args.dryRun;
+          const dryRun = !!args.dryRun || !!args['dry-run'];
           const { isLLMEnabled } = await import('../../llm/provider.js');
           if (!isLLMEnabled()) {
             emitResult(
@@ -313,7 +327,7 @@ export default defineCommand({
           const { findConsolidationCandidates, executeConsolidation } = await import('../../memory/consolidation.js');
 
           if (consolidationAction === 'preview') {
-            const clusters = await findConsolidationCandidates(process.cwd(), project.id, { threshold });
+            const clusters = await findConsolidationCandidates(project.rootPath, project.id, { threshold });
             emitResult(
               { project, clusters, action: consolidationAction },
               clusters.length === 0
@@ -327,7 +341,7 @@ export default defineCommand({
           }
 
           if (consolidationAction === 'execute') {
-            const result = await executeConsolidation(process.cwd(), project.id, { threshold });
+            const result = await executeConsolidation(project.rootPath, project.id, { threshold });
             emitResult(
               { project, action: consolidationAction, ...result },
               result.clustersFound === 0
@@ -346,11 +360,10 @@ export default defineCommand({
           const promoteAction = (args.action as string | undefined) || 'promote';
           const { promoteToMiniSkill, loadAllMiniSkills, deleteMiniSkill } = await import('../../skills/mini-skills.js');
           const { initMiniSkillStore } = await import('../../store/mini-skill-store.js');
-          const { dataDir } = await getCliProjectContext();
           await initMiniSkillStore(dataDir);
 
           if (promoteAction === 'list') {
-            const skills = await loadAllMiniSkills(process.cwd());
+            const skills = await loadAllMiniSkills(project.rootPath);
             emitResult(
               { project, skills, action: promoteAction },
               skills.length === 0 ? 'No mini-skills found.' : skills.map((skill) => `- #${skill.id} ${skill.title}`).join('\n'),
@@ -365,7 +378,7 @@ export default defineCommand({
               emitError('skillId is required for "memorix memory promote --action delete"', asJson);
               return;
             }
-            const deleted = await deleteMiniSkill(process.cwd(), skillId);
+            const deleted = await deleteMiniSkill(project.rootPath, skillId);
             if (!deleted) {
               emitError(`Mini-skill #${skillId} not found`, asJson);
               return;
@@ -385,12 +398,12 @@ export default defineCommand({
           const matched = filterReadableObservations(
             observations.filter((obs) => obs.projectId === project.id && ids.includes(obs.id)),
             reader,
-          );
+          ).filter((observation) => resolveObservationVisibility(observation) === 'project');
           if (matched.length === 0) {
-            emitError(`No observations found for IDs: ${ids.join(', ')}`, asJson);
+            emitError(`No project-visible observations found for IDs: ${ids.join(', ')}. Private and team records cannot be promoted into shared skills.`, asJson);
             return;
           }
-          const skill = await promoteToMiniSkill(process.cwd(), project.id, matched, {
+          const skill = await promoteToMiniSkill(project.rootPath, project.id, matched, {
             trigger: args.trigger as string | undefined,
             instruction: args.instruction as string | undefined,
             tags: parseCsvList(args.tags as string | undefined),
@@ -409,7 +422,7 @@ export default defineCommand({
           console.log('Usage:');
           console.log('  memorix memory search --query "timeout bug" [--limit 10]');
           console.log('  memorix memory recent [--limit 10]');
-          console.log('  memorix memory store --text "..." [--title "..."] [--type discovery]');
+          console.log('  memorix memory store --text "..." [--title "..."] [--type discovery] [--visibility project|personal|team]');
           console.log('  memorix memory suggest-topic-key --type decision --title "..."');
           console.log('  memorix memory detail --id 42');
           console.log('  memorix memory detail obs:42@org/project');

--- a/src/cli/commands/message.ts
+++ b/src/cli/commands/message.ts
@@ -1,5 +1,5 @@
 import { defineCommand } from 'citty';
-import { emitError, emitResult, getCliProjectContext, shortId } from './operator-shared.js';
+import { emitError, emitResult, getCliProjectContext, resolveCliActorId, shortId } from './operator-shared.js';
 
 export default defineCommand({
   meta: {
@@ -22,12 +22,18 @@ export default defineCommand({
     const asJson = !!args.json;
 
     try {
-      const { project, teamStore } = await getCliProjectContext();
+      const { project, teamStore, identity } = await getCliProjectContext();
+      const senderAgentId = resolveCliActorId(args.from, identity, 'from');
+      const inboxAgentId = resolveCliActorId(
+        (args.agentId as string | undefined) ?? (args.from as string | undefined),
+        identity,
+        'agentId',
+      );
 
       switch (action) {
         case 'send': {
-          if (!args.from || !args.type || !args.content) {
-            emitError('from, type, and content are required for "memorix message send"', asJson);
+          if (!senderAgentId || !args.type || !args.content) {
+            emitError('type, content, and an active CLI identity or from agentId are required for "memorix message send"', asJson);
             return;
           }
           if (!args.to && !args.toRole) {
@@ -36,7 +42,7 @@ export default defineCommand({
           }
           const message = teamStore.sendMessage({
             projectId: project.id,
-            senderAgentId: args.from as string,
+            senderAgentId,
             recipientAgentId: (args.to as string | undefined) ?? null,
             type: args.type as string,
             content: args.content as string,
@@ -58,13 +64,13 @@ export default defineCommand({
         }
 
         case 'broadcast': {
-          if (!args.from || !args.type || !args.content) {
-            emitError('from, type, and content are required for "memorix message broadcast"', asJson);
+          if (!senderAgentId || !args.type || !args.content) {
+            emitError('type, content, and an active CLI identity or from agentId are required for "memorix message broadcast"', asJson);
             return;
           }
           const message = teamStore.sendMessage({
             projectId: project.id,
-            senderAgentId: args.from as string,
+            senderAgentId,
             recipientAgentId: null,
             type: args.type as string,
             content: args.content as string,
@@ -82,15 +88,14 @@ export default defineCommand({
         }
 
         case 'inbox': {
-          const agentId = (args.agentId as string | undefined) || (args.from as string | undefined);
-          if (!agentId) {
-            emitError('agentId is required for "memorix message inbox"', asJson);
+          if (!inboxAgentId) {
+            emitError('an active CLI identity or agentId is required for "memorix message inbox"', asJson);
             return;
           }
-          const messages = teamStore.getInbox(project.id, agentId);
-          const unreadCount = teamStore.getUnreadCount(project.id, agentId);
+          const messages = teamStore.getInbox(project.id, inboxAgentId);
+          const unreadCount = teamStore.getUnreadCount(project.id, inboxAgentId);
           if (args.markRead) {
-            teamStore.markAllRead(project.id, agentId);
+            teamStore.markAllRead(project.id, inboxAgentId);
           }
           emitResult(
             { project, unreadCount, messages },

--- a/src/cli/commands/operator-shared.ts
+++ b/src/cli/commands/operator-shared.ts
@@ -20,6 +20,16 @@ export async function getCliProjectContext(options?: { searchIndex?: boolean; pr
 
   const project = detection.project;
   const dataDir = await getProjectDataDir(project.id);
+  try {
+    const { MaintenanceTargetStore } = await import('../../runtime/maintenance-targets.js');
+    new MaintenanceTargetStore(dataDir).register({
+      projectId: project.id,
+      projectRoot: project.rootPath,
+      dataDir,
+    });
+  } catch {
+    // CLI reads remain available even if optional background maintenance metadata fails.
+  }
   await initObservations(dataDir);
   await initSessionStore(dataDir);
   const teamStore = await initTeamStore(dataDir);

--- a/src/cli/commands/operator-shared.ts
+++ b/src/cli/commands/operator-shared.ts
@@ -3,16 +3,33 @@ import { getProjectDataDir } from '../../store/persistence.js';
 import { initObservations, prepareSearchIndex } from '../../memory/observations.js';
 import { initSessionStore } from '../../store/session-store.js';
 import { initTeamStore, type TeamStore } from '../../team/team-store.js';
-import type { ProjectInfo, ObservationType, ObservationStatus } from '../../types.js';
+import type {
+  ProjectInfo,
+  ObservationReader,
+  ObservationStatus,
+  ObservationType,
+  ObservationVisibility,
+} from '../../types.js';
+import { getCliInvocation } from '../invocation.js';
+import { resolveCliIdentity, type CliIdentity } from '../identity.js';
 
 export interface CliProjectContext {
   project: ProjectInfo;
   dataDir: string;
   teamStore: TeamStore;
+  reader: ObservationReader;
+  identity: CliIdentity | null;
+  identityWarning?: string;
 }
 
 export async function getCliProjectContext(options?: { searchIndex?: boolean; projectRoot?: string }): Promise<CliProjectContext> {
-  const detection = detectProjectWithDiagnostics(options?.projectRoot ?? process.cwd());
+  const invocation = getCliInvocation();
+  const detection = detectProjectWithDiagnostics(
+    options?.projectRoot
+      ?? invocation.projectRoot
+      ?? process.env.MEMORIX_PROJECT_ROOT
+      ?? process.cwd(),
+  );
   if (!detection.project) {
     const detail = detection.failure?.detail ?? 'No git repository found in the current directory.';
     throw new Error(detail);
@@ -38,7 +55,21 @@ export async function getCliProjectContext(options?: { searchIndex?: boolean; pr
     await prepareSearchIndex();
   }
 
-  return { project, dataDir, teamStore };
+  const identity = await resolveCliIdentity({
+    project,
+    dataDir,
+    teamStore,
+    explicitActorId: invocation.actorId,
+  });
+
+  return {
+    project,
+    dataDir,
+    teamStore,
+    reader: identity.reader,
+    identity: identity.identity,
+    ...(identity.warning ? { identityWarning: identity.warning } : {}),
+  };
 }
 
 export function emitResult<T>(data: T, text: string, asJson?: boolean): void {
@@ -117,4 +148,58 @@ export function coerceObservationStatus(input?: string): ObservationStatus {
     );
   }
   return normalized;
+}
+
+export function coerceObservationVisibility(input?: string): ObservationVisibility {
+  const normalized = (input ?? 'project').trim().toLowerCase();
+  if (normalized === 'personal' || normalized === 'project' || normalized === 'team') {
+    return normalized;
+  }
+  throw new Error('visibility must be personal, project, or team');
+}
+
+/**
+ * Project scope is deliberately the default. Private and team-scoped records
+ * require an identity selected by the operator, so a plain shell does not
+ * accidentally gain access to another agent's work.
+ */
+export function resolveCliWriteScope(
+  context: Pick<CliProjectContext, 'identity' | 'reader'>,
+  visibilityInput?: string,
+): {
+  visibility: ObservationVisibility;
+  createdByAgentId?: string;
+  visibilityReader: ObservationReader;
+} {
+  const visibility = coerceObservationVisibility(visibilityInput);
+  if (visibility !== 'project' && !context.identity) {
+    throw new Error(
+      `visibility=${visibility} requires an active CLI identity. Run "memorix identity join --agent-type <agent>" or "memorix identity use --agent-id <id>" first.`,
+    );
+  }
+  if (visibility === 'team' && context.reader.isTeamMember !== true) {
+    throw new Error('team visibility requires an active coordination identity for this project.');
+  }
+
+  return {
+    visibility,
+    ...(context.identity ? { createdByAgentId: context.identity.agentId } : {}),
+    visibilityReader: context.reader,
+  };
+}
+
+/**
+ * Coordination commands can use the current CLI identity implicitly, while
+ * retaining explicit IDs for scripts and backwards-compatible invocations.
+ */
+export function resolveCliActorId(
+  explicitValue: unknown,
+  identity: CliIdentity | null,
+  field = 'agentId',
+): string | undefined {
+  const explicit = typeof explicitValue === 'string' ? explicitValue.trim() : '';
+  if (identity && explicit && explicit !== identity.agentId) {
+    throw new Error(`${field} does not match the active CLI identity. Use "memorix identity clear" before acting as a different agent.`);
+  }
+  return explicit || identity?.agentId;
 }

--- a/src/cli/commands/poll.ts
+++ b/src/cli/commands/poll.ts
@@ -3,6 +3,8 @@ import { computePoll, computeWatermark } from '../../team/poll.js';
 import { getObservationStore } from '../../store/obs-store.js';
 import { getAllObservations } from '../../memory/observations.js';
 import { withFreshIndex } from '../../memory/freshness.js';
+import { filterReadableObservations } from '../../memory/visibility.js';
+import type { ObservationReader } from '../../types.js';
 import { emitError, emitResult, getCliProjectContext, shortId } from './operator-shared.js';
 
 export default defineCommand({
@@ -21,20 +23,29 @@ export default defineCommand({
     try {
       const { project, teamStore } = await getCliProjectContext();
       const agentId = args.agentId as string | undefined;
+      let reader: ObservationReader = { projectId: project.id };
 
       let watermark = computeWatermark(0, 0, 0);
       if (agentId) {
         const agent = teamStore.getAgent(agentId);
-        if (!agent) {
+        if (!agent || agent.project_id !== project.id) {
           emitError(`Unknown agent "${agentId}"`, asJson);
           return;
         }
+        reader = {
+          projectId: project.id,
+          agentId,
+          isTeamMember: agent.status === 'active',
+        };
 
         const lastSeen = agent.last_seen_obs_generation;
         const currentGen = getObservationStore().getGeneration();
         const projectObs = await withFreshIndex(() =>
-          getAllObservations().filter(
-            (obs) => obs.projectId === project.id && (obs.writeGeneration ?? 0) > lastSeen,
+          filterReadableObservations(
+            getAllObservations().filter(
+              (obs) => obs.projectId === project.id && (obs.writeGeneration ?? 0) > lastSeen,
+            ),
+            reader,
           ),
         );
         watermark = computeWatermark(lastSeen, currentGen, projectObs.length);

--- a/src/cli/commands/poll.ts
+++ b/src/cli/commands/poll.ts
@@ -4,8 +4,7 @@ import { getObservationStore } from '../../store/obs-store.js';
 import { getAllObservations } from '../../memory/observations.js';
 import { withFreshIndex } from '../../memory/freshness.js';
 import { filterReadableObservations } from '../../memory/visibility.js';
-import type { ObservationReader } from '../../types.js';
-import { emitError, emitResult, getCliProjectContext, shortId } from './operator-shared.js';
+import { emitError, emitResult, getCliProjectContext, resolveCliActorId, shortId } from './operator-shared.js';
 
 export default defineCommand({
   meta: {
@@ -21,9 +20,9 @@ export default defineCommand({
     const asJson = !!args.json;
 
     try {
-      const { project, teamStore } = await getCliProjectContext();
-      const agentId = args.agentId as string | undefined;
-      let reader: ObservationReader = { projectId: project.id };
+      const { project, teamStore, identity, reader: activeReader } = await getCliProjectContext();
+      const agentId = resolveCliActorId(args.agentId, identity);
+      let reader = activeReader;
 
       let watermark = computeWatermark(0, 0, 0);
       if (agentId) {

--- a/src/cli/commands/reasoning.ts
+++ b/src/cli/commands/reasoning.ts
@@ -31,6 +31,7 @@ export default defineCommand({
 
     try {
       const { project } = await getCliProjectContext({ searchIndex: action === 'search' });
+      const reader = { projectId: project.id };
 
       switch (action) {
         case 'store': {
@@ -108,6 +109,7 @@ export default defineCommand({
             type: 'reasoning',
             projectId: scope === 'global' ? undefined : project.id,
             status: 'active',
+            reader: scope === 'global' ? {} : reader,
           });
           emitResult(
             { project, scope, entries: result.entries },

--- a/src/cli/commands/reasoning.ts
+++ b/src/cli/commands/reasoning.ts
@@ -1,7 +1,14 @@
 import { defineCommand } from 'citty';
 import { compactSearch } from '../../compact/engine.js';
 import { storeObservation } from '../../memory/observations.js';
-import { emitError, emitResult, getCliProjectContext, parseCsvList, parsePositiveInt } from './operator-shared.js';
+import {
+  emitError,
+  emitResult,
+  getCliProjectContext,
+  parseCsvList,
+  parsePositiveInt,
+  resolveCliWriteScope,
+} from './operator-shared.js';
 
 export default defineCommand({
   meta: {
@@ -20,6 +27,7 @@ export default defineCommand({
     files: { type: 'string', description: 'Comma-separated file list' },
     relatedCommits: { type: 'string', description: 'Comma-separated related commit hashes' },
     relatedEntities: { type: 'string', description: 'Comma-separated related entity names' },
+    visibility: { type: 'string', description: 'Reasoning visibility: project (default), personal, or team' },
     query: { type: 'string', description: 'Search query for reasoning traces' },
     limit: { type: 'string', description: 'Search result limit' },
     scope: { type: 'string', description: 'project or global scope for search' },
@@ -30,8 +38,7 @@ export default defineCommand({
     const asJson = !!args.json;
 
     try {
-      const { project } = await getCliProjectContext({ searchIndex: action === 'search' });
-      const reader = { projectId: project.id };
+      const { project, reader, identity } = await getCliProjectContext({ searchIndex: action === 'search' });
 
       switch (action) {
         case 'store': {
@@ -64,6 +71,10 @@ export default defineCommand({
           if (risks.length > 0) {
             narrativeParts.push(`Risks: ${risks.join('; ')}`);
           }
+          const writeScope = resolveCliWriteScope(
+            { reader, identity },
+            args.visibility as string | undefined,
+          );
 
           const result = await storeObservation({
             entityName,
@@ -85,6 +96,7 @@ export default defineCommand({
             relatedEntities,
             projectId: project.id,
             source: 'manual',
+            ...writeScope,
           });
 
           emitResult(
@@ -123,7 +135,7 @@ export default defineCommand({
           console.log('Memorix Reasoning Commands');
           console.log('');
           console.log('Usage:');
-          console.log('  memorix reasoning store --entity auth --decision "Use SQLite" --rationale "..."');
+          console.log('  memorix reasoning store --entity auth --decision "Use SQLite" --rationale "..." [--visibility project|personal|team]');
           console.log('  memorix reasoning search --query "why sqlite" [--scope project|global --limit 10]');
       }
     } catch (error) {

--- a/src/cli/commands/retention.ts
+++ b/src/cli/commands/retention.ts
@@ -24,6 +24,8 @@ function toDocument(obs: Awaited<ReturnType<typeof getAllObservations>>[number])
     source: obs.source ?? 'agent',
     sourceDetail: obs.sourceDetail ?? '',
     valueCategory: obs.valueCategory ?? '',
+    admissionState: obs.admissionState ?? '',
+    admissionReason: obs.admissionReason ?? '',
   };
 }
 

--- a/src/cli/commands/retention.ts
+++ b/src/cli/commands/retention.ts
@@ -1,6 +1,7 @@
 import { defineCommand } from 'citty';
 import { getAllObservations } from '../../memory/observations.js';
 import { archiveExpired, explainRetention, getArchiveCandidates, getRetentionSummary, getRetentionZone, rankByRelevance } from '../../memory/retention.js';
+import { filterReadableObservations } from '../../memory/visibility.js';
 import type { MemorixDocument } from '../../types.js';
 import { emitError, emitResult, getCliProjectContext } from './operator-shared.js';
 
@@ -43,8 +44,11 @@ export default defineCommand({
 
     try {
       const { project, dataDir } = await getCliProjectContext();
-      const activeDocs = getAllObservations()
-        .filter((obs) => obs.projectId === project.id && (obs.status ?? 'active') === 'active')
+      const reader = { projectId: project.id };
+      const activeDocs = filterReadableObservations(
+        getAllObservations().filter((obs) => obs.projectId === project.id && (obs.status ?? 'active') === 'active'),
+        reader,
+      )
         .map(toDocument);
 
       switch (action) {
@@ -67,7 +71,7 @@ export default defineCommand({
         }
 
         case 'archive': {
-          const result = await archiveExpired(dataDir, undefined, undefined, project.id);
+          const result = await archiveExpired(dataDir, undefined, undefined, project.id, reader);
           emitResult(
             { project, result },
             result.archived === 0

--- a/src/cli/commands/retention.ts
+++ b/src/cli/commands/retention.ts
@@ -43,8 +43,7 @@ export default defineCommand({
     const asJson = !!args.json;
 
     try {
-      const { project, dataDir } = await getCliProjectContext();
-      const reader = { projectId: project.id };
+      const { project, dataDir, reader } = await getCliProjectContext();
       const activeDocs = filterReadableObservations(
         getAllObservations().filter((obs) => obs.projectId === project.id && (obs.status ?? 'active') === 'active'),
         reader,

--- a/src/cli/commands/serve-http.ts
+++ b/src/cli/commands/serve-http.ts
@@ -24,6 +24,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { ObservationStore } from '../../store/obs-store.js';
 import { resolveToolProfile } from '../../server/tool-profile.js';
 import { scopeKnowledgeGraphToProject } from '../../memory/graph-scope.js';
+import { canManageObservation, filterReadableObservations } from '../../memory/visibility.js';
 
 export const DEFAULT_SESSION_TIMEOUT_MS = 30 * 60 * 1000;
 
@@ -558,7 +559,7 @@ export default defineCommand({
 
     async function loadDashboardObservations(dataDir: string) {
       const store = await getDashboardObservationStore(dataDir);
-      return store.loadAll();
+      return filterReadableObservations(await store.loadAll(), {});
     }
 
     async function loadDashboardProjectObservations(
@@ -567,7 +568,10 @@ export default defineCommand({
       status?: string,
     ) {
       const store = await getDashboardObservationStore(dataDir);
-      return store.loadByProject(projectId, status ? { status } : undefined);
+      return filterReadableObservations(
+        await store.loadByProject(projectId, status ? { status } : undefined),
+        { projectId },
+      );
     }
 
     // Resolve static directory (dist/dashboard/static)
@@ -1321,6 +1325,8 @@ export default defineCommand({
             sendJson({ error: 'Observation not found' }, 404);
           } else if ((matchObs as any).projectId !== delProjectId) {
             sendJson({ error: `Observation #${obsId} belongs to project "${(matchObs as any).projectId}", not "${delProjectId}"` }, 403);
+          } else if (!canManageObservation(matchObs, { projectId: delProjectId })) {
+            sendJson({ error: `Observation #${obsId} is not manageable from the unbound dashboard.` }, 403);
           } else {
             await store.remove(obsId);
             // Sync: clean up graph entity references

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -6,6 +6,7 @@ import { withFreshIndex } from '../../memory/freshness.js';
 import { getAllObservations } from '../../memory/observations.js';
 import { getObservationStore } from '../../store/obs-store.js';
 import { filterReadableObservations } from '../../memory/visibility.js';
+import { saveCliIdentity } from '../identity.js';
 import { emitError, emitResult, getCliProjectContext, parsePositiveInt } from './operator-shared.js';
 
 export default defineCommand({
@@ -19,6 +20,7 @@ export default defineCommand({
     instanceId: { type: 'string', description: 'Stable instance identity across restarts' },
     projectRoot: { type: 'string', description: 'Absolute project root used to bind the session context' },
     joinTeam: { type: 'boolean', description: 'Explicitly join orchestration coordination state for this session' },
+    use: { type: 'boolean', description: 'Make the joined coordination identity active for later CLI commands' },
     role: { type: 'string', description: 'Explicit role override used only when --joinTeam is set' },
     sessionId: { type: 'string', description: 'Custom session ID (optional)' },
     summary: { type: 'string', description: 'Structured session summary for session end' },
@@ -36,6 +38,14 @@ export default defineCommand({
 
       switch (action) {
         case 'start': {
+          if (args.use && !args.joinTeam) {
+            emitError('use requires --joinTeam when starting a session.', asJson);
+            return;
+          }
+          if (args.use && !args.agent && !args.agentType) {
+            emitError('use requires --agent or --agentType so Memorix can activate a coordination identity.', asJson);
+            return;
+          }
           const result = await startSession(dataDir, project.id, {
             sessionId: args.sessionId as string | undefined,
             agent: args.agent as string | undefined,
@@ -60,6 +70,16 @@ export default defineCommand({
             });
           } else if (shouldJoinTeam) {
             teamJoinNotice = 'Coordination join skipped: provide --agent or --agentType to create a coordination identity.';
+          }
+
+          let identityActivated = false;
+          if (args.use && agentRecord) {
+            await saveCliIdentity(dataDir, {
+              agentId: agentRecord.agent_id,
+              projectId: project.id,
+              activatedAt: new Date().toISOString(),
+            });
+            identityActivated = true;
           }
 
           let watermark = computeWatermark(0, 0, 0);
@@ -101,6 +121,7 @@ export default defineCommand({
               joined: !!agentRecord,
               notice: teamJoinNotice,
             },
+            identityActivated,
             watermark,
             rescue: {
               staleAgents: rescuedAgentIds,
@@ -117,6 +138,7 @@ export default defineCommand({
             agentRecord
               ? `Agent: ${agentRecord.name} [${agentRecord.agent_type}] as ${agentRecord.role} (${agentRecord.agent_id})`
               : '',
+            identityActivated ? 'CLI identity activated for follow-up memory and coordination commands.' : '',
             !agentRecord ? 'Coordination identity: not joined (memory/session context only)' : '',
             teamJoinNotice ?? '',
             agentRecord && watermark.newObservationCount > 0
@@ -177,7 +199,7 @@ export default defineCommand({
           console.log('Memorix Session Commands');
           console.log('');
           console.log('Usage:');
-          console.log('  memorix session start [--agent codex --agentType codex --instanceId abc] [--projectRoot <path>] [--joinTeam]');
+          console.log('  memorix session start [--agent codex --agentType codex --instanceId abc] [--projectRoot <path>] [--joinTeam --use]');
           console.log('  memorix session end --sessionId <id> [--summary "..."]');
           console.log('  memorix session context [--limit 3]');
           console.log('');

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -5,6 +5,7 @@ import { computeWatermark } from '../../team/poll.js';
 import { withFreshIndex } from '../../memory/freshness.js';
 import { getAllObservations } from '../../memory/observations.js';
 import { getObservationStore } from '../../store/obs-store.js';
+import { filterReadableObservations } from '../../memory/visibility.js';
 import { emitError, emitResult, getCliProjectContext, parsePositiveInt } from './operator-shared.js';
 
 export default defineCommand({
@@ -70,8 +71,11 @@ export default defineCommand({
             const store = getObservationStore();
             const currentGen = store.getGeneration();
             const projectObs = await withFreshIndex(() =>
-              getAllObservations().filter(
-                (obs) => obs.projectId === project.id && (obs.writeGeneration ?? 0) > lastSeen,
+              filterReadableObservations(
+                getAllObservations().filter(
+                  (obs) => obs.projectId === project.id && (obs.writeGeneration ?? 0) > lastSeen,
+                ),
+                { projectId: project.id, agentId: agentRecord.agent_id, isTeamMember: agentRecord.status === 'active' },
               ),
             );
             watermark = computeWatermark(lastSeen, currentGen, projectObs.length);

--- a/src/cli/commands/skills.ts
+++ b/src/cli/commands/skills.ts
@@ -1,6 +1,7 @@
 import { defineCommand } from 'citty';
 import type { AgentTarget } from '../../types.js';
 import { getObservationStore } from '../../store/obs-store.js';
+import { filterReadableObservations } from '../../memory/visibility.js';
 import { emitError, emitResult, getCliProjectContext } from './operator-shared.js';
 
 export default defineCommand({
@@ -37,8 +38,10 @@ export default defineCommand({
         }
 
         case 'generate': {
-          const observations = (await getObservationStore().loadAll())
-            .filter((obs) => obs.projectId === project.id)
+          const observations = filterReadableObservations(
+            await getObservationStore().loadAll(),
+            { projectId: project.id },
+          )
             .map((obs) => ({
               id: obs.id,
               entityName: obs.entityName,
@@ -82,8 +85,10 @@ export default defineCommand({
             return;
           }
 
-          const observations = (await getObservationStore().loadAll())
-            .filter((obs) => obs.projectId === project.id)
+          const observations = filterReadableObservations(
+            await getObservationStore().loadAll(),
+            { projectId: project.id },
+          )
             .map((obs) => ({
               id: obs.id,
               entityName: obs.entityName,

--- a/src/cli/commands/skills.ts
+++ b/src/cli/commands/skills.ts
@@ -1,7 +1,7 @@
 import { defineCommand } from 'citty';
 import type { AgentTarget } from '../../types.js';
 import { getObservationStore } from '../../store/obs-store.js';
-import { filterReadableObservations } from '../../memory/visibility.js';
+import { filterReadableObservations, resolveObservationVisibility } from '../../memory/visibility.js';
 import { emitError, emitResult, getCliProjectContext } from './operator-shared.js';
 
 export default defineCommand({
@@ -20,7 +20,7 @@ export default defineCommand({
     const asJson = !!args.json;
 
     try {
-      const { project } = await getCliProjectContext();
+      const { project, reader } = await getCliProjectContext();
       const { SkillsEngine } = await import('../../skills/engine.js');
       const engine = new SkillsEngine(project.rootPath);
 
@@ -40,8 +40,8 @@ export default defineCommand({
         case 'generate': {
           const observations = filterReadableObservations(
             await getObservationStore().loadAll(),
-            { projectId: project.id },
-          )
+            reader,
+          ).filter((observation) => resolveObservationVisibility(observation) === 'project')
             .map((obs) => ({
               id: obs.id,
               entityName: obs.entityName,
@@ -87,8 +87,8 @@ export default defineCommand({
 
           const observations = filterReadableObservations(
             await getObservationStore().loadAll(),
-            { projectId: project.id },
-          )
+            reader,
+          ).filter((observation) => resolveObservationVisibility(observation) === 'project')
             .map((obs) => ({
               id: obs.id,
               entityName: obs.entityName,

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -39,8 +39,8 @@ export default defineCommand({
       const { initObservationStore, getObservationStore } = await import('../../store/obs-store.js');
       await initObservationStore(dataDir);
       const store = getObservationStore();
-      const data = await store.loadAll() as Array<{ projectId?: string; status?: string }>;
-      const projectObs = data.filter(o => o.projectId === project.id);
+      const { filterReadableObservations } = await import('../../memory/visibility.js');
+      const projectObs = filterReadableObservations(await store.loadAll(), { projectId: project.id });
       obsCount = projectObs.length;
       activeCount = projectObs.filter(o => (o.status ?? 'active') === 'active').length;
     } catch { /* ignore */ }
@@ -165,7 +165,8 @@ export default defineCommand({
       const { initObservationStore, getObservationStore } = await import('../../store/obs-store.js');
       await initObservationStore(dataDir);
       const store = getObservationStore();
-      const allObs = await store.loadAll() as Array<{ source?: string; type?: string }>;
+      const { filterReadableObservations } = await import('../../memory/visibility.js');
+      const allObs = filterReadableObservations(await store.loadAll(), { projectId: project.id });
       const gitCount = allObs.filter(o => o.source === 'git').length;
       const reasoningCount = allObs.filter(o => o.type === 'reasoning').length;
       if (gitCount > 0 || reasoningCount > 0) {

--- a/src/cli/commands/task.ts
+++ b/src/cli/commands/task.ts
@@ -1,5 +1,13 @@
 import { defineCommand } from 'citty';
-import { emitError, emitResult, getCliProjectContext, parseCsvList, parseOptionalJsonObject, shortId } from './operator-shared.js';
+import {
+  emitError,
+  emitResult,
+  getCliProjectContext,
+  parseCsvList,
+  parseOptionalJsonObject,
+  resolveCliActorId,
+  shortId,
+} from './operator-shared.js';
 
 export default defineCommand({
   meta: {
@@ -24,7 +32,8 @@ export default defineCommand({
     const asJson = !!args.json;
 
     try {
-      const { project, teamStore } = await getCliProjectContext();
+      const { project, teamStore, identity } = await getCliProjectContext();
+      const agentId = resolveCliActorId(args.agentId, identity);
 
       switch (action) {
         case 'create': {
@@ -51,7 +60,7 @@ export default defineCommand({
             description: args.description as string,
             deps: parseCsvList(args.deps as string | undefined),
             metadata,
-            createdBy: args.agentId as string | undefined,
+            createdBy: agentId,
             requiredRole: args.requiredRole as string | undefined,
             preferredRole: args.preferredRole as string | undefined,
           });
@@ -65,11 +74,11 @@ export default defineCommand({
         }
 
         case 'claim': {
-          if (!args.taskId || !args.agentId) {
-            emitError('taskId and agentId are required for "memorix task claim"', asJson);
+          if (!args.taskId || !agentId) {
+            emitError('taskId and an active CLI identity or agentId are required for "memorix task claim"', asJson);
             return;
           }
-          const result = teamStore.claimTask(args.taskId as string, args.agentId as string);
+          const result = teamStore.claimTask(args.taskId as string, agentId);
           if (!result.success) {
             emitError(result.reason ?? 'Unable to claim task', asJson);
             return;
@@ -83,11 +92,11 @@ export default defineCommand({
         }
 
         case 'complete': {
-          if (!args.taskId || !args.agentId || !args.result) {
-            emitError('taskId, agentId, and result are required for "memorix task complete"', asJson);
+          if (!args.taskId || !agentId || !args.result) {
+            emitError('taskId, result, and an active CLI identity or agentId are required for "memorix task complete"', asJson);
             return;
           }
-          const result = teamStore.completeTask(args.taskId as string, args.agentId as string, args.result as string);
+          const result = teamStore.completeTask(args.taskId as string, agentId, args.result as string);
           if (!result.success) {
             emitError(result.reason ?? 'Unable to complete task', asJson);
             return;
@@ -101,11 +110,11 @@ export default defineCommand({
         }
 
         case 'fail': {
-          if (!args.taskId || !args.agentId || !args.result) {
-            emitError('taskId, agentId, and result are required for "memorix task fail"', asJson);
+          if (!args.taskId || !agentId || !args.result) {
+            emitError('taskId, result, and an active CLI identity or agentId are required for "memorix task fail"', asJson);
             return;
           }
-          const result = teamStore.failTask(args.taskId as string, args.agentId as string, args.result as string);
+          const result = teamStore.failTask(args.taskId as string, agentId, args.result as string);
           if (!result.success) {
             emitError(result.reason ?? 'Unable to fail task', asJson);
             return;
@@ -119,11 +128,11 @@ export default defineCommand({
         }
 
         case 'release': {
-          if (!args.taskId || !args.agentId) {
-            emitError('taskId and agentId are required for "memorix task release"', asJson);
+          if (!args.taskId || !agentId) {
+            emitError('taskId and an active CLI identity or agentId are required for "memorix task release"', asJson);
             return;
           }
-          const result = teamStore.releaseTask(args.taskId as string, args.agentId as string);
+          const result = teamStore.releaseTask(args.taskId as string, agentId);
           if (!result.success) {
             emitError(result.reason ?? 'Unable to release task', asJson);
             return;
@@ -138,8 +147,8 @@ export default defineCommand({
 
         case 'list': {
           const tasks =
-            args.available && args.agentId
-              ? teamStore.listTasksForAgent(project.id, args.agentId as string)
+            args.available && agentId
+              ? teamStore.listTasksForAgent(project.id, agentId)
               : teamStore.listTasks(
                   project.id,
                   args.available

--- a/src/cli/commands/team.ts
+++ b/src/cli/commands/team.ts
@@ -1,6 +1,7 @@
 import { defineCommand } from 'citty';
 import { AGENT_TYPE_ROLE_MAP } from '../../team/team-store.js';
-import { emitError, emitResult, getCliProjectContext, parseCsvList, parsePositiveInt, shortId } from './operator-shared.js';
+import { clearCliIdentity } from '../identity.js';
+import { emitError, emitResult, getCliProjectContext, parseCsvList, parsePositiveInt, resolveCliActorId, shortId } from './operator-shared.js';
 
 export default defineCommand({
   meta: {
@@ -27,7 +28,8 @@ export default defineCommand({
     const asJson = !!args.json;
 
     try {
-      const { project, teamStore } = await getCliProjectContext();
+      const { project, dataDir, teamStore, identity } = await getCliProjectContext();
+      const selectedAgentId = resolveCliActorId(args.agentId, identity);
 
       switch (action) {
         case 'join': {
@@ -53,20 +55,22 @@ export default defineCommand({
         }
 
         case 'leave': {
-          const agentId = args.agentId as string | undefined;
-          if (!agentId) {
-            emitError('agentId is required for "memorix team leave"', asJson);
+          if (!selectedAgentId) {
+            emitError('an active CLI identity or agentId is required for "memorix team leave"', asJson);
             return;
           }
-          const left = teamStore.leaveAgent(agentId);
-          const releasedLocks = teamStore.releaseAllLocks(agentId);
-          const releasedTasks = teamStore.releaseTasksByAgent(agentId);
+          const left = teamStore.leaveAgent(selectedAgentId);
+          const releasedLocks = teamStore.releaseAllLocks(selectedAgentId);
+          const releasedTasks = teamStore.releaseTasksByAgent(selectedAgentId);
           if (!left) {
-            emitError(`Agent "${agentId}" not found`, asJson);
+            emitError(`Agent "${selectedAgentId}" not found`, asJson);
             return;
+          }
+          if (identity?.agentId === selectedAgentId) {
+            await clearCliIdentity(dataDir);
           }
           emitResult(
-            { project, agentId, releasedLocks, releasedTasks },
+            { project, agentId: selectedAgentId, releasedLocks, releasedTasks },
             `Left team: released ${releasedLocks} lock(s), ${releasedTasks} task(s)`,
             asJson,
           );

--- a/src/cli/commands/transfer.ts
+++ b/src/cli/commands/transfer.ts
@@ -1,6 +1,40 @@
 import { defineCommand } from 'citty';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
 import { exportAsJson, exportAsMarkdown, importFromJson } from '../../memory/export-import.js';
 import { emitError, emitResult, getCliProjectContext } from './operator-shared.js';
+
+async function readStandardInput(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let content = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      content += chunk;
+    });
+    process.stdin.on('end', () => resolve(content));
+    process.stdin.on('error', reject);
+  });
+}
+
+async function readImportPayload(args: Record<string, unknown>, projectRoot: string): Promise<string> {
+  const data = typeof args.data === 'string' ? args.data.trim() : '';
+  const file = typeof args.file === 'string' ? args.file.trim() : '';
+  const readFromStdin = args.stdin === true || data === '-';
+  const sources = Number(Boolean(data && data !== '-')) + Number(Boolean(file)) + Number(readFromStdin);
+  if (sources !== 1) {
+    throw new Error('Choose exactly one import source: --data <json>, --file <path>, or --stdin.');
+  }
+  if (readFromStdin) return readStandardInput();
+  if (file) return fs.readFile(path.resolve(projectRoot, file), 'utf8');
+  return data;
+}
+
+async function writeExportPayload(projectRoot: string, output: string, payload: string): Promise<string> {
+  const outputPath = path.resolve(projectRoot, output);
+  await fs.mkdir(path.dirname(outputPath), { recursive: true });
+  await fs.writeFile(outputPath, payload, 'utf8');
+  return outputPath;
+}
 
 export default defineCommand({
   meta: {
@@ -10,6 +44,9 @@ export default defineCommand({
   args: {
     format: { type: 'string', description: 'Export format: json or markdown' },
     data: { type: 'string', description: 'JSON payload from a previous export' },
+    file: { type: 'string', description: 'File containing a JSON payload to import' },
+    stdin: { type: 'boolean', description: 'Read a JSON import payload from standard input' },
+    out: { type: 'string', description: 'Write the export payload to this file instead of stdout' },
     json: { type: 'boolean', description: 'Emit machine-readable JSON output' },
   },
   run: async ({ args }) => {
@@ -17,31 +54,45 @@ export default defineCommand({
     const asJson = !!args.json;
 
     try {
-      const { project, dataDir } = await getCliProjectContext();
+      const { project, dataDir, reader } = await getCliProjectContext();
 
       switch (action) {
         case 'export': {
           const format = (args.format as string | undefined) === 'markdown' ? 'markdown' : 'json';
           if (format === 'markdown') {
-            const markdown = await exportAsMarkdown(dataDir, project.id);
+            const markdown = await exportAsMarkdown(dataDir, project.id, reader);
+            const output = (args.out as string | undefined)?.trim();
+            if (output) {
+              const outputPath = await writeExportPayload(project.rootPath, output, markdown);
+              emitResult({ project, format, outputPath }, `Export written: ${outputPath}`, asJson);
+              return;
+            }
             emitResult({ project, format, markdown }, markdown, asJson);
             return;
           }
-          const exported = await exportAsJson(dataDir, project.id);
+          const exported = await exportAsJson(dataDir, project.id, reader);
+          const serialized = JSON.stringify(exported, null, 2);
+          const output = (args.out as string | undefined)?.trim();
+          if (output) {
+            const outputPath = await writeExportPayload(project.rootPath, output, `${serialized}\n`);
+            emitResult(
+              { project, format, outputPath, stats: exported.stats },
+              `Export written: ${outputPath}`,
+              asJson,
+            );
+            return;
+          }
           emitResult(
             { project, format, export: exported },
-            JSON.stringify(exported, null, 2),
+            serialized,
             asJson,
           );
           return;
         }
 
         case 'import': {
-          const raw = (args.data as string | undefined)?.trim();
-          if (!raw) {
-            emitError('data is required for "memorix transfer import"', asJson);
-            return;
-          }
+          const raw = (await readImportPayload(args as Record<string, unknown>, project.rootPath)).trim();
+          if (!raw) throw new Error('Import payload is empty.');
           let parsed: Parameters<typeof importFromJson>[1];
           try {
             parsed = JSON.parse(raw);
@@ -62,7 +113,9 @@ export default defineCommand({
           console.log('Memorix Transfer Commands');
           console.log('');
           console.log('Usage:');
-          console.log('  memorix transfer export [--format json|markdown]');
+          console.log('  memorix transfer export [--format json|markdown] [--out ./.memorix-export.json]');
+          console.log('  memorix transfer import --file ./.memorix-export.json');
+          console.log('  memorix transfer import --stdin');
           console.log('  memorix transfer import --data "<json>"');
       }
     } catch (error) {

--- a/src/cli/identity.ts
+++ b/src/cli/identity.ts
@@ -1,0 +1,89 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import type { ObservationReader, ProjectInfo } from '../types.js';
+import type { TeamStore } from '../team/team-store.js';
+
+export interface CliIdentity {
+  agentId: string;
+  projectId: string;
+  activatedAt: string;
+}
+
+export interface CliIdentityResolution {
+  identity: CliIdentity | null;
+  reader: ObservationReader;
+  warning?: string;
+}
+
+function identityPath(dataDir: string): string {
+  return path.join(dataDir, 'cli-identity.json');
+}
+
+function isCliIdentity(value: unknown): value is CliIdentity {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Partial<CliIdentity>;
+  return typeof candidate.agentId === 'string'
+    && typeof candidate.projectId === 'string'
+    && typeof candidate.activatedAt === 'string';
+}
+
+export async function loadCliIdentity(dataDir: string, projectId: string): Promise<CliIdentity | null> {
+  try {
+    const parsed = JSON.parse(await fs.readFile(identityPath(dataDir), 'utf8'));
+    return isCliIdentity(parsed) && parsed.projectId === projectId ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function saveCliIdentity(dataDir: string, identity: CliIdentity): Promise<void> {
+  await fs.writeFile(identityPath(dataDir), `${JSON.stringify(identity, null, 2)}\n`, 'utf8');
+}
+
+export async function clearCliIdentity(dataDir: string): Promise<void> {
+  await fs.rm(identityPath(dataDir), { force: true });
+}
+
+/**
+ * An unbound terminal remains project-scoped. Private and team access becomes
+ * available only after the operator explicitly chooses an active team identity.
+ */
+export async function resolveCliIdentity(options: {
+  project: ProjectInfo;
+  dataDir: string;
+  teamStore: TeamStore;
+  explicitActorId?: string;
+}): Promise<CliIdentityResolution> {
+  const stored = await loadCliIdentity(options.dataDir, options.project.id);
+  const requestedAgentId = options.explicitActorId ?? stored?.agentId;
+  const projectReader: ObservationReader = { projectId: options.project.id };
+  if (!requestedAgentId) return { identity: null, reader: projectReader };
+
+  const agent = options.teamStore.getAgent(requestedAgentId);
+  const activeForProject = agent
+    && agent.project_id === options.project.id
+    && agent.status === 'active';
+  if (!activeForProject) {
+    if (options.explicitActorId) {
+      throw new Error(`CLI actor "${requestedAgentId}" is not an active member of this project.`);
+    }
+    return {
+      identity: null,
+      reader: projectReader,
+      warning: `Saved CLI identity "${requestedAgentId}" is no longer active for this project.`,
+    };
+  }
+
+  return {
+    identity: stored ?? {
+      agentId: agent.agent_id,
+      projectId: options.project.id,
+      activatedAt: new Date().toISOString(),
+    },
+    reader: {
+      projectId: options.project.id,
+      agentId: agent.agent_id,
+      isTeamMember: true,
+    },
+  };
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -129,8 +129,9 @@ async function getWorkbenchHeader(): Promise<string[]> {
         const dataDir = await getProjectDataDir(proj.id);
         await initStore(dataDir);
         const { getObservationStore: getStore } = await import('../store/obs-store.js');
-        const obs = await getStore().loadAll() as any[];
-        const active = obs.filter((o: any) => (o.status ?? 'active') === 'active').length;
+        const { filterReadableObservations } = await import('../memory/visibility.js');
+        const obs = filterReadableObservations(await getStore().loadAll(), { projectId: proj.id });
+        const active = obs.filter((o) => (o.status ?? 'active') === 'active').length;
         if (active > 0) {
           memLabel = `${BOLD}${active}${RESET} ${DIM}active${RESET}`;
         }
@@ -801,6 +802,7 @@ async function runSearch(query: string): Promise<void> {
   
   try {
     const { searchObservations, getDb, hydrateIndex } = await import('../store/orama-store.js');
+    const { filterReadableObservations } = await import('../memory/visibility.js');
     const { getProjectDataDir } = await import('../store/persistence.js');
     const { detectProject } = await import('../project/detector.js');
     const { initObservations } = await import('../memory/observations.js');
@@ -825,7 +827,7 @@ async function runSearch(query: string): Promise<void> {
     await hydrateIndex(allObs);
     mark('hydrateIndex');
     
-    const results = await searchObservations({ query, limit: 10, projectId: project.id });
+    const results = await searchObservations({ query, limit: 10, projectId: project.id, reader: { projectId: project.id } });
     mark('search');
     s.stop('Search complete');
     
@@ -855,14 +857,16 @@ async function runList(): Promise<void> {
     const { getProjectDataDir } = await import('../store/persistence.js');
     const { detectProject } = await import('../project/detector.js');
     const { initObservationStore: initStore, getObservationStore: getStore } = await import('../store/obs-store.js');
+    const { filterReadableObservations } = await import('../memory/visibility.js');
     
     const project = detectProject(process.cwd());
     if (!project) { s.stop('No git repo'); p.log.error(NO_GIT_MSG); return; }
     const dataDir = await getProjectDataDir(project.id);
     await initStore(dataDir);
-    const observations = await getStore().loadAll() as unknown as Array<{
-      id: number; title: string; type: string; timestamp: string; status?: string;
-    }>;
+    const observations = filterReadableObservations(
+      await getStore().loadAll(),
+      { projectId: project.id },
+    );
     
     const active = observations.filter(o => (o.status ?? 'active') === 'active');
     const recent = active.slice(-10).reverse();
@@ -876,7 +880,7 @@ async function runList(): Promise<void> {
     
     console.log('');
     for (const o of recent) {
-      const typeLabel = { gotcha: '[!]', decision: '[D]', 'problem-solution': '[S]', discovery: '[?]', 'how-it-works': '[H]', 'what-changed': '[C]' }[o.type] ?? '[·]';
+      const typeLabel = ({ gotcha: '[!]', decision: '[D]', 'problem-solution': '[S]', discovery: '[?]', 'how-it-works': '[H]', 'what-changed': '[C]' } as Record<string, string>)[o.type] ?? '[·]';
       console.log(`  ${typeLabel} #${o.id} ${o.title?.slice(0, 60) ?? '(untitled)'}`);
     }
     console.log('');

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,6 +19,8 @@ import { execSync, spawn } from 'node:child_process';
 import { getCliVersion } from './version.js';
 import { importBundledMemcode } from './memcode-bootstrap.js';
 import { installCliPipeErrorGuard } from './pipe-errors.js';
+import { normalizeCliInvocation } from './invocation.js';
+import { printCliGuideForHelp, renderCliGuide } from './command-guide.js';
 
 installCliPipeErrorGuard();
 
@@ -931,11 +933,26 @@ async function runCommand(cmd: string, _args: string[] = []): Promise<void> {
 // Main command
 // ============================================================
 
+async function runMemoryShortcut(action: string, args: Record<string, unknown>): Promise<void> {
+  const { detectProject } = await import('../project/detector.js');
+  if (!detectProject(process.cwd())) {
+    console.log(NO_GIT_MSG);
+    process.exitCode = 1;
+    return;
+  }
+  const memory = await import('./commands/memory.js');
+  await memory.default.run?.({
+    args: { ...args, _: [action] },
+    rawArgs: [],
+    cmd: memory.default,
+  } as any);
+}
+
 const main = defineCommand({
   meta: {
     name: 'memorix',
     version: getCliVersion(),
-    description: 'Local-first memory control plane for AI coding agents via MCP',
+    description: 'Local-first memory control plane for AI coding agents through CLI, MCP, and local workflows',
   },
   subCommands: {
     // One-shot product commands (primary user paths)
@@ -964,18 +981,55 @@ const main = defineCommand({
       },
     })),
     search: () => Promise.resolve(defineCommand({
-      meta: { name: 'search', description: 'Search memories' },
-      args: { query: { type: 'positional', description: 'Search query', required: true } },
-      async run({ args }) { await runSearch(args.query as string); },
+      meta: { name: 'search', description: 'Shortcut for `memorix memory search`' },
+      args: {
+        query: { type: 'positional', description: 'Search query', required: true },
+        limit: { type: 'string', description: 'Maximum results' },
+        json: { type: 'boolean', description: 'Emit machine-readable JSON output' },
+      },
+      async run({ args }) {
+        await runMemoryShortcut('search', {
+          query: args.query,
+          limit: args.limit,
+          json: args.json,
+        });
+      },
     })),
     remember: () => Promise.resolve(defineCommand({
-      meta: { name: 'remember', description: 'Store a quick memory' },
-      args: { text: { type: 'positional', description: 'Text to remember', required: true } },
-      async run({ args }) { await runRemember(args.text as string); },
+      meta: { name: 'remember', description: 'Shortcut for `memorix memory store`' },
+      args: {
+        text: { type: 'positional', description: 'Text to remember', required: true },
+        title: { type: 'string', description: 'Optional observation title' },
+        type: { type: 'string', description: 'Observation type' },
+        visibility: { type: 'string', description: 'project (default), personal, or team' },
+        json: { type: 'boolean', description: 'Emit machine-readable JSON output' },
+      },
+      async run({ args }) {
+        await runMemoryShortcut('store', {
+          text: args.text,
+          title: args.title,
+          type: args.type,
+          visibility: args.visibility,
+          json: args.json,
+        });
+      },
     })),
     recent: () => Promise.resolve(defineCommand({
-      meta: { name: 'recent', description: 'View recent memories' },
-      async run() { await runList(); },
+      meta: { name: 'recent', description: 'Shortcut for `memorix memory recent`' },
+      args: {
+        limit: { type: 'string', description: 'Maximum results' },
+        json: { type: 'boolean', description: 'Emit machine-readable JSON output' },
+      },
+      async run({ args }) { await runMemoryShortcut('recent', { limit: args.limit, json: args.json }); },
+    })),
+    help: () => Promise.resolve(defineCommand({
+      meta: { name: 'help', description: 'Show action-oriented help for a command group' },
+      args: {
+        command: { type: 'positional', description: 'Command group to inspect', required: false },
+      },
+      async run({ args }) {
+        console.log(renderCliGuide(args.command as string | undefined));
+      },
     })),
     // Infrastructure commands
     init: () => import('./commands/init.js').then(m => m.default),
@@ -1000,6 +1054,7 @@ const main = defineCommand({
     audit: () => import('./commands/audit.js').then(m => m.default),
     transfer: () => import('./commands/transfer.js').then(m => m.default),
     skills: () => import('./commands/skills.js').then(m => m.default),
+    identity: () => import('./commands/identity.js').then(m => m.default),
     session: () => import('./commands/session.js').then(m => m.default),
     team: () => import('./commands/team.js').then(m => m.default),
     task: () => import('./commands/task.js').then(m => m.default),
@@ -1035,6 +1090,13 @@ const main = defineCommand({
     cleanup: () => import('./commands/cleanup.js').then(m => m.default),
     uninstall: () => import('./commands/uninstall.js').then(m => m.default),
     orchestrate: () => import('./commands/orchestrate.js').then(m => m.default),
+    workbench: () => Promise.resolve(defineCommand({
+      meta: { name: 'workbench', description: 'Open the interactive terminal memory control plane' },
+      async run() {
+        const { startWorkbench } = await import('./workbench.js');
+        await startWorkbench();
+      },
+    })),
     memcode: () => Promise.resolve(defineCommand({
       meta: { name: 'memcode', description: 'Enter memcode TUI — native coding agent with memory' },
       async run() {
@@ -1052,8 +1114,8 @@ const main = defineCommand({
     // Guard: if citty already resolved a subcommand, its run() was called before this.
     // Detect by checking if the first CLI arg matches a registered subcommand name.
     const firstArg = process.argv[2];
-    const knownSubs = ['ask', 'search', 'remember', 'recent', 'memcode', 'config',
-      'init', 'setup', 'integrate', 'memory', 'context', 'explain', 'codegraph', 'knowledge', 'reasoning', 'retention', 'formation', 'audit', 'transfer', 'skills',
+    const knownSubs = ['ask', 'search', 'remember', 'recent', 'help', 'workbench', 'memcode', 'config',
+      'init', 'setup', 'integrate', 'memory', 'context', 'explain', 'codegraph', 'knowledge', 'reasoning', 'retention', 'formation', 'audit', 'transfer', 'skills', 'identity',
       'session', 'team', 'task', 'message', 'lock', 'handoff', 'poll',
       'receipt',
       'serve', 'serve-http', 'status', 'sync',
@@ -1084,6 +1146,8 @@ const main = defineCommand({
       console.error(`Memorix v${getCliVersion()} — Local-first memory control plane\n`);
       console.error('Usage: memorix <command>\n');
       console.error('Commands:');
+      console.error('  help       Show action-oriented help (`memorix memory --help`)');
+      console.error('  workbench  Open interactive terminal memory control plane');
       console.error('  memcode    Enter memcode TUI (native coding agent)');
       console.error('  ask "q"    Ask Memorix a question (single-shot chat)');
       console.error('             Pipe: echo "q" | memorix ask');
@@ -1100,6 +1164,7 @@ const main = defineCommand({
       console.error('  audit      Audit trail and project attribution checks');
       console.error('  transfer   Export/import memory snapshots');
       console.error('  skills     List/generate/show project skills');
+      console.error('  identity   Select the explicit CLI actor for private/team memory');
       console.error('  team       Join/status/role operations for coordination state');
       console.error('  task       Create/claim/complete/list team tasks');
       console.error('  message    Send/broadcast/read team messages');
@@ -1125,4 +1190,12 @@ const main = defineCommand({
   },
 });
 
-runMain(main);
+try {
+  normalizeCliInvocation();
+  if (!printCliGuideForHelp()) {
+    runMain(main);
+  }
+} catch (error) {
+  console.error(`Memorix CLI invocation error: ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 1;
+}

--- a/src/cli/invocation.ts
+++ b/src/cli/invocation.ts
@@ -1,0 +1,115 @@
+import { existsSync, statSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export interface CliInvocation {
+  projectRoot?: string;
+  actorId?: string;
+}
+
+type InvocationOption = 'projectRoot' | 'actorId';
+
+const GLOBAL_OPTIONS: Record<string, InvocationOption> = {
+  '--cwd': 'projectRoot',
+  '--project-root': 'projectRoot',
+  '--as': 'actorId',
+  '--actor': 'actorId',
+};
+
+// Existing commands use camelCase Citty keys. Preserve them for compatibility
+// while accepting the shell-native kebab-case spelling everywhere.
+const FLAG_ALIASES: Record<string, string> = {
+  '--agent-type': '--agentType',
+  '--instance-id': '--instanceId',
+  '--agent-id': '--agentId',
+  '--from-agent-id': '--fromAgentId',
+  '--to-agent-id': '--toAgentId',
+  '--join-team': '--joinTeam',
+  '--session-id': '--sessionId',
+  '--task-id': '--taskId',
+  '--topic-key': '--topicKey',
+  '--graph-limit': '--graphLimit',
+  '--graph-query': '--graphQuery',
+  '--skill-id': '--skillId',
+  '--required-role': '--requiredRole',
+  '--preferred-role': '--preferredRole',
+  '--to-role': '--toRole',
+  '--handoff-status': '--handoffStatus',
+  '--max-concurrent': '--maxConcurrent',
+  '--role-id': '--roleId',
+  '--preferred-agent-types': '--preferredAgentTypes',
+  '--files-modified': '--filesModified',
+  '--expected-outcome': '--expectedOutcome',
+  '--related-commits': '--relatedCommits',
+  '--related-entities': '--relatedEntities',
+  '--mime-type': '--mimeType',
+  '--mark-read': '--markRead',
+  '--mark-inbox-read': '--markInboxRead',
+};
+
+function readOption(argument: string): { name: string; value?: string } {
+  const equals = argument.indexOf('=');
+  return equals === -1
+    ? { name: argument }
+    : { name: argument.slice(0, equals), value: argument.slice(equals + 1) };
+}
+
+/**
+ * Normalize the small set of global operator flags before Citty resolves a
+ * command. This gives every CLI command the same project and actor anchors
+ * without duplicating those flags across dozens of command definitions.
+ */
+export function normalizeCliInvocation(argv: string[] = process.argv): CliInvocation {
+  const normalized = argv.slice(0, 2);
+  const invocation: CliInvocation = {};
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--') {
+      normalized.push(...argv.slice(index));
+      break;
+    }
+
+    const { name, value: inlineValue } = readOption(argument);
+    const target = GLOBAL_OPTIONS[name];
+    if (!target) {
+      const alias = FLAG_ALIASES[name];
+      normalized.push(alias
+        ? (inlineValue === undefined ? alias : `${alias}=${inlineValue}`)
+        : argument);
+      continue;
+    }
+
+    const value = inlineValue ?? argv[index + 1];
+    if (!value || value.startsWith('--')) {
+      throw new Error(`${name} requires a value`);
+    }
+    invocation[target] = value;
+    if (inlineValue === undefined) index += 1;
+  }
+
+  if (invocation.projectRoot) {
+    const projectRoot = resolve(invocation.projectRoot);
+    if (!existsSync(projectRoot) || !statSync(projectRoot).isDirectory()) {
+      throw new Error(`CLI project directory does not exist: ${projectRoot}`);
+    }
+    process.chdir(projectRoot);
+    process.env.MEMORIX_CLI_PROJECT_ROOT = projectRoot;
+    invocation.projectRoot = projectRoot;
+  }
+
+  if (invocation.actorId) {
+    process.env.MEMORIX_CLI_ACTOR_ID = invocation.actorId;
+  }
+
+  process.argv = normalized;
+  return invocation;
+}
+
+export function getCliInvocation(): CliInvocation {
+  const projectRoot = process.env.MEMORIX_CLI_PROJECT_ROOT?.trim();
+  const actorId = process.env.MEMORIX_CLI_ACTOR_ID?.trim();
+  return {
+    ...(projectRoot ? { projectRoot } : {}),
+    ...(actorId ? { actorId } : {}),
+  };
+}

--- a/src/cli/tui/chat-service.ts
+++ b/src/cli/tui/chat-service.ts
@@ -3,7 +3,8 @@ import { loadDotenv } from '../../config/dotenv-loader.js';
 import { initLLM, isLLMEnabled, getLLMConfig, callLLMWithTools } from '../../llm/provider.js';
 import type { ChatMessage, ToolDefinition, ToolCall } from '../../llm/provider.js';
 import { initObservations, prepareSearchIndex, storeObservation, resolveObservations, getObservation, getAllObservations } from '../../memory/observations.js';
-import type { ObservationType } from '../../types.js';
+import { canManageObservation, filterReadableObservations } from '../../memory/visibility.js';
+import type { ObservationReader, ObservationType } from '../../types.js';
 import { detectProject } from '../../project/detector.js';
 import { getLastSearchMode } from '../../store/orama-store.js';
 import { getProjectDataDir } from '../../store/persistence.js';
@@ -208,19 +209,20 @@ async function prepareProjectSearch(projectId: string, dataDir: string): Promise
 
 interface ToolExecutionContext {
   projectId: string;
+  reader: ObservationReader;
   collectedSources: ChatSource[];
 }
 
 function executeSearchMemories(args: { query: string; limit?: number }, ctx: ToolExecutionContext): Promise<string> {
   const limit = Math.min(args.limit ?? SEARCH_LIMIT, 10);
-  return compactSearch({ query: args.query, limit, projectId: ctx.projectId, status: 'active' })
+  return compactSearch({ query: args.query, limit, projectId: ctx.projectId, status: 'active', reader: ctx.reader })
     .then((result) => {
       const entries = result.entries.slice(0, DETAIL_LIMIT);
       if (entries.length === 0) return 'No memories found for that query.';
 
       // Collect sources for citation tracking
       const refs = entries.map((e) => ({ id: e.id, projectId: ctx.projectId }));
-      return compactDetail(refs).then((detail) => {
+      return compactDetail(refs, { reader: ctx.reader }).then((detail) => {
         for (let i = 0; i < detail.documents.length; i++) {
           const doc = detail.documents[i];
           const score = entries[i]?.score ?? 0;
@@ -235,7 +237,7 @@ function executeSearchMemories(args: { query: string; limit?: number }, ctx: Too
 }
 
 function executeGetMemoryDetail(args: { id: number }, ctx: ToolExecutionContext): Promise<string> {
-  return compactDetail([{ id: args.id, projectId: ctx.projectId }])
+  return compactDetail([{ id: args.id, projectId: ctx.projectId }], { reader: ctx.reader })
     .then((detail) => {
       if (detail.documents.length === 0) return `Observation ${args.id} not found.`;
       const doc = detail.documents[0];
@@ -295,6 +297,7 @@ function executeStoreMemory(
     facts: args.facts,
     projectId: ctx.projectId,
     source: 'agent',
+    visibilityReader: ctx.reader,
   }).then((result) => {
     const obs = result.observation;
     ctx.collectedSources.push({
@@ -314,7 +317,7 @@ function executeUpdateMemory(
   ctx: ToolExecutionContext,
 ): string {
   const obs = getObservation(args.id, ctx.projectId);
-  if (!obs) return `Observation ${args.id} not found.`;
+  if (!obs || !canManageObservation(obs, ctx.reader)) return `Observation ${args.id} not found.`;
 
   const shouldAppend = args.append !== false; // default true
   const newNarrative = shouldAppend
@@ -334,6 +337,7 @@ function executeUpdateMemory(
     projectId: ctx.projectId,
     topicKey: obs.topicKey,
     source: 'agent',
+    visibilityReader: ctx.reader,
   }).catch(() => {/* non-blocking */});
 
   return `Updated observation [obs:${args.id}] — ${shouldAppend ? 'appended to' : 'replaced'} narrative${args.facts?.length ? ` and added ${args.facts.length} facts` : ''}. Changes will be persisted asynchronously.`;
@@ -344,7 +348,7 @@ function executeDeleteMemory(
   ctx: ToolExecutionContext,
 ): Promise<string> {
   const obs = getObservation(args.id, ctx.projectId);
-  if (!obs) return Promise.resolve(`Observation ${args.id} not found.`);
+  if (!obs || !canManageObservation(obs, ctx.reader)) return Promise.resolve(`Observation ${args.id} not found.`);
 
   return resolveObservations([args.id], 'resolved')
     .then((result) => {
@@ -361,8 +365,10 @@ function executeListRecentMemories(
   ctx: ToolExecutionContext,
 ): string {
   const limit = Math.min(args.limit ?? 10, 20);
-  let allObs = getAllObservations()
-    .filter(o => o.projectId === ctx.projectId && o.status !== 'archived' && o.status !== 'resolved');
+  let allObs = filterReadableObservations(
+    getAllObservations().filter(o => o.projectId === ctx.projectId && o.status !== 'archived' && o.status !== 'resolved'),
+    ctx.reader,
+  );
 
   if (args.type) {
     allObs = allObs.filter(o => o.type === args.type);
@@ -453,11 +459,12 @@ export async function askMemoryQuestion(
       limit: SEARCH_LIMIT,
       projectId: project.id,
       status: 'active',
+      reader: { projectId: project.id },
     });
     const topEntries = searchResult.entries.slice(0, DETAIL_LIMIT);
     const detailRefs = topEntries.map((entry) => ({ id: entry.id, projectId: project.id }));
     const detailResult = detailRefs.length > 0
-      ? await compactDetail(detailRefs)
+      ? await compactDetail(detailRefs, { reader: { projectId: project.id } })
       : { documents: [], formatted: '', totalTokens: 0 };
     const sources = detailResult.documents.map((doc, index) => toSource(doc, topEntries[index]?.score ?? 0));
 
@@ -488,6 +495,7 @@ export async function askMemoryQuestion(
 
   const ctx: ToolExecutionContext = {
     projectId: project.id,
+    reader: { projectId: project.id },
     collectedSources: [],
   };
 
@@ -641,11 +649,12 @@ export async function askMemoryQuestionStream(
       limit: SEARCH_LIMIT,
       projectId: project.id,
       status: 'active',
+      reader: { projectId: project.id },
     });
     const topEntries = searchResult.entries.slice(0, DETAIL_LIMIT);
     const detailRefs = topEntries.map((entry) => ({ id: entry.id, projectId: project.id }));
     const detailResult = detailRefs.length > 0
-      ? await compactDetail(detailRefs)
+      ? await compactDetail(detailRefs, { reader: { projectId: project.id } })
       : { documents: [], formatted: '', totalTokens: 0 };
     const sources = detailResult.documents.map((doc, index) => toSource(doc, topEntries[index]?.score ?? 0));
 
@@ -672,6 +681,7 @@ export async function askMemoryQuestionStream(
 
   const ctx: ToolExecutionContext = {
     projectId: project.id,
+    reader: { projectId: project.id },
     collectedSources: [],
   };
 

--- a/src/cli/tui/chat-service.ts
+++ b/src/cli/tui/chat-service.ts
@@ -5,10 +5,9 @@ import type { ChatMessage, ToolDefinition, ToolCall } from '../../llm/provider.j
 import { initObservations, prepareSearchIndex, storeObservation, resolveObservations, getObservation, getAllObservations } from '../../memory/observations.js';
 import { canManageObservation, filterReadableObservations } from '../../memory/visibility.js';
 import type { ObservationReader, ObservationType } from '../../types.js';
-import { detectProject } from '../../project/detector.js';
 import { getLastSearchMode } from '../../store/orama-store.js';
-import { getProjectDataDir } from '../../store/persistence.js';
 import type { MemorixDocument } from '../../types.js';
+import { getTuiOperatorContext } from './operator-context.js';
 
 export interface ChatHistoryTurn {
   role: 'user' | 'assistant';
@@ -210,7 +209,16 @@ async function prepareProjectSearch(projectId: string, dataDir: string): Promise
 interface ToolExecutionContext {
   projectId: string;
   reader: ObservationReader;
+  writerAgentId?: string;
   collectedSources: ChatSource[];
+}
+
+async function resolveTuiContext() {
+  try {
+    return await getTuiOperatorContext();
+  } catch {
+    return null;
+  }
 }
 
 function executeSearchMemories(args: { query: string; limit?: number }, ctx: ToolExecutionContext): Promise<string> {
@@ -298,6 +306,7 @@ function executeStoreMemory(
     projectId: ctx.projectId,
     source: 'agent',
     visibilityReader: ctx.reader,
+    ...(ctx.writerAgentId ? { createdByAgentId: ctx.writerAgentId } : {}),
   }).then((result) => {
     const obs = result.observation;
     ctx.collectedSources.push({
@@ -405,10 +414,10 @@ export async function askMemoryQuestion(
     };
   }
 
-  const project = detectProject(process.cwd());
+  const operatorContext = await resolveTuiContext();
 
   // No project + no LLM → dead end
-  if (!project) {
+  if (!operatorContext) {
     loadDotenv(process.cwd());
     initLLM({ scope: 'agent' });
     if (!isLLMEnabled()) {
@@ -444,10 +453,11 @@ export async function askMemoryQuestion(
     };
   }
 
+  const { project, dataDir, reader, identity } = operatorContext;
+
   loadDotenv(project.rootPath);
   initLLM({ scope: 'agent' });
 
-  const dataDir = await getProjectDataDir(project.id);
   await prepareProjectSearch(project.id, dataDir);
 
   const searchMode = normalizeSearchMode(getLastSearchMode(project.id) || 'fulltext');
@@ -459,12 +469,12 @@ export async function askMemoryQuestion(
       limit: SEARCH_LIMIT,
       projectId: project.id,
       status: 'active',
-      reader: { projectId: project.id },
+      reader,
     });
     const topEntries = searchResult.entries.slice(0, DETAIL_LIMIT);
     const detailRefs = topEntries.map((entry) => ({ id: entry.id, projectId: project.id }));
     const detailResult = detailRefs.length > 0
-      ? await compactDetail(detailRefs, { reader: { projectId: project.id } })
+      ? await compactDetail(detailRefs, { reader })
       : { documents: [], formatted: '', totalTokens: 0 };
     const sources = detailResult.documents.map((doc, index) => toSource(doc, topEntries[index]?.score ?? 0));
 
@@ -495,7 +505,8 @@ export async function askMemoryQuestion(
 
   const ctx: ToolExecutionContext = {
     projectId: project.id,
-    reader: { projectId: project.id },
+    reader,
+    ...(identity ? { writerAgentId: identity.agentId } : {}),
     collectedSources: [],
   };
 
@@ -592,10 +603,10 @@ export async function askMemoryQuestionStream(
     };
   }
 
-  const project = detectProject(process.cwd());
+  const operatorContext = await resolveTuiContext();
 
   // No project + no LLM → dead end
-  if (!project) {
+  if (!operatorContext) {
     loadDotenv(process.cwd());
     initLLM({ scope: 'agent' });
     if (!isLLMEnabled()) {
@@ -634,10 +645,11 @@ export async function askMemoryQuestionStream(
     };
   }
 
+  const { project, dataDir, reader, identity } = operatorContext;
+
   loadDotenv(project.rootPath);
   initLLM({ scope: 'agent' });
 
-  const dataDir = await getProjectDataDir(project.id);
   await prepareProjectSearch(project.id, dataDir);
 
   const searchMode = normalizeSearchMode(getLastSearchMode(project.id) || 'fulltext');
@@ -649,12 +661,12 @@ export async function askMemoryQuestionStream(
       limit: SEARCH_LIMIT,
       projectId: project.id,
       status: 'active',
-      reader: { projectId: project.id },
+      reader,
     });
     const topEntries = searchResult.entries.slice(0, DETAIL_LIMIT);
     const detailRefs = topEntries.map((entry) => ({ id: entry.id, projectId: project.id }));
     const detailResult = detailRefs.length > 0
-      ? await compactDetail(detailRefs, { reader: { projectId: project.id } })
+      ? await compactDetail(detailRefs, { reader })
       : { documents: [], formatted: '', totalTokens: 0 };
     const sources = detailResult.documents.map((doc, index) => toSource(doc, topEntries[index]?.score ?? 0));
 
@@ -681,7 +693,8 @@ export async function askMemoryQuestionStream(
 
   const ctx: ToolExecutionContext = {
     projectId: project.id,
-    reader: { projectId: project.id },
+    reader,
+    ...(identity ? { writerAgentId: identity.agentId } : {}),
     collectedSources: [],
   };
 

--- a/src/cli/tui/data.ts
+++ b/src/cli/tui/data.ts
@@ -144,8 +144,9 @@ export async function getHealthInfo(projectId?: string): Promise<HealthInfo> {
     const dataDir = await getProjectDataDir(effectiveProjectId);
     await initStore(dataDir);
     const allObs = (await getStore().loadAll()) as any[];
-    // Filter by project — flat storage shares one observations.json across projects
-    const obs = allObs.filter((o: any) => o.projectId === effectiveProjectId);
+    const { filterReadableObservations } = await import('../../memory/visibility.js');
+    // The TUI is an unbound local reader, so it renders only project-visible facts.
+    const obs = filterReadableObservations(allObs, { projectId: effectiveProjectId });
     const active = obs.filter((o: any) => (o.status ?? 'active') === 'active');
 
     defaults.totalMemories = obs.length;
@@ -230,8 +231,8 @@ export async function getRecentMemories(limit = 8, projectId?: string): Promise<
     const dataDir = await getProjectDataDir(effectiveProjectId);
     await initStore(dataDir);
     const allObs = (await getStore().loadAll()) as any[];
-    // Filter by project — flat storage shares one observations.json
-    const projectObs = allObs.filter((o: any) => o.projectId === effectiveProjectId);
+    const { filterReadableObservations } = await import('../../memory/visibility.js');
+    const projectObs = filterReadableObservations(allObs, { projectId: effectiveProjectId });
     const active = projectObs.filter((o: any) => (o.status ?? 'active') === 'active');
     const filtered = active.filter((o: any) => !/^(Ran:|Command:|Executed:)\s/i.test(o.title || ''));
 
@@ -262,7 +263,7 @@ export async function searchMemories(query: string, limit = 10): Promise<SearchR
     await initObservations(dataDir);
     await prepareSearchIndex();
 
-    const results = await searchObservations({ query, limit, projectId: proj.id });
+    const results = await searchObservations({ query, limit, projectId: proj.id, reader: { projectId: proj.id } });
 
     const typeIcons: Record<string, string> = {
       gotcha: '!',
@@ -488,6 +489,7 @@ export async function getKnowledgeGraph(
     const { getProjectDataDir } = await import('../../store/persistence.js');
     const { initObservationStore } = await import('../../store/obs-store.js');
     const { initObservations, getAllObservations } = await import('../../memory/observations.js');
+    const { filterReadableObservations } = await import('../../memory/visibility.js');
     const { initMiniSkillStore, getMiniSkillStore } = await import('../../store/mini-skill-store.js');
     const { generateKnowledgeGraph } = await import('../../wiki/knowledge-graph.js');
 
@@ -500,7 +502,7 @@ export async function getKnowledgeGraph(
     await initObservations(dataDir);
     await initMiniSkillStore(dataDir);
 
-    const observations = getAllObservations();
+    const observations = filterReadableObservations(getAllObservations(), { projectId: effectiveProjectId });
     const skills = await getMiniSkillStore().loadByProject(effectiveProjectId);
 
     return generateKnowledgeGraph({
@@ -519,6 +521,7 @@ export async function getKnowledgeBase(projectId?: string): Promise<import('../.
     const { getProjectDataDir } = await import('../../store/persistence.js');
     const { initObservationStore } = await import('../../store/obs-store.js');
     const { initObservations, getAllObservations } = await import('../../memory/observations.js');
+    const { filterReadableObservations } = await import('../../memory/visibility.js');
     const { initMiniSkillStore, getMiniSkillStore } = await import('../../store/mini-skill-store.js');
     const { generateKnowledgeBase } = await import('../../wiki/generator.js');
 
@@ -531,7 +534,7 @@ export async function getKnowledgeBase(projectId?: string): Promise<import('../.
     await initObservations(dataDir);
     await initMiniSkillStore(dataDir);
 
-    const observations = getAllObservations();
+    const observations = filterReadableObservations(getAllObservations(), { projectId: effectiveProjectId });
     const skills = await getMiniSkillStore().loadByProject(effectiveProjectId);
 
     return generateKnowledgeBase({

--- a/src/cli/tui/data.ts
+++ b/src/cli/tui/data.ts
@@ -6,6 +6,7 @@
  */
 
 import * as fs from 'node:fs';
+import { getTuiOperatorContext } from './operator-context.js';
 
 export interface ProjectInfo {
   name: string;
@@ -98,9 +99,7 @@ function truncate(text: string, max = 60): string {
 
 export async function getProjectInfo(): Promise<ProjectInfo | null> {
   try {
-    const { detectProject } = await import('../../project/detector.js');
-    const proj = detectProject(process.cwd());
-    if (!proj) return null;
+    const { project: proj } = await getTuiOperatorContext();
     return {
       name: proj.name,
       id: proj.id,
@@ -127,12 +126,8 @@ export async function getHealthInfo(projectId?: string): Promise<HealthInfo> {
   };
 
   try {
-    const { detectProject } = await import('../../project/detector.js');
-    const { getProjectDataDir } = await import('../../store/persistence.js');
     const { initObservationStore: initStore, getObservationStore: getStore } = await import('../../store/obs-store.js');
-
-    const proj = detectProject(process.cwd());
-    if (!proj) return defaults;
+    const { project: proj, dataDir, reader } = await getTuiOperatorContext();
 
     // Load .env BEFORE any process.env reads or provider initialization (#46)
     try {
@@ -141,12 +136,11 @@ export async function getHealthInfo(projectId?: string): Promise<HealthInfo> {
     } catch { /* best-effort */ }
 
     const effectiveProjectId = projectId || proj.id;
-    const dataDir = await getProjectDataDir(effectiveProjectId);
+    if (effectiveProjectId !== proj.id) return defaults;
     await initStore(dataDir);
     const allObs = (await getStore().loadAll()) as any[];
     const { filterReadableObservations } = await import('../../memory/visibility.js');
-    // The TUI is an unbound local reader, so it renders only project-visible facts.
-    const obs = filterReadableObservations(allObs, { projectId: effectiveProjectId });
+    const obs = filterReadableObservations(allObs, reader);
     const active = obs.filter((o: any) => (o.status ?? 'active') === 'active');
 
     defaults.totalMemories = obs.length;
@@ -220,19 +214,15 @@ export async function getHealthInfo(projectId?: string): Promise<HealthInfo> {
 
 export async function getRecentMemories(limit = 8, projectId?: string): Promise<MemoryItem[]> {
   try {
-    const { detectProject } = await import('../../project/detector.js');
-    const { getProjectDataDir } = await import('../../store/persistence.js');
     const { initObservationStore: initStore, getObservationStore: getStore } = await import('../../store/obs-store.js');
-
-    const proj = detectProject(process.cwd());
-    if (!proj) return [];
+    const { project: proj, dataDir, reader } = await getTuiOperatorContext();
 
     const effectiveProjectId = projectId || proj.id;
-    const dataDir = await getProjectDataDir(effectiveProjectId);
+    if (effectiveProjectId !== proj.id) return [];
     await initStore(dataDir);
     const allObs = (await getStore().loadAll()) as any[];
     const { filterReadableObservations } = await import('../../memory/visibility.js');
-    const projectObs = filterReadableObservations(allObs, { projectId: effectiveProjectId });
+    const projectObs = filterReadableObservations(allObs, reader);
     const active = projectObs.filter((o: any) => (o.status ?? 'active') === 'active');
     const filtered = active.filter((o: any) => !/^(Ran:|Command:|Executed:)\s/i.test(o.title || ''));
 
@@ -252,18 +242,13 @@ export async function getRecentMemories(limit = 8, projectId?: string): Promise<
 export async function searchMemories(query: string, limit = 10): Promise<SearchResult[]> {
   try {
     const { searchObservations } = await import('../../store/orama-store.js');
-    const { getProjectDataDir } = await import('../../store/persistence.js');
-    const { detectProject } = await import('../../project/detector.js');
     const { initObservations, prepareSearchIndex } = await import('../../memory/observations.js');
+    const { project: proj, dataDir, reader } = await getTuiOperatorContext();
 
-    const proj = detectProject(process.cwd());
-    if (!proj) return [];
-
-    const dataDir = await getProjectDataDir(proj.id);
     await initObservations(dataDir);
     await prepareSearchIndex();
 
-    const results = await searchObservations({ query, limit, projectId: proj.id, reader: { projectId: proj.id } });
+    const results = await searchObservations({ query, limit, projectId: proj.id, reader });
 
     const typeIcons: Record<string, string> = {
       gotcha: '!',
@@ -291,15 +276,10 @@ export async function searchMemories(query: string, limit = 10): Promise<SearchR
 
 export async function storeQuickMemory(text: string): Promise<{ id: number; title: string } | null> {
   try {
-    const { detectProject } = await import('../../project/detector.js');
-    const { getProjectDataDir } = await import('../../store/persistence.js');
     const { initObservations, storeObservation } = await import('../../memory/observations.js');
     const { initObservationStore } = await import('../../store/obs-store.js');
+    const { project: proj, dataDir, reader, identity } = await getTuiOperatorContext();
 
-    const proj = detectProject(process.cwd());
-    if (!proj) return null;
-
-    const dataDir = await getProjectDataDir(proj.id);
     await initObservationStore(dataDir);
     await initObservations(dataDir);
 
@@ -311,6 +291,8 @@ export async function storeQuickMemory(text: string): Promise<{ id: number; titl
       facts: [],
       projectId: proj.id,
       sourceDetail: 'explicit',
+      visibilityReader: reader,
+      ...(identity ? { createdByAgentId: identity.agentId } : {}),
     });
 
     return { id: result.observation.id, title: text.slice(0, 100) };
@@ -485,24 +467,21 @@ export async function getKnowledgeGraph(
   projectId?: string,
 ): Promise<import('../../wiki/types.js').ProjectKnowledgeGraph | null> {
   try {
-    const { detectProject } = await import('../../project/detector.js');
-    const { getProjectDataDir } = await import('../../store/persistence.js');
     const { initObservationStore } = await import('../../store/obs-store.js');
     const { initObservations, getAllObservations } = await import('../../memory/observations.js');
     const { filterReadableObservations } = await import('../../memory/visibility.js');
     const { initMiniSkillStore, getMiniSkillStore } = await import('../../store/mini-skill-store.js');
     const { generateKnowledgeGraph } = await import('../../wiki/knowledge-graph.js');
 
-    const proj = detectProject(process.cwd());
-    if (!proj) return null;
+    const { project: proj, dataDir, reader } = await getTuiOperatorContext();
 
     const effectiveProjectId = projectId || proj.id;
-    const dataDir = await getProjectDataDir(effectiveProjectId);
+    if (effectiveProjectId !== proj.id) return null;
     await initObservationStore(dataDir);
     await initObservations(dataDir);
     await initMiniSkillStore(dataDir);
 
-    const observations = filterReadableObservations(getAllObservations(), { projectId: effectiveProjectId });
+    const observations = filterReadableObservations(getAllObservations(), reader);
     const skills = await getMiniSkillStore().loadByProject(effectiveProjectId);
 
     return generateKnowledgeGraph({
@@ -517,24 +496,21 @@ export async function getKnowledgeGraph(
 
 export async function getKnowledgeBase(projectId?: string): Promise<import('../../wiki/types.js').ProjectKnowledgeOverview | null> {
   try {
-    const { detectProject } = await import('../../project/detector.js');
-    const { getProjectDataDir } = await import('../../store/persistence.js');
     const { initObservationStore } = await import('../../store/obs-store.js');
     const { initObservations, getAllObservations } = await import('../../memory/observations.js');
     const { filterReadableObservations } = await import('../../memory/visibility.js');
     const { initMiniSkillStore, getMiniSkillStore } = await import('../../store/mini-skill-store.js');
     const { generateKnowledgeBase } = await import('../../wiki/generator.js');
 
-    const proj = detectProject(process.cwd());
-    if (!proj) return null;
+    const { project: proj, dataDir, reader } = await getTuiOperatorContext();
 
     const effectiveProjectId = projectId || proj.id;
-    const dataDir = await getProjectDataDir(effectiveProjectId);
+    if (effectiveProjectId !== proj.id) return null;
     await initObservationStore(dataDir);
     await initObservations(dataDir);
     await initMiniSkillStore(dataDir);
 
-    const observations = filterReadableObservations(getAllObservations(), { projectId: effectiveProjectId });
+    const observations = filterReadableObservations(getAllObservations(), reader);
     const skills = await getMiniSkillStore().loadByProject(effectiveProjectId);
 
     return generateKnowledgeBase({

--- a/src/cli/tui/operator-context.ts
+++ b/src/cli/tui/operator-context.ts
@@ -1,0 +1,60 @@
+import { initTeamStore } from '../../team/team-store.js';
+import { loadCliIdentity, resolveCliIdentity } from '../identity.js';
+import { getCliInvocation } from '../invocation.js';
+import type { CliProjectContext } from '../commands/operator-shared.js';
+
+export type TuiOperatorContext = Omit<CliProjectContext, 'teamStore'>;
+
+/**
+ * The Ink workbench is another CLI entry point, not an alternate security
+ * model. It uses the same identity resolver, but avoids opening coordination
+ * state until an actor was explicitly selected.
+ */
+export async function getTuiOperatorContext(): Promise<TuiOperatorContext> {
+  const invocation = getCliInvocation();
+  const { detectProject } = await import('../../project/detector.js');
+  const project = detectProject(
+    invocation.projectRoot
+      ?? process.env.MEMORIX_PROJECT_ROOT
+      ?? process.cwd(),
+  );
+  if (!project) throw new Error('No git repository found in the current directory.');
+
+  const { getProjectDataDir } = await import('../../store/persistence.js');
+  const dataDir = await getProjectDataDir(project.id);
+  try {
+    const { MaintenanceTargetStore } = await import('../../runtime/maintenance-targets.js');
+    new MaintenanceTargetStore(dataDir).register({
+      projectId: project.id,
+      projectRoot: project.rootPath,
+      dataDir,
+    });
+  } catch {
+    // Workbench reads remain available when optional maintenance metadata fails.
+  }
+
+  const savedIdentity = await loadCliIdentity(dataDir, project.id);
+  if (!invocation.actorId && !savedIdentity) {
+    return {
+      project,
+      dataDir,
+      reader: { projectId: project.id },
+      identity: null,
+    };
+  }
+
+  const teamStore = await initTeamStore(dataDir);
+  const resolved = await resolveCliIdentity({
+    project,
+    dataDir,
+    teamStore,
+    explicitActorId: invocation.actorId,
+  });
+  return {
+    project,
+    dataDir,
+    reader: resolved.reader,
+    identity: resolved.identity,
+    ...(resolved.warning ? { identityWarning: resolved.warning } : {}),
+  };
+}

--- a/src/cli/tui/views/MemoryView.tsx
+++ b/src/cli/tui/views/MemoryView.tsx
@@ -65,7 +65,8 @@ export function MemoryView({ projectId, focusRefId, selectedIdx, onNavigateKnowl
     (async () => {
       try {
         setLoading(true);
-        const { getObservation, initObservations, getAllObservations } = await import('../../../memory/observations.js');
+        const { initObservations, getAllObservations } = await import('../../../memory/observations.js');
+        const { filterReadableObservations } = await import('../../../memory/visibility.js');
         const { getProjectDataDir } = await import('../../../store/persistence.js');
         const { initObservationStore } = await import('../../../store/obs-store.js');
         const { detectProject } = await import('../../../project/detector.js');
@@ -73,13 +74,16 @@ export function MemoryView({ projectId, focusRefId, selectedIdx, onNavigateKnowl
         const proj = detectProject(process.cwd());
         if (!proj) return;
 
-        const dataDir = await getProjectDataDir(projectId || proj.id);
+        const effectiveProjectId = projectId || proj.id;
+        const dataDir = await getProjectDataDir(effectiveProjectId);
         await initObservationStore(dataDir);
         await initObservations(dataDir);
 
         const obsId = parseInt(idMatch[1], 10);
-        const allObs = getAllObservations();
-        const obs = allObs.find((o: any) => o.id === obsId);
+        const obs = filterReadableObservations(
+          getAllObservations().filter((observation) => observation.projectId === effectiveProjectId),
+          { projectId: effectiveProjectId },
+        ).find((observation) => observation.id === obsId);
         if (obs) {
           setDetailItem({
             id: obs.id,

--- a/src/cli/tui/views/MemoryView.tsx
+++ b/src/cli/tui/views/MemoryView.tsx
@@ -67,22 +67,20 @@ export function MemoryView({ projectId, focusRefId, selectedIdx, onNavigateKnowl
         setLoading(true);
         const { initObservations, getAllObservations } = await import('../../../memory/observations.js');
         const { filterReadableObservations } = await import('../../../memory/visibility.js');
-        const { getProjectDataDir } = await import('../../../store/persistence.js');
         const { initObservationStore } = await import('../../../store/obs-store.js');
-        const { detectProject } = await import('../../../project/detector.js');
+        const { getTuiOperatorContext } = await import('../operator-context.js');
 
-        const proj = detectProject(process.cwd());
-        if (!proj) return;
+        const { project: proj, dataDir, reader } = await getTuiOperatorContext();
 
         const effectiveProjectId = projectId || proj.id;
-        const dataDir = await getProjectDataDir(effectiveProjectId);
+        if (effectiveProjectId !== proj.id) return;
         await initObservationStore(dataDir);
         await initObservations(dataDir);
 
         const obsId = parseInt(idMatch[1], 10);
         const obs = filterReadableObservations(
           getAllObservations().filter((observation) => observation.projectId === effectiveProjectId),
-          { projectId: effectiveProjectId },
+          reader,
         ).find((observation) => observation.id === obsId);
         if (obs) {
           setDetailItem({

--- a/src/codegraph/auto-context.ts
+++ b/src/codegraph/auto-context.ts
@@ -20,6 +20,7 @@ import {
   type ProjectContextOverview,
 } from './project-context.js';
 import { CodeGraphStore } from './store.js';
+import { isEligibleForAutomaticDelivery } from '../memory/admission.js';
 import {
   lensPathCandidates,
   lensVerificationHints,
@@ -70,6 +71,14 @@ function activeProjectObservations(
   projectId: string,
 ): ProjectContextObservation[] {
   return observations.filter(obs => obs.projectId === projectId && (obs.status ?? 'active') === 'active');
+}
+
+function deliveryEligibleProjectObservations(
+  observations: ProjectContextObservation[],
+  projectId: string,
+): ProjectContextObservation[] {
+  return activeProjectObservations(observations, projectId)
+    .filter((observation) => isEligibleForAutomaticDelivery(observation));
 }
 
 function decideRefresh(input: {
@@ -176,12 +185,26 @@ export async function buildAutoProjectContext(input: {
           activeProjectObservations(input.observations, input.project.id) as any,
         );
         try {
-          const { enqueueClaimRequalification } = await import('../runtime/lifecycle.js');
+          const { MaintenanceTargetStore } = await import('../runtime/maintenance-targets.js');
+          new MaintenanceTargetStore(input.dataDir).register({
+            projectId: input.project.id,
+            projectRoot: input.project.rootPath,
+            dataDir: input.dataDir,
+          });
+          const {
+            enqueueClaimRequalification,
+            enqueueObservationQualification,
+          } = await import('../runtime/lifecycle.js');
           enqueueClaimRequalification({
             dataDir: input.dataDir,
             projectId: input.project.id,
             source: 'foreground-refresh',
             snapshotId: store.latestSnapshot(input.project.id)?.id,
+          });
+          enqueueObservationQualification({
+            dataDir: input.dataDir,
+            projectId: input.project.id,
+            source: 'foreground-refresh',
           });
         } catch {
           // The completed scan remains useful even if its later maintenance cannot queue.
@@ -201,7 +224,9 @@ export async function buildAutoProjectContext(input: {
   const explain = buildProjectContextExplain({
     project: input.project,
     store,
-    observations: input.observations,
+    // Binding sees all active evidence, but automatic delivery sees only
+    // evidence that has passed the control-plane admission gate.
+    observations: deliveryEligibleProjectObservations(input.observations, input.project.id),
     exclude,
   });
   const overview = explain.overview;

--- a/src/codegraph/auto-context.ts
+++ b/src/codegraph/auto-context.ts
@@ -2,6 +2,7 @@ import { existsSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { getResolvedConfig } from '../config/resolved-config.js';
 import { buildTaskWorkset, type TaskWorkset, type WorksetCaution } from '../knowledge/workset.js';
+import type { ContextDeliveryTarget } from '../knowledge/context-assembly.js';
 import type { ProjectInfo } from '../types.js';
 import { backfillMissingObservationCodeRefs, type CodeRefBackfillResult } from './binder.js';
 import { collectCurrentProjectFacts, formatGitFact, type CurrentProjectFacts } from './current-facts.js';
@@ -118,6 +119,8 @@ export async function buildAutoProjectContext(input: {
    * request. MCP and hook callers use this to keep their response path fast.
    */
   enqueueRefresh?: () => void | Promise<void>;
+  /** The caller surface is recorded in the Workset receipt, not its prompt. */
+  deliveryTarget?: ContextDeliveryTarget;
 }): Promise<AutoProjectContext> {
   const refreshMode = input.refresh ?? 'auto';
   const now = input.now ?? new Date();
@@ -300,6 +303,7 @@ export async function buildAutoProjectContext(input: {
       stale: overview.freshness.stale,
     },
     runtimeCautions,
+    ...(input.deliveryTarget ? { deliveryTarget: input.deliveryTarget } : {}),
   });
 
   return {

--- a/src/codegraph/context-pack.ts
+++ b/src/codegraph/context-pack.ts
@@ -316,6 +316,7 @@ export async function attachTaskWorkset(input: {
       stale: input.pack.warnings.filter(warning => warning.status === 'stale').length,
     },
     runtimeCautions: input.runtimeCautions,
+    deliveryTarget: 'context-pack',
   });
   return { ...input.pack, workset };
 }

--- a/src/codegraph/project-context.ts
+++ b/src/codegraph/project-context.ts
@@ -16,6 +16,8 @@ export interface ProjectContextObservation {
   title: string;
   type: string;
   status?: string;
+  /** Automatic capture must be qualified before it can source a project brief. */
+  admissionState?: 'ephemeral' | 'candidate' | 'qualified';
   createdAt?: string;
   updatedAt?: string;
   /** Explicit file paths recorded with a memory, used only before Code Memory exists. */

--- a/src/compact/engine.ts
+++ b/src/compact/engine.ts
@@ -232,6 +232,8 @@ export async function compactDetail(
         source: obs.source ?? 'agent',
         sourceDetail: obs.sourceDetail ?? '',
         valueCategory: obs.valueCategory ?? '',
+        admissionState: obs.admissionState ?? '',
+        admissionReason: obs.admissionReason ?? '',
       });
     } else {
       missingRefs.push(ref);
@@ -401,6 +403,8 @@ function observationToDocument(obs: ReturnType<typeof getAllObservations>[number
     source: obs.source ?? 'agent',
     sourceDetail: obs.sourceDetail ?? '',
     valueCategory: obs.valueCategory ?? '',
+    admissionState: obs.admissionState ?? '',
+    admissionReason: obs.admissionReason ?? '',
   };
 }
 

--- a/src/compact/engine.ts
+++ b/src/compact/engine.ts
@@ -9,7 +9,7 @@
  * Layer 3 (detail)   → Full observation content (~500-1000 tokens/result)
  */
 
-import type { SearchOptions, IndexEntry, TimelineContext, MemorixDocument, ObservationRef, MemoryRef, MiniSkill, SourceSnapshot } from '../types.js';
+import type { SearchOptions, IndexEntry, TimelineContext, MemorixDocument, ObservationRef, MemoryRef, MiniSkill, SourceSnapshot, ObservationReader } from '../types.js';
 import { searchObservations, getTimeline, getObservationsByIds, makeOramaObservationId } from '../store/orama-store.js';
 import { getObservation, getAllObservations } from '../memory/observations.js';
 import { ensureFreshIndex } from '../memory/freshness.js';
@@ -21,6 +21,7 @@ import { getObservationStore } from '../store/obs-store.js';
 import { getMiniSkillStore } from '../store/mini-skill-store.js';
 import { miniSkillToDocument, resolveProvenanceStatus, type ProvenanceStatus } from '../skills/mini-skills.js';
 import { redactCredentials } from '../memory/secret-filter.js';
+import { canReadObservation, filterReadableObservations } from '../memory/visibility.js';
 
 export function normalizeMemoryBrowseQuery(query: string): string {
   const trimmed = query.trim();
@@ -76,14 +77,17 @@ export async function compactSearch(options: SearchOptions): Promise<{
   let formatted = formatIndexTable(entries, searchOptions.query, !options.projectId);
 
   if (entries.length === 0 && options.projectId) {
-    const allObservations = getAllObservations();
+    const allObservations = filterReadableObservations(getAllObservations(), options.reader);
     const projectAliases = new Set(await resolveAliases(options.projectId).catch(() => [options.projectId]));
     const projectHasStoredMemory = allObservations.some((obs) => obs.projectId && projectAliases.has(obs.projectId));
     if (!projectHasStoredMemory) {
       formatted =
-        `This project does not have any Memorix memories yet.\n\n` +
-        `It looks like a fresh project: the tool call worked, but there is nothing stored to retrieve yet.\n\n` +
-        `Memories will start appearing after observations, session summaries, hook captures, or git-memory are written.`;
+        options.reader
+          ? `No Memorix memories are available to this session yet.\n\n` +
+            `The tool call worked, but this session has no project-visible memory to retrieve.`
+          : `This project does not have any Memorix memories yet.\n\n` +
+            `It looks like a fresh project: the tool call worked, but there is nothing stored to retrieve yet.\n\n` +
+            `Memories will start appearing after observations, session summaries, hook captures, or git-memory are written.`;
     } else {
       formatted =
         `No memories found matching "${options.query}".\n\n` +
@@ -106,12 +110,13 @@ export async function compactTimeline(
   projectId?: string,
   depthBefore = 3,
   depthAfter = 3,
+  reader?: ObservationReader,
 ): Promise<{
   timeline: TimelineContext;
   formatted: string;
   totalTokens: number;
 }> {
-  const result = await getTimeline(anchorId, projectId, depthBefore, depthAfter);
+  const result = await getTimeline(anchorId, projectId, depthBefore, depthAfter, reader);
 
   const timeline: TimelineContext = {
     anchorId,
@@ -135,6 +140,7 @@ export async function compactTimeline(
  */
 export async function compactDetail(
   idsOrRefs: number[] | ObservationRef[] | string[],
+  options: { reader?: ObservationReader } = {},
 ): Promise<{
   documents: MemorixDocument[];
   formatted: string;
@@ -212,7 +218,7 @@ export async function compactDetail(
   const missingRefs: ObservationRef[] = [];
   for (const ref of refs) {
     const obs = getObservation(ref.id, ref.projectId);
-    if (obs && (ref.projectId ? obs.projectId === ref.projectId : true)) {
+    if (obs && (ref.projectId ? obs.projectId === ref.projectId : true) && canReadObservation(obs, options.reader)) {
       documentMap.set(toRefKey(ref), {
         id: makeOramaObservationId(obs.projectId, obs.id),
         observationId: obs.id,
@@ -234,6 +240,9 @@ export async function compactDetail(
         valueCategory: obs.valueCategory ?? '',
         admissionState: obs.admissionState ?? '',
         admissionReason: obs.admissionReason ?? '',
+        visibility: obs.visibility ?? 'project',
+        createdByAgentId: obs.createdByAgentId ?? '',
+        sharedWithAgentIds: JSON.stringify(obs.sharedWithAgentIds ?? []),
       });
     } else {
       missingRefs.push(ref);
@@ -244,19 +253,19 @@ export async function compactDetail(
     for (const ref of missingRefs) {
       const fallbackDocs = await getObservationsByIds([ref.id], ref.projectId);
       const doc = fallbackDocs[0];
-      if (doc) {
+      if (doc && canReadObservation(doc, options.reader)) {
         documentMap.set(toRefKey(ref), doc);
         continue;
       }
       const stored = await getPersistedObservation(ref);
-      if (stored) {
+      if (stored && canReadObservation(stored, options.reader)) {
         documentMap.set(toRefKey(ref), observationToDocument(stored));
       }
     }
   }
 
   // Build cross-reference map for all requested observations
-  const allObs = getAllObservations();
+  const allObs = filterReadableObservations(getAllObservations(), options.reader);
   const crossRefMap = new Map<string, string[]>();
   for (const ref of refs) {
     const obs = getObservation(ref.id, ref.projectId);
@@ -405,6 +414,9 @@ function observationToDocument(obs: ReturnType<typeof getAllObservations>[number
     valueCategory: obs.valueCategory ?? '',
     admissionState: obs.admissionState ?? '',
     admissionReason: obs.admissionReason ?? '',
+    visibility: obs.visibility ?? 'project',
+    createdByAgentId: obs.createdByAgentId ?? '',
+    sharedWithAgentIds: JSON.stringify(obs.sharedWithAgentIds ?? []),
   };
 }
 

--- a/src/compact/index-format.ts
+++ b/src/compact/index-format.ts
@@ -179,6 +179,8 @@ export function formatObservationDetail(doc: {
   entityName: string;
   sourceDetail?: string;
   valueCategory?: string;
+  admissionState?: string;
+  admissionReason?: string;
   source?: string;
   commitHash?: string;
   relatedCommits?: string[];
@@ -187,7 +189,15 @@ export function formatObservationDetail(doc: {
   const lines: string[] = [];
 
   // Provenance header — shown before #ID when sourceDetail (or legacy source='git') is set
-  const header = buildProvenanceHeader(doc.sourceDetail, doc.valueCategory, doc.source, doc.commitHash, doc.relatedCommits);
+  const header = buildProvenanceHeader(
+    doc.sourceDetail,
+    doc.valueCategory,
+    doc.admissionState,
+    doc.admissionReason,
+    doc.source,
+    doc.commitHash,
+    doc.relatedCommits,
+  );
   if (header) {
     lines.push(header);
     lines.push('');
@@ -236,6 +246,8 @@ export function formatObservationDetail(doc: {
 function buildProvenanceHeader(
   sourceDetail?: string,
   valueCategory?: string,
+  admissionState?: string,
+  admissionReason?: string,
   source?: string,
   commitHash?: string,
   relatedCommits?: string[],
@@ -257,11 +269,22 @@ function buildProvenanceHeader(
     lines.push(verificationLine);
   }
 
-  if (valueCategory === 'core') {
+  if (valueCategory === 'core' && admissionState !== 'candidate' && admissionState !== 'ephemeral') {
     lines.push('[CORE] Core — immune to decay');
+  } else if (valueCategory === 'core') {
+    lines.push('[CORE] Core candidate — not durable until qualification completes');
   } else if (valueCategory === 'ephemeral') {
     lines.push('[WARN] Ephemeral — short-lived signal');
   }
+
+  if (admissionState === 'candidate') {
+    lines.push('[PENDING] Candidate — excluded from automatic context until current Code Memory qualifies it');
+  } else if (admissionState === 'ephemeral') {
+    lines.push('[TRACE] Ephemeral capture — excluded from automatic context');
+  } else if (admissionState === 'qualified') {
+    lines.push('[QUALIFIED] Automatic evidence passed current Code Memory qualification');
+  }
+  if (admissionReason) lines.push(`Admission: ${redactCredentials(admissionReason)}`);
 
   return lines.join('\n');
 }

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -23,6 +23,8 @@ import { resetDotenv } from '../config/dotenv-loader.js';
 import { initProjectRoot } from '../config/yaml-loader.js';
 import { clearProjectRoot } from '../config/yaml-loader.js';
 import { scopeKnowledgeGraphToProject } from '../memory/graph-scope.js';
+import { canManageObservation, filterReadableObservations } from '../memory/visibility.js';
+import type { Observation } from '../types.js';
 
 // MIME types for static file serving
 const MIME_TYPES: Record<string, string> = {
@@ -57,6 +59,15 @@ function sendError(res: ServerResponse, message: string, status = 500) {
  */
 function filterByProject<T extends { projectId?: string }>(items: T[], projectId: string): T[] {
     return items.filter(item => item.projectId === projectId);
+}
+
+/**
+ * The dashboard has no per-agent authentication. Treat it as an unbound reader:
+ * project facts remain inspectable, while personal and team-scoped records stay
+ * in their owning MCP session.
+ */
+function filterDashboardObservations(observations: Observation[], projectId: string): Observation[] {
+    return filterReadableObservations(observations, { projectId });
 }
 
 function isActiveStatus(status?: string): boolean {
@@ -147,7 +158,10 @@ async function handleApi(
                 // List all unique project IDs from observations data (flat storage)
                 // Deduplicate using alias registry – aliased IDs are merged under canonical
                 try {
-                    const allObs = await getObservationStore().loadAll() as Array<{ projectId?: string; status?: string }>;
+                    const allObs = filterReadableObservations(
+                        await getObservationStore().loadAll(),
+                        {},
+                    ) as Array<{ projectId?: string; status?: string }>;
                     const projectSet = new Map<string, number>();
                     for (const obs of allObs) {
                         if (!isActiveStatus(obs.status)) continue;
@@ -204,14 +218,20 @@ async function handleApi(
                 await initGraphStore(effectiveDataDir);
                 const gStore = getGraphStore();
                 const graph = { entities: gStore.loadEntities(), relations: gStore.loadRelations() };
-                const graphObs = await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' });
+                const graphObs = filterDashboardObservations(
+                    await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' }),
+                    effectiveProjectId,
+                );
                 const scoped = scopeKnowledgeGraphToProject(graph, graphObs);
                 sendJson(res, { entities: scoped.entities, relations: scoped.relations });
                 break;
             }
 
             case '/observations': {
-                const observations = await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' });
+                const observations = filterDashboardObservations(
+                    await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' }),
+                    effectiveProjectId,
+                );
                 sendJson(res, observations);
                 break;
             }
@@ -226,7 +246,10 @@ async function handleApi(
             case '/stats': {
                 await initGraphStore(effectiveDataDir);
                 const graph = { entities: getGraphStore().loadEntities(), relations: getGraphStore().loadRelations() };
-                const observations = await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' }) as Array<{ type?: string; id?: number; createdAt?: string; title?: string; entityName?: string; relatedEntities?: string[]; status?: string }>;
+                const observations = filterDashboardObservations(
+                    await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' }),
+                    effectiveProjectId,
+                ) as Array<{ type?: string; id?: number; createdAt?: string; title?: string; entityName?: string; relatedEntities?: string[]; status?: string }>;
                 const nextId = await getObservationStore().loadIdCounter();
 
                 // Project-scoped graph counts (must match /api/graph and /api/export)
@@ -362,7 +385,10 @@ async function handleApi(
             }
 
             case '/retention': {
-                const observations = await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' }) as Array<{
+                const observations = filterDashboardObservations(
+                    await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' }),
+                    effectiveProjectId,
+                ) as Array<{
                     id?: number;
                     title?: string;
                     type?: string;
@@ -423,7 +449,10 @@ async function handleApi(
 
                 await initMiniSkillStore(effectiveDataDir);
 
-                const allObs = await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' });
+                const allObs = filterDashboardObservations(
+                    await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' }),
+                    effectiveProjectId,
+                );
                 const skills = await getMiniSkillStore().loadByProject(effectiveProjectId);
 
                 const overview = generateKnowledgeBase({
@@ -444,7 +473,10 @@ async function handleApi(
                 await initMiniSkillStore(effectiveDataDir);
                 await initGraphStore(effectiveDataDir);
 
-                const allObs = await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' });
+                const allObs = filterDashboardObservations(
+                    await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' }),
+                    effectiveProjectId,
+                );
                 const skills = await getMiniSkillStore().loadByProject(effectiveProjectId);
 
                 const fullGraph = { entities: getGraphStore().loadEntities(), relations: getGraphStore().loadRelations() };
@@ -597,7 +629,7 @@ async function handleApi(
 
             case '/identity': {
                 // Project identity health — with classification layering (matches control-plane contract)
-                const allObs = await getObservationStore().loadAll() as Array<{ projectId?: string }>;
+                const allObs = filterReadableObservations(await getObservationStore().loadAll(), {}) as Array<{ projectId?: string }>;
                 const allProjectIds = [...new Set(allObs.map(o => o.projectId).filter(Boolean))] as string[];
 
                 // Classify every known ID (real / temporary / placeholder) + dirty axis
@@ -698,6 +730,8 @@ async function handleApi(
                     } else if (matchObs.projectId !== effectiveProjectId) {
                         // Cross-project deletion guard: reject if obs belongs to a different project
                         sendError(res, `Observation #${obsId} belongs to project "${matchObs.projectId}", not "${effectiveProjectId}"`, 403);
+                    } else if (!canManageObservation(matchObs, { projectId: effectiveProjectId })) {
+                        sendError(res, `Observation #${obsId} is not manageable from the unbound dashboard.`, 403);
                     } else {
                         await obsStore.remove(obsId);
 
@@ -722,7 +756,10 @@ async function handleApi(
                 if (apiPath === '/export') {
                     await initGraphStore(effectiveDataDir);
                     const fullGraph = { entities: getGraphStore().loadEntities(), relations: getGraphStore().loadRelations() };
-                    const observations = await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' });
+                    const observations = filterDashboardObservations(
+                        await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' }),
+                        effectiveProjectId,
+                    );
                     const nextId = await getObservationStore().loadIdCounter();
                     const scoped = scopeKnowledgeGraphToProject(fullGraph, observations);
                     const exportData = {

--- a/src/hooks/admission.ts
+++ b/src/hooks/admission.ts
@@ -1,0 +1,117 @@
+import type { ObservationAdmissionState, ObservationType } from '../types.js';
+import { isSignificantKnowledge } from './significance-filter.js';
+import type { NormalizedHookInput } from './types.js';
+
+export type HookCaptureCategory =
+  | 'file_modify'
+  | 'file_read'
+  | 'command'
+  | 'search'
+  | 'memorix_internal'
+  | 'unknown';
+
+export type HookAdmissionDecision =
+  | { action: 'drop'; reason: string }
+  | {
+    action: 'store';
+    admissionState: ObservationAdmissionState;
+    admissionReason: string;
+    valueCategory: 'core' | 'contextual' | 'ephemeral';
+  };
+
+const FAILURE_PATTERN = /\b(fail(?:ed|ure)?|error|exception|assert(?:ion)?|exit code [1-9]|TypeError|ReferenceError|SyntaxError|ENOENT|ECONNREFUSED|panic)\b/i;
+const DECISION_PATTERN = /\b(decision|decided|choose|chosen|because|trade-?off|invariant|root cause|workaround|must|should not)\b/i;
+const TASK_PATTERN = /\b(add|implement|fix|refactor|migrate|upgrade|debug|investigate|test|release|deploy|remove)\b/i;
+const VALIDATION_PATTERN = /\b(test|tests|vitest|jest|pytest|playwright|cypress|typecheck|lint|build|cargo test|go test)\b/i;
+const FOCUSED_VALIDATION_PATTERN = /(?:--run|--filter|--grep|\s-t\s|\.test\.|\.spec\.|::[\w-]+)/i;
+const ROUTINE_SUCCESS_PATTERN = /\b(added \d+ packages|up to date|passed|all tests pass|tests? passed|0 failures|success(?:fully)?)\b/i;
+
+function isCandidateType(type: ObservationType): boolean {
+  return type === 'decision' ||
+    type === 'gotcha' ||
+    type === 'problem-solution' ||
+    type === 'trade-off' ||
+    type === 'why-it-exists';
+}
+
+function candidate(
+  admissionReason: string,
+  valueCategory: 'core' | 'contextual' = 'contextual',
+): HookAdmissionDecision {
+  return { action: 'store', admissionState: 'candidate', admissionReason, valueCategory };
+}
+
+function ephemeral(admissionReason: string): HookAdmissionDecision {
+  return { action: 'store', admissionState: 'ephemeral', admissionReason, valueCategory: 'ephemeral' };
+}
+
+/**
+ * Cheap, deterministic first-pass admission for cross-agent hooks. It never
+ * promotes an automatic record directly to durable context: background
+ * qualification must still prove a current Code Memory reference.
+ */
+export function assessHookAdmission(input: {
+  hook: NormalizedHookInput;
+  category: HookCaptureCategory;
+  content: string;
+  observationType: ObservationType;
+}): HookAdmissionDecision {
+  const { hook, category, content, observationType } = input;
+  const command = hook.command ?? '';
+  const hasFailure = FAILURE_PATTERN.test(content);
+  const hasDecision = DECISION_PATTERN.test(content) || isCandidateType(observationType);
+  const isValidation = VALIDATION_PATTERN.test(command) || VALIDATION_PATTERN.test(content);
+  const isFocusedValidation = FOCUSED_VALIDATION_PATTERN.test(command);
+  const isRoutineSuccess = ROUTINE_SUCCESS_PATTERN.test(content);
+
+  if (hasFailure) {
+    return candidate('automatic capture contains a concrete failure or verification signal');
+  }
+  if (hasDecision) {
+    return candidate('automatic capture contains a decision or durable rationale', 'core');
+  }
+
+  if (hook.event === 'user_prompt') {
+    return TASK_PATTERN.test(content)
+      ? candidate('user task contains a concrete technical action')
+      : { action: 'drop', reason: 'prompt has no durable technical task signal' };
+  }
+
+  if (hook.event === 'post_response') {
+    // Agent integrations such as OpenCode emit concise end-of-turn summaries.
+    // Keep technically meaningful ones as candidates; qualification still
+    // prevents them from becoming automatic context without code evidence.
+    return isSignificantKnowledge(content).isSignificant
+      ? candidate('assistant response records a concrete technical outcome')
+      : { action: 'drop', reason: 'response has no durable technical outcome' };
+  }
+
+  if (hook.event === 'session_end') {
+    // The handler already applies a minimum-content gate for session end.
+    // Preserve a compact handoff trace, but keep it out of automatic context
+    // until later qualification.
+    return candidate('session-end summary awaits Code Memory qualification');
+  }
+
+  if (category === 'file_modify') {
+    return candidate('file mutation awaits Code Memory qualification');
+  }
+
+  if (category === 'command') {
+    if (isValidation && isFocusedValidation && !isRoutineSuccess) {
+      return candidate('focused validation result awaits Code Memory qualification');
+    }
+    if (isValidation || isRoutineSuccess) {
+      return ephemeral('routine command result retained only as a short-lived trace');
+    }
+    return ephemeral('command activity retained only as a short-lived trace');
+  }
+
+  if (category === 'search' || category === 'unknown') {
+    return content.length >= 300
+      ? ephemeral('unverified automatic activity retained only as a short-lived trace')
+      : { action: 'drop', reason: 'automatic activity has insufficient evidence' };
+  }
+
+  return { action: 'drop', reason: 'capture category is not eligible for automatic storage' };
+}

--- a/src/hooks/handler.ts
+++ b/src/hooks/handler.ts
@@ -2,15 +2,20 @@
  * Hook Handler
  *
  * Unified entry point for all agent hooks.
- * Architecture: Normalize → Classify → Policy → Store → Respond
+ * Architecture: Normalize → Classify → Admit → Store → Respond
  *
  * Design principles (inspired by claude-mem + mcp-memory-service):
- * - Store-first: capture generously, filter at read time
+ * - Candidate-first: automatic capture is never durable context by default
  * - Tool Taxonomy: declarative policies per tool category
  * - Pattern = classification only: determines observation type, not storage
  */
 
 import type { ObservationType } from '../types.js';
+import {
+  assessHookAdmission,
+  type HookAdmissionDecision,
+  type HookCaptureCategory,
+} from './admission.js';
 import { normalizeHookInput } from './normalizer.js';
 import { detectBestPattern, patternToObservationType } from './pattern-detector.js';
 import { isSignificantKnowledge, isRetrievedResult, isTrivialCommand } from './significance-filter.js';
@@ -49,7 +54,7 @@ const NOISE_COMMANDS = [
 // ─── Tool Taxonomy ───
 
 /** Tool categories for storage policy */
-type ToolCategory = 'file_modify' | 'file_read' | 'command' | 'search' | 'memorix_internal' | 'unknown';
+type ToolCategory = HookCaptureCategory;
 
 /** Storage policy per tool category */
 interface StoragePolicy {
@@ -233,7 +238,12 @@ function generateTitle(input: NormalizedHookInput, patternType: string): string 
   return `Activity (${patternType})`;
 }
 
-function buildObservation(input: NormalizedHookInput, content: string, category: ToolCategory) {
+function buildObservation(
+  input: NormalizedHookInput,
+  content: string,
+  category: ToolCategory,
+  admission?: Extract<HookAdmissionDecision, { action: 'store' }>,
+) {
   const pattern = detectBestPattern(content);
   const policy = STORAGE_POLICY[category] ?? STORAGE_POLICY.unknown;
   const fallbackType = input.filePath ? 'what-changed' : policy.defaultType;
@@ -252,6 +262,11 @@ function buildObservation(input: NormalizedHookInput, content: string, category:
     ],
     concepts: pattern?.matchedKeywords ?? [],
     filesModified: input.filePath ? [input.filePath] : [],
+    ...(admission ? {
+      valueCategory: admission.valueCategory,
+      admissionState: admission.admissionState,
+      admissionReason: admission.admissionReason,
+    } : {}),
   };
 }
 
@@ -281,6 +296,7 @@ async function handleSessionStart(input: NormalizedHookInput): Promise<{
       const { initMiniSkillStore } = await import('../store/mini-skill-store.js');
       const { initSessionStore } = await import('../store/session-store.js');
       const { initAliasRegistry, registerAlias } = await import('../project/aliases.js');
+      const { MaintenanceTargetStore } = await import('../runtime/maintenance-targets.js');
       const { buildAutoProjectContext, formatAutoProjectContextPrompt } = await import('../codegraph/auto-context.js');
 
       const rawProject = detectProject(input.cwd || process.cwd());
@@ -289,6 +305,11 @@ async function handleSessionStart(input: NormalizedHookInput): Promise<{
 
       initAliasRegistry(dataDir);
       const canonicalId = await registerAlias(rawProject);
+      new MaintenanceTargetStore(dataDir).register({
+        projectId: canonicalId,
+        projectRoot: rawProject.rootPath,
+        dataDir,
+      });
       await initObservationStore(dataDir);
       await initMiniSkillStore(dataDir);
       await initSessionStore(dataDir);
@@ -353,8 +374,17 @@ async function handleHookEventCore(input: NormalizedHookInput): Promise<{
     if (endContent.length < 50) {
       return { observation: null, output: defaultOutput };
     }
+    const draft = buildObservation(input, endContent, 'unknown');
+    const admission = assessHookAdmission({
+      hook: input,
+      category: 'unknown',
+      content: endContent,
+      observationType: draft.type,
+    });
     return {
-      observation: buildObservation(input, endContent, 'unknown'),
+      observation: admission.action === 'store'
+        ? buildObservation(input, endContent, 'unknown', admission)
+        : null,
       output: defaultOutput,
     };
   }
@@ -426,8 +456,17 @@ async function handleHookEventCore(input: NormalizedHookInput): Promise<{
   }
   markTriggered(cooldownKey);
 
+  const draft = buildObservation(input, content, category);
+  const admission = assessHookAdmission({
+    hook: input,
+    category,
+    content,
+    observationType: draft.type,
+  });
   return {
-    observation: buildObservation(input, content, category),
+    observation: admission.action === 'store'
+      ? buildObservation(input, content, category, admission)
+      : null,
     output: defaultOutput,
   };
 }
@@ -441,17 +480,24 @@ async function queueCodegraphRefreshForMutation(input: NormalizedHookInput): Pro
       { getProjectDataDir },
       { initAliasRegistry, registerAlias },
       { enqueueCodegraphRefresh },
+      { MaintenanceTargetStore },
     ] = await Promise.all([
       import('../project/detector.js'),
       import('../store/persistence.js'),
       import('../project/aliases.js'),
       import('../runtime/lifecycle.js'),
+      import('../runtime/maintenance-targets.js'),
     ]);
     const project = detectProject(input.cwd || process.cwd());
     if (!project) return;
     const dataDir = await getProjectDataDir(project.id);
     initAliasRegistry(dataDir);
     const projectId = await registerAlias(project);
+    new MaintenanceTargetStore(dataDir).register({
+      projectId,
+      projectRoot: project.rootPath,
+      dataDir,
+    });
     enqueueCodegraphRefresh({
       dataDir,
       projectId,
@@ -466,11 +512,25 @@ async function queueCodegraphRefreshForMutation(input: NormalizedHookInput): Pro
 export async function handleHookEvent(input: NormalizedHookInput): Promise<{
   observation: ReturnType<typeof buildObservation> | null;
   output: HookOutput;
+}>;
+export async function handleHookEvent(input: NormalizedHookInput, options: {
+  deferMaintenance?: boolean;
+}): Promise<{
+  observation: ReturnType<typeof buildObservation> | null;
+  output: HookOutput;
+}>;
+export async function handleHookEvent(input: NormalizedHookInput, options: {
+  deferMaintenance?: boolean;
+} = {}): Promise<{
+  observation: ReturnType<typeof buildObservation> | null;
+  output: HookOutput;
 }> {
   try {
     return await handleHookEventCore(input);
   } finally {
-    await queueCodegraphRefreshForMutation(input);
+    // The CLI persists an automatic observation after this function returns.
+    // It defers scheduling so a fast worker never scans before that write.
+    if (!options.deferMaintenance) await queueCodegraphRefreshForMutation(input);
   }
 }
 
@@ -571,7 +631,7 @@ export async function runHook(agentOverride?: string, eventOverride?: string): P
   }
 
   const input = normalizeHookInput(payload);
-  const { observation, output } = await handleHookEvent(input);
+  const { observation, output } = await handleHookEvent(input, { deferMaintenance: true });
 
   if (observation) {
     try {
@@ -582,6 +642,7 @@ export async function runHook(agentOverride?: string, eventOverride?: string): P
       const { detectProject } = await import('../project/detector.js');
       const { getProjectDataDir } = await import('../store/persistence.js');
       const { initAliasRegistry, registerAlias } = await import('../project/aliases.js');
+      const { MaintenanceTargetStore } = await import('../runtime/maintenance-targets.js');
 
       const rawProject = detectProject(input.cwd || process.cwd());
       if (!rawProject) throw new Error('No .git found');
@@ -591,100 +652,31 @@ export async function runHook(agentOverride?: string, eventOverride?: string): P
       initAliasRegistry(dataDir);
       const canonicalId = await registerAlias(rawProject);
       const projectId = canonicalId;
+      new MaintenanceTargetStore(dataDir).register({
+        projectId,
+        projectRoot: rawProject.rootPath,
+        dataDir,
+      });
       
       await initObservationStore(dataDir);
       await initMSStore(dataDir);
       await initSessStore(dataDir);
       await initObservations(dataDir);
       await storeObservation({ ...observation, projectId, sourceDetail: 'hook' });
-
-      // Shadow mode: Formation Pipeline metrics (fire-and-forget, never blocks)
-      try {
-        const { runFormation } = await import('../memory/formation/index.js');
-        const formationMode = (process.env.MEMORIX_FORMATION_MODE as 'shadow' | 'active' | 'fallback') || 'shadow';
-        const samplingRate = parseFloat(process.env.MEMORIX_FORMATION_HOOKS_SAMPLING_RATE || '0.1');
-        const shouldSample = Math.random() < samplingRate;
-
-        if (shouldSample) {
-          const { withFreshIndex } = await import('../memory/freshness.js');
-          const { getAllObservations } = await import('../memory/observations.js');
-          await withFreshIndex(() => getAllObservations());
-        }
-
-        // In hooks, shadow mode by default for performance
-        // Sampling rate controls how often we run full resolve (expensive)
-        const searchFn = shouldSample
-          ? async (q: string, limit: number, pid: string) => {
-              const { compactSearch, compactDetail } = await import('../compact/engine.js');
-              const result = await compactSearch({ query: q, limit, projectId: pid, status: 'active' });
-              if (result.entries.length === 0) return [];
-              const details = await compactDetail(result.entries.map(e => e.id));
-              return details.documents.map((d, i) => ({
-                id: Number(d.id.replace('obs-', '')),
-                observationId: d.observationId,
-                title: d.title,
-                narrative: d.narrative,
-                facts: d.facts,
-                entityName: d.entityName,
-                type: d.type,
-                score: result.entries[i]?.score ?? 0,
-              }));
-            }
-          : async () => []; // Skip search for speed (shadow mode)
-
-        const getObsFn = shouldSample
-          ? (id: number) => {
-              const { getObservation } = require('../memory/observations.js');
-              const o = getObservation(id);
-              if (!o) return null;
-              return {
-                id: o.id,
-                entityName: o.entityName,
-                type: o.type,
-                title: o.title,
-                narrative: o.narrative,
-                facts: o.facts,
-                topicKey: o.topicKey,
-              };
-            }
-          : () => null;
-
-        const getEntityNamesFn = shouldSample
-          ? () => {
-              const { graphManager } = require('../memory/graph.js');
-              return graphManager.getEntityNames();
-            }
-          : () => [];
-
-        runFormation({
-          entityName: observation.entityName,
-          type: observation.type,
-          title: observation.title,
-          narrative: observation.narrative,
-          facts: observation.facts,
-          projectId,
-          source: 'hook' as const,
-        }, {
-          mode: formationMode,
-          useLLM: false,
-          minValueScore: 0.3,
-          hooksSamplingRate: samplingRate,
-          searchMemories: searchFn,
-          getObservation: getObsFn,
-          getEntityNames: getEntityNamesFn,
-        }).catch(() => {});
-      } catch { /* Formation is optional — never break hooks */ }
-
-      // Feedback: tell the agent what was saved
-      const emoji = TYPE_EMOJI[observation.type] ?? '[PLAN]';
-      output.systemMessage = (output.systemMessage ?? '') +
-        `\n${emoji} Memorix saved: ${observation.title} [${observation.type}]`;
+      // Automatic capture is deliberately quiet. Candidate state and later
+      // qualification are visible through Memorix inspection, not injected as
+      // a stream of status messages into the host agent's context.
     } catch (storeErr) {
       // Diagnostic log — hooks must never break the agent, but silent
       // swallow makes end-to-end debugging impossible.
       console.error('[memorix] hook store failed:', (storeErr as Error)?.message ?? storeErr);
     }
   }
+
+  // A candidate must be durable before a Code Memory refresh can qualify it.
+  // Keep direct handleHookEvent() backward-compatible, but make the real CLI
+  // hook path explicitly capture first and schedule second.
+  await queueCodegraphRefreshForMutation(input);
 
   // Build hookSpecificOutput — Claude Code only supports it for 3 event types:
   //   PreToolUse, UserPromptSubmit, PostToolUse

--- a/src/hooks/handler.ts
+++ b/src/hooks/handler.ts
@@ -306,6 +306,7 @@ async function handleSessionStart(input: NormalizedHookInput): Promise<{
               maxFiles: 5_000,
             });
           }),
+        deliveryTarget: 'hook-session-start',
       });
       contextSummary = `\n\n${formatAutoProjectContextPrompt(context)}`;
     } catch (sessErr) {

--- a/src/hooks/handler.ts
+++ b/src/hooks/handler.ts
@@ -10,6 +10,7 @@
  * - Pattern = classification only: determines observation type, not storage
  */
 
+import { createHash } from 'node:crypto';
 import type { ObservationType } from '../types.js';
 import {
   assessHookAdmission,
@@ -39,6 +40,11 @@ const MIN_PROMPT_LENGTH = 20;
 
 /** Max content length (truncate beyond this) */
 const MAX_CONTENT_LENGTH = 4000;
+
+function deriveHookActorId(input: NormalizedHookInput): string {
+  const material = `${input.agent ?? 'unknown'}\u0000${input.sessionId ?? 'unknown'}`;
+  return `hook:${createHash('sha256').update(material).digest('hex').slice(0, 24)}`;
+}
 
 /** Truly trivial commands — standalone navigation/inspection only */
 const NOISE_COMMANDS = [
@@ -266,6 +272,10 @@ function buildObservation(
       valueCategory: admission.valueCategory,
       admissionState: admission.admissionState,
       admissionReason: admission.admissionReason,
+      // Automatic capture is private until current code can qualify it for
+      // shared project delivery. The opaque actor is stable within a hook session.
+      visibility: 'personal' as const,
+      createdByAgentId: deriveHookActorId(input),
     } : {}),
   };
 }
@@ -298,6 +308,7 @@ async function handleSessionStart(input: NormalizedHookInput): Promise<{
       const { initAliasRegistry, registerAlias } = await import('../project/aliases.js');
       const { MaintenanceTargetStore } = await import('../runtime/maintenance-targets.js');
       const { buildAutoProjectContext, formatAutoProjectContextPrompt } = await import('../codegraph/auto-context.js');
+      const { filterReadableObservations } = await import('../memory/visibility.js');
 
       const rawProject = detectProject(input.cwd || process.cwd());
       if (!rawProject) throw new Error('No .git found');
@@ -313,7 +324,10 @@ async function handleSessionStart(input: NormalizedHookInput): Promise<{
       await initObservationStore(dataDir);
       await initMiniSkillStore(dataDir);
       await initSessionStore(dataDir);
-      const activeObservations = await getStore().loadByProject(canonicalId, { status: 'active' });
+      const activeObservations = filterReadableObservations(
+        await getStore().loadByProject(canonicalId, { status: 'active' }),
+        { projectId: canonicalId },
+      );
       const context = await buildAutoProjectContext({
         project: { ...rawProject, id: canonicalId },
         dataDir,

--- a/src/knowledge/context-assembly.ts
+++ b/src/knowledge/context-assembly.ts
@@ -1,0 +1,97 @@
+/**
+ * Shared metadata contract for every bounded context delivery surface.
+ * The rendered Workset stays agent-facing; this receipt is for JSON, explain,
+ * diagnostics, and future handoff adapters.
+ */
+export type ContextDeliveryTarget =
+  | 'project-context'
+  | 'context-pack'
+  | 'hook-session-start'
+  | 'session-handoff';
+
+export type ContextCandidateKind =
+  | 'task'
+  | 'current-fact'
+  | 'code-state'
+  | 'semantic-code'
+  | 'start-here'
+  | 'memory'
+  | 'claim'
+  | 'knowledge-page'
+  | 'workflow'
+  | 'verification'
+  | 'caution';
+
+export type ContextCandidateFreshness = 'current' | 'suspect' | 'stale' | 'unknown';
+export type ContextCandidateTrust = 'source-backed' | 'derived' | 'historical';
+
+export interface ContextReceiptSelection {
+  kind: ContextCandidateKind;
+  /** Stable source id when the candidate has one; never raw content. */
+  id?: string;
+  reason: string;
+  freshness?: ContextCandidateFreshness;
+  trust?: ContextCandidateTrust;
+}
+
+export interface ContextReceiptOmission {
+  kind: ContextCandidateKind;
+  reason: 'token-budget' | 'hidden-by-task-lens' | 'unavailable';
+  count: number;
+}
+
+export interface ContextReceipt {
+  version: '1.2.2';
+  target: ContextDeliveryTarget;
+  elapsedMs: number;
+  budget: {
+    maxTokens: number;
+    tokenCount: number;
+  };
+  selected: ContextReceiptSelection[];
+  omitted: ContextReceiptOmission[];
+  scheduledActions: string[];
+}
+
+function displayTarget(target: ContextDeliveryTarget): string {
+  switch (target) {
+    case 'project-context': return 'Project Context';
+    case 'context-pack': return 'Context Pack';
+    case 'hook-session-start': return 'SessionStart hook';
+    case 'session-handoff': return 'session handoff';
+  }
+}
+
+/** A human-facing diagnostic formatter. Do not append this to agent context. */
+export function formatContextReceipt(receipt: ContextReceipt): string {
+  const lines = [
+    'Context delivery receipt',
+    `- Target: ${displayTarget(receipt.target)}`,
+    `- Budget: ${receipt.budget.tokenCount}/${receipt.budget.maxTokens} tokens`,
+    `- Assembly: ${receipt.elapsedMs} ms`,
+    `- Selected: ${receipt.selected.length} item(s)`,
+  ];
+
+  if (receipt.selected.length > 0) {
+    lines.push('', 'Selected evidence');
+    for (const item of receipt.selected.slice(0, 20)) {
+      const id = item.id ? ` ${item.id}` : '';
+      const qualifiers = [item.trust, item.freshness].filter(Boolean).join(', ');
+      lines.push(`- ${item.kind}${id}: ${item.reason}${qualifiers ? ` (${qualifiers})` : ''}`);
+    }
+  }
+
+  if (receipt.omitted.length > 0) {
+    lines.push('', 'Withheld by budget');
+    for (const item of receipt.omitted) {
+      lines.push(`- ${item.kind}: ${item.count} item(s) (${item.reason})`);
+    }
+  }
+
+  if (receipt.scheduledActions.length > 0) {
+    lines.push('', 'Scheduled follow-up');
+    for (const action of receipt.scheduledActions) lines.push(`- ${action}`);
+  }
+
+  return lines.join('\n');
+}

--- a/src/knowledge/workset.ts
+++ b/src/knowledge/workset.ts
@@ -6,6 +6,14 @@ import { KnowledgeWorkspaceStore } from './workspace-store.js';
 import { loadKnowledgeWorkspace } from './workspace.js';
 import { WorkflowStore } from './workflow-store.js';
 import { selectWorkflows } from './workflows.js';
+import type {
+  ContextCandidateFreshness,
+  ContextCandidateKind,
+  ContextDeliveryTarget,
+  ContextReceipt,
+  ContextReceiptOmission,
+  ContextReceiptSelection,
+} from './context-assembly.js';
 import type { CodeGraphProviderQuality, ExternalCodeGraphOutline } from '../codegraph/types.js';
 import type { KnowledgeClaim, ClaimEvidenceRef } from './types.js';
 import type { KnowledgePageRecord, KnowledgeWorkspace } from './workspace-types.js';
@@ -98,6 +106,8 @@ export interface TaskWorkset {
     tokenCount: number;
     omitted: string[];
   };
+  /** Privacy-safe selection metadata for diagnostics, never appended to the prompt. */
+  receipt: ContextReceipt;
   prompt: string;
 }
 
@@ -128,6 +138,8 @@ export interface BuildTaskWorksetInput {
   };
   runtimeCautions?: WorksetCaution[];
   maxTokens?: number;
+  /** Delivery surface controls receipt semantics without changing prompt shape. */
+  deliveryTarget?: ContextDeliveryTarget;
 }
 
 function unique(values: string[]): string[] {
@@ -228,35 +240,104 @@ function appendLine(
   maxTokens: number,
   omitted: string[],
   omittedKind: string,
+  selected?: ContextReceiptSelection[],
+  receiptSelection?: ContextReceiptSelection,
 ): boolean {
   const next = lines.length ? lines.join('\n') + '\n' + candidate : candidate;
   if (countTextTokens(next) <= maxTokens) {
     lines.push(candidate);
+    if (receiptSelection) selected?.push(receiptSelection);
     return true;
   }
   omitted.push(omittedKind);
   return false;
 }
 
+function freshnessForMemory(status: WorksetMemorySource['status']): ContextCandidateFreshness {
+  if (status === 'current' || status === 'suspect' || status === 'stale') return status;
+  return 'unknown';
+}
+
+function receiptOmissionKind(raw: string): ContextCandidateKind | undefined {
+  if (raw.includes('task')) return 'task';
+  if (raw.includes('fact')) return 'current-fact';
+  if (raw.includes('state')) return 'code-state';
+  if (raw.includes('semantic')) return 'semantic-code';
+  if (raw.includes('start')) return 'start-here';
+  if (raw.includes('memory')) return 'memory';
+  if (raw.includes('claim')) return 'claim';
+  if (raw.includes('knowledge-page')) return 'knowledge-page';
+  if (raw.includes('workflow')) return 'workflow';
+  if (raw.includes('verification')) return 'verification';
+  if (raw.includes('caution')) return 'caution';
+  return undefined;
+}
+
+function receiptOmissions(omitted: string[], hiddenCautionMemoryCount: number): ContextReceiptOmission[] {
+  const counts = new Map<ContextCandidateKind, number>();
+  for (const raw of omitted) {
+    const kind = receiptOmissionKind(raw);
+    if (!kind || raw.endsWith('-heading')) continue;
+    counts.set(kind, (counts.get(kind) ?? 0) + 1);
+  }
+  const receipt: ContextReceiptOmission[] = [...counts.entries()].map(([kind, count]) => ({
+    kind,
+    reason: 'token-budget',
+    count,
+  }));
+  if (hiddenCautionMemoryCount > 0) {
+    receipt.push({
+      kind: 'caution',
+      reason: 'hidden-by-task-lens',
+      count: hiddenCautionMemoryCount,
+    });
+  }
+  return receipt;
+}
+
+function scheduledActions(cautions: WorksetCaution[]): string[] {
+  return cautions
+    .filter(caution => caution.kind === 'codegraph-refresh-queued')
+    .map(caution => short(caution.message, 28));
+}
+
 /**
  * Render a bounded prompt from whole evidence items. It never cuts a page,
  * workflow, or claim body into an untraceable partial fragment.
  */
-export function renderTaskWorksetPrompt(input: Omit<TaskWorkset, 'prompt' | 'budget'> & {
+export function renderTaskWorksetPrompt(input: Omit<TaskWorkset, 'prompt' | 'budget' | 'receipt'> & {
   budget?: Partial<TaskWorkset['budget']>;
-}): { prompt: string; tokenCount: number; omitted: string[] } {
+}): {
+  prompt: string;
+  tokenCount: number;
+  /** Compatibility summary: unique omission categories. */
+  omitted: string[];
+  /** Internal receipt input: one entry per candidate that did not fit. */
+  omittedItems: string[];
+  selected: ContextReceiptSelection[];
+} {
   const maxTokens = input.budget?.maxTokens ?? 180;
   const omitted: string[] = [];
+  const selected: ContextReceiptSelection[] = [];
   const lines: string[] = ['Memorix Autopilot Brief'];
   const task = short(input.task || 'Continue the current task.', 34);
-  appendLine(lines, 'Task: ' + task, maxTokens, omitted, 'task-detail');
+  appendLine(lines, 'Task: ' + task, maxTokens, omitted, 'task-detail', selected, {
+    kind: 'task',
+    reason: 'current task supplied by the caller',
+    trust: 'source-backed',
+  });
   appendLine(lines, 'Task lens: ' + input.lens, maxTokens, omitted, 'lens');
 
   if (input.cautions.length > 0 || input.cautionMemory.length > 0) {
     appendLine(lines, '', maxTokens, omitted, 'caution-heading');
     appendLine(lines, 'Cautions', maxTokens, omitted, 'caution-heading');
     for (const caution of input.cautions.slice(0, 6)) {
-      appendLine(lines, '- ' + short(caution.message, 22), maxTokens, omitted, 'caution');
+      appendLine(lines, '- ' + short(caution.message, 22), maxTokens, omitted, 'caution', selected, {
+        kind: 'caution',
+        id: 'caution:' + caution.kind,
+        reason: 'current project caution',
+        trust: 'source-backed',
+      });
     }
     for (const memory of input.cautionMemory.slice(0, 3)) {
       const location = memory.path
@@ -269,6 +350,14 @@ export function renderTaskWorksetPrompt(input: Omit<TaskWorkset, 'prompt' | 'bud
         maxTokens,
         omitted,
         'caution-memory',
+        selected,
+        {
+          kind: 'memory',
+          id: 'memory:' + memory.id,
+          reason: 'task-relevant memory requiring source verification',
+          freshness: freshnessForMemory(memory.status),
+          trust: 'historical',
+        },
       );
     }
     if (input.hiddenCautionMemoryCount > 0) {
@@ -280,14 +369,23 @@ export function renderTaskWorksetPrompt(input: Omit<TaskWorkset, 'prompt' | 'bud
     appendLine(lines, '', maxTokens, omitted, 'facts-heading');
     appendLine(lines, 'Current project facts', maxTokens, omitted, 'facts-heading');
     for (const fact of input.currentFacts.slice(0, 4)) {
-      appendLine(lines, '- ' + short(fact, 40), maxTokens, omitted, 'current-fact');
+      appendLine(lines, '- ' + short(fact, 40), maxTokens, omitted, 'current-fact', selected, {
+        kind: 'current-fact',
+        reason: 'current project state',
+        trust: 'source-backed',
+      });
     }
   }
 
   if (input.codeState) {
     appendLine(lines, '', maxTokens, omitted, 'state-heading');
     appendLine(lines, 'Project state', maxTokens, omitted, 'state-heading');
-    appendLine(lines, input.codeState, maxTokens, omitted, 'code-state');
+    appendLine(lines, input.codeState, maxTokens, omitted, 'code-state', selected, {
+      kind: 'code-state',
+      ...(input.provenance.snapshotId ? { id: 'snapshot:' + input.provenance.snapshotId } : {}),
+      reason: 'latest available Code State snapshot',
+      trust: 'source-backed',
+    });
   }
 
   if (input.semanticCode && (input.semanticCode.entryPoints.length > 0 || input.semanticCode.relations.length > 0)) {
@@ -301,6 +399,13 @@ export function renderTaskWorksetPrompt(input: Omit<TaskWorkset, 'prompt' | 'bud
         maxTokens,
         omitted,
         'semantic-relation',
+        selected,
+        {
+          kind: 'semantic-code',
+          id: 'code:' + location,
+          reason: 'validated optional semantic code relation',
+          trust: 'derived',
+        },
       );
     }
     if (input.semanticCode.relations.length === 0) {
@@ -312,6 +417,13 @@ export function renderTaskWorksetPrompt(input: Omit<TaskWorkset, 'prompt' | 'bud
           maxTokens,
           omitted,
           'semantic-entry',
+          selected,
+          {
+            kind: 'semantic-code',
+            id: 'code:' + location,
+            reason: 'validated optional semantic code entry point',
+            trust: 'derived',
+          },
         );
       }
     }
@@ -321,7 +433,12 @@ export function renderTaskWorksetPrompt(input: Omit<TaskWorkset, 'prompt' | 'bud
     appendLine(lines, '', maxTokens, omitted, 'start-heading');
     appendLine(lines, 'Start here', maxTokens, omitted, 'start-heading');
     for (const source of input.startHere.slice(0, 5)) {
-      appendLine(lines, '- ' + source, maxTokens, omitted, 'start-here');
+      appendLine(lines, '- ' + source, maxTokens, omitted, 'start-here', selected, {
+        kind: 'start-here',
+        id: 'path:' + source,
+        reason: 'task-lensed starting point',
+        trust: 'derived',
+      });
     }
   }
 
@@ -338,6 +455,14 @@ export function renderTaskWorksetPrompt(input: Omit<TaskWorkset, 'prompt' | 'bud
         maxTokens,
         omitted,
         'reliable-memory',
+        selected,
+        {
+          kind: 'memory',
+          id: 'memory:' + memory.id,
+          reason: 'current code-bound memory',
+          freshness: freshnessForMemory(memory.status),
+          trust: 'historical',
+        },
       );
     }
   }
@@ -346,10 +471,27 @@ export function renderTaskWorksetPrompt(input: Omit<TaskWorkset, 'prompt' | 'bud
     appendLine(lines, '', maxTokens, omitted, 'knowledge-heading');
     appendLine(lines, 'Project knowledge', maxTokens, omitted, 'knowledge-heading');
     for (const claim of input.claims.slice(0, 3)) {
-      appendLine(lines, '- ' + claim.assertion + ' [' + claim.id + ']', maxTokens, omitted, 'claim');
+      appendLine(lines, '- ' + claim.assertion + ' [' + claim.id + ']', maxTokens, omitted, 'claim', selected, {
+        kind: 'claim',
+        id: 'claim:' + claim.id,
+        reason: 'source-qualified task match',
+        trust: 'source-backed',
+      });
     }
     for (const page of input.pages.slice(0, 2)) {
-      appendLine(lines, '- page: ' + page.relativePath, maxTokens, omitted, 'knowledge-page');
+      const supportsDeliveredClaim = page.claimIds.some(claimId => selected.some(item => (
+        item.kind === 'claim' && item.id === 'claim:' + claimId
+      )));
+      if (!supportsDeliveredClaim) {
+        omitted.push('knowledge-page-dependency');
+        continue;
+      }
+      appendLine(lines, '- page: ' + page.relativePath, maxTokens, omitted, 'knowledge-page', selected, {
+        kind: 'knowledge-page',
+        id: 'page:' + page.id,
+        reason: 'approved page linked to a selected claim',
+        trust: 'source-backed',
+      });
     }
   }
 
@@ -363,6 +505,13 @@ export function renderTaskWorksetPrompt(input: Omit<TaskWorkset, 'prompt' | 'bud
         maxTokens,
         omitted,
         'workflow',
+        selected,
+        {
+          kind: 'workflow',
+          id: 'workflow:' + workflow.id,
+          reason: 'task-matching project workflow',
+          trust: 'source-backed',
+        },
       );
     }
   }
@@ -371,7 +520,11 @@ export function renderTaskWorksetPrompt(input: Omit<TaskWorkset, 'prompt' | 'bud
     appendLine(lines, '', maxTokens, omitted, 'verification-heading');
     appendLine(lines, 'Verify', maxTokens, omitted, 'verification-heading');
     for (const check of input.verification.slice(0, 4)) {
-      appendLine(lines, '- ' + short(check, 20), maxTokens, omitted, 'verification');
+      appendLine(lines, '- ' + short(check, 20), maxTokens, omitted, 'verification', selected, {
+        kind: 'verification',
+        reason: 'task-lensed verification guidance',
+        trust: 'derived',
+      });
     }
   }
 
@@ -379,6 +532,8 @@ export function renderTaskWorksetPrompt(input: Omit<TaskWorkset, 'prompt' | 'bud
     prompt: lines.join('\n'),
     tokenCount: countTextTokens(lines.join('\n')),
     omitted: unique(omitted),
+    omittedItems: omitted,
+    selected,
   };
 }
 
@@ -388,6 +543,7 @@ export function renderTaskWorksetPrompt(input: Omit<TaskWorkset, 'prompt' | 'bud
  * context response.
  */
 export async function buildTaskWorkset(input: BuildTaskWorksetInput): Promise<TaskWorkset> {
+  const startedAt = Date.now();
   const task = input.task?.trim() ?? '';
   const maxTokens = Math.max(96, Math.min(Math.floor(input.maxTokens ?? 180), 320));
   const cautions = [...(input.runtimeCautions ?? []), ...snapshotCautions(input)];
@@ -503,6 +659,18 @@ export async function buildTaskWorkset(input: BuildTaskWorksetInput): Promise<Ta
     ...base,
     budget: { maxTokens },
   });
+  const receipt: ContextReceipt = {
+    version: '1.2.2',
+    target: input.deliveryTarget ?? 'project-context',
+    elapsedMs: Math.max(0, Date.now() - startedAt),
+    budget: {
+      maxTokens,
+      tokenCount: rendered.tokenCount,
+    },
+    selected: rendered.selected,
+    omitted: receiptOmissions(rendered.omittedItems, base.hiddenCautionMemoryCount),
+    scheduledActions: scheduledActions(normalizedCautions),
+  };
   return {
     ...base,
     budget: {
@@ -510,6 +678,7 @@ export async function buildTaskWorkset(input: BuildTaskWorksetInput): Promise<Ta
       tokenCount: rendered.tokenCount,
       omitted: rendered.omitted,
     },
+    receipt,
     prompt: rendered.prompt,
   };
 }

--- a/src/memory/admission.ts
+++ b/src/memory/admission.ts
@@ -1,0 +1,54 @@
+import type { Observation, ObservationAdmissionState, ObservationType } from '../types.js';
+
+const DURABLE_AUTOMATIC_TYPES = new Set<ObservationType>([
+  'decision',
+  'gotcha',
+  'problem-solution',
+  'trade-off',
+  'why-it-exists',
+]);
+
+/**
+ * Legacy observations predate admission metadata and retain their existing
+ * delivery behavior. New automatic captures must explicitly earn delivery.
+ */
+export function isEligibleForAutomaticDelivery(observation: Pick<Observation, 'admissionState'>): boolean {
+  return observation.admissionState !== 'ephemeral' && observation.admissionState !== 'candidate';
+}
+
+export function isCandidateObservation(observation: Pick<Observation, 'admissionState'>): boolean {
+  return observation.admissionState === 'candidate';
+}
+
+export function isEligibleForKnowledgePromotion(
+  observation: Pick<Observation, 'admissionState' | 'valueCategory'>,
+): boolean {
+  return isEligibleForAutomaticDelivery(observation) && observation.valueCategory !== 'ephemeral';
+}
+
+export interface CandidateQualification {
+  admissionState: ObservationAdmissionState;
+  admissionReason: string;
+}
+
+/**
+ * Automatic hook records can become default-deliverable only after a current
+ * Code Memory link backs a non-ephemeral candidate. This deliberately does
+ * not create a claim: claims keep their explicit/Git source boundary.
+ */
+export function qualifyCandidateFromCurrentCode(input: {
+  observation: Pick<Observation, 'admissionState' | 'valueCategory' | 'type'>;
+  currentCodeReferenceCount: number;
+}): CandidateQualification | undefined {
+  if (!isCandidateObservation(input.observation)) return undefined;
+  if (input.observation.valueCategory === 'ephemeral') return undefined;
+  if (input.currentCodeReferenceCount <= 0) return undefined;
+
+  const typeLabel = DURABLE_AUTOMATIC_TYPES.has(input.observation.type)
+    ? 'high-value automatic record'
+    : 'automatic record';
+  return {
+    admissionState: 'qualified',
+    admissionReason: `${typeLabel} qualified against ${input.currentCodeReferenceCount} current Code Memory reference(s)`,
+  };
+}

--- a/src/memory/admission.ts
+++ b/src/memory/admission.ts
@@ -1,4 +1,5 @@
 import type { Observation, ObservationAdmissionState, ObservationType } from '../types.js';
+import { resolveObservationVisibility } from './visibility.js';
 
 const DURABLE_AUTOMATIC_TYPES = new Set<ObservationType>([
   'decision',
@@ -21,9 +22,11 @@ export function isCandidateObservation(observation: Pick<Observation, 'admission
 }
 
 export function isEligibleForKnowledgePromotion(
-  observation: Pick<Observation, 'admissionState' | 'valueCategory'>,
+  observation: Pick<Observation, 'admissionState' | 'valueCategory' | 'visibility'>,
 ): boolean {
-  return isEligibleForAutomaticDelivery(observation) && observation.valueCategory !== 'ephemeral';
+  return isEligibleForAutomaticDelivery(observation)
+    && observation.valueCategory !== 'ephemeral'
+    && resolveObservationVisibility(observation) === 'project';
 }
 
 export interface CandidateQualification {

--- a/src/memory/consolidation.ts
+++ b/src/memory/consolidation.ts
@@ -17,6 +17,7 @@
 
 import type { Observation } from '../types.js';
 import { getObservationStore } from '../store/obs-store.js';
+import { isEligibleForAutomaticDelivery } from './admission.js';
 
 /** Default similarity threshold for merging (0.0-1.0) */
 const DEFAULT_SIMILARITY_THRESHOLD = 0.45;
@@ -134,10 +135,14 @@ async function loadConsolidationPage(
 }
 
 function findClusters(observations: Observation[], threshold: number): ConsolidationCluster[] {
-  if (observations.length < MIN_CLUSTER_SIZE) return [];
+  // Pending automatic evidence must stay individually inspectable until its
+  // source-backed qualification step completes. Consolidating it first would
+  // erase the evidence grain the control plane still needs to audit.
+  const eligible = observations.filter(isEligibleForAutomaticDelivery);
+  if (eligible.length < MIN_CLUSTER_SIZE) return [];
 
   const groups = new Map<string, Observation[]>();
-  for (const obs of observations) {
+  for (const obs of eligible) {
     const key = `${obs.entityName}::${obs.type}`;
     const group = groups.get(key) ?? [];
     group.push(obs);

--- a/src/memory/consolidation.ts
+++ b/src/memory/consolidation.ts
@@ -18,6 +18,7 @@
 import type { Observation } from '../types.js';
 import { getObservationStore } from '../store/obs-store.js';
 import { isEligibleForAutomaticDelivery } from './admission.js';
+import { resolveObservationVisibility } from './visibility.js';
 
 /** Default similarity threshold for merging (0.0-1.0) */
 const DEFAULT_SIMILARITY_THRESHOLD = 0.45;
@@ -138,7 +139,12 @@ function findClusters(observations: Observation[], threshold: number): Consolida
   // Pending automatic evidence must stay individually inspectable until its
   // source-backed qualification step completes. Consolidating it first would
   // erase the evidence grain the control plane still needs to audit.
-  const eligible = observations.filter(isEligibleForAutomaticDelivery);
+  // Consolidation is a project-level maintenance action. Personal notes and
+  // targeted handoffs must remain individually inspectable and are never
+  // merged by a background job or another agent's manual cleanup.
+  const eligible = observations
+    .filter(isEligibleForAutomaticDelivery)
+    .filter((observation) => resolveObservationVisibility(observation) === 'project');
   if (eligible.length < MIN_CLUSTER_SIZE) return [];
 
   const groups = new Map<string, Observation[]>();

--- a/src/memory/disclosure-policy.ts
+++ b/src/memory/disclosure-policy.ts
@@ -85,6 +85,7 @@ export function evidenceBasisLine(basis: EvidenceBasis, commitHash?: string): st
 export interface ProvenanceFields {
   sourceDetail?: string;
   valueCategory?: string;
+  admissionState?: string;
   /** Legacy fallback: observations ingested before Phase 1 only have source='git'. */
   source?: string;
 }
@@ -112,8 +113,12 @@ export function resolveSourceDetail(
  * Classify a single observation or index entry into a disclosure layer.
  */
 export function classifyLayer(fields: ProvenanceFields): DisclosureLayer {
-  const { valueCategory } = fields;
+  const { valueCategory, admissionState } = fields;
   const sd = resolveSourceDetail(fields.sourceDetail, fields.source);
+
+  // New automatic records must earn delivery through the control plane.
+  // Preserve legacy behavior for records created before admission metadata.
+  if (admissionState === 'candidate' || admissionState === 'ephemeral') return 'L1';
 
   // Core-valued memories are always promoted to L2, regardless of source.
   if (valueCategory === 'core') return 'L2';

--- a/src/memory/export-import.ts
+++ b/src/memory/export-import.ts
@@ -10,8 +10,9 @@
  * Import: JSON format only (full fidelity restore)
  */
 
-import type { Observation } from '../types.js';
+import type { Observation, ObservationReader } from '../types.js';
 import type { Session } from '../types.js';
+import { filterReadableObservations } from './visibility.js';
 import { getObservationStore } from '../store/obs-store.js';
 import { getSessionStore } from '../store/session-store.js';
 
@@ -41,12 +42,18 @@ const OBSERVATION_ICONS: Record<string, string> = {
 export async function exportAsJson(
   projectDir: string,
   projectId: string,
+  reader?: ObservationReader,
 ): Promise<MemorixExport> {
   const store = getObservationStore();
   const allObs = await store.loadAll();
   const allSessions = await getSessionStore().loadAll();
 
-  const projectObs = allObs.filter(o => o.projectId === projectId);
+  // Agent-facing callers supply a reader; trusted maintenance callers may
+  // intentionally omit it for a complete local backup or migration.
+  const projectObs = filterReadableObservations(
+    allObs.filter(o => o.projectId === projectId),
+    reader,
+  );
   const projectSessions = allSessions.filter(s => s.projectId === projectId);
 
   // Type breakdown
@@ -75,8 +82,9 @@ export async function exportAsJson(
 export async function exportAsMarkdown(
   projectDir: string,
   projectId: string,
+  reader?: ObservationReader,
 ): Promise<string> {
-  const data = await exportAsJson(projectDir, projectId);
+  const data = await exportAsJson(projectDir, projectId, reader);
   const lines: string[] = [];
 
   lines.push(`# Memorix Export: ${projectId}`);

--- a/src/memory/graph-context.ts
+++ b/src/memory/graph-context.ts
@@ -1,6 +1,7 @@
 import { auditMemoryQuality, type MemoryQualityAuditReport } from './quality-audit.js';
 import type { Observation } from '../types.js';
 import { getRetentionZone } from './retention.js';
+import { isEligibleForAutomaticDelivery } from './admission.js';
 
 export interface GraphContextPacketOptions {
   projectId: string;
@@ -225,6 +226,8 @@ function scoreForPacket(obs: Observation, queryTokens: string[], referenceTime: 
     source: obs.source ?? 'agent',
     sourceDetail: obs.sourceDetail ?? '',
     valueCategory: obs.valueCategory ?? '',
+    admissionState: obs.admissionState ?? '',
+    admissionReason: obs.admissionReason ?? '',
   }, referenceTime) !== 'active') {
     score -= 2;
   }
@@ -348,8 +351,11 @@ export function buildGraphContextPacket(
     ...audit.issues.orphans.map((entry) => entry.id),
     ...audit.issues.retentionCandidates.map((entry) => entry.id),
   ]);
-  const filteredObservations = observations.filter((obs) => obs.projectId === options.projectId && !riskIds.has(obs.id));
-  const baseObservations = filteredObservations.length > 0 ? filteredObservations : observations;
+  const deliveryEligible = observations.filter(
+    (obs) => obs.projectId === options.projectId && isEligibleForAutomaticDelivery(obs),
+  );
+  const filteredObservations = deliveryEligible.filter((obs) => !riskIds.has(obs.id));
+  const baseObservations = filteredObservations.length > 0 ? filteredObservations : deliveryEligible;
   const memories = pickMemories(baseObservations, options.projectId, options.query, options.limit ?? 5, referenceTime);
   const entities = buildEntities(memories);
   const entityNames = new Set(entities.map((entity) => entity.name));

--- a/src/memory/observations.ts
+++ b/src/memory/observations.ts
@@ -8,7 +8,14 @@
  * and in the Orama search index (for full-text + vector search).
  */
 
-import type { Observation, ObservationType, ObservationStatus, MemorixDocument, ProgressInfo } from '../types.js';
+import type {
+  Observation,
+  ObservationAdmissionState,
+  ObservationType,
+  ObservationStatus,
+  MemorixDocument,
+  ProgressInfo,
+} from '../types.js';
 import { TOPIC_KEY_FAMILIES } from '../types.js';
 import {
   insertObservation,
@@ -25,13 +32,14 @@ import {
   makeOramaObservationId,
   getLastSearchMode,
   searchObservations,
+  updateObservationMetadata,
 } from '../store/orama-store.js';
 import { getObservationStore, initObservationStore } from '../store/obs-store.js';
 import { countTextTokens } from '../compact/token-budget.js';
 import { extractEntities, enrichConcepts } from './entity-extractor.js';
 import { getEmbeddingProvider, isEmbeddingExplicitlyDisabled } from '../embedding/provider.js';
 import { sanitizeCredentials } from './secret-filter.js';
-import { enqueueClaimDerivation } from '../runtime/lifecycle.js';
+import { enqueueClaimDerivation, enqueueObservationQualification } from '../runtime/lifecycle.js';
 
 /** In-memory observation list (loaded from persistence on init) */
 let observations: Observation[] = [];
@@ -134,6 +142,20 @@ function queueClaimDerivation(observation: Observation): void {
     });
   } catch {
     // The observation remains durable; a later scan can recover its claim.
+  }
+}
+
+function queueObservationQualification(observation: Observation): void {
+  const dataDir = projectDir;
+  if (!dataDir || observation.admissionState !== 'candidate') return;
+  try {
+    enqueueObservationQualification({
+      dataDir,
+      projectId: observation.projectId,
+      source: 'automatic-capture:' + observation.id,
+    });
+  } catch {
+    // Candidate evidence remains available for a later qualification scan.
   }
 }
 
@@ -253,6 +275,8 @@ export async function storeObservation(input: {
   relatedEntities?: string[];
   sourceDetail?: 'explicit' | 'hook' | 'git-ingest';
   valueCategory?: 'core' | 'contextual' | 'ephemeral';
+  admissionState?: ObservationAdmissionState;
+  admissionReason?: string;
   createdByAgentId?: string;
 }): Promise<{ observation: Observation; upserted: boolean }> {
   const now = new Date().toISOString();
@@ -355,6 +379,8 @@ export async function storeObservation(input: {
           relatedEntities: input.relatedEntities,
           sourceDetail: input.sourceDetail,
           valueCategory: input.valueCategory,
+          admissionState: input.admissionState,
+          admissionReason: input.admissionReason ? sanitizeCredentials(input.admissionReason) : undefined,
           createdByAgentId: input.createdByAgentId,
           // Predict the generation that atomic() will commit after this callback.
           // bumpGeneration() runs after fn(tx) returns, incrementing by 1.
@@ -409,6 +435,8 @@ export async function storeObservation(input: {
         relatedEntities: input.relatedEntities,
         sourceDetail: input.sourceDetail,
         valueCategory: input.valueCategory,
+        admissionState: input.admissionState,
+        admissionReason: input.admissionReason ? sanitizeCredentials(input.admissionReason) : undefined,
         createdByAgentId: input.createdByAgentId,
         writeGeneration: 0,
       };
@@ -435,6 +463,8 @@ export async function storeObservation(input: {
       source: input.source ?? 'agent',
       sourceDetail: input.sourceDetail ?? '',
       valueCategory: input.valueCategory ?? '',
+      admissionState: input.admissionState ?? '',
+      admissionReason: input.admissionReason ? sanitizeCredentials(input.admissionReason) : '',
     };
 
     await insertObservation(doc);
@@ -448,6 +478,7 @@ export async function storeObservation(input: {
   }
 
   await bindObservationCodeRefsBestEffort(observation);
+  queueObservationQualification(observation);
   queueClaimDerivation(observation);
 
   // Generate embedding async (fire-and-forget) — never blocks MCP response
@@ -518,6 +549,8 @@ async function upsertObservation(
     progress?: ProgressInfo;
     sourceDetail?: 'explicit' | 'hook' | 'git-ingest';
     valueCategory?: 'core' | 'contextual' | 'ephemeral';
+    admissionState?: ObservationAdmissionState;
+    admissionReason?: string;
   },
   now: string,
 ): Promise<Observation> {
@@ -556,6 +589,8 @@ async function upsertObservation(
   if (input.progress) existing.progress = input.progress;
   if (input.sourceDetail !== undefined) existing.sourceDetail = input.sourceDetail;
   if (input.valueCategory !== undefined) existing.valueCategory = input.valueCategory;
+  if (input.admissionState !== undefined) existing.admissionState = input.admissionState;
+  if (input.admissionReason !== undefined) existing.admissionReason = sanitizeCredentials(input.admissionReason);
 
   // Re-index in Orama WITHOUT embedding first (non-blocking)
   const doc: MemorixDocument = {
@@ -577,6 +612,8 @@ async function upsertObservation(
     source: existing.source ?? 'agent',
     sourceDetail: existing.sourceDetail ?? '',
     valueCategory: existing.valueCategory ?? '',
+    admissionState: existing.admissionState ?? '',
+    admissionReason: existing.admissionReason ?? '',
   };
 
   // Remove old doc and insert updated one (with retry for concurrent upsert race)
@@ -603,6 +640,7 @@ async function upsertObservation(
   }
 
   await bindObservationCodeRefsBestEffort(existing);
+  queueObservationQualification(existing);
   queueClaimDerivation(existing);
 
   // Generate embedding async (fire-and-forget) — never blocks MCP response
@@ -649,6 +687,72 @@ async function upsertObservation(
  */
 export function getObservation(id: number, projectId?: string): Observation | undefined {
   return observations.find((o) => o.id === id && (projectId ? o.projectId === projectId : true));
+}
+
+/**
+ * Promote or demote an automatic observation without changing its content.
+ * The expected-state guard keeps concurrent maintenance workers from
+ * resurrecting an observation that another writer has already changed.
+ */
+export async function updateObservationAdmission(input: {
+  observationId: number;
+  projectId?: string;
+  expectedState?: ObservationAdmissionState;
+  admissionState: ObservationAdmissionState;
+  admissionReason: string;
+}): Promise<Observation | undefined> {
+  await ensureFreshObservations();
+  const cached = observations.find((observation) =>
+    observation.id === input.observationId &&
+    (!input.projectId || observation.projectId === input.projectId),
+  );
+  if (!cached) return undefined;
+
+  const now = new Date().toISOString();
+  const admissionReason = sanitizeCredentials(input.admissionReason).slice(0, 240);
+  const apply = (current: Observation): Observation | undefined => {
+    if (input.projectId && current.projectId !== input.projectId) return undefined;
+    if (input.expectedState && current.admissionState !== input.expectedState) return undefined;
+    return {
+      ...current,
+      admissionState: input.admissionState,
+      admissionReason,
+      updatedAt: now,
+    };
+  };
+
+  let updated: Observation | undefined;
+  if (projectDir) {
+    const store = getObservationStore();
+    await store.atomic(async (tx) => {
+      const current = await tx.getById(input.observationId);
+      if (!current) return;
+      const next = apply(current);
+      if (!next) return;
+      await tx.update(next);
+      updated = next;
+    });
+  } else {
+    updated = apply(cached);
+  }
+
+  if (!updated) return undefined;
+  observations = observations.map((observation) =>
+    observation.id === updated!.id && observation.projectId === updated!.projectId
+      ? updated!
+      : observation,
+  );
+
+  try {
+    await updateObservationMetadata(updated.projectId, updated.id, {
+      admissionState: updated.admissionState,
+      admissionReason: updated.admissionReason,
+    });
+  } catch {
+    // SQLite is canonical. The next index hydration repairs a missed update.
+  }
+
+  return updated;
 }
 
 /**
@@ -701,6 +805,8 @@ export async function resolveObservations(
         source: obs.source ?? 'agent',
         sourceDetail: obs.sourceDetail ?? '',
         valueCategory: obs.valueCategory ?? '',
+        admissionState: obs.admissionState ?? '',
+        admissionReason: obs.admissionReason ?? '',
       };
       await insertObservation(doc);
       // Async embedding update (fire-and-forget)
@@ -904,6 +1010,8 @@ export async function reindexObservations(): Promise<number> {
         source: obs.source ?? 'agent',
         sourceDetail: obs.sourceDetail ?? '',
         valueCategory: obs.valueCategory ?? '',
+        admissionState: obs.admissionState ?? '',
+        admissionReason: obs.admissionReason ?? '',
         ...(compatibleEmbedding ? { embedding: compatibleEmbedding } : {}),
       };
       await insertObservation(doc);
@@ -1114,6 +1222,8 @@ export async function backfillVectorEmbeddings(options: {
             source: obs.source ?? 'agent',
             sourceDetail: obs.sourceDetail ?? '',
             valueCategory: obs.valueCategory ?? '',
+            admissionState: obs.admissionState ?? '',
+            admissionReason: obs.admissionReason ?? '',
             embedding,
           };
           await insertObservation(doc);

--- a/src/memory/observations.ts
+++ b/src/memory/observations.ts
@@ -11,6 +11,8 @@
 import type {
   Observation,
   ObservationAdmissionState,
+  ObservationReader,
+  ObservationVisibility,
   ObservationType,
   ObservationStatus,
   MemorixDocument,
@@ -40,6 +42,7 @@ import { extractEntities, enrichConcepts } from './entity-extractor.js';
 import { getEmbeddingProvider, isEmbeddingExplicitlyDisabled } from '../embedding/provider.js';
 import { sanitizeCredentials } from './secret-filter.js';
 import { enqueueClaimDerivation, enqueueObservationQualification } from '../runtime/lifecycle.js';
+import { canManageObservation, resolveObservationVisibility } from './visibility.js';
 
 /** In-memory observation list (loaded from persistence on init) */
 let observations: Observation[] = [];
@@ -277,7 +280,11 @@ export async function storeObservation(input: {
   valueCategory?: 'core' | 'contextual' | 'ephemeral';
   admissionState?: ObservationAdmissionState;
   admissionReason?: string;
+  visibility?: ObservationVisibility;
+  sharedWithAgentIds?: string[];
   createdByAgentId?: string;
+  /** Optional caller-bound write scope for topic-key upserts. */
+  visibilityReader?: ObservationReader;
 }): Promise<{ observation: Observation; upserted: boolean }> {
   const now = new Date().toISOString();
 
@@ -297,6 +304,9 @@ export async function storeObservation(input: {
       o => o.topicKey === input.topicKey && o.projectId === input.projectId,
     );
     if (existing) {
+      if (input.visibilityReader && !canManageObservation(existing, input.visibilityReader)) {
+        throw new Error('Cannot update a memory outside this session\'s write scope.');
+      }
       return { observation: await upsertObservation(existing, input, now), upserted: true };
     }
   }
@@ -344,6 +354,9 @@ export async function storeObservation(input: {
         if (input.topicKey) {
           const diskExisting = await tx.findByTopicKey(input.projectId, input.topicKey);
           if (diskExisting) {
+            if (input.visibilityReader && !canManageObservation(diskExisting, input.visibilityReader)) {
+              throw new Error('Cannot update a memory outside this session\'s write scope.');
+            }
             // Switch to upsert path — update the existing observation after this
             // short transaction has released its lock.
             upsertedInsideLock = true;
@@ -381,6 +394,8 @@ export async function storeObservation(input: {
           valueCategory: input.valueCategory,
           admissionState: input.admissionState,
           admissionReason: input.admissionReason ? sanitizeCredentials(input.admissionReason) : undefined,
+          visibility: input.visibility ?? 'project',
+          sharedWithAgentIds: input.sharedWithAgentIds,
           createdByAgentId: input.createdByAgentId,
           // Predict the generation that atomic() will commit after this callback.
           // bumpGeneration() runs after fn(tx) returns, incrementing by 1.
@@ -437,6 +452,8 @@ export async function storeObservation(input: {
         valueCategory: input.valueCategory,
         admissionState: input.admissionState,
         admissionReason: input.admissionReason ? sanitizeCredentials(input.admissionReason) : undefined,
+        visibility: input.visibility ?? 'project',
+        sharedWithAgentIds: input.sharedWithAgentIds,
         createdByAgentId: input.createdByAgentId,
         writeGeneration: 0,
       };
@@ -465,6 +482,9 @@ export async function storeObservation(input: {
       valueCategory: input.valueCategory ?? '',
       admissionState: input.admissionState ?? '',
       admissionReason: input.admissionReason ? sanitizeCredentials(input.admissionReason) : '',
+      visibility: input.visibility ?? 'project',
+      createdByAgentId: input.createdByAgentId ?? '',
+      sharedWithAgentIds: JSON.stringify(input.sharedWithAgentIds ?? []),
     };
 
     await insertObservation(doc);
@@ -479,7 +499,9 @@ export async function storeObservation(input: {
 
   await bindObservationCodeRefsBestEffort(observation);
   queueObservationQualification(observation);
-  queueClaimDerivation(observation);
+  if (resolveObservationVisibility(observation) === 'project') {
+    queueClaimDerivation(observation);
+  }
 
   // Generate embedding async (fire-and-forget) — never blocks MCP response
   // Track in vectorMissingIds until embedding is successfully written.
@@ -551,6 +573,8 @@ async function upsertObservation(
     valueCategory?: 'core' | 'contextual' | 'ephemeral';
     admissionState?: ObservationAdmissionState;
     admissionReason?: string;
+    visibility?: ObservationVisibility;
+    sharedWithAgentIds?: string[];
   },
   now: string,
 ): Promise<Observation> {
@@ -591,6 +615,8 @@ async function upsertObservation(
   if (input.valueCategory !== undefined) existing.valueCategory = input.valueCategory;
   if (input.admissionState !== undefined) existing.admissionState = input.admissionState;
   if (input.admissionReason !== undefined) existing.admissionReason = sanitizeCredentials(input.admissionReason);
+  if (input.visibility !== undefined) existing.visibility = input.visibility;
+  if (input.sharedWithAgentIds !== undefined) existing.sharedWithAgentIds = input.sharedWithAgentIds;
 
   // Re-index in Orama WITHOUT embedding first (non-blocking)
   const doc: MemorixDocument = {
@@ -614,6 +640,9 @@ async function upsertObservation(
     valueCategory: existing.valueCategory ?? '',
     admissionState: existing.admissionState ?? '',
     admissionReason: existing.admissionReason ?? '',
+    visibility: existing.visibility ?? 'project',
+    createdByAgentId: existing.createdByAgentId ?? '',
+    sharedWithAgentIds: JSON.stringify(existing.sharedWithAgentIds ?? []),
   };
 
   // Remove old doc and insert updated one (with retry for concurrent upsert race)
@@ -641,7 +670,9 @@ async function upsertObservation(
 
   await bindObservationCodeRefsBestEffort(existing);
   queueObservationQualification(existing);
-  queueClaimDerivation(existing);
+  if (resolveObservationVisibility(existing) === 'project') {
+    queueClaimDerivation(existing);
+  }
 
   // Generate embedding async (fire-and-forget) — never blocks MCP response
   const searchableText = [input.title, input.narrative, ...(input.facts ?? [])].join(' ');
@@ -700,6 +731,7 @@ export async function updateObservationAdmission(input: {
   expectedState?: ObservationAdmissionState;
   admissionState: ObservationAdmissionState;
   admissionReason: string;
+  visibility?: ObservationVisibility;
 }): Promise<Observation | undefined> {
   await ensureFreshObservations();
   const cached = observations.find((observation) =>
@@ -717,6 +749,7 @@ export async function updateObservationAdmission(input: {
       ...current,
       admissionState: input.admissionState,
       admissionReason,
+      ...(input.visibility !== undefined ? { visibility: input.visibility } : {}),
       updatedAt: now,
     };
   };
@@ -747,9 +780,14 @@ export async function updateObservationAdmission(input: {
     await updateObservationMetadata(updated.projectId, updated.id, {
       admissionState: updated.admissionState,
       admissionReason: updated.admissionReason,
+      ...(updated.visibility !== undefined ? { visibility: updated.visibility } : {}),
     });
   } catch {
     // SQLite is canonical. The next index hydration repairs a missed update.
+  }
+
+  if (updated.admissionState === 'qualified' && resolveObservationVisibility(updated) === 'project') {
+    queueClaimDerivation(updated);
   }
 
   return updated;
@@ -807,6 +845,9 @@ export async function resolveObservations(
         valueCategory: obs.valueCategory ?? '',
         admissionState: obs.admissionState ?? '',
         admissionReason: obs.admissionReason ?? '',
+        visibility: obs.visibility ?? 'project',
+        createdByAgentId: obs.createdByAgentId ?? '',
+        sharedWithAgentIds: JSON.stringify(obs.sharedWithAgentIds ?? []),
       };
       await insertObservation(doc);
       // Async embedding update (fire-and-forget)
@@ -1012,6 +1053,9 @@ export async function reindexObservations(): Promise<number> {
         valueCategory: obs.valueCategory ?? '',
         admissionState: obs.admissionState ?? '',
         admissionReason: obs.admissionReason ?? '',
+        visibility: obs.visibility ?? 'project',
+        createdByAgentId: obs.createdByAgentId ?? '',
+        sharedWithAgentIds: JSON.stringify(obs.sharedWithAgentIds ?? []),
         ...(compatibleEmbedding ? { embedding: compatibleEmbedding } : {}),
       };
       await insertObservation(doc);
@@ -1136,6 +1180,7 @@ export async function probeSearchIndex(projectId: string): Promise<string> {
   await searchObservations({
     query: 'semantic memory retrieval status',
     projectId,
+    reader: { projectId },
     limit: 1,
     status: 'all',
     trackAccess: false,
@@ -1224,6 +1269,9 @@ export async function backfillVectorEmbeddings(options: {
             valueCategory: obs.valueCategory ?? '',
             admissionState: obs.admissionState ?? '',
             admissionReason: obs.admissionReason ?? '',
+            visibility: obs.visibility ?? 'project',
+            createdByAgentId: obs.createdByAgentId ?? '',
+            sharedWithAgentIds: JSON.stringify(obs.sharedWithAgentIds ?? []),
             embedding,
           };
           await insertObservation(doc);

--- a/src/memory/quality-audit.ts
+++ b/src/memory/quality-audit.ts
@@ -137,6 +137,8 @@ export function auditMemoryQuality(
       source: obs.source ?? 'agent',
       sourceDetail: obs.sourceDetail ?? '',
       valueCategory: obs.valueCategory ?? '',
+      admissionState: obs.admissionState ?? '',
+      admissionReason: obs.admissionReason ?? '',
     }, options.referenceTime) !== 'active')
     .map((obs) => makeEntry(obs, 'Outside active retention zone'));
 

--- a/src/memory/retention.ts
+++ b/src/memory/retention.ts
@@ -113,6 +113,10 @@ export function isImmune(doc: MemorixDocument): boolean {
   // Probe observations are operational heartbeats -- never immune, regardless of valueCategory or access.
   if (doc.type === 'probe') return false;
 
+  // A candidate has not earned durable status. Never let an automatic core
+  // classification turn unqualified capture into permanently retained memory.
+  if (doc.admissionState === 'candidate' || doc.admissionState === 'ephemeral') return false;
+
   // formation-classified core memories are immune regardless of type
   if (doc.valueCategory === 'core') return true;
 
@@ -134,6 +138,11 @@ export function isImmune(doc: MemorixDocument): boolean {
 export function getImmunityReason(doc: MemorixDocument): string | null {
   // Probe observations are never immune
   if (doc.type === 'probe') return null;
+
+  // Automatic traces and candidates have not earned durable status. Keep the
+  // explanation aligned with isImmune() even when an earlier classifier gave
+  // a candidate the core value category.
+  if (doc.admissionState === 'candidate' || doc.admissionState === 'ephemeral') return null;
 
   if (doc.valueCategory === 'core') return 'core valueCategory (formation-classified)';
   const importance = getImportanceLevel(doc);
@@ -401,6 +410,8 @@ function toRetentionDocument(
     source: obs.source ?? 'agent',
     sourceDetail: obs.sourceDetail ?? '',
     valueCategory: obs.valueCategory ?? '',
+    admissionState: obs.admissionState ?? '',
+    admissionReason: obs.admissionReason ?? '',
   };
 }
 

--- a/src/memory/retention.ts
+++ b/src/memory/retention.ts
@@ -15,8 +15,9 @@
  * retention period but are no longer permanently immune — they decay normally.
  */
 
-import type { MemorixDocument, Observation } from '../types.js';
+import type { MemorixDocument, Observation, ObservationReader } from '../types.js';
 import { getObservationStore } from '../store/obs-store.js';
+import { canManageObservation } from './visibility.js';
 
 // ── Importance → Retention Period mapping ────────────────────────────
 
@@ -378,6 +379,8 @@ export interface ArchiveExpiredBatchOptions {
   limit?: number;
   referenceTime?: Date;
   accessMap?: Map<number, { accessCount: number; lastAccessedAt: string }>;
+  /** Omit only for trusted background maintenance. */
+  reader?: ObservationReader;
 }
 
 export interface ArchiveExpiredBatchResult {
@@ -434,6 +437,7 @@ export async function archiveExpiredBatch(
   const hasMore = page.length > limit;
   const scanned = hasMore ? page.slice(0, limit) : page;
   const candidateIds = scanned
+    .filter((observation) => !options.reader || canManageObservation(observation, options.reader))
     .filter((observation) => getRetentionZone(
       toRetentionDocument(observation, options.accessMap),
       options.referenceTime,
@@ -472,6 +476,7 @@ export async function archiveExpired(
   referenceTime?: Date,
   accessMap?: Map<number, { accessCount: number; lastAccessedAt: string }>,
   projectId?: string,
+  reader?: ObservationReader,
 ): Promise<{ archived: number; remaining: number }> {
   const store = getObservationStore();
   if (projectId) {
@@ -483,12 +488,16 @@ export async function archiveExpired(
         afterId,
         referenceTime,
         accessMap,
+        reader,
       });
       archived += batch.archived;
       afterId = batch.nextCursor;
     } while (afterId !== undefined);
 
-    const remaining = await store.countByProject(projectId, { status: 'active' });
+    const remainingObservations = await store.loadByProject(projectId, { status: 'active' });
+    const remaining = reader
+      ? remainingObservations.filter((observation) => canManageObservation(observation, reader)).length
+      : remainingObservations.length;
     return { archived, remaining };
   }
 

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -12,6 +12,7 @@
  */
 
 import type { Observation, Session } from '../types.js';
+import { isEligibleForAutomaticDelivery } from './admission.js';
 import { classifyLayer } from './disclosure-policy.js';
 import { resolveAliases } from '../project/aliases.js';
 import { getObservationStore } from '../store/obs-store.js';
@@ -369,13 +370,15 @@ export async function getSessionContext(
 
   // L1: recent hook activity signals (titles only, most recent first)
   const l1HookObs = projectObs
-    .filter((obs) => classifyLayer(obs) === 'L1')
+    .filter((obs) => isEligibleForAutomaticDelivery(obs) && classifyLayer(obs) === 'L1')
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
     .slice(0, 3);
 
   // L3: git-ingest evidence count (pointer only, not injected)
   const l3GitCount = projectObs.filter((obs) => classifyLayer(obs) === 'L3').length;
-  const totalHookCount = projectObs.filter((obs) => classifyLayer(obs) === 'L1').length;
+  const totalHookCount = projectObs
+    .filter((obs) => isEligibleForAutomaticDelivery(obs) && classifyLayer(obs) === 'L1')
+    .length;
 
   // Active entities: unique entity names from top-scored L2 memories.
   // Surfaced in L1 Routing as next-hop search guidance — not working context.

--- a/src/memory/visibility.ts
+++ b/src/memory/visibility.ts
@@ -1,0 +1,80 @@
+import type { ObservationReader, ObservationVisibility } from '../types.js';
+
+/** Minimal common shape shared by persisted observations and Orama documents. */
+export interface VisibilityRecord {
+  projectId: string;
+  visibility?: ObservationVisibility | string;
+  createdByAgentId?: string;
+  sharedWithAgentIds?: string[] | string;
+}
+
+/**
+ * Pre-control-plane records were intentionally project-shared. Preserve that
+ * behavior so an upgrade does not make a user's historical memory disappear.
+ */
+export function resolveObservationVisibility(record: Pick<VisibilityRecord, 'visibility'>): ObservationVisibility {
+  switch (record.visibility) {
+    case 'personal':
+    case 'team':
+    case 'project':
+      return record.visibility;
+    default:
+      return 'project';
+  }
+}
+
+function sharedAgentIds(record: VisibilityRecord): string[] {
+  if (Array.isArray(record.sharedWithAgentIds)) return record.sharedWithAgentIds;
+  if (typeof record.sharedWithAgentIds !== 'string' || !record.sharedWithAgentIds) return [];
+  try {
+    const parsed = JSON.parse(record.sharedWithAgentIds);
+    return Array.isArray(parsed) ? parsed.filter((id): id is string => typeof id === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * The policy is intentionally fail-closed for personal and team scopes. A
+ * missing actor never turns a private record into a project-wide result.
+ * `undefined` is reserved for trusted internal maintenance, not MCP delivery.
+ */
+export function canReadObservation(record: VisibilityRecord, reader?: ObservationReader): boolean {
+  if (!reader) return true;
+
+  const sameProject = reader.projectId === record.projectId;
+  const visibility = resolveObservationVisibility(record);
+  // An explicit global search may inspect project-visible facts across projects,
+  // but it never gains a team or personal scope without a bound project.
+  if (visibility === 'project') return !reader.projectId || sameProject;
+  if (!sameProject || !reader.agentId) return false;
+
+  if (visibility === 'team') return reader.isTeamMember === true;
+  return record.createdByAgentId === reader.agentId || sharedAgentIds(record).includes(reader.agentId);
+}
+
+/**
+ * Reading a targeted handoff does not grant the recipient permission to alter
+ * it. Project evidence is jointly maintainable; personal records stay owned by
+ * their creator; team records require an active team member.
+ */
+export function canManageObservation(record: VisibilityRecord, reader?: ObservationReader): boolean {
+  if (!reader) return true;
+  if (!reader.projectId || reader.projectId !== record.projectId) return false;
+
+  switch (resolveObservationVisibility(record)) {
+    case 'project':
+      return true;
+    case 'team':
+      return reader.isTeamMember === true;
+    case 'personal':
+      return Boolean(reader.agentId && record.createdByAgentId === reader.agentId);
+  }
+}
+
+export function filterReadableObservations<T extends VisibilityRecord>(
+  observations: readonly T[],
+  reader?: ObservationReader,
+): T[] {
+  return reader ? observations.filter((observation) => canReadObservation(observation, reader)) : [...observations];
+}

--- a/src/orchestrate/memorix-bridge.ts
+++ b/src/orchestrate/memorix-bridge.ts
@@ -126,6 +126,8 @@ export function storeVerifiedFix(fix: FixResult): void {
         source: 'agent',
         sourceDetail: 'hook',
         valueCategory: confidence === 'high' ? 'core' : 'contextual',
+        admissionState: 'candidate',
+        admissionReason: 'verified orchestration fix awaits current Code Memory qualification',
       });
     } catch { /* fire-and-forget */ }
   })();
@@ -158,6 +160,8 @@ export function storeFixExhausted(fix: FixResult): void {
         source: 'agent',
         sourceDetail: 'hook',
         valueCategory: 'contextual',
+        admissionState: 'candidate',
+        admissionReason: 'automatic orchestration failure awaits current Code Memory qualification',
       });
     } catch { /* fire-and-forget */ }
   })();
@@ -300,6 +304,8 @@ export function storeTaskCompletion(opts: {
         source: 'agent',
         sourceDetail: 'hook',
         valueCategory: 'ephemeral',
+        admissionState: 'ephemeral',
+        admissionReason: 'pipeline completion retained only as a short-lived trace',
       });
     } catch { /* fire-and-forget */ }
   })();
@@ -338,6 +344,8 @@ export function storePipelineSummary(opts: {
         source: 'agent',
         sourceDetail: 'hook',
         valueCategory: 'contextual',
+        admissionState: 'candidate',
+        admissionReason: 'automatic pipeline summary awaits current Code Memory qualification',
       });
     } catch { /* fire-and-forget */ }
   })();

--- a/src/orchestrate/memorix-bridge.ts
+++ b/src/orchestrate/memorix-bridge.ts
@@ -90,6 +90,14 @@ async function getSearchObservations() {
   return _searchObservations;
 }
 
+function automaticActorId(...parts: string[]): string {
+  return `orchestrator:${createHash('sha256').update(parts.join('\u0000')).digest('hex').slice(0, 24)}`;
+}
+
+function isEligibleAutomaticLesson(entry: { admissionState?: string }): boolean {
+  return entry.admissionState !== 'candidate' && entry.admissionState !== 'ephemeral';
+}
+
 // ── 5a. Fix Loop Memory (CORE — always on) ────────────────────────
 
 /**
@@ -104,6 +112,7 @@ export function storeVerifiedFix(fix: FixResult): void {
 
   const errorHash = hashErrorPattern(fix.errorOutput);
   const confidence = fix.fixAttempt === 1 ? 'high' : fix.fixAttempt === 2 ? 'medium' : 'low';
+  const createdByAgentId = automaticActorId(fix.projectId, 'verified-fix', fix.gate, errorHash);
 
   // Fire-and-forget — catches all errors silently
   void (async () => {
@@ -128,6 +137,9 @@ export function storeVerifiedFix(fix: FixResult): void {
         valueCategory: confidence === 'high' ? 'core' : 'contextual',
         admissionState: 'candidate',
         admissionReason: 'verified orchestration fix awaits current Code Memory qualification',
+        visibility: 'personal',
+        createdByAgentId,
+        visibilityReader: { projectId: fix.projectId, agentId: createdByAgentId },
       });
     } catch { /* fire-and-forget */ }
   })();
@@ -140,6 +152,7 @@ export function storeVerifiedFix(fix: FixResult): void {
  */
 export function storeFixExhausted(fix: FixResult): void {
   const errorHash = hashErrorPattern(fix.errorOutput);
+  const createdByAgentId = automaticActorId(fix.projectId, 'fix-exhausted', fix.gate, errorHash);
 
   void (async () => {
     try {
@@ -162,6 +175,9 @@ export function storeFixExhausted(fix: FixResult): void {
         valueCategory: 'contextual',
         admissionState: 'candidate',
         admissionReason: 'automatic orchestration failure awaits current Code Memory qualification',
+        visibility: 'personal',
+        createdByAgentId,
+        visibilityReader: { projectId: fix.projectId, agentId: createdByAgentId },
       });
     } catch { /* fire-and-forget */ }
   })();
@@ -186,6 +202,7 @@ export async function searchKnownFixes(
       search({
         query: searchQuery,
         projectId,
+        reader: { projectId },
         type: 'problem-solution',
         limit: 3,
         status: 'active',
@@ -194,6 +211,7 @@ export async function searchKnownFixes(
     ]);
 
     return (results as any[])
+      .filter(isEligibleAutomaticLesson)
       .filter((r: any) => (r.score ?? 1) > 0.3) // Only reasonably relevant
       .map((r: any) => ({
         id: r.id ?? 0,
@@ -230,6 +248,7 @@ export async function searchLessons(
       search({
         query,
         projectId,
+        reader: { projectId },
         limit: config.maxLessons + 2, // Fetch extra for filtering
         status: 'active',
       }),
@@ -237,6 +256,7 @@ export async function searchLessons(
     ]);
 
     const lessons = (results as any[])
+      .filter(isEligibleAutomaticLesson)
       .filter((r: any) =>
         (r.type === 'problem-solution' || r.type === 'gotcha') &&
         (r.score ?? 1) > 0.5, // Only high-relevance (Safeguard 5: project isolation already handled by projectId filter)
@@ -286,6 +306,8 @@ export function storeTaskCompletion(opts: {
   durationMs: number;
   tailOutput: string;
 }): void {
+  const createdByAgentId = automaticActorId(opts.projectId, opts.pipelineId, opts.taskId, opts.agentName);
+
   void (async () => {
     try {
       const store = await getStoreObservation();
@@ -306,6 +328,9 @@ export function storeTaskCompletion(opts: {
         valueCategory: 'ephemeral',
         admissionState: 'ephemeral',
         admissionReason: 'pipeline completion retained only as a short-lived trace',
+        visibility: 'personal',
+        createdByAgentId,
+        visibilityReader: { projectId: opts.projectId, agentId: createdByAgentId },
       });
     } catch { /* fire-and-forget */ }
   })();
@@ -324,6 +349,8 @@ export function storePipelineSummary(opts: {
   failed: number;
   elapsedMs: number;
 }): void {
+  const createdByAgentId = automaticActorId(opts.projectId, opts.pipelineId, 'summary');
+
   void (async () => {
     try {
       const store = await getStoreObservation();
@@ -346,6 +373,9 @@ export function storePipelineSummary(opts: {
         valueCategory: 'contextual',
         admissionState: 'candidate',
         admissionReason: 'automatic pipeline summary awaits current Code Memory qualification',
+        visibility: 'personal',
+        createdByAgentId,
+        visibilityReader: { projectId: opts.projectId, agentId: createdByAgentId },
       });
     } catch { /* fire-and-forget */ }
   })();

--- a/src/runtime/control-plane-maintenance.ts
+++ b/src/runtime/control-plane-maintenance.ts
@@ -11,6 +11,7 @@ export const CONTROL_PLANE_MAINTENANCE_KINDS: readonly MaintenanceJobKind[] = [
   'retention-archive',
   'consolidation',
   'codegraph-refresh',
+  'observation-qualify',
   'claim-derive',
   'claim-requalification',
   'knowledge-compile',

--- a/src/runtime/isolated-maintenance.ts
+++ b/src/runtime/isolated-maintenance.ts
@@ -12,6 +12,7 @@ export const ISOLATED_MAINTENANCE_JOB_KINDS: readonly MaintenanceJobKind[] = [
   'retention-archive',
   'consolidation',
   'codegraph-refresh',
+  'observation-qualify',
   'claim-derive',
   'claim-requalification',
   'knowledge-compile',

--- a/src/runtime/lifecycle.ts
+++ b/src/runtime/lifecycle.ts
@@ -66,6 +66,24 @@ export function enqueueClaimDerivation(input: {
 }
 
 /**
+ * Automatic captures are initially only candidates. Qualification runs in the
+ * durable maintenance lane after Code Memory has a chance to refresh.
+ */
+export function enqueueObservationQualification(input: {
+  dataDir: string;
+  projectId: string;
+  source: string;
+  queue?: MaintenanceQueue;
+}): void {
+  queueFor(input).enqueue({
+    projectId: input.projectId,
+    kind: 'observation-qualify',
+    dedupeKey: 'observation-qualify',
+    payload: { source: input.source, limit: 100 },
+  });
+}
+
+/**
  * The follow-up jobs operate on the same workspace the Workset reads: a
  * versioned workspace when present, otherwise the local workspace.
  */

--- a/src/runtime/maintenance-jobs.ts
+++ b/src/runtime/maintenance-jobs.ts
@@ -8,6 +8,7 @@ export const MAINTENANCE_JOB_KINDS = [
   'retention-archive',
   'consolidation',
   'codegraph-refresh',
+  'observation-qualify',
   'claim-derive',
   'claim-requalification',
   'knowledge-compile',

--- a/src/runtime/maintenance-runner.ts
+++ b/src/runtime/maintenance-runner.ts
@@ -3,6 +3,7 @@ import { loadDotenv } from '../config/dotenv-loader.js';
 import { initProjectRoot } from '../config/yaml-loader.js';
 import { initLLM } from '../llm/provider.js';
 import { initObservationStore } from '../store/obs-store.js';
+import { initObservations } from '../memory/observations.js';
 import {
   MAINTENANCE_JOB_KINDS,
   type MaintenanceJob,
@@ -58,6 +59,7 @@ export async function executeMaintenanceRequest(
   initProjectRoot(request.projectRoot);
   loadDotenv(request.projectRoot);
   await initObservationStore(request.dataDir);
+  await initObservations(request.dataDir);
   if (request.job.kind === 'consolidation') initLLM();
 
   const handler = createProjectMaintenanceHandler(

--- a/src/runtime/project-maintenance.ts
+++ b/src/runtime/project-maintenance.ts
@@ -6,6 +6,7 @@ import { runMaintenanceInChildProcess } from './isolated-maintenance.js';
 import {
   enqueueClaimRequalification,
   enqueueKnowledgeFollowups,
+  enqueueObservationQualification,
   type MaintenanceQueue,
 } from './lifecycle.js';
 
@@ -14,6 +15,7 @@ const DEFAULT_RETENTION_BATCH_SIZE = 100;
 const DEFAULT_CONSOLIDATION_BATCH_SIZE = 200;
 const DEFAULT_CODEGRAPH_MAX_FILES = 5_000;
 const DEFAULT_CLAIM_DERIVATION_BATCH_SIZE = 100;
+const DEFAULT_OBSERVATION_QUALIFICATION_BATCH_SIZE = 100;
 const VECTOR_RETRY_DELAY_MS = 5_000;
 const DEDUP_PER_PAIR_TIMEOUT_MS = 5_000;
 
@@ -62,6 +64,19 @@ function claimDerivationBatchSize(payload: Record<string, unknown>): number {
 }
 
 function claimDerivationCursor(payload: Record<string, unknown>): number {
+  const value = payload.cursor;
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.max(0, Math.floor(value))
+    : 0;
+}
+
+function observationQualificationBatchSize(payload: Record<string, unknown>): number {
+  const value = payload.limit;
+  if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_OBSERVATION_QUALIFICATION_BATCH_SIZE;
+  return Math.min(500, Math.max(1, Math.floor(value)));
+}
+
+function observationQualificationCursor(payload: Record<string, unknown>): number {
   const value = payload.cursor;
   return typeof value === 'number' && Number.isFinite(value)
     ? Math.max(0, Math.floor(value))
@@ -275,6 +290,77 @@ export function createProjectMaintenanceHandler(
         ...(snapshot?.id ? { snapshotId: snapshot.id } : {}),
         ...(options.maintenanceQueue ? { queue: options.maintenanceQueue } : {}),
       });
+      enqueueObservationQualification({
+        projectId,
+        dataDir: projectDir,
+        source: 'codegraph-refresh',
+        ...(options.maintenanceQueue ? { queue: options.maintenanceQueue } : {}),
+      });
+      return { action: 'complete' };
+    }
+
+    if (job.kind === 'observation-qualify') {
+      const [
+        { CodeGraphStore },
+        { bindObservationToCode },
+        { getObservationStore },
+        { qualifyCandidateFromCurrentCode },
+        { updateObservationAdmission },
+      ] = await Promise.all([
+        import('../codegraph/store.js'),
+        import('../codegraph/binder.js'),
+        import('../store/obs-store.js'),
+        import('../memory/admission.js'),
+        import('../memory/observations.js'),
+      ]);
+      const codeStore = new CodeGraphStore();
+      await codeStore.init(projectDir);
+      const limit = observationQualificationBatchSize(job.payload);
+      const page = await getObservationStore().loadByProject(projectId, {
+        status: 'active',
+        afterId: observationQualificationCursor(job.payload),
+        limit: limit + 1,
+      });
+      const hasMore = page.length > limit;
+      const observations = hasMore ? page.slice(0, limit) : page;
+      const indexedAtMs = Date.parse(codeStore.status(projectId).indexedAt ?? '');
+
+      for (const observation of observations) {
+        if (observation.admissionState !== 'candidate') continue;
+        // A candidate may only earn delivery after a Code Memory scan that
+        // happened at or after it was captured. A stale snapshot is evidence
+        // about an earlier project state, not a reason to inject this record.
+        if (!Number.isFinite(indexedAtMs) || indexedAtMs < Date.parse(observation.createdAt)) continue;
+        await bindObservationToCode(codeStore, observation);
+        const currentCodeReferenceCount = codeStore
+          .listObservationRefs(projectId, observation.id)
+          .filter((reference) => reference.status === 'current')
+          .length;
+        const qualification = qualifyCandidateFromCurrentCode({
+          observation,
+          currentCodeReferenceCount,
+        });
+        if (!qualification) continue;
+        await updateObservationAdmission({
+          observationId: observation.id,
+          projectId,
+          expectedState: 'candidate',
+          ...qualification,
+        });
+      }
+
+      if (hasMore && observations.length > 0) {
+        return {
+          action: 'reschedule',
+          delayMs: 0,
+          resetAttempts: true,
+          payload: {
+            ...job.payload,
+            cursor: observations[observations.length - 1].id,
+            limit,
+          },
+        };
+      }
       return { action: 'complete' };
     }
 

--- a/src/runtime/project-maintenance.ts
+++ b/src/runtime/project-maintenance.ts
@@ -345,6 +345,9 @@ export function createProjectMaintenanceHandler(
           observationId: observation.id,
           projectId,
           expectedState: 'candidate',
+          // Automatic capture earns project visibility only after a current
+          // Code Memory link exists. Explicit/private records retain scope.
+          ...(observation.sourceDetail === 'hook' ? { visibility: 'project' as const } : {}),
           ...qualification,
         });
       }

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -25,7 +25,13 @@ import type {
   ProgressInfo,
   ProjectInfo,
   DetectionResult,
+  ObservationReader,
 } from './types.js';
+import {
+  canManageObservation,
+  canReadObservation,
+  filterReadableObservations,
+} from './memory/visibility.js';
 
 // ── Re-exports for convenience ──────────────────────────────────────
 
@@ -97,12 +103,17 @@ export interface ResolveResult {
  * Memorix observations without MCP overhead.
  *
  * Each client initializes its own SQLite backend and Orama search index,
- * scoped to a single project. Call `close()` when done to release resources.
+ * scoped to a single project. It is an unbound project reader by default, so
+ * it exposes only project-shared records and cannot alter personal or team
+ * records. Use an identity-bound MCP session for private coordination data.
+ * Call `close()` when done to release resources.
  */
 export class MemoryClient {
   private _projectId: string;
   private _projectRoot: string;
   private _dataDir: string;
+  /** SDK calls are unbound by default, so they see only project-shared records. */
+  private _reader: ObservationReader;
   private _closed = false;
 
   // Internal module references — loaded lazily to avoid top-level side effects
@@ -116,6 +127,7 @@ export class MemoryClient {
     this._projectId = projectId;
     this._projectRoot = projectRoot;
     this._dataDir = dataDir;
+    this._reader = { projectId };
   }
 
   /** The canonical project ID (derived from Git remote or local path) */
@@ -182,6 +194,7 @@ export class MemoryClient {
     return this._observations.storeObservation({
       ...input,
       projectId: this._projectId,
+      visibilityReader: this._reader,
     });
   }
 
@@ -207,6 +220,7 @@ export class MemoryClient {
       type: options.type,
       source: options.source,
       status: options.status === 'all' ? undefined : (options.status ?? 'active'),
+      reader: this._reader,
     };
 
     return this._oramaStore.searchObservations(searchOpts);
@@ -218,7 +232,8 @@ export class MemoryClient {
   async get(id: number): Promise<Observation | undefined> {
     this._ensureOpen();
     await this._freshness.withFreshIndex(() => {});
-    return this._observations.getObservation(id, this._projectId);
+    const observation = this._observations.getObservation(id, this._projectId);
+    return observation && canReadObservation(observation, this._reader) ? observation : undefined;
   }
 
   /**
@@ -227,7 +242,10 @@ export class MemoryClient {
   async getAll(): Promise<Observation[]> {
     this._ensureOpen();
     await this._freshness.withFreshIndex(() => {});
-    return this._observations.getProjectObservations(this._projectId);
+    return filterReadableObservations(
+      this._observations.getProjectObservations(this._projectId),
+      this._reader,
+    );
   }
 
   /**
@@ -236,7 +254,10 @@ export class MemoryClient {
   async count(): Promise<number> {
     this._ensureOpen();
     await this._freshness.withFreshIndex(() => {});
-    return this._observations.getProjectObservations(this._projectId).length;
+    return filterReadableObservations(
+      this._observations.getProjectObservations(this._projectId),
+      this._reader,
+    ).length;
   }
 
   /**
@@ -253,7 +274,16 @@ export class MemoryClient {
    */
   async resolve(ids: number[], status: ObservationStatus = 'resolved'): Promise<ResolveResult> {
     this._ensureOpen();
-    return this._observations.resolveObservations(ids, status);
+    const manageableIds = ids.filter((id) => {
+      const observation = this._observations.getObservation(id, this._projectId);
+      return observation && canManageObservation(observation, this._reader);
+    });
+    const deniedIds = ids.filter((id) => !manageableIds.includes(id));
+    const result = await this._observations.resolveObservations(manageableIds, status);
+    return {
+      resolved: result.resolved,
+      notFound: [...new Set([...result.notFound, ...deniedIds])],
+    };
   }
 
   /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -2425,6 +2425,8 @@ export async function createMemorixServer(
         source: obs.source ?? 'agent',
         sourceDetail: obs.sourceDetail ?? '',
         valueCategory: obs.valueCategory ?? '',
+        admissionState: obs.admissionState ?? '',
+        admissionReason: obs.admissionReason ?? '',
       }));
 
       if (docs.length === 0) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -3864,7 +3864,7 @@ export async function createMemorixServer(
       title: 'Transfer Memories',
       description:
         'Export or import project memories. ' +
-        'Action "export": export observations and sessions (JSON or Markdown). ' +
+        'Action "export": export observations visible to the current agent and project sessions (JSON or Markdown). ' +
         'Action "import": import from a JSON export (re-assigns IDs, skips duplicate topicKeys).',
       inputSchema: {
         action: z.enum(['export', 'import']).describe('Operation: export or import'),
@@ -3876,10 +3876,10 @@ export async function createMemorixServer(
       if (action === 'export') {
         const { exportAsJson, exportAsMarkdown } = await import('./memory/export-import.js');
         if (format === 'markdown') {
-          const md = await exportAsMarkdown(projectDir, project.id);
+          const md = await exportAsMarkdown(projectDir, project.id, getObservationReader());
           return { content: [{ type: 'text' as const, text: md }] };
         }
-        const data = await exportAsJson(projectDir, project.id);
+        const data = await exportAsJson(projectDir, project.id, getObservationReader());
         const json = JSON.stringify(data, null, 2);
         return {
           content: [{

--- a/src/server.ts
+++ b/src/server.ts
@@ -29,12 +29,13 @@ import { checkProjectAttribution, auditProjectObservations } from './memory/attr
 import { createAutoRelations } from './memory/auto-relations.js';
 import { extractEntities } from './memory/entity-extractor.js';
 import { scopeKnowledgeGraphToProject } from './memory/graph-scope.js';
+import { canManageObservation, canReadObservation, filterReadableObservations, resolveObservationVisibility } from './memory/visibility.js';
 import { compactSearch, compactTimeline, compactDetail } from './compact/engine.js';
 import { buildGraphContextPacket, formatGraphContextPrompt } from './memory/graph-context.js';
 import { detectProject } from './project/detector.js';
 import { registerAlias, initAliasRegistry, resolveAliases, autoMergeByBaseName } from './project/aliases.js';
 import { getProjectDataDir } from './store/persistence.js';
-import type { ObservationType, RuleSource, AgentTarget, MCPServerEntry } from './types.js';
+import type { ObservationType, RuleSource, AgentTarget, MCPServerEntry, ObservationReader } from './types.js';
 import { RulesSyncer } from './rules/syncer.js';
 import { WorkspaceSyncEngine } from './workspace/engine.js';
 import {
@@ -261,8 +262,10 @@ export async function createMemorixServer(
   let rawProject: import('./types.js').ProjectInfo;
   let projectResolved = true;
   let projectResolutionError: string | null = null;
-    let explicitProjectBound = false; // Set true when memorix_session_start binds via projectRoot
-    let currentAgentId: string | undefined; // Session-scoped coordination identity for attribution after explicit join
+  let explicitProjectBound = false; // Set true when memorix_session_start binds via projectRoot
+  let currentAgentId: string | undefined; // Session-scoped coordination identity for attribution after explicit join
+  let teamStore!: import('./team/team-store.js').TeamStore;
+  let initTeamStoreForProject: ((dataDir: string) => Promise<import('./team/team-store.js').TeamStore>) | undefined;
   if (detectedProject) {
     rawProject = detectedProject;
   } else {
@@ -582,6 +585,23 @@ export async function createMemorixServer(
     return (originalRegisterTool as (...innerArgs: unknown[]) => unknown)(name, ...args) as never;
   }) as typeof server.registerTool;
 
+  const getObservationReader = (scope: 'project' | 'global' = 'project'): ObservationReader => {
+    let isTeamMember = false;
+    if (teamFeaturesEnabled && currentAgentId) {
+      try {
+        const agent = teamStore.getAgent(currentAgentId);
+        isTeamMember = agent?.project_id === project.id && agent.status === 'active';
+      } catch {
+        // A missing coordination store must never grant team visibility.
+      }
+    }
+    return {
+      ...(scope === 'project' ? { projectId: project.id } : {}),
+      ...(currentAgentId ? { agentId: currentAgentId } : {}),
+      isTeamMember,
+    };
+  };
+
   // ================================================================
   // Memorix Extended Tools (3-layer Progressive Disclosure)
   // ================================================================
@@ -602,7 +622,7 @@ export async function createMemorixServer(
         'problem-solution ([FIX] bug fix), how-it-works ([INFO] explanation), what-changed ([CHANGE] change), ' +
         'discovery ([DISCOVERY] insight), why-it-exists ([WHY] rationale), trade-off ([TRADEOFF] compromise), ' +
         'session-request ([SESSION] original goal). ' +
-        'Stored memories persist across sessions and are shared with other IDEs and agents (Cursor, Windsurf, Claude Code, Codex, Copilot, Gemini CLI, OpenCode, OpenClaw, Hermes Agent, Oh-my-Pi, Kiro, Antigravity, Trae) via the same local data directory.',
+        'Project visibility is the default. Personal or team visibility requires an explicitly joined coordination identity.',
       inputSchema: {
         entityName: z.string().describe('The entity this observation belongs to (e.g., "auth-module", "port-config")'),
         type: z.enum(OBSERVATION_TYPES).describe('Observation type for classification'),
@@ -623,12 +643,30 @@ export async function createMemorixServer(
         }).optional().describe('Progress tracking for task/feature observations'),
         relatedCommits: z.array(z.string()).optional().describe('Git commit hashes this memory relates to (links ground truth ↔ reasoning)'),
         relatedEntities: z.array(z.string()).optional().describe('Other entity names this memory cross-references'),
+        visibility: z.enum(['personal', 'project', 'team']).optional().describe(
+          'Retrieval scope. Project is the normal shared default; personal/team require memorix_session_start with joinTeam=true.',
+        ),
       },
     },
-    async ({ entityName: rawEntityName, type: rawType, title: rawTitle, narrative, facts, filesModified, concepts, topicKey, progress, relatedCommits, relatedEntities }) => {
+    async ({ entityName: rawEntityName, type: rawType, title: rawTitle, narrative, facts, filesModified, concepts, topicKey, progress, relatedCommits, relatedEntities, visibility }) => {
       const unresolved = requireResolvedProject('store memory in the current project');
       if (unresolved) return unresolved;
-      return withFreshIndex(async () => {
+      const requestedVisibility = (visibility ?? 'project') as 'personal' | 'project' | 'team';
+      const reader = getObservationReader();
+      if (requestedVisibility !== 'project' && !currentAgentId) {
+        return {
+          content: [{ type: 'text' as const, text: 'Personal or team memory requires memorix_session_start with joinTeam=true so Memorix can bind an owner.' }],
+          isError: true as const,
+        };
+      }
+      if (requestedVisibility === 'team' && !reader.isTeamMember) {
+        return {
+          content: [{ type: 'text' as const, text: 'Team memory requires an active coordination membership in the current project.' }],
+          isError: true as const,
+        };
+      }
+      try {
+      return await withFreshIndex(async () => {
 
       // Mutable copies — Formation Pipeline may improve these
       let entityName = rawEntityName;
@@ -678,9 +716,9 @@ export async function createMemorixServer(
             useLLM: isLLMEnabled(),
             minValueScore: 0.3,
             searchMemories: async (q: string, limit: number, pid: string): Promise<SearchHit[]> => {
-              const result = await compactSearch({ query: q, limit, projectId: pid, status: 'active' });
+              const result = await compactSearch({ query: q, limit, projectId: pid, status: 'active', reader });
               if (result.entries.length === 0) return [];
-              const details = await compactDetail(result.entries.map(e => e.id));
+              const details = await compactDetail(result.entries.map(e => e.id), { reader });
               return details.documents.map((d, i) => ({
                 id: Number(d.id.replace('obs-', '')),
                 observationId: d.observationId,
@@ -694,7 +732,7 @@ export async function createMemorixServer(
             },
             getObservation: (id: number) => {
               const o = getObservation(id);
-              if (!o) return null;
+              if (!o || o.projectId !== project.id || !canReadObservation(o, reader)) return null;
               return {
                 id: o.id,
                 entityName: o.entityName,
@@ -753,7 +791,7 @@ export async function createMemorixServer(
         if (action === 'merge' && targetId) {
           // Merge into existing observation
           const targetObs = getObservation(targetId);
-          if (targetObs) {
+          if (targetObs && targetObs.projectId === project.id && canReadObservation(targetObs, reader)) {
             await storeObservation({
               entityName: targetObs.entityName,
               type: targetObs.type,
@@ -767,6 +805,8 @@ export async function createMemorixServer(
               progress: progress as import('./types.js').ProgressInfo | undefined,
               sourceDetail: 'explicit',
               createdByAgentId: currentAgentId,
+              visibility,
+              visibilityReader: reader,
             });
             return {
               content: [{
@@ -778,7 +818,7 @@ export async function createMemorixServer(
         } else if (action === 'evolve' && targetId) {
           // Evolve existing observation
           const targetObs = getObservation(targetId);
-          if (targetObs) {
+          if (targetObs && targetObs.projectId === project.id && canReadObservation(targetObs, reader)) {
             await storeObservation({
               entityName: targetObs.entityName,
               type: targetObs.type,
@@ -792,6 +832,8 @@ export async function createMemorixServer(
               progress: progress as import('./types.js').ProgressInfo | undefined,
               sourceDetail: 'explicit',
               createdByAgentId: currentAgentId,
+              visibility,
+              visibilityReader: reader,
             });
             return {
               content: [{
@@ -824,12 +866,13 @@ export async function createMemorixServer(
             limit: 5,
             projectId: project.id,
             status: 'active',
+            reader,
           });
           const similarEntries = searchResult.entries.map(e => e);
           if (similarEntries.length > 0) {
             // Fetch full details for comparison
             const similarIds = similarEntries.map(e => e.id);
-            const details = await compactDetail(similarIds);
+            const details = await compactDetail(similarIds, { reader });
             const existingMemories: ExistingMemory[] = details.documents.map((d, i) => ({
               id: d.observationId,
               title: d.title,
@@ -850,7 +893,7 @@ export async function createMemorixServer(
             if (decision.action === 'UPDATE' && decision.targetId) {
               // Merge into existing memory (Mem0-style UPDATE)
               const targetObs = getObservation(decision.targetId);
-              if (targetObs) {
+              if (targetObs && targetObs.projectId === project.id && canReadObservation(targetObs, reader)) {
                 await storeObservation({
                   entityName: targetObs.entityName,
                   type: targetObs.type,
@@ -864,6 +907,8 @@ export async function createMemorixServer(
                   progress: progress as import('./types.js').ProgressInfo | undefined,
                   sourceDetail: 'explicit',
                   createdByAgentId: currentAgentId,
+                  visibility,
+                  visibilityReader: reader,
                 });
                 compactAction = `[UPDATED] Compact UPDATE: merged into #${decision.targetId} (${decision.reason})`;
                 compactMerged = true;
@@ -963,7 +1008,11 @@ export async function createMemorixServer(
       // in a different project — signals a potential wrong-bucket write.
       let attributionWarning = '';
       try {
-        const attrCheck = await checkProjectAttribution(entityName, project.id, getAllObservations());
+        const attrCheck = await checkProjectAttribution(
+          entityName,
+          project.id,
+          filterReadableObservations(getAllObservations(), reader),
+        );
         if (attrCheck.suspicious) {
           attributionWarning = `\n[WARN] Attribution notice: entity "${entityName}" has 0 observations in ` +
             `"${project.id}" but ${attrCheck.count} in "${attrCheck.knownIn}" ` +
@@ -989,6 +1038,8 @@ export async function createMemorixServer(
         sourceDetail: 'explicit',
         valueCategory: formationResult?.evaluation.category,
         createdByAgentId: currentAgentId,
+        visibility,
+        visibilityReader: reader,
       });
 
       // Add a reference to the entity's observations
@@ -1023,14 +1074,15 @@ export async function createMemorixServer(
             const compactStart = Date.now();
             const searchResult = await compactSearch({
               query: `${title} ${narrative.substring(0, 200)}`,
-              limit: 5,
-              projectId: project.id,
-              status: 'active',
+            limit: 5,
+            projectId: project.id,
+            status: 'active',
+            reader,
             });
             const similarEntries = searchResult.entries.map(e => e);
             if (similarEntries.length > 0) {
               const similarIds = similarEntries.map(e => e.id);
-              const details = await compactDetail(similarIds);
+              const details = await compactDetail(similarIds, { reader });
               const existingMemories: ExistingMemory[] = details.documents.map((d, i) => ({
                 id: d.observationId,
                 title: d.title,
@@ -1056,9 +1108,9 @@ export async function createMemorixServer(
             useLLM: isLLMEnabled(),
             minValueScore: 0.3,
             searchMemories: async (q: string, limit: number, pid: string): Promise<SearchHit[]> => {
-              const result = await compactSearch({ query: q, limit, projectId: pid, status: 'active' });
+              const result = await compactSearch({ query: q, limit, projectId: pid, status: 'active', reader });
               if (result.entries.length === 0) return [];
-              const details = await compactDetail(result.entries.map(e => e.id));
+              const details = await compactDetail(result.entries.map(e => e.id), { reader });
               return details.documents.map((d, i) => ({
                 id: Number(d.id.replace('obs-', '')),
                 observationId: d.observationId,
@@ -1072,7 +1124,7 @@ export async function createMemorixServer(
             },
             getObservation: (id: number) => {
               const o = getObservation(id);
-              if (!o) return null;
+              if (!o || o.projectId !== project.id || !canReadObservation(o, reader)) return null;
               return { id: o.id, entityName: o.entityName, type: o.type, title: o.title, narrative: o.narrative, facts: o.facts, topicKey: o.topicKey };
             },
             getEntityNames: () => graphManager.getEntityNames(),
@@ -1112,6 +1164,15 @@ export async function createMemorixServer(
         ],
       };
       }); // withFreshIndex
+      } catch (error) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: error instanceof Error ? error.message : 'Failed to store memory.',
+          }],
+          isError: true as const,
+        };
+      }
     },
   );
 
@@ -1208,6 +1269,7 @@ export async function createMemorixServer(
         projectId: scope === 'global' ? undefined : project.id,
         status: (status as 'active' | 'resolved' | 'archived' | 'all') ?? 'active',
         source: source as 'agent' | 'git' | 'manual' | undefined,
+        reader: getObservationReader(scope === 'global' ? 'global' : 'project'),
       });
 
       const timeoutPromise = new Promise<never>((_, reject) =>
@@ -1279,7 +1341,10 @@ export async function createMemorixServer(
       if (unresolved) return unresolved;
 
       const { getObservationStore } = await import('./store/obs-store.js');
-      const observations = await getObservationStore().loadByProject(project.id);
+      const observations = filterReadableObservations(
+        await getObservationStore().loadByProject(project.id),
+        getObservationReader(),
+      );
       const packet = buildGraphContextPacket(observations, {
         projectId: project.id,
         query,
@@ -1339,7 +1404,10 @@ export async function createMemorixServer(
         import('./runtime/maintenance-jobs.js'),
         import('./runtime/lifecycle.js'),
       ]);
-      const observations = await getObservationStore().loadByProject(project.id, { status: 'active' });
+      const observations = filterReadableObservations(
+        await getObservationStore().loadByProject(project.id, { status: 'active' }),
+        getObservationReader(),
+      );
       const context = await buildAutoProjectContext({
         project,
         dataDir: projectDir,
@@ -1441,7 +1509,10 @@ export async function createMemorixServer(
       await store.init(projectDir);
       const codegraphConfig = getResolvedConfig({ projectRoot: project.rootPath }).codegraph;
       const exclude = codegraphConfig.excludePatterns;
-      const observations = await getObservationStore().loadByProject(project.id, { status: 'active' });
+      const observations = filterReadableObservations(
+        await getObservationStore().loadByProject(project.id, { status: 'active' }),
+        getObservationReader(),
+      );
       observations.reverse();
       const basePack = assembleContextPackForTask({
         store,
@@ -1863,9 +1934,15 @@ export async function createMemorixServer(
       },
     },
     async ({ ids, status }) => {
-      const { resolveObservations } = await import('./memory/observations.js');
+      const { resolveObservations, getObservation } = await import('./memory/observations.js');
       const safeIds = (Array.isArray(ids) ? ids : [ids]).map(id => coerceNumber(id, 0)).filter(id => id > 0);
-      const result = await resolveObservations(safeIds, (status as 'resolved' | 'archived') ?? 'resolved');
+      const reader = getObservationReader();
+      const authorizedIds = safeIds.filter((id) => {
+        const observation = getObservation(id, project.id);
+        return observation ? canManageObservation(observation, reader) : false;
+      });
+      const result = await resolveObservations(authorizedIds, (status as 'resolved' | 'archived') ?? 'resolved');
+      const deniedCount = safeIds.length - authorizedIds.length;
 
       const parts: string[] = [];
       if (result.resolved.length > 0) {
@@ -1873,6 +1950,9 @@ export async function createMemorixServer(
       }
       if (result.notFound.length > 0) {
         parts.push(`[WARN] Not found: #${result.notFound.join(', #')}`);
+      }
+      if (deniedCount > 0) {
+        parts.push(`[WARN] Skipped ${deniedCount} observation(s) outside this session's write scope.`);
       }
       parts.push('\nResolved memories are hidden from default search. Use status="all" to include them.');
       parts.push('[STATS] Run `memorix_retention` with `action: "report"` to check remaining cleanup status.');
@@ -1919,6 +1999,7 @@ export async function createMemorixServer(
     async ({ entityName, decision, alternatives, rationale, constraints, expectedOutcome, risks, concepts, filesModified, relatedCommits, relatedEntities }) => {
       const unresolved = requireResolvedProject('store reasoning in the current project');
       if (unresolved) return unresolved;
+      const reader = getObservationReader();
       return withFreshIndex(async () => {
 
       // Build structured narrative from reasoning fields
@@ -1948,7 +2029,11 @@ export async function createMemorixServer(
       // ── Attribution guard (passive, non-blocking) ─────────────────
       let reasoningAttributionWarning = '';
       try {
-        const attrCheck = await checkProjectAttribution(entityName, project.id, getAllObservations());
+        const attrCheck = await checkProjectAttribution(
+          entityName,
+          project.id,
+          filterReadableObservations(getAllObservations(), reader),
+        );
         if (attrCheck.suspicious) {
           reasoningAttributionWarning = `\n[WARN] Attribution notice: entity "${entityName}" has 0 observations in ` +
             `"${project.id}" but ${attrCheck.count} in "${attrCheck.knownIn}" ` +
@@ -1970,6 +2055,7 @@ export async function createMemorixServer(
         relatedEntities,
         sourceDetail: 'explicit',
         createdByAgentId: currentAgentId,
+        visibility: 'project',
       });
 
       await graphManager.addObservations([
@@ -2013,7 +2099,11 @@ export async function createMemorixServer(
       const minCount = threshold ?? 2;
       let entries: import('./memory/attribution-guard.js').AuditEntry[];
       try {
-        entries = await auditProjectObservations(project.id, await withFreshIndex(() => getAllObservations()), minCount);
+        entries = await auditProjectObservations(
+          project.id,
+          await withFreshIndex(() => filterReadableObservations(getAllObservations(), getObservationReader())),
+          minCount,
+        );
       } catch (err) {
         return {
           content: [{
@@ -2096,6 +2186,7 @@ export async function createMemorixServer(
         type: 'reasoning' as ObservationType,
         projectId: scope === 'global' ? undefined : project.id,
         status: 'active',
+        reader: getObservationReader(scope === 'global' ? 'global' : 'project'),
       }));
 
       if (result.entries.length === 0) {
@@ -2132,7 +2223,11 @@ export async function createMemorixServer(
     },
     async ({ query, dryRun }) => {
       const { getAllObservations, resolveObservations } = await import('./memory/observations.js');
-      const allObs = await withFreshIndex(() => getAllObservations().filter(o => (o.status ?? 'active') === 'active' && o.projectId === project.id));
+      const reader = getObservationReader();
+      const allObs = await withFreshIndex(() => filterReadableObservations(
+        getAllObservations().filter(o => (o.status ?? 'active') === 'active' && o.projectId === project.id),
+        reader,
+      ).filter((observation) => canManageObservation(observation, reader)));
 
       if (allObs.length < 2) {
         return { content: [{ type: 'text' as const, text: 'Not enough active memories to deduplicate.' }] };
@@ -2151,7 +2246,7 @@ export async function createMemorixServer(
       // If query provided, search for relevant memories; otherwise take latest 20
       let candidates: typeof allObs;
       if (query) {
-        const searchResult = await compactSearch({ query, limit: 20, projectId: project.id, status: 'active' });
+        const searchResult = await compactSearch({ query, limit: 20, projectId: project.id, status: 'active', reader });
         const idSet = new Set(searchResult.entries.map(e => e.id));
         candidates = allObs.filter(o => idSet.has(o.id));
       } else {
@@ -2257,6 +2352,7 @@ export async function createMemorixServer(
         project.id,
         safeBefore,
         safeAfter,
+        getObservationReader(),
       );
 
       return {
@@ -2307,14 +2403,17 @@ export async function createMemorixServer(
       // Priority: typedRefs > refs > ids (each is a complete, homogeneous input path)
       let result;
       try {
+        const hasCrossProjectRef = safeRefs.some((ref) => ref.projectId && ref.projectId !== project.id)
+          || safeTypedRefs.some((ref) => ref.includes('@') && !ref.endsWith(`@${project.id}`));
+        const reader = getObservationReader(hasCrossProjectRef ? 'global' : 'project');
         if (safeTypedRefs.length > 0) {
           // Pass typed ref strings directly — compactDetail handles parsing
-          result = await compactDetail(safeTypedRefs);
+          result = await compactDetail(safeTypedRefs, { reader });
         } else if (safeRefs.length > 0) {
-          result = await compactDetail(safeRefs);
+          result = await compactDetail(safeRefs, { reader });
         } else {
           // Bare numeric IDs are scoped to the current project
-          result = await compactDetail(safeIds.map(id => ({ id, projectId: project.id })));
+          result = await compactDetail(safeIds.map(id => ({ id, projectId: project.id })), { reader });
         }
       } catch (err) {
         return { content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }], isError: true };
@@ -2363,13 +2462,17 @@ export async function createMemorixServer(
     },
     async (args: { action?: string }) => {
       const action = args.action ?? 'report';
-      const { getRetentionSummary, getArchiveCandidates, rankByRelevance, archiveExpired, getRetentionZone, explainRetention } = await import('./memory/retention.js');
+      const { getRetentionSummary, getArchiveCandidates, rankByRelevance, getRetentionZone, explainRetention } = await import('./memory/retention.js');
       const { getDb } = await import('./store/orama-store.js');
       const { search } = await import('@orama/orama');
 
       // Shared: build MemorixDocument[] from in-memory observations
-      const { getAllObservations } = await import('./memory/observations.js');
-      const allObs = await withFreshIndex(() => getAllObservations());
+      const { getAllObservations, resolveObservations } = await import('./memory/observations.js');
+      const reader = getObservationReader();
+      const allObs = await withFreshIndex(() => filterReadableObservations(
+        getAllObservations().filter((observation) => observation.projectId === project.id),
+        reader,
+      ));
 
       // Pull current access metadata from the live Orama index so access-based
       // immunity (e.g. accessCount >= 3) still works in retention/report/archive
@@ -2393,19 +2496,6 @@ export async function createMemorixServer(
         // less precise immunity/reporting.
       }
 
-      // Handle archive action
-      if (action === 'archive') {
-        const result = await archiveExpired(projectDir, undefined, accessMap, project.id);
-        if (result.archived === 0) {
-          return {
-            content: [{ type: 'text' as const, text: '[OK] No expired observations to archive. All memories are within their retention period.' }],
-          };
-        }
-        return {
-          content: [{ type: 'text' as const, text: `[ARCHIVED] Archived ${result.archived} expired observations (status set to 'archived' in-place)\n${result.remaining} active observations remaining.\n\nArchived memories are hidden from default search but can be found with status: "all".` }],
-        };
-      }
-
       const docs: import('./types.js').MemorixDocument[] = allObs.map(obs => ({
         id: `obs-${obs.id}`,
         observationId: obs.id,
@@ -2427,11 +2517,32 @@ export async function createMemorixServer(
         valueCategory: obs.valueCategory ?? '',
         admissionState: obs.admissionState ?? '',
         admissionReason: obs.admissionReason ?? '',
+        visibility: obs.visibility ?? 'project',
+        createdByAgentId: obs.createdByAgentId ?? '',
+        sharedWithAgentIds: JSON.stringify(obs.sharedWithAgentIds ?? []),
       }));
 
       if (docs.length === 0) {
         return {
           content: [{ type: 'text' as const, text: 'No observations found for this project.' }],
+        };
+      }
+
+      if (action === 'archive') {
+        const managedIds = new Set(
+          allObs
+            .filter((observation) => canManageObservation(observation, reader))
+            .map((observation) => observation.id),
+        );
+        const candidates = getArchiveCandidates(docs).filter((document) => managedIds.has(document.observationId));
+        if (candidates.length === 0) {
+          return {
+            content: [{ type: 'text' as const, text: '[OK] No expired memories in this session\'s write scope to archive.' }],
+          };
+        }
+        const result = await resolveObservations(candidates.map((document) => document.observationId), 'archived');
+        return {
+          content: [{ type: 'text' as const, text: `[ARCHIVED] Archived ${result.resolved.length} expired observation(s) in this session's write scope.\n${Math.max(0, managedIds.size - result.resolved.length)} visible writable observations remaining.` }],
         };
       }
 
@@ -2809,7 +2920,10 @@ export async function createMemorixServer(
     const allObs = await withFreshIndex(() => getAllObservations());
     const scoped = scopeKnowledgeGraphToProject(
       graph,
-      allObs.filter(observation => observation.projectId === project.id),
+      filterReadableObservations(
+        allObs.filter(observation => observation.projectId === project.id),
+        getObservationReader(),
+      ),
     );
     return { entities: scoped.entities, relations: scoped.relations };
   }
@@ -3151,12 +3265,10 @@ export async function createMemorixServer(
 
       // action === 'generate'
       const { getObservationStore: getStore } = await import('./store/obs-store.js');
-      const allObs = await getStore().loadAll() as Array<{
-        id?: number; entityName?: string; type?: string; title?: string;
-        narrative?: string; facts?: string[]; concepts?: string[];
-        filesModified?: string[]; createdAt?: string;
-        status?: string; source?: 'agent' | 'git' | 'manual';
-      }>;
+      const allObs = filterReadableObservations(
+        (await getStore().loadAll()).filter((observation) => observation.projectId === project.id),
+        getObservationReader(),
+      );
 
       const obsData = allObs.map(o => ({
         id: o.id || 0,
@@ -3288,7 +3400,11 @@ export async function createMemorixServer(
       // Load observations by ID — only active observations can be promoted
       const { getAllObservations } = await import('./memory/observations.js');
       const allObs = await withFreshIndex(() => getAllObservations());
-      const matched = allObs.filter(o => observationIds.includes(o.id));
+      const reader = getObservationReader();
+      const matched = filterReadableObservations(
+        allObs.filter((observation) => observation.projectId === project.id && observationIds.includes(observation.id)),
+        reader,
+      );
 
       if (matched.length === 0) {
         return { content: [{ type: 'text' as const, text: `No observations found for IDs: [${observationIds.join(', ')}]. Use \`memorix_search\` to find valid IDs.` }], isError: true };
@@ -3298,6 +3414,14 @@ export async function createMemorixServer(
       const nonActive = matched.filter(o => (o.status ?? 'active') !== 'active');
       if (nonActive.length > 0) {
         return { content: [{ type: 'text' as const, text: `Cannot promote: ${nonActive.length} observation(s) are not active: ${nonActive.map(o => `#${o.id} (${o.status})`).join(', ')}. Only active observations can be promoted to permanent knowledge.` }], isError: true };
+      }
+
+      const nonProjectShared = matched.filter((observation) => resolveObservationVisibility(observation) !== 'project');
+      if (nonProjectShared.length > 0) {
+        return {
+          content: [{ type: 'text' as const, text: `Cannot promote private or team-scoped observations: ${nonProjectShared.map((observation) => `#${observation.id}`).join(', ')}. Promote only deliberate project-shared knowledge.` }],
+          isError: true,
+        };
       }
 
       const skill = await promoteToMiniSkill(projectDir, project.id, matched, { trigger, instruction, tags });
@@ -3533,8 +3657,11 @@ export async function createMemorixServer(
           const lastSeen = registeredAgent.last_seen_obs_generation;
           const store = getObservationStore();
           const currentGen = store.getGeneration();
-          const projectObs = await withFreshIndex(() => getAllObservations().filter(
-            o => o.projectId === project.id && (o.writeGeneration ?? 0) > lastSeen,
+          const projectObs = await withFreshIndex(() => filterReadableObservations(
+            getAllObservations().filter(
+              o => o.projectId === project.id && (o.writeGeneration ?? 0) > lastSeen,
+            ),
+            getObservationReader(),
           ));
           const wm = computeWatermark(lastSeen, currentGen, projectObs.length);
           if (wm.newObservationCount > 0) {
@@ -3974,8 +4101,6 @@ export async function createMemorixServer(
 
   // Use shared TeamStore (from HTTP server) or create new one (stdio mode).
   // All team state is canonical in SQLite — no JSON persistence, no sync/flush.
-  let teamStore!: import('./team/team-store.js').TeamStore;
-  let initTeamStoreForProject: ((dataDir: string) => Promise<import('./team/team-store.js').TeamStore>) | undefined;
   if (teamFeaturesEnabled) {
     const { initTeamStore } = await import('./team/team-store.js');
     initTeamStoreForProject = initTeamStore;
@@ -4261,7 +4386,7 @@ export async function createMemorixServer(
         'Action "inbox": read this agent\'s inbox.',
       inputSchema: {
         action: z.enum(['send', 'broadcast', 'inbox']).describe('Operation to perform'),
-        from: z.string().optional().describe('Sender agent ID (for send/broadcast)'),
+        from: z.string().optional().describe('Your sender agent ID. Omit it to use this session identity.'),
         to: z.string().optional().describe('Receiver agent ID (for send)'),
         type: z.enum(['request', 'response', 'info', 'announcement', 'contract', 'error', 'handoff']).optional().describe('Message type (for send/broadcast)'),
         content: z.string().optional().describe('Message content (for send/broadcast)'),
@@ -4272,13 +4397,20 @@ export async function createMemorixServer(
       },
     },
     async ({ action, from, to, type: msgType, content, agentId, markRead, toRole, handoffStatus }) => {
+      const requireCurrentTeamAgent = () => {
+        if (!currentAgentId) return null;
+        const agent = teamStore.getAgent(currentAgentId);
+        return agent?.project_id === project.id && agent.status === 'active' ? agent : null;
+      };
       if (action === 'send') {
-        if (!from || !msgType || !content) return { content: [{ type: 'text' as const, text: '[ERROR] from, type, and content required for send' }], isError: true };
+        const sender = requireCurrentTeamAgent();
+        if (!sender || !msgType || !content) return { content: [{ type: 'text' as const, text: '[ERROR] active session identity, type, and content required for send' }], isError: true };
+        if (from && from !== currentAgentId) return { content: [{ type: 'text' as const, text: '[ERROR] from must match the current session identity' }], isError: true };
         if (!to && !toRole) return { content: [{ type: 'text' as const, text: '[ERROR] either to (agent ID) or toRole is required for send' }], isError: true };
         if (content.length > 10_000) return { content: [{ type: 'text' as const, text: '[ERROR] Message too large (max 10KB)' }], isError: true };
         const msg = teamStore.sendMessage({
           projectId: project.id,
-          senderAgentId: from,
+          senderAgentId: currentAgentId!,
           recipientAgentId: to ?? null,
           type: msgType,
           content,
@@ -4290,11 +4422,13 @@ export async function createMemorixServer(
         return { content: [{ type: 'text' as const, text: `Message sent (${msgType}) to ${target} | ID: ${msg.id.slice(0, 8)}…${toRole ? ` [role: ${toRole}]` : ''}` }] };
       }
       if (action === 'broadcast') {
-        if (!from || !msgType || !content) return { content: [{ type: 'text' as const, text: '[ERROR] from, type, and content required for broadcast' }], isError: true };
+        const sender = requireCurrentTeamAgent();
+        if (!sender || !msgType || !content) return { content: [{ type: 'text' as const, text: '[ERROR] active session identity, type, and content required for broadcast' }], isError: true };
+        if (from && from !== currentAgentId) return { content: [{ type: 'text' as const, text: '[ERROR] from must match the current session identity' }], isError: true };
         if (content.length > 10_000) return { content: [{ type: 'text' as const, text: '[ERROR] Message too large (max 10KB)' }], isError: true };
         const msg = teamStore.sendMessage({
           projectId: project.id,
-          senderAgentId: from,
+          senderAgentId: currentAgentId!,
           recipientAgentId: null,
           type: msgType,
           content,
@@ -4303,8 +4437,12 @@ export async function createMemorixServer(
         return { content: [{ type: 'text' as const, text: `Broadcast (${msgType}) | ID: ${msg.id.slice(0, 8)}…` }] };
       }
       // inbox
-      const inboxId = agentId || from || '';
-      if (!inboxId) return { content: [{ type: 'text' as const, text: '[ERROR] agentId required for inbox' }], isError: true };
+      const inboxAgent = requireCurrentTeamAgent();
+      if (!inboxAgent) return { content: [{ type: 'text' as const, text: '[ERROR] active session identity required for inbox' }], isError: true };
+      if ((agentId && agentId !== currentAgentId) || (from && from !== currentAgentId)) {
+        return { content: [{ type: 'text' as const, text: '[ERROR] inbox access is limited to the current session identity' }], isError: true };
+      }
+      const inboxId = currentAgentId!;
       const inbox = teamStore.getInbox(project.id, inboxId);
       const unread = teamStore.getUnreadCount(project.id, inboxId);
       if (inbox.length === 0) return { content: [{ type: 'text' as const, text: 'Inbox empty' }] };
@@ -4336,32 +4474,42 @@ export async function createMemorixServer(
     },
     async ({ agentId, markInboxRead }) => {
       const { computeWatermark, computePoll } = await import('./team/poll.js');
+      if (agentId && agentId !== currentAgentId) {
+        return {
+          content: [{ type: 'text' as const, text: '[ERROR] agentId must match the current session identity.' }],
+          isError: true as const,
+        };
+      }
+      const effectiveAgentId = currentAgentId;
 
       // Compute watermark — requires observation store access
       let watermark = computeWatermark(0, 0, 0);
-      if (agentId) {
-        const agent = teamStore.getAgent(agentId);
+      if (effectiveAgentId) {
+        const agent = teamStore.getAgent(effectiveAgentId);
         if (agent) {
           const lastSeen = agent.last_seen_obs_generation;
           const store = getObservationStore();
           const currentGen = store.getGeneration();
-          const projectObs = await withFreshIndex(() => getAllObservations().filter(
-            o => o.projectId === project.id && (o.writeGeneration ?? 0) > lastSeen,
+          const projectObs = await withFreshIndex(() => filterReadableObservations(
+            getAllObservations().filter(
+              o => o.projectId === project.id && (o.writeGeneration ?? 0) > lastSeen,
+            ),
+            getObservationReader(),
           ));
           watermark = computeWatermark(lastSeen, currentGen, projectObs.length);
 
           // Advance watermark so next poll sees only truly new observations
-          teamStore.updateWatermark(agentId, currentGen);
+          teamStore.updateWatermark(effectiveAgentId, currentGen);
           // Heartbeat — proves this agent is alive
-          teamStore.heartbeat(agentId);
+          teamStore.heartbeat(effectiveAgentId);
         }
       }
 
-      const poll = computePoll(teamStore, project.id, agentId ?? null, watermark);
+      const poll = computePoll(teamStore, project.id, effectiveAgentId ?? null, watermark);
 
       // Optionally mark inbox as read
-      if (markInboxRead && agentId) {
-        teamStore.markAllRead(project.id, agentId);
+      if (markInboxRead && effectiveAgentId) {
+        teamStore.markAllRead(project.id, effectiveAgentId);
       }
 
       // Format as readable text
@@ -4434,7 +4582,8 @@ export async function createMemorixServer(
       title: 'Team Handoff — Agent Context Transfer',
       description:
         'Create a structured handoff artifact when passing work to another agent. ' +
-        'The handoff is stored as a durable observation (searchable, immune to archival) ' +
+        'A targeted handoff is visible only to its sender and recipient; a broadcast handoff is team-visible. ' +
+        'The handoff is stored as a durable observation (immune to archival) ' +
         'and a notification message is sent to the recipient. ' +
         'Use this when completing a task and another agent should continue, ' +
         'or when you want to leave context for whoever works on this next.',
@@ -4450,6 +4599,34 @@ export async function createMemorixServer(
     },
     async ({ fromAgentId, summary, context, toAgentId, taskId, filesModified, concepts }) => {
       const { createHandoffArtifact } = await import('./team/handoff.js');
+      if (!currentAgentId) {
+        return {
+          content: [{ type: 'text' as const, text: 'Create a coordination identity first: call memorix_session_start with joinTeam=true.' }],
+          isError: true as const,
+        };
+      }
+      if (fromAgentId !== currentAgentId) {
+        return {
+          content: [{ type: 'text' as const, text: 'fromAgentId must match the identity returned for this session. Memorix will not create a handoff on behalf of another agent.' }],
+          isError: true as const,
+        };
+      }
+      const sender = teamStore.getAgent(currentAgentId);
+      if (!sender || sender.project_id !== project.id || sender.status !== 'active') {
+        return {
+          content: [{ type: 'text' as const, text: 'The current coordination identity is not an active member of this project.' }],
+          isError: true as const,
+        };
+      }
+      if (toAgentId) {
+        const recipient = teamStore.getAgent(toAgentId);
+        if (!recipient || recipient.project_id !== project.id) {
+          return {
+            content: [{ type: 'text' as const, text: 'The handoff recipient must be an agent registered in the current project.' }],
+            isError: true as const,
+          };
+        }
+      }
 
       const result = await createHandoffArtifact(
         {

--- a/src/store/orama-store.ts
+++ b/src/store/orama-store.ts
@@ -175,6 +175,8 @@ async function initializeDb(
     source: 'string' as const,
     sourceDetail: 'string' as const,
     valueCategory: 'string' as const,
+    admissionState: 'string' as const,
+    admissionReason: 'string' as const,
     documentType: 'string' as const,
     knowledgeLayer: 'string' as const,
   };
@@ -390,6 +392,10 @@ export async function hydrateIndex(
         lastAccessedAt: obs.lastAccessedAt || '',
         status: obs.status ?? 'active',
         source: obs.source || 'agent',
+        sourceDetail: obs.sourceDetail ?? '',
+        valueCategory: obs.valueCategory ?? '',
+        admissionState: obs.admissionState ?? '',
+        admissionReason: obs.admissionReason ?? '',
         documentType: 'observation',
         knowledgeLayer: resolveKnowledgeLayer('observation', obs.sourceDetail, obs.source),
         ...(compatibleVector ? { embedding: compatibleVector } : {}),
@@ -441,6 +447,26 @@ export async function insertObservation(doc: MemorixDocument): Promise<void> {
   const database = await getDb();
   await insert(database, doc);
   rememberObservationDoc(doc);
+}
+
+/**
+ * Update retrieval metadata without rebuilding an embedding. Admission is
+ * deliberately metadata-only: promotion must not create another embedding
+ * request or delay a background qualification job.
+ */
+export async function updateObservationMetadata(
+  projectId: string,
+  observationId: number,
+  patch: Pick<MemorixDocument, 'admissionState' | 'admissionReason'>,
+): Promise<boolean> {
+  const database = await getDb();
+  const id = makeOramaObservationId(projectId, observationId);
+  const existing = getByID(database, id) as MemorixDocument | undefined;
+  if (!existing) return false;
+  const next = { ...existing, ...patch };
+  await update(database, id, next);
+  rememberObservationDoc(next);
+  return true;
 }
 
 /**
@@ -682,6 +708,7 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
         source: (doc.source || 'agent') as 'agent' | 'git' | 'manual',
         sourceDetail: (doc.sourceDetail || undefined) as 'explicit' | 'hook' | 'git-ingest' | undefined,
         valueCategory: (doc.valueCategory || undefined) as 'core' | 'contextual' | 'ephemeral' | undefined,
+        admissionState: (doc.admissionState || undefined) as IndexEntry['admissionState'],
         entityName: doc.entityName || undefined,
         documentType: (doc.documentType || 'observation') as 'observation' | 'mini-skill',
         knowledgeLayer: (doc.knowledgeLayer || 'project-truth') as KnowledgeLayer,
@@ -750,6 +777,16 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
       ...entry,
       score: isCommandStyleEntry(entry.title) ? entry.score * 0.3 : entry.score,
     }));
+  }
+
+  // Automatic capture is useful as an audit trail, but unqualified evidence
+  // should not crowd out durable project knowledge in ordinary retrieval.
+  // Keep it available as a fallback when it is all the project has.
+  if (hasQuery) {
+    const qualifiedEntries = intermediate.filter(
+      (entry) => entry.admissionState !== 'candidate' && entry.admissionState !== 'ephemeral',
+    );
+    if (qualifiedEntries.length > 0) intermediate = qualifiedEntries;
   }
 
   // Re-sort: chronological for WHEN queries, relevance for others
@@ -1093,7 +1130,7 @@ export async function getTimeline(
 
   const toIndexEntry = (obs: {
     id: number; type: string; title: string; tokens: number; createdAt: string;
-    source?: string; sourceDetail?: string; valueCategory?: string;
+    source?: string; sourceDetail?: string; valueCategory?: string; admissionState?: string;
   }): IndexEntry => {
     const obsType = obs.type as ObservationType;
     return {
@@ -1106,6 +1143,7 @@ export async function getTimeline(
       source: (obs.source as IndexEntry['source']) || undefined,
       sourceDetail: (obs.sourceDetail as IndexEntry['sourceDetail']) || undefined,
       valueCategory: (obs.valueCategory as IndexEntry['valueCategory']) || undefined,
+      admissionState: (obs.admissionState as IndexEntry['admissionState']) || undefined,
     };
   };
 

--- a/src/store/orama-store.ts
+++ b/src/store/orama-store.ts
@@ -9,9 +9,10 @@
  */
 
 import { create, insert, search, remove, update, count, getByID, type AnyOrama } from '@orama/orama';
-import type { MemorixDocument, SearchOptions, IndexEntry, KnowledgeLayer } from '../types.js';
+import type { MemorixDocument, SearchOptions, IndexEntry, KnowledgeLayer, ObservationReader } from '../types.js';
 import { OBSERVATION_ICONS, type ObservationType } from '../types.js';
 import { resolveKnowledgeLayer } from '../skills/mini-skills.js';
+import { canReadObservation } from '../memory/visibility.js';
 import { getEmbeddingProvider, type EmbeddingProvider } from '../embedding/provider.js';
 import { calculateProjectAffinity, extractProjectKeywords, type AffinityContext, type MemoryContent } from './project-affinity.js';
 import { detectQueryIntent, applyIntentBoost } from '../search/intent-detector.js';
@@ -177,6 +178,9 @@ async function initializeDb(
     valueCategory: 'string' as const,
     admissionState: 'string' as const,
     admissionReason: 'string' as const,
+    visibility: 'string' as const,
+    createdByAgentId: 'string' as const,
+    sharedWithAgentIds: 'string' as const,
     documentType: 'string' as const,
     knowledgeLayer: 'string' as const,
   };
@@ -396,6 +400,9 @@ export async function hydrateIndex(
         valueCategory: obs.valueCategory ?? '',
         admissionState: obs.admissionState ?? '',
         admissionReason: obs.admissionReason ?? '',
+        visibility: obs.visibility ?? 'project',
+        createdByAgentId: obs.createdByAgentId ?? '',
+        sharedWithAgentIds: JSON.stringify(obs.sharedWithAgentIds ?? []),
         documentType: 'observation',
         knowledgeLayer: resolveKnowledgeLayer('observation', obs.sourceDetail, obs.source),
         ...(compatibleVector ? { embedding: compatibleVector } : {}),
@@ -457,7 +464,7 @@ export async function insertObservation(doc: MemorixDocument): Promise<void> {
 export async function updateObservationMetadata(
   projectId: string,
   observationId: number,
-  patch: Pick<MemorixDocument, 'admissionState' | 'admissionReason'>,
+  patch: Partial<Pick<MemorixDocument, 'admissionState' | 'admissionReason' | 'visibility' | 'createdByAgentId' | 'sharedWithAgentIds'>>,
 ): Promise<boolean> {
   const database = await getDb();
   const id = makeOramaObservationId(projectId, observationId);
@@ -669,6 +676,9 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
       const doc = hit.document as unknown as MemorixDocument;
       return projectIds.includes(doc.projectId);
     })
+    // Visibility is enforced before scoring/ranking so private records cannot
+    // affect result order, fallback behavior, or downstream detail reads.
+    .filter((hit) => canReadObservation(hit.document as unknown as MemorixDocument, options.reader))
     // Post-filter by status (active/resolved/archived)
     .filter((hit) => {
       if (statusFilter === 'all') return true;
@@ -709,6 +719,7 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
         sourceDetail: (doc.sourceDetail || undefined) as 'explicit' | 'hook' | 'git-ingest' | undefined,
         valueCategory: (doc.valueCategory || undefined) as 'core' | 'contextual' | 'ephemeral' | undefined,
         admissionState: (doc.admissionState || undefined) as IndexEntry['admissionState'],
+        visibility: (doc.visibility || undefined) as IndexEntry['visibility'],
         entityName: doc.entityName || undefined,
         documentType: (doc.documentType || 'observation') as 'observation' | 'mini-skill',
         knowledgeLayer: (doc.knowledgeLayer || 'project-truth') as KnowledgeLayer,
@@ -997,7 +1008,8 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
   let entries: IndexEntry[] = intermediate.map(({ rawTime: _, _isCommandLog: _c, ...rest }: any) => rest);
 
   for (const hit of results.hits) {
-    rememberObservationDoc(hit.document as unknown as MemorixDocument);
+    const doc = hit.document as unknown as MemorixDocument;
+    if (canReadObservation(doc, options.reader)) rememberObservationDoc(doc);
   }
 
   // Explainable recall: annotate entries with match reasons (O(1) lookup via Map)
@@ -1050,7 +1062,10 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
 
   // Record access for returned results (fire-and-forget, non-blocking).
   if (options.trackAccess !== false) {
-    const hitDocs = results.hits.map((h) => ({ id: h.id, doc: h.document as unknown as MemorixDocument }));
+    const returnedKeys = new Set(entries.map((entry) => makeEntryKey(entry.projectId, entry.id)));
+    const hitDocs = results.hits
+      .map((hit) => ({ id: hit.id, doc: hit.document as unknown as MemorixDocument }))
+      .filter(({ doc }) => returnedKeys.has(makeEntryKey(doc.projectId, doc.observationId)));
     recordAccessBatch(hitDocs).catch(() => {});
   }
 
@@ -1108,6 +1123,7 @@ export async function getTimeline(
   projectId?: string,
   depthBefore = 3,
   depthAfter = 3,
+  reader?: ObservationReader,
 ): Promise<{ before: IndexEntry[]; anchor: IndexEntry | null; after: IndexEntry[] }> {
   // Use in-memory observations for reliable lookup
   // (Orama search with empty term is unreliable — same fix as compactDetail)
@@ -1116,9 +1132,9 @@ export async function getTimeline(
   const rawObs = await withFreshIndex(() => getAllObservations());
 
   // Filter by project if specified — prevents cross-project context leaking
-  const allObs = projectId
+  const allObs = (projectId
     ? rawObs.filter((o) => o.projectId === projectId)
-    : rawObs;
+    : rawObs).filter((observation) => canReadObservation(observation, reader));
 
   // Sort by creation time
   const sorted = allObs.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
@@ -1130,7 +1146,7 @@ export async function getTimeline(
 
   const toIndexEntry = (obs: {
     id: number; type: string; title: string; tokens: number; createdAt: string;
-    source?: string; sourceDetail?: string; valueCategory?: string; admissionState?: string;
+    source?: string; sourceDetail?: string; valueCategory?: string; admissionState?: string; visibility?: string;
   }): IndexEntry => {
     const obsType = obs.type as ObservationType;
     return {
@@ -1144,6 +1160,7 @@ export async function getTimeline(
       sourceDetail: (obs.sourceDetail as IndexEntry['sourceDetail']) || undefined,
       valueCategory: (obs.valueCategory as IndexEntry['valueCategory']) || undefined,
       admissionState: (obs.admissionState as IndexEntry['admissionState']) || undefined,
+      visibility: (obs.visibility as IndexEntry['visibility']) || undefined,
     };
   };
 

--- a/src/store/sqlite-db.ts
+++ b/src/store/sqlite-db.ts
@@ -57,7 +57,9 @@ CREATE TABLE IF NOT EXISTS observations (
   relatedCommits  TEXT,
   relatedEntities TEXT,
   sourceDetail    TEXT,
-  valueCategory   TEXT
+  valueCategory   TEXT,
+  admissionState  TEXT,
+  admissionReason TEXT
 );
 `;
 
@@ -529,6 +531,7 @@ CREATE INDEX IF NOT EXISTS idx_observations_projectId ON observations(projectId)
 CREATE INDEX IF NOT EXISTS idx_observations_topicKey ON observations(projectId, topicKey);
 CREATE INDEX IF NOT EXISTS idx_observations_status ON observations(status);
 CREATE INDEX IF NOT EXISTS idx_observations_project_status_id ON observations(projectId, status, id);
+CREATE INDEX IF NOT EXISTS idx_observations_project_admission ON observations(projectId, status, admissionState, id);
 CREATE INDEX IF NOT EXISTS idx_mini_skills_projectId ON mini_skills(projectId);
 CREATE INDEX IF NOT EXISTS idx_sessions_projectId ON sessions(projectId);
 CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(projectId, status);
@@ -590,6 +593,14 @@ function addColumnIfMissing(db: any, table: string, column: string, definition: 
 }
 
 const SCHEMA_MIGRATIONS: SchemaMigration[] = [
+  {
+    id: '1.2.2-observation-admission',
+    apply: (db) => {
+      addColumnIfMissing(db, 'observations', 'admissionState', 'admissionState TEXT');
+      addColumnIfMissing(db, 'observations', 'admissionReason', 'admissionReason TEXT');
+      db.exec('CREATE INDEX IF NOT EXISTS idx_observations_project_admission ON observations(projectId, status, admissionState, id)');
+    },
+  },
   {
     id: '1.2-code-state-snapshots',
     apply: (db) => {

--- a/src/store/sqlite-db.ts
+++ b/src/store/sqlite-db.ts
@@ -59,7 +59,9 @@ CREATE TABLE IF NOT EXISTS observations (
   sourceDetail    TEXT,
   valueCategory   TEXT,
   admissionState  TEXT,
-  admissionReason TEXT
+  admissionReason TEXT,
+  visibility      TEXT,
+  sharedWithAgentIds TEXT
 );
 `;
 
@@ -532,6 +534,7 @@ CREATE INDEX IF NOT EXISTS idx_observations_topicKey ON observations(projectId, 
 CREATE INDEX IF NOT EXISTS idx_observations_status ON observations(status);
 CREATE INDEX IF NOT EXISTS idx_observations_project_status_id ON observations(projectId, status, id);
 CREATE INDEX IF NOT EXISTS idx_observations_project_admission ON observations(projectId, status, admissionState, id);
+CREATE INDEX IF NOT EXISTS idx_observations_project_visibility ON observations(projectId, status, visibility, id);
 CREATE INDEX IF NOT EXISTS idx_mini_skills_projectId ON mini_skills(projectId);
 CREATE INDEX IF NOT EXISTS idx_sessions_projectId ON sessions(projectId);
 CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(projectId, status);
@@ -599,6 +602,14 @@ const SCHEMA_MIGRATIONS: SchemaMigration[] = [
       addColumnIfMissing(db, 'observations', 'admissionState', 'admissionState TEXT');
       addColumnIfMissing(db, 'observations', 'admissionReason', 'admissionReason TEXT');
       db.exec('CREATE INDEX IF NOT EXISTS idx_observations_project_admission ON observations(projectId, status, admissionState, id)');
+    },
+  },
+  {
+    id: '1.2.2-observation-visibility',
+    apply: (db) => {
+      addColumnIfMissing(db, 'observations', 'visibility', 'visibility TEXT');
+      addColumnIfMissing(db, 'observations', 'sharedWithAgentIds', 'sharedWithAgentIds TEXT');
+      db.exec('CREATE INDEX IF NOT EXISTS idx_observations_project_visibility ON observations(projectId, status, visibility, id)');
     },
   },
   {

--- a/src/store/sqlite-store.ts
+++ b/src/store/sqlite-store.ts
@@ -49,6 +49,8 @@ function obsToRow(obs: Observation): Record<string, unknown> {
     relatedEntities: obs.relatedEntities ? JSON.stringify(obs.relatedEntities) : null,
     sourceDetail: obs.sourceDetail ?? null,
     valueCategory: obs.valueCategory ?? null,
+    admissionState: obs.admissionState ?? null,
+    admissionReason: obs.admissionReason ?? null,
     createdByAgentId: obs.createdByAgentId ?? null,
     writeGeneration: obs.writeGeneration ?? 0,
   };
@@ -80,6 +82,8 @@ function rowToObs(row: any): Observation {
     ...(row.relatedEntities ? { relatedEntities: safeJsonParse(row.relatedEntities, []) } : {}),
     ...(row.sourceDetail ? { sourceDetail: row.sourceDetail } : {}),
     ...(row.valueCategory ? { valueCategory: row.valueCategory } : {}),
+    ...(row.admissionState ? { admissionState: row.admissionState } : {}),
+    ...(row.admissionReason ? { admissionReason: row.admissionReason } : {}),
     ...(row.createdByAgentId ? { createdByAgentId: row.createdByAgentId } : {}),
     ...(row.writeGeneration ? { writeGeneration: row.writeGeneration } : {}),
   } as Observation;
@@ -132,12 +136,12 @@ export class SqliteBackend implements ObservationStore {
         (id, entityName, type, title, narrative, facts, filesModified, concepts, tokens,
          createdAt, updatedAt, projectId, hasCausalLanguage, topicKey, revisionCount,
          sessionId, status, progress, source, commitHash, relatedCommits, relatedEntities,
-         sourceDetail, valueCategory, createdByAgentId, writeGeneration)
+         sourceDetail, valueCategory, admissionState, admissionReason, createdByAgentId, writeGeneration)
       VALUES
         (@id, @entityName, @type, @title, @narrative, @facts, @filesModified, @concepts, @tokens,
          @createdAt, @updatedAt, @projectId, @hasCausalLanguage, @topicKey, @revisionCount,
          @sessionId, @status, @progress, @source, @commitHash, @relatedCommits, @relatedEntities,
-         @sourceDetail, @valueCategory, @createdByAgentId, @writeGeneration)
+         @sourceDetail, @valueCategory, @admissionState, @admissionReason, @createdByAgentId, @writeGeneration)
     `);
     this.stmtUpdate = this.stmtInsert; // INSERT OR REPLACE works for both
     this.stmtSetStatus = this.db.prepare(`UPDATE observations SET status = ? WHERE id = ?`);

--- a/src/store/sqlite-store.ts
+++ b/src/store/sqlite-store.ts
@@ -51,6 +51,8 @@ function obsToRow(obs: Observation): Record<string, unknown> {
     valueCategory: obs.valueCategory ?? null,
     admissionState: obs.admissionState ?? null,
     admissionReason: obs.admissionReason ?? null,
+    visibility: obs.visibility ?? null,
+    sharedWithAgentIds: obs.sharedWithAgentIds ? JSON.stringify(obs.sharedWithAgentIds) : null,
     createdByAgentId: obs.createdByAgentId ?? null,
     writeGeneration: obs.writeGeneration ?? 0,
   };
@@ -84,6 +86,8 @@ function rowToObs(row: any): Observation {
     ...(row.valueCategory ? { valueCategory: row.valueCategory } : {}),
     ...(row.admissionState ? { admissionState: row.admissionState } : {}),
     ...(row.admissionReason ? { admissionReason: row.admissionReason } : {}),
+    ...(row.visibility ? { visibility: row.visibility } : {}),
+    ...(row.sharedWithAgentIds ? { sharedWithAgentIds: safeJsonParse(row.sharedWithAgentIds, []) } : {}),
     ...(row.createdByAgentId ? { createdByAgentId: row.createdByAgentId } : {}),
     ...(row.writeGeneration ? { writeGeneration: row.writeGeneration } : {}),
   } as Observation;
@@ -136,12 +140,14 @@ export class SqliteBackend implements ObservationStore {
         (id, entityName, type, title, narrative, facts, filesModified, concepts, tokens,
          createdAt, updatedAt, projectId, hasCausalLanguage, topicKey, revisionCount,
          sessionId, status, progress, source, commitHash, relatedCommits, relatedEntities,
-         sourceDetail, valueCategory, admissionState, admissionReason, createdByAgentId, writeGeneration)
+         sourceDetail, valueCategory, admissionState, admissionReason, visibility, sharedWithAgentIds,
+         createdByAgentId, writeGeneration)
       VALUES
         (@id, @entityName, @type, @title, @narrative, @facts, @filesModified, @concepts, @tokens,
          @createdAt, @updatedAt, @projectId, @hasCausalLanguage, @topicKey, @revisionCount,
          @sessionId, @status, @progress, @source, @commitHash, @relatedCommits, @relatedEntities,
-         @sourceDetail, @valueCategory, @admissionState, @admissionReason, @createdByAgentId, @writeGeneration)
+         @sourceDetail, @valueCategory, @admissionState, @admissionReason, @visibility, @sharedWithAgentIds,
+         @createdByAgentId, @writeGeneration)
     `);
     this.stmtUpdate = this.stmtInsert; // INSERT OR REPLACE works for both
     this.stmtSetStatus = this.db.prepare(`UPDATE observations SET status = ? WHERE id = ?`);

--- a/src/team/handoff.ts
+++ b/src/team/handoff.ts
@@ -57,6 +57,8 @@ export async function createHandoffArtifact(
     topicKey?: string;
     sourceDetail?: 'explicit' | 'hook' | 'git-ingest';
     valueCategory?: 'core' | 'contextual' | 'ephemeral';
+    visibility?: 'personal' | 'project' | 'team';
+    sharedWithAgentIds?: string[];
     createdByAgentId?: string;
   }) => Promise<{ observation: { id: number }; upserted: boolean }>,
   teamStore: TeamStore,
@@ -82,6 +84,11 @@ export async function createHandoffArtifact(
     topicKey: input.taskId ? `handoff:${input.taskId}:${input.fromAgentId}` : undefined,
     sourceDetail: 'explicit',
     valueCategory: 'core',  // immune to retention archival
+    // A direct handoff is not a project-wide memo. The sender retains access
+    // and the explicit recipient receives a read grant. Broadcast handoffs
+    // are deliberately visible only to active team members.
+    visibility: input.toAgentId ? 'personal' : 'team',
+    ...(input.toAgentId ? { sharedWithAgentIds: [input.toAgentId] } : {}),
     createdByAgentId: input.fromAgentId,
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,14 @@ export const OBSERVATION_ICONS: Record<ObservationType, string> = {
 /** Observation lifecycle status */
 export type ObservationStatus = 'active' | 'resolved' | 'archived';
 
+/**
+ * Control-plane admission state for automatically captured observations.
+ * Candidate and ephemeral records remain inspectable, but only qualified
+ * records are eligible for automatic context delivery. Missing state preserves
+ * legacy behavior for observations written before this policy existed.
+ */
+export type ObservationAdmissionState = 'ephemeral' | 'candidate' | 'qualified';
+
 /** Progress tracking for task/feature observations */
 export interface ProgressInfo {
   feature: string;
@@ -132,6 +140,10 @@ export interface Observation {
   sourceDetail?: 'explicit' | 'hook' | 'git-ingest';
   /** Value category from formation pipeline evaluation */
   valueCategory?: 'core' | 'contextual' | 'ephemeral';
+  /** Control-plane admission state for automatic capture and delivery. */
+  admissionState?: ObservationAdmissionState;
+  /** Short, sanitized explanation for the latest admission decision. */
+  admissionReason?: string;
   /** Phase 4a: Agent ID that created this observation (team attribution) */
   createdByAgentId?: string;
   /** Phase 4a: Monotonic write generation — snapshot of storage_generation at write time (watermark coherence) */
@@ -176,6 +188,8 @@ export interface IndexEntry {
   sourceDetail?: 'explicit' | 'hook' | 'git-ingest';
   /** Value category for source-aware ranking */
   valueCategory?: 'core' | 'contextual' | 'ephemeral';
+  /** Control-plane admission state when known. */
+  admissionState?: ObservationAdmissionState;
   /** Explainable recall: why this result matched. */
   matchedFields?: string[];
   /** Entity name — used for entity-affinity scoring and workstream deduplication. */
@@ -258,6 +272,10 @@ export interface MemorixDocument {
   sourceDetail?: string;
   /** Value category from formation evaluation */
   valueCategory?: string;
+  /** Control-plane admission state for automatic capture and delivery. */
+  admissionState?: string;
+  /** Short, sanitized explanation for the latest admission decision. */
+  admissionReason?: string;
   /** Optional vector embedding for semantic/hybrid retrieval */
   embedding?: number[];
   /** Document type: observation or mini-skill (Phase 3a) */

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,6 +93,25 @@ export type ObservationStatus = 'active' | 'resolved' | 'archived';
  */
 export type ObservationAdmissionState = 'ephemeral' | 'candidate' | 'qualified';
 
+/**
+ * Who may retrieve an observation through agent-facing memory surfaces.
+ * Missing visibility is a legacy record and resolves to `project`.
+ */
+export type ObservationVisibility = 'personal' | 'project' | 'team';
+
+/**
+ * Identity available to an agent-facing retrieval call. Internal maintenance
+ * deliberately omits this and may inspect all project records for lifecycle work.
+ */
+export interface ObservationReader {
+  /** Bound project for a normal project-scoped call. Omit only for explicit global search. */
+  projectId?: string;
+  /** Stable coordination identity, available after an explicit team join. */
+  agentId?: string;
+  /** True only when agentId is an active member of the bound project team. */
+  isTeamMember?: boolean;
+}
+
 /** Progress tracking for task/feature observations */
 export interface ProgressInfo {
   feature: string;
@@ -144,6 +163,10 @@ export interface Observation {
   admissionState?: ObservationAdmissionState;
   /** Short, sanitized explanation for the latest admission decision. */
   admissionReason?: string;
+  /** Retrieval scope. Legacy records without a value remain project-visible. */
+  visibility?: ObservationVisibility;
+  /** Explicit additional readers for a personal record, used by targeted handoffs. */
+  sharedWithAgentIds?: string[];
   /** Phase 4a: Agent ID that created this observation (team attribution) */
   createdByAgentId?: string;
   /** Phase 4a: Monotonic write generation — snapshot of storage_generation at write time (watermark coherence) */
@@ -190,6 +213,8 @@ export interface IndexEntry {
   valueCategory?: 'core' | 'contextual' | 'ephemeral';
   /** Control-plane admission state when known. */
   admissionState?: ObservationAdmissionState;
+  /** Retrieval scope when known. */
+  visibility?: ObservationVisibility;
   /** Explainable recall: why this result matched. */
   matchedFields?: string[];
   /** Entity name — used for entity-affinity scoring and workstream deduplication. */
@@ -230,6 +255,8 @@ export interface SearchOptions {
   source?: 'agent' | 'git' | 'manual';
   /** Internal observability probes can disable access tracking without affecting normal search behavior. */
   trackAccess?: boolean;
+  /** Internal reader context for agent-facing visibility filtering. */
+  reader?: ObservationReader;
 }
 
 /** Topic key family heuristics for suggesting stable topic keys */
@@ -276,6 +303,12 @@ export interface MemorixDocument {
   admissionState?: string;
   /** Short, sanitized explanation for the latest admission decision. */
   admissionReason?: string;
+  /** Retrieval scope for agent-facing filtering. */
+  visibility?: string;
+  /** Agent that owns a personal record, or authored a shared record. */
+  createdByAgentId?: string;
+  /** Explicit readers for a targeted personal record. */
+  sharedWithAgentIds?: string;
   /** Optional vector embedding for semantic/hybrid retrieval */
   embedding?: number[];
   /** Document type: observation or mini-skill (Phase 3a) */

--- a/src/wiki/generator.ts
+++ b/src/wiki/generator.ts
@@ -1,4 +1,5 @@
 import type { Observation, MiniSkill } from '../types.js';
+import { isEligibleForKnowledgePromotion } from '../memory/admission.js';
 import type { KnowledgeSourceRef, KnowledgeItem, KnowledgeSection, ProjectKnowledgeOverview } from './types.js';
 
 const COMMAND_LOG_TITLE = /^(Ran:|Command:|Executed:)\s/i;
@@ -63,6 +64,7 @@ function isEligible(o: Observation, projectId: string): boolean {
   if (isCommandLog(o)) return false;
   if (isInactive(o)) return false;
   if (isOtherProject(o, projectId)) return false;
+  if (!isEligibleForKnowledgePromotion(o)) return false;
   if (o.valueCategory === 'ephemeral') return false;
   if (!contextualHasSubstance(o)) return false;
   return true;

--- a/tests/cli/codegraph-command.test.ts
+++ b/tests/cli/codegraph-command.test.ts
@@ -8,6 +8,8 @@ import { initObservations, storeObservation } from '../../src/memory/observation
 import { closeAllDatabases } from '../../src/store/sqlite-db.js';
 import { initObservationStore, resetObservationStore } from '../../src/store/obs-store.js';
 import { resetDb } from '../../src/store/orama-store.js';
+import { MaintenanceJobStore } from '../../src/runtime/maintenance-jobs.js';
+import { MaintenanceTargetStore } from '../../src/runtime/maintenance-targets.js';
 import { resetSessionStore } from '../../src/store/session-store.js';
 import { resetTeamStore } from '../../src/team/team-store.js';
 
@@ -159,6 +161,37 @@ describe('codegraph CLI command', () => {
     expect(result.stdout).toContain('Reliable memory');
     expect(result.stdout).toContain('authMiddleware');
     expect(result.stdout).toContain('src/auth.ts');
+  });
+
+  it('queues candidate qualification after a direct Code Memory refresh', async () => {
+    await initObservationStore(dataDir);
+    await initObservations(dataDir);
+    await storeObservation({
+      entityName: 'auth',
+      type: 'what-changed',
+      title: 'Automatic auth edit',
+      narrative: 'The hook changed src/auth.ts.',
+      filesModified: ['src/auth.ts'],
+      projectId: 'local/repo',
+      sourceDetail: 'hook',
+      valueCategory: 'contextual',
+      admissionState: 'candidate',
+      admissionReason: 'file mutation awaits Code Memory qualification',
+    });
+
+    await runCommand({ _: ['refresh'], json: true });
+
+    expect(new MaintenanceTargetStore(dataDir).get('local/repo')).toMatchObject({
+      projectRoot: repoDir,
+      dataDir,
+    });
+    expect(new MaintenanceJobStore(dataDir).list({ projectId: 'local/repo' })).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'observation-qualify',
+        dedupeKey: 'observation-qualify',
+        payload: expect.objectContaining({ source: 'manual-codegraph-refresh' }),
+      }),
+    ]));
   });
 
   it('keeps old refs stale after a file disappears on refresh', async () => {

--- a/tests/cli/command-guide.test.ts
+++ b/tests/cli/command-guide.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest';
+import { printCliGuideForHelp, renderCliGuide } from '../../src/cli/command-guide.js';
+
+describe('CLI command guide', () => {
+  it('renders action-oriented help for manual command namespaces', () => {
+    const guide = renderCliGuide('memory');
+    expect(guide).toContain('memorix memory store');
+    expect(guide).toContain('memorix identity join');
+    expect(guide).toContain('--cwd <git-project>');
+  });
+
+  it('intercepts namespace --help before generic argument metadata hides actions', () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      expect(printCliGuideForHelp(['transfer', '--help'])).toBe(true);
+      expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('memorix transfer import --file'));
+      expect(printCliGuideForHelp(['unknown', '--help'])).toBe(false);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/tests/cli/context-command.test.ts
+++ b/tests/cli/context-command.test.ts
@@ -198,6 +198,8 @@ describe('project context CLI commands', () => {
     expect(result.stdout).toContain('#1 decision');
     expect(result.stdout).toContain('authMiddleware keeps JWT verification centralized');
     expect(result.stdout).toContain('src/auth.ts');
+    expect(result.stdout).toContain('Context delivery receipt');
+    expect(result.stdout).toContain('Target: Project Context');
     expect(result.stdout).not.toContain('SQLite');
   });
 
@@ -216,6 +218,14 @@ describe('project context CLI commands', () => {
       status: 'current',
     });
     expect(parsed.explain.overview.code.files).toBe(3);
+    expect(parsed.receipt).toMatchObject({
+      version: '1.2.2',
+      target: 'project-context',
+      budget: {
+        maxTokens: expect.any(Number),
+        tokenCount: expect.any(Number),
+      },
+    });
   });
 
   it('includes code memory health in doctor JSON', async () => {

--- a/tests/cli/identity-command.test.ts
+++ b/tests/cli/identity-command.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import identityCommand from '../../src/cli/commands/identity.js';
+import memoryCommand from '../../src/cli/commands/memory.js';
+import sessionCommand from '../../src/cli/commands/session.js';
+import taskCommand from '../../src/cli/commands/task.js';
+import { getRecentMemories, searchMemories } from '../../src/cli/tui/data.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+import { resetObservationStore } from '../../src/store/obs-store.js';
+import { resetSessionStore } from '../../src/store/session-store.js';
+import { resetTeamStore } from '../../src/team/team-store.js';
+import { resetDb } from '../../src/store/orama-store.js';
+
+async function runCommand(command: any, args: Record<string, unknown>) {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...parts) => logs.push(parts.map(String).join(' ')));
+  const errSpy = vi.spyOn(console, 'error').mockImplementation((...parts) => errors.push(parts.map(String).join(' ')));
+  const originalExitCode = process.exitCode;
+  process.exitCode = undefined;
+
+  try {
+    await command.run?.({ args, rawArgs: [], cmd: command } as any);
+    return {
+      stdout: logs.join('\n'),
+      stderr: errors.join('\n'),
+      exitCode: process.exitCode ?? 0,
+    };
+  } finally {
+    process.exitCode = originalExitCode;
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+  }
+}
+
+describe('CLI identity control plane', () => {
+  const originalCwd = process.cwd();
+  const originalDataDir = process.env.MEMORIX_DATA_DIR;
+  const originalEmbedding = process.env.MEMORIX_EMBEDDING;
+  const originalProjectRoot = process.env.MEMORIX_CLI_PROJECT_ROOT;
+  const originalActorId = process.env.MEMORIX_CLI_ACTOR_ID;
+  let sandboxRoot = '';
+  let repoDir = '';
+  let dataDir = '';
+
+  beforeEach(() => {
+    sandboxRoot = mkdtempSync(path.join(tmpdir(), 'memorix-cli-identity-'));
+    repoDir = path.join(sandboxRoot, 'repo');
+    dataDir = path.join(sandboxRoot, 'data');
+    mkdirSync(repoDir, { recursive: true });
+    writeFileSync(path.join(repoDir, 'README.md'), '# identity test\n', 'utf8');
+    execSync('git init', { cwd: repoDir, stdio: 'ignore' });
+    process.chdir(repoDir);
+    process.env.MEMORIX_DATA_DIR = dataDir;
+    process.env.MEMORIX_EMBEDDING = 'off';
+    delete process.env.MEMORIX_CLI_PROJECT_ROOT;
+    delete process.env.MEMORIX_CLI_ACTOR_ID;
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    if (originalDataDir === undefined) delete process.env.MEMORIX_DATA_DIR;
+    else process.env.MEMORIX_DATA_DIR = originalDataDir;
+    if (originalEmbedding === undefined) delete process.env.MEMORIX_EMBEDDING;
+    else process.env.MEMORIX_EMBEDDING = originalEmbedding;
+    if (originalProjectRoot === undefined) delete process.env.MEMORIX_CLI_PROJECT_ROOT;
+    else process.env.MEMORIX_CLI_PROJECT_ROOT = originalProjectRoot;
+    if (originalActorId === undefined) delete process.env.MEMORIX_CLI_ACTOR_ID;
+    else process.env.MEMORIX_CLI_ACTOR_ID = originalActorId;
+    resetObservationStore();
+    resetSessionStore();
+    resetTeamStore();
+    await resetDb();
+    closeAllDatabases();
+    rmSync(sandboxRoot, { recursive: true, force: true });
+  });
+
+  it('keeps a plain CLI project-scoped, then restores private memory and coordination ergonomics after identity activation', async () => {
+    const denied = await runCommand(memoryCommand, {
+      _: ['store'],
+      text: 'Private deployment credential rotation notes.',
+      title: 'Private deployment note',
+      visibility: 'personal',
+      json: true,
+    });
+    expect(denied.exitCode).toBe(1);
+    expect(JSON.parse(denied.stderr).error).toContain('requires an active CLI identity');
+
+    const joined = await runCommand(identityCommand, {
+      _: ['join'],
+      agentType: 'codex',
+      instanceId: 'identity-test-terminal',
+      name: 'Codex test terminal',
+      json: true,
+    });
+    expect(joined.exitCode).toBe(0);
+    const agent = JSON.parse(joined.stdout).agent;
+
+    const stored = await runCommand(memoryCommand, {
+      _: ['store'],
+      text: 'Private deployment credential rotation notes.',
+      title: 'Private deployment note',
+      visibility: 'personal',
+      json: true,
+    });
+    expect(stored.exitCode).toBe(0);
+    const privateObservation = JSON.parse(stored.stdout).observation;
+    expect(privateObservation).toMatchObject({
+      visibility: 'personal',
+      createdByAgentId: agent.agent_id,
+    });
+    expect(await searchMemories('credential rotation')).toHaveLength(1);
+    expect((await getRecentMemories()).map((entry) => entry.id)).toContain(privateObservation.id);
+
+    const unsafePromotion = await runCommand(memoryCommand, {
+      _: ['promote'],
+      ids: String(privateObservation.id),
+      json: true,
+    });
+    expect(unsafePromotion.exitCode).toBe(1);
+    expect(JSON.parse(unsafePromotion.stderr).error).toContain('cannot be promoted into shared skills');
+
+    const task = await runCommand(taskCommand, {
+      _: ['create'],
+      description: 'Verify the identity-aware task command',
+      json: true,
+    });
+    expect(task.exitCode).toBe(0);
+    expect(JSON.parse(task.stdout).task.created_by).toBe(agent.agent_id);
+
+    const cleared = await runCommand(identityCommand, { _: ['clear'], json: true });
+    expect(cleared.exitCode).toBe(0);
+
+    const hidden = await runCommand(memoryCommand, {
+      _: ['search'],
+      query: 'credential rotation',
+      json: true,
+    });
+    expect(hidden.exitCode).toBe(0);
+    expect(JSON.parse(hidden.stdout).entries).toHaveLength(0);
+    expect(await searchMemories('credential rotation')).toHaveLength(0);
+
+    const restored = await runCommand(identityCommand, {
+      _: ['use'],
+      agentId: agent.agent_id,
+      json: true,
+    });
+    expect(restored.exitCode).toBe(0);
+
+    const visible = await runCommand(memoryCommand, {
+      _: ['search'],
+      query: 'credential rotation',
+      json: true,
+    });
+    expect(visible.exitCode).toBe(0);
+    expect(JSON.parse(visible.stdout).entries).toHaveLength(1);
+  });
+
+  it('activates a persistent identity through an explicit coordination session and rejects incomplete activation', async () => {
+    const incomplete = await runCommand(sessionCommand, {
+      _: ['start'],
+      joinTeam: true,
+      use: true,
+      json: true,
+    });
+    expect(incomplete.exitCode).toBe(1);
+    expect(JSON.parse(incomplete.stderr).error).toContain('requires --agent or --agentType');
+
+    const started = await runCommand(sessionCommand, {
+      _: ['start'],
+      agent: 'Codex release terminal',
+      agentType: 'codex',
+      instanceId: 'release-terminal',
+      joinTeam: true,
+      use: true,
+      json: true,
+    });
+    expect(started.exitCode).toBe(0);
+    const startPayload = JSON.parse(started.stdout);
+    expect(startPayload.identityActivated).toBe(true);
+    expect(startPayload.agent.agentId).toBeTruthy();
+
+    const status = await runCommand(identityCommand, { _: ['status'], json: true });
+    expect(status.exitCode).toBe(0);
+    expect(JSON.parse(status.stdout).identity.agentId).toBe(startPayload.agent.agentId);
+  });
+});

--- a/tests/cli/invocation.test.ts
+++ b/tests/cli/invocation.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { normalizeCliInvocation } from '../../src/cli/invocation.js';
+
+describe('CLI invocation normalization', () => {
+  const originalArgv = process.argv;
+  const originalCwd = process.cwd();
+  const originalProjectRoot = process.env.MEMORIX_CLI_PROJECT_ROOT;
+  const originalActorId = process.env.MEMORIX_CLI_ACTOR_ID;
+  const cleanupRoots: string[] = [];
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    process.chdir(originalCwd);
+    if (originalProjectRoot === undefined) delete process.env.MEMORIX_CLI_PROJECT_ROOT;
+    else process.env.MEMORIX_CLI_PROJECT_ROOT = originalProjectRoot;
+    if (originalActorId === undefined) delete process.env.MEMORIX_CLI_ACTOR_ID;
+    else process.env.MEMORIX_CLI_ACTOR_ID = originalActorId;
+    for (const root of cleanupRoots.splice(0)) {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('binds a common project root and normalizes shell-native flag spellings before command parsing', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'memorix-cli-invocation-'));
+    cleanupRoots.push(root);
+    const invocation = normalizeCliInvocation([
+      'node',
+      'memorix',
+      'session',
+      'start',
+      '--cwd',
+      root,
+      '--as',
+      'agent-123',
+      '--agent-type',
+      'codex',
+      '--join-team',
+      '--instance-id=local-terminal',
+    ]);
+
+    expect(invocation).toEqual({ projectRoot: root, actorId: 'agent-123' });
+    expect(process.cwd()).toBe(root);
+    expect(process.env.MEMORIX_CLI_PROJECT_ROOT).toBe(root);
+    expect(process.env.MEMORIX_CLI_ACTOR_ID).toBe('agent-123');
+    expect(process.argv.slice(2)).toEqual([
+      'session',
+      'start',
+      '--agentType',
+      'codex',
+      '--joinTeam',
+      '--instanceId=local-terminal',
+    ]);
+  });
+
+  it('rejects a nonexistent --cwd before a command can run', () => {
+    expect(() => normalizeCliInvocation([
+      'node',
+      'memorix',
+      'memory',
+      'search',
+      '--cwd',
+      path.join(tmpdir(), 'memorix-path-does-not-exist'),
+    ])).toThrow('CLI project directory does not exist');
+  });
+
+  it('preserves command-owned dashed flags instead of rewriting their meaning globally', () => {
+    const root = mkdtempSync(path.join(tmpdir(), 'memorix-cli-invocation-'));
+    cleanupRoots.push(root);
+    normalizeCliInvocation([
+      'node',
+      'memorix',
+      'uninstall',
+      '--cwd',
+      root,
+      '--dry-run',
+    ]);
+
+    expect(process.argv.slice(2)).toEqual(['uninstall', '--dry-run']);
+  });
+});

--- a/tests/cli/transfer-file.test.ts
+++ b/tests/cli/transfer-file.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import memoryCommand from '../../src/cli/commands/memory.js';
+import transferCommand from '../../src/cli/commands/transfer.js';
+import { storeObservation } from '../../src/memory/observations.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+import { resetObservationStore } from '../../src/store/obs-store.js';
+import { resetSessionStore } from '../../src/store/session-store.js';
+import { resetTeamStore } from '../../src/team/team-store.js';
+import { resetDb } from '../../src/store/orama-store.js';
+
+async function runCommand(command: any, args: Record<string, unknown>) {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...parts) => logs.push(parts.map(String).join(' ')));
+  const errSpy = vi.spyOn(console, 'error').mockImplementation((...parts) => errors.push(parts.map(String).join(' ')));
+  const originalExitCode = process.exitCode;
+  process.exitCode = undefined;
+
+  try {
+    await command.run?.({ args, rawArgs: [], cmd: command } as any);
+    return { stdout: logs.join('\n'), stderr: errors.join('\n'), exitCode: process.exitCode ?? 0 };
+  } finally {
+    process.exitCode = originalExitCode;
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+  }
+}
+
+describe('CLI transfer file I/O', () => {
+  const originalCwd = process.cwd();
+  const originalDataDir = process.env.MEMORIX_DATA_DIR;
+  const originalEmbedding = process.env.MEMORIX_EMBEDDING;
+  let sandboxRoot = '';
+  let repoDir = '';
+  let dataDir = '';
+
+  beforeEach(() => {
+    sandboxRoot = mkdtempSync(path.join(tmpdir(), 'memorix-cli-transfer-'));
+    repoDir = path.join(sandboxRoot, 'repo');
+    dataDir = path.join(sandboxRoot, 'data');
+    mkdirSync(repoDir, { recursive: true });
+    writeFileSync(path.join(repoDir, 'README.md'), '# transfer test\n', 'utf8');
+    execSync('git init', { cwd: repoDir, stdio: 'ignore' });
+    process.chdir(repoDir);
+    process.env.MEMORIX_DATA_DIR = dataDir;
+    process.env.MEMORIX_EMBEDDING = 'off';
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    if (originalDataDir === undefined) delete process.env.MEMORIX_DATA_DIR;
+    else process.env.MEMORIX_DATA_DIR = originalDataDir;
+    if (originalEmbedding === undefined) delete process.env.MEMORIX_EMBEDDING;
+    else process.env.MEMORIX_EMBEDDING = originalEmbedding;
+    resetObservationStore();
+    resetSessionStore();
+    resetTeamStore();
+    await resetDb();
+    closeAllDatabases();
+    rmSync(sandboxRoot, { recursive: true, force: true });
+  });
+
+  it('writes a portable export to a file and accepts that file as an import source', async () => {
+    const stored = await runCommand(memoryCommand, {
+      _: ['store'],
+      text: 'File based exports avoid Windows command line length limits.',
+      title: 'CLI file transfer',
+      json: true,
+    });
+    expect(stored.exitCode).toBe(0);
+
+    await storeObservation({
+      entityName: 'private-transfer-test',
+      type: 'discovery',
+      title: 'Personal export exclusion',
+      narrative: 'An unbound terminal must not export this record.',
+      projectId: 'local/repo',
+      visibility: 'personal',
+      createdByAgentId: 'another-agent',
+    });
+
+    const output = '.memorix-test/export.json';
+    const exported = await runCommand(transferCommand, {
+      _: ['export'],
+      format: 'json',
+      out: output,
+      json: true,
+    });
+    expect(exported.exitCode).toBe(0);
+    const outputPath = JSON.parse(exported.stdout).outputPath as string;
+    expect(existsSync(outputPath)).toBe(true);
+    const snapshot = JSON.parse(readFileSync(outputPath, 'utf8'));
+    expect(snapshot.stats.observationCount).toBe(1);
+    expect(snapshot.observations.map((observation: { title: string }) => observation.title)).not.toContain('Personal export exclusion');
+
+    const imported = await runCommand(transferCommand, {
+      _: ['import'],
+      file: output,
+      json: true,
+    });
+    expect(imported.exitCode).toBe(0);
+    expect(JSON.parse(imported.stdout).result).toMatchObject({
+      observationsImported: expect.any(Number),
+      sessionsImported: expect.any(Number),
+    });
+  });
+});

--- a/tests/codegraph/auto-context.test.ts
+++ b/tests/codegraph/auto-context.test.ts
@@ -12,6 +12,7 @@ import { getAllObservations, initObservations, storeObservation } from '../../sr
 import { closeAllDatabases } from '../../src/store/sqlite-db.js';
 import { initObservationStore, resetObservationStore } from '../../src/store/obs-store.js';
 import { resetDb } from '../../src/store/orama-store.js';
+import { MaintenanceJobStore } from '../../src/runtime/maintenance-jobs.js';
 import { resetSessionStore } from '../../src/store/session-store.js';
 import { resetTeamStore } from '../../src/team/team-store.js';
 
@@ -99,6 +100,63 @@ describe('auto project context', () => {
     expect(text).toBe(context.workset.prompt);
     expect(context.workset.budget.tokenCount).toBeLessThanOrEqual(context.workset.budget.maxTokens);
     expect(context.workset.receipt.target).toBe('project-context');
+  });
+
+  it('does not source an unqualified automatic capture in an agent brief', async () => {
+    await storeObservation({
+      entityName: 'auth',
+      type: 'what-changed',
+      title: 'Automatic auth hook capture',
+      narrative: 'The hook observed an edit in src/auth.ts.',
+      filesModified: ['src/auth.ts'],
+      projectId: 'local/repo',
+      sourceDetail: 'hook',
+      valueCategory: 'contextual',
+      admissionState: 'candidate',
+      admissionReason: 'file mutation awaits Code Memory qualification',
+    });
+
+    const context = await buildAutoProjectContext({
+      project: { id: 'local/repo', name: 'repo', rootPath: repoDir },
+      dataDir,
+      observations: getAllObservations(),
+      refresh: 'always',
+      task: 'continue auth work',
+    });
+
+    expect(context.explain.sources.map((source) => source.title)).not.toContain('Automatic auth hook capture');
+    expect(formatAutoProjectContextPrompt(context)).not.toContain('Automatic auth hook capture');
+  });
+
+  it('queues candidate qualification after a foreground Code Memory refresh', async () => {
+    await storeObservation({
+      entityName: 'auth',
+      type: 'what-changed',
+      title: 'Automatic auth hook capture',
+      narrative: 'The hook observed an edit in src/auth.ts.',
+      filesModified: ['src/auth.ts'],
+      projectId: 'local/repo',
+      sourceDetail: 'hook',
+      valueCategory: 'contextual',
+      admissionState: 'candidate',
+      admissionReason: 'file mutation awaits Code Memory qualification',
+    });
+
+    await buildAutoProjectContext({
+      project: { id: 'local/repo', name: 'repo', rootPath: repoDir },
+      dataDir,
+      observations: getAllObservations(),
+      refresh: 'always',
+      task: 'continue auth work',
+    });
+
+    expect(new MaintenanceJobStore(dataDir).list({ projectId: 'local/repo' })).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        kind: 'observation-qualify',
+        dedupeKey: 'observation-qualify',
+        payload: expect.objectContaining({ source: 'foreground-refresh' }),
+      }),
+    ]));
   });
 
   it('uses a validated local semantic outline without adding raw external code', async () => {

--- a/tests/codegraph/auto-context.test.ts
+++ b/tests/codegraph/auto-context.test.ts
@@ -98,6 +98,7 @@ describe('auto project context', () => {
     expect(text).not.toContain('SQLite');
     expect(text).toBe(context.workset.prompt);
     expect(context.workset.budget.tokenCount).toBeLessThanOrEqual(context.workset.budget.maxTokens);
+    expect(context.workset.receipt.target).toBe('project-context');
   });
 
   it('uses a validated local semantic outline without adding raw external code', async () => {

--- a/tests/codegraph/context-pack.test.ts
+++ b/tests/codegraph/context-pack.test.ts
@@ -1,5 +1,14 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { assembleContextPack, buildContextPackPrompt, selectRelevantObservations } from '../../src/codegraph/context-pack.js';
+import {
+  assembleContextPack,
+  attachTaskWorkset,
+  buildContextPackPrompt,
+  selectRelevantObservations,
+} from '../../src/codegraph/context-pack.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
 
 describe('buildContextPackPrompt', () => {
   it('renders memories, code facts, freshness warnings, reads, and verification', () => {
@@ -325,5 +334,43 @@ describe('buildContextPackPrompt', () => {
     expect(text).not.toContain('.claude/worktrees/release/src/release.ts');
     expect(text).toContain('src/extra.ts');
     expect(text).not.toContain('src/overflow.ts');
+  });
+
+  it('marks Context Pack as a distinct bounded delivery target', async () => {
+    const dataDir = mkdtempSync(path.join(tmpdir(), 'memorix-context-pack-receipt-'));
+    try {
+      const pack = await attachTaskWorkset({
+        pack: {
+          task: 'Continue the auth bug.',
+          memories: [{
+            id: 1,
+            title: 'JWT validation stays in authMiddleware',
+            type: 'decision',
+            status: 'current',
+            reason: 'current code reference',
+            path: 'src/auth.ts',
+          }],
+          codeFacts: [],
+          warnings: [],
+          suggestedReads: ['src/auth.ts'],
+          suggestedVerification: ['Run the focused auth test.'],
+        },
+        projectId: 'org/repo',
+        dataDir,
+        lens: 'bugfix',
+        worktreeDirty: false,
+      });
+
+      expect(pack.workset?.receipt).toMatchObject({
+        version: '1.2.2',
+        target: 'context-pack',
+      });
+      expect(pack.workset?.receipt.selected).toEqual(expect.arrayContaining([
+        expect.objectContaining({ kind: 'start-here', id: 'path:src/auth.ts' }),
+      ]));
+    } finally {
+      closeAllDatabases();
+      rmSync(dataDir, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/hooks/admission.test.ts
+++ b/tests/hooks/admission.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest';
+
+import { assessHookAdmission } from '../../src/hooks/admission.js';
+import type { NormalizedHookInput } from '../../src/hooks/types.js';
+
+function hook(overrides: Partial<NormalizedHookInput> = {}): NormalizedHookInput {
+  return {
+    event: 'post_tool',
+    agent: 'claude',
+    timestamp: '2026-07-24T00:00:00.000Z',
+    sessionId: 'session-1',
+    cwd: 'C:/workspace/project',
+    raw: {},
+    ...overrides,
+  };
+}
+
+describe('hook admission', () => {
+  it('keeps a routine successful test as an ephemeral trace', () => {
+    const decision = assessHookAdmission({
+      hook: hook({ command: 'npm test' }),
+      category: 'command',
+      content: 'Command: npm test\nTests 17 passed (17)\nTest Files 2 passed (2)',
+      observationType: 'discovery',
+    });
+
+    expect(decision).toEqual(expect.objectContaining({
+      action: 'store',
+      admissionState: 'ephemeral',
+      valueCategory: 'ephemeral',
+    }));
+  });
+
+  it('keeps a focused failed validation as a candidate', () => {
+    const decision = assessHookAdmission({
+      hook: hook({ command: 'npx vitest run tests/auth.test.ts' }),
+      category: 'command',
+      content: 'Command: npx vitest run tests/auth.test.ts\nFAIL tests/auth.test.ts: expected 200, received 401',
+      observationType: 'problem-solution',
+    });
+
+    expect(decision).toEqual(expect.objectContaining({
+      action: 'store',
+      admissionState: 'candidate',
+      valueCategory: 'contextual',
+    }));
+  });
+
+  it('keeps a concrete file mutation as a candidate instead of directly durable memory', () => {
+    const decision = assessHookAdmission({
+      hook: hook({
+        event: 'post_edit',
+        filePath: 'src/auth.ts',
+        edits: [{ oldString: 'return false;', newString: 'return verifyToken(token);' }],
+      }),
+      category: 'file_modify',
+      content: 'File: src/auth.ts\nEdit: return false; -> return verifyToken(token);',
+      observationType: 'what-changed',
+    });
+
+    expect(decision).toEqual(expect.objectContaining({
+      action: 'store',
+      admissionState: 'candidate',
+      valueCategory: 'contextual',
+    }));
+  });
+
+  it('keeps a concise technical assistant response as a candidate', () => {
+    const decision = assessHookAdmission({
+      hook: hook({
+        event: 'post_response',
+        aiResponse: 'Implemented token rotation and refreshed the auth cache after successful validation.',
+      }),
+      category: 'unknown',
+      content: 'Implemented token rotation and refreshed the auth cache after successful validation.',
+      observationType: 'discovery',
+    });
+
+    expect(decision).toEqual(expect.objectContaining({
+      action: 'store',
+      admissionState: 'candidate',
+      valueCategory: 'contextual',
+    }));
+  });
+
+  it('drops a non-technical assistant acknowledgment', () => {
+    expect(assessHookAdmission({
+      hook: hook({ event: 'post_response', aiResponse: 'Thanks, I will take care of it.' }),
+      category: 'unknown',
+      content: 'Thanks, I will take care of it.',
+      observationType: 'discovery',
+    })).toEqual(expect.objectContaining({ action: 'drop' }));
+  });
+
+  it('drops a non-technical conversational prompt', () => {
+    expect(assessHookAdmission({
+      hook: hook({ event: 'user_prompt', userPrompt: 'Could you take a look when you have time?' }),
+      category: 'unknown',
+      content: 'Could you take a look when you have time?',
+      observationType: 'discovery',
+    })).toEqual(expect.objectContaining({ action: 'drop' }));
+  });
+});

--- a/tests/hooks/handler-e2e.test.ts
+++ b/tests/hooks/handler-e2e.test.ts
@@ -82,6 +82,7 @@ export function verifyToken(token: string) {
     expect(observation).not.toBeNull();
     expect(observation!.entityName).toBe('auth');
     expect(observation!.narrative.length).toBeGreaterThan(50);
+    expect(observation!.admissionState).toBe('candidate');
   });
 
   it('queues one durable Code Memory refresh after repeated real file mutations', async () => {
@@ -119,6 +120,33 @@ export function verifyToken(token: string) {
     }
   });
 
+  it('allows the CLI hook path to defer a file-mutation refresh until capture is durable', async () => {
+    const sandboxRoot = mkdtempSync(path.join(tmpdir(), 'memorix-hook-deferred-'));
+    const repoDir = path.join(sandboxRoot, 'repo');
+    const dataDir = path.join(sandboxRoot, 'data');
+    try {
+      mkdirSync(path.join(repoDir, 'src'), { recursive: true });
+      writeFileSync(path.join(repoDir, 'src', 'auth.ts'), 'export const auth = true;\n', 'utf8');
+      execSync('git init', { cwd: repoDir, stdio: 'ignore' });
+      process.env.MEMORIX_DATA_DIR = dataDir;
+
+      await handleHookEvent({
+        event: 'post_edit',
+        agent: 'claude',
+        timestamp: new Date().toISOString(),
+        sessionId: 'deferred-hook-session',
+        cwd: repoDir,
+        filePath: 'src/auth.ts',
+        raw: {},
+      }, { deferMaintenance: true });
+
+      expect(new MaintenanceJobStore(dataDir).list({ projectId: 'local/repo' })).toHaveLength(0);
+    } finally {
+      closeAllDatabases();
+      rmSync(sandboxRoot, { recursive: true, force: true });
+    }
+  });
+
   // ─── PostToolUse: Edit (code modifications) ───
   it('should auto-store for Edit tool (code modification)', async () => {
     const payload = {
@@ -141,6 +169,7 @@ export function verifyToken(token: string) {
     const { observation } = await handleHookEvent(input);
     expect(observation).not.toBeNull();
     expect(observation!.narrative).toContain('PORT');
+    expect(observation!.admissionState).toBe('candidate');
   });
 
   // ─── PostToolUse: Bash (npm install, test, build) ───
@@ -169,6 +198,7 @@ export function verifyToken(token: string) {
     const { observation } = await handleHookEvent(input);
     expect(observation).not.toBeNull();
     expect(observation!.narrative).toContain('npm test');
+    expect(observation!.admissionState).toBe('ephemeral');
   });
 
   // ─── PostToolUse: Bash with SHORT output (edge case) ───
@@ -195,6 +225,7 @@ export function verifyToken(token: string) {
     const { observation } = await handleHookEvent(input);
     // Short output but command is meaningful → should store
     expect(observation).not.toBeNull();
+    expect(observation!.admissionState).toBe('ephemeral');
   });
 
   // ─── UserPromptSubmit ───
@@ -213,6 +244,7 @@ export function verifyToken(token: string) {
     const { observation } = await handleHookEvent(input);
     expect(observation).not.toBeNull();
     expect(observation!.narrative).toContain('JWT');
+    expect(observation!.admissionState).toBe('candidate');
   });
 
   // ─── UserPromptSubmit: SHORT prompt (edge case) ───

--- a/tests/integration/dashboard-project-scope.test.ts
+++ b/tests/integration/dashboard-project-scope.test.ts
@@ -91,9 +91,10 @@ describe('Standalone Dashboard Project Scope', () => {
       { id: 4, entityName: 'billing-service', type: 'problem-solution', title: 'Webhook retry', narrative: 'Fixed webhook retries', facts: [], projectId: PROJECT_B, status: 'active', createdAt: new Date().toISOString() },
       { id: 5, entityName: 'auth-module', type: 'session-request', title: 'Old handoff', narrative: 'Superseded request', facts: [], projectId: PROJECT_A, status: 'resolved', createdAt: new Date().toISOString() },
       { id: 6, entityName: 'billing-service', type: 'session-request', title: 'Archived note', narrative: 'No longer current', facts: [], projectId: PROJECT_B, status: 'resolved', createdAt: new Date().toISOString() },
+      { id: 7, entityName: 'auth-module', type: 'session-request', title: 'Private handoff', narrative: 'Only the owning agent may inspect this.', facts: [], projectId: PROJECT_A, status: 'active', visibility: 'personal', createdByAgentId: 'private-agent', createdAt: new Date().toISOString() },
     ];
     await fs.writeFile(path.join(dataDir, 'observations.json'), JSON.stringify(observations));
-    await fs.writeFile(path.join(dataDir, 'counter.json'), JSON.stringify({ nextId: 7 }));
+    await fs.writeFile(path.join(dataDir, 'counter.json'), JSON.stringify({ nextId: 8 }));
 
     // Seed graph with entities from both projects
     const graphLines = [
@@ -188,6 +189,16 @@ describe('Standalone Dashboard Project Scope', () => {
     expect(ids).toEqual([1, 2]);
   });
 
+  it('keeps personal observations out of the unbound dashboard and rejects deletion', async () => {
+    const { status: observationsStatus, body: observations } = await fetchJson('/api/observations');
+    expect(observationsStatus).toBe(200);
+    expect(observations.map((observation: any) => observation.id)).not.toContain(7);
+
+    const { status, body } = await fetchJson('/api/observations/7', { method: 'DELETE' });
+    expect(status).toBe(403);
+    expect(body.error).toContain('not manageable');
+  });
+
   it('does not expose standalone dashboard JSON to arbitrary origins', async () => {
     const response = await fetch(`${DASH_BASE}/api/project`, {
       headers: { Origin: 'https://evil.example' },
@@ -202,7 +213,7 @@ describe('Standalone Dashboard Project Scope', () => {
     expect(status).toBe(200);
 
     expect(body.observations).toBe(2);
-    expect(body.nextId).toBe(7);
+    expect(body.nextId).toBe(8);
   });
 
   it('GET /api/maintenance exposes project-scoped background work state', async () => {

--- a/tests/integration/visibility-boundary.test.ts
+++ b/tests/integration/visibility-boundary.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/embedding/provider.js', () => ({
+  getEmbeddingProvider: async () => null,
+  isVectorSearchAvailable: async () => false,
+  isEmbeddingExplicitlyDisabled: () => true,
+  resetProvider: () => {},
+}));
+
+vi.mock('../../src/llm/provider.js', () => ({
+  initLLM: () => null,
+  isLLMEnabled: () => false,
+  getLLMConfig: () => null,
+  setLLMConfig: () => {},
+}));
+
+vi.mock('../../src/config.js', () => ({
+  getLLMApiKey: () => null,
+  getLLMProvider: () => 'openai',
+  getLLMModel: (fallback?: string) => fallback ?? 'gpt-4.1-nano',
+  getLLMBaseUrl: (fallback?: string) => fallback ?? 'https://api.openai.com/v1',
+}));
+
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createMemorixServer } from '../../src/server.js';
+import { resetDb } from '../../src/store/orama-store.js';
+import { resetObservationStore } from '../../src/store/obs-store.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+import { resetResolvedConfigCache } from '../../src/config/resolved-config.js';
+import { resetTomlConfigCache } from '../../src/config/toml-loader.js';
+
+function getHandler(server: any, name: string): (args: Record<string, unknown>) => Promise<any> {
+  const handler = server._registeredTools?.[name]?.handler;
+  expect(handler).toBeTypeOf('function');
+  return handler;
+}
+
+function text(result: any): string {
+  return (result?.content ?? [])
+    .filter((item: any) => item?.type === 'text')
+    .map((item: any) => item.text)
+    .join('\n');
+}
+
+function agentId(result: any): string {
+  const match = text(result).match(/Agent ID: (\S+)/);
+  expect(match).toBeTruthy();
+  return match![1];
+}
+
+describe('MCP observation visibility boundary', () => {
+  it('keeps a targeted handoff readable only by its sender and recipient', async () => {
+    const dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-visibility-data-'));
+    const projectDir = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-visibility-project-'));
+    const previousDataDir = process.env.MEMORIX_DATA_DIR;
+    process.env.MEMORIX_DATA_DIR = dataDir;
+    await fs.mkdir(path.join(projectDir, '.git'));
+    resetTomlConfigCache();
+    resetResolvedConfigCache();
+    resetObservationStore();
+    await resetDb();
+
+    try {
+      const first = await createMemorixServer(projectDir, undefined, undefined, { toolProfile: 'team' } as any);
+      const second = await createMemorixServer(projectDir, undefined, undefined, { toolProfile: 'team' } as any);
+      const third = await createMemorixServer(projectDir, undefined, undefined, { toolProfile: 'team' } as any);
+
+      const startA = getHandler(first.server as any, 'memorix_session_start');
+      const startB = getHandler(second.server as any, 'memorix_session_start');
+      const startC = getHandler(third.server as any, 'memorix_session_start');
+      const idA = agentId(await startA({ agent: 'visibility-a', agentType: 'codex', joinTeam: true }));
+      const idB = agentId(await startB({ agent: 'visibility-b', agentType: 'claude-code', joinTeam: true }));
+      agentId(await startC({ agent: 'visibility-c', agentType: 'windsurf', joinTeam: true }));
+
+      const handoffA = getHandler(first.server as any, 'memorix_handoff');
+      const created = await handoffA({
+        fromAgentId: idA,
+        toAgentId: idB,
+        taskId: 'visibility-task',
+        summary: 'Targeted visibility handoff',
+        context: 'Only the recipient should be able to retrieve this context.',
+      });
+      expect(created.isError).not.toBe(true);
+      const idMatch = text(created).match(/Observation: #(\d+)/);
+      expect(idMatch).toBeTruthy();
+      const handoffId = Number(idMatch![1]);
+
+      const searchB = getHandler(second.server as any, 'memorix_search');
+      const searchC = getHandler(third.server as any, 'memorix_search');
+      expect(text(await searchB({ query: 'Targeted visibility handoff' }))).toContain('Targeted visibility handoff');
+      expect(text(await searchC({ query: 'Targeted visibility handoff' }))).not.toContain('Targeted visibility handoff');
+
+      const detailB = getHandler(second.server as any, 'memorix_detail');
+      const detailC = getHandler(third.server as any, 'memorix_detail');
+      expect(text(await detailB({ ids: [handoffId] }))).toContain('Only the recipient should be able to retrieve this context.');
+      expect(text(await detailC({ ids: [handoffId] }))).not.toContain('Only the recipient should be able to retrieve this context.');
+
+      // New memories default to project visibility, but an upsert must not turn
+      // an existing targeted handoff public simply because visibility is omitted.
+      const ownerUpdate = await getHandler(first.server as any, 'memorix_store')({
+        entityName: 'team-handoff',
+        type: 'session-request',
+        title: 'Updated targeted visibility handoff',
+        narrative: 'The sender can update the handoff without changing who can read it.',
+        topicKey: `handoff:visibility-task:${idA}`,
+      });
+      expect(ownerUpdate.isError).not.toBe(true);
+      expect(text(await searchB({ query: 'Updated targeted visibility handoff' }))).toContain('Updated targeted visibility handoff');
+      expect(text(await searchC({ query: 'Updated targeted visibility handoff' }))).not.toContain('Updated targeted visibility handoff');
+
+      const overwrite = await getHandler(third.server as any, 'memorix_store')({
+        entityName: 'team-handoff',
+        type: 'decision',
+        title: 'Overwrite targeted handoff',
+        narrative: 'A third agent must not be able to mutate a targeted handoff by guessing its topic key.',
+        topicKey: `handoff:visibility-task:${idA}`,
+      });
+      expect(overwrite.isError).toBe(true);
+      expect(text(overwrite)).toContain('write scope');
+
+      const forged = await getHandler(second.server as any, 'memorix_handoff')({
+        fromAgentId: idA,
+        summary: 'Forged sender',
+        context: 'This must fail.',
+      });
+      expect(forged.isError).toBe(true);
+      expect(text(forged)).toContain('must match');
+    } finally {
+      if (previousDataDir === undefined) delete process.env.MEMORIX_DATA_DIR;
+      else process.env.MEMORIX_DATA_DIR = previousDataDir;
+      resetTomlConfigCache();
+      resetResolvedConfigCache();
+      resetObservationStore();
+      await resetDb();
+      closeAllDatabases();
+      await fs.rm(dataDir, { recursive: true, force: true });
+      await fs.rm(projectDir, { recursive: true, force: true });
+    }
+  }, 90_000);
+});

--- a/tests/knowledge/workset.test.ts
+++ b/tests/knowledge/workset.test.ts
@@ -146,6 +146,25 @@ describe('Task Workset', () => {
     expect(workset.prompt).toContain('Project knowledge');
     expect(workset.prompt).toContain('Project workflow');
     expect(workset.budget.tokenCount).toBeLessThanOrEqual(workset.budget.maxTokens);
+    expect(workset.receipt).toMatchObject({
+      version: '1.2.2',
+      target: 'project-context',
+      budget: {
+        maxTokens: workset.budget.maxTokens,
+        tokenCount: workset.budget.tokenCount,
+      },
+    });
+    expect(workset.receipt.selected).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'start-here', id: 'path:package.json' }),
+    ]));
+    expect(workset.receipt.selected).not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'claim', id: 'claim:' + written.claim.id }),
+      expect.objectContaining({ kind: 'knowledge-page' }),
+    ]));
+    expect(workset.receipt.omitted).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'claim', reason: 'token-budget' }),
+      expect.objectContaining({ kind: 'knowledge-page', reason: 'token-budget' }),
+    ]));
   });
 
   it('returns no generic knowledge dump when task terms do not match durable artifacts', async () => {
@@ -205,5 +224,43 @@ describe('Task Workset', () => {
     expect(workset.prompt).toContain('uncommitted changes');
     expect(workset.prompt).toContain('incomplete');
     expect(workset.budget.tokenCount).toBeLessThanOrEqual(96);
+    expect(workset.receipt.selected).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'caution', id: 'caution:dirty-worktree' }),
+      expect.objectContaining({ kind: 'caution', id: 'caution:incomplete-scan' }),
+    ]));
+    expect(workset.receipt.omitted).toEqual(expect.arrayContaining([
+      expect.objectContaining({ reason: 'token-budget' }),
+    ]));
+    expect(workset.receipt.omitted.find(item => item.kind === 'start-here')).toMatchObject({
+      reason: 'token-budget',
+      count: expect.any(Number),
+    });
+    expect(workset.receipt.omitted.find(item => item.kind === 'start-here')!.count).toBeGreaterThan(1);
+  });
+
+  it('records queued maintenance without adding a diagnostic block to the agent prompt', async () => {
+    const root = tempDir();
+    const workset = await buildTaskWorkset({
+      projectId: 'org/repo',
+      dataDir: root,
+      task: 'Continue the auth fix.',
+      lens: 'bugfix',
+      currentFacts: ['Git: clean worktree'],
+      startHere: ['src/auth.ts'],
+      reliableMemory: [],
+      cautionMemory: [],
+      verificationHints: ['Run the focused auth test.'],
+      worktreeDirty: false,
+      freshness: { suspect: 0, stale: 0 },
+      runtimeCautions: [{
+        kind: 'codegraph-refresh-queued',
+        message: 'Code Memory refresh queued; this brief uses the latest completed scan.',
+      }],
+    });
+
+    expect(workset.receipt.scheduledActions).toEqual([
+      'Code Memory refresh queued; this brief uses the latest completed scan.',
+    ]);
+    expect(workset.prompt).not.toContain('Context delivery receipt');
   });
 });

--- a/tests/memory/consolidation.test.ts
+++ b/tests/memory/consolidation.test.ts
@@ -74,6 +74,25 @@ describe('Memory Consolidation', () => {
       expect(clusters[0].ids.length).toBeGreaterThanOrEqual(2);
     });
 
+    it('keeps similar pending automatic evidence individually inspectable', async () => {
+      for (const title of ['Pending auth edit one', 'Pending auth edit two']) {
+        await storeObservation({
+          entityName: 'auth',
+          type: 'what-changed',
+          title,
+          narrative: 'Changed session verification in src/auth.ts.',
+          filesModified: ['src/auth.ts'],
+          projectId: PROJECT_ID,
+          sourceDetail: 'hook',
+          valueCategory: 'contextual',
+          admissionState: 'candidate',
+          admissionReason: 'file mutation awaits Code Memory qualification',
+        });
+      }
+
+      expect(await findConsolidationCandidates(testDir, PROJECT_ID, { threshold: 0.1 })).toHaveLength(0);
+    });
+
     it('should not cluster across different entities', async () => {
       await storeObservation({
         entityName: 'auth', type: 'gotcha', title: 'Token expiry silent failure',

--- a/tests/memory/export-import.test.ts
+++ b/tests/memory/export-import.test.ts
@@ -85,6 +85,37 @@ describe('Export', () => {
     expect(dataB.observations[0].title).toBe('Project B decision');
   });
 
+  it('filters private and team records through an explicit export reader', async () => {
+    await storeObservation({
+      entityName: 'auth', type: 'decision', title: 'Shared decision',
+      narrative: 'Everyone in the project can use this.', projectId: PROJECT_ID,
+    });
+    await storeObservation({
+      entityName: 'auth', type: 'discovery', title: 'Private triage',
+      narrative: 'Only its owner can export this.', projectId: PROJECT_ID,
+      visibility: 'personal', createdByAgentId: 'agent-owner',
+    });
+    await storeObservation({
+      entityName: 'auth', type: 'discovery', title: 'Team triage',
+      narrative: 'Only active team members can export this.', projectId: PROJECT_ID,
+      visibility: 'team', createdByAgentId: 'agent-owner',
+    });
+
+    const unbound = await exportAsJson(testDir, PROJECT_ID, { projectId: PROJECT_ID });
+    expect(unbound.observations.map((observation) => observation.title)).toEqual(['Shared decision']);
+
+    const owner = await exportAsJson(testDir, PROJECT_ID, {
+      projectId: PROJECT_ID,
+      agentId: 'agent-owner',
+      isTeamMember: true,
+    });
+    expect(owner.observations.map((observation) => observation.title)).toEqual([
+      'Shared decision',
+      'Private triage',
+      'Team triage',
+    ]);
+  });
+
   it('should export as readable Markdown', async () => {
     await storeObservation({
       entityName: 'auth', type: 'decision', title: 'Use JWT',

--- a/tests/memory/graph-context.test.ts
+++ b/tests/memory/graph-context.test.ts
@@ -63,6 +63,31 @@ describe('buildGraphContextPacket', () => {
     expect(packet.entities[0].name).toBe('release-flow');
   });
 
+  it('does not inject an unqualified automatic candidate into a graph context packet', () => {
+    const packet = buildGraphContextPacket([
+      obs({
+        id: 1,
+        entityName: 'auth',
+        title: 'Qualified auth decision',
+        narrative: 'Use signed sessions for the auth flow.',
+        type: 'decision',
+        valueCategory: 'core',
+      }),
+      obs({
+        id: 2,
+        entityName: 'auth',
+        title: 'Automatic auth edit',
+        narrative: 'Hook observed a change in src/auth.ts.',
+        source: 'agent',
+        sourceDetail: 'hook',
+        admissionState: 'candidate',
+        valueCategory: 'contextual',
+      }),
+    ], { projectId: 'AVIDS2/memorix', query: 'auth session', limit: 5 });
+
+    expect(packet.memories.map((memory) => memory.id)).toEqual([1]);
+  });
+
   it('keeps prompt risks scoped to selected context instead of global noise', () => {
     const packet = buildGraphContextPacket([
       obs({ id: 1, entityName: 'memcode-memory', title: 'Graph context injection', narrative: 'Use GraphContext Packet for memory injection.', type: 'decision', valueCategory: 'core' }),

--- a/tests/memory/retention.test.ts
+++ b/tests/memory/retention.test.ts
@@ -13,6 +13,7 @@ import {
   calculateRelevance,
   rankByRelevance,
   isImmune,
+  getImmunityReason,
   getRetentionZone,
   getArchiveCandidates,
   getRetentionSummary,
@@ -121,6 +122,16 @@ describe('Retention & Decay', () => {
     it('should protect core valueCategory observations', () => {
       expect(isImmune(makeDoc({ type: 'gotcha', valueCategory: 'core' }))).toBe(true);
       expect(isImmune(makeDoc({ type: 'discovery', valueCategory: 'core' }))).toBe(true);
+    });
+
+    it('does not misreport an unqualified automatic core candidate as immune', () => {
+      const candidate = makeDoc({
+        type: 'decision',
+        valueCategory: 'core',
+        admissionState: 'candidate',
+      });
+      expect(isImmune(candidate)).toBe(false);
+      expect(getImmunityReason(candidate)).toBeNull();
     });
 
     it('should protect frequently accessed observations', () => {

--- a/tests/memory/retention.test.ts
+++ b/tests/memory/retention.test.ts
@@ -357,6 +357,24 @@ describe('Retention & Decay', () => {
       expect(all.find((observation) => observation.id === 2)?.status ?? 'active').toBe('active');
     });
 
+    it('does not archive private observations for an unbound project reader', async () => {
+      const now = new Date();
+      const expiredDate = new Date(now.getTime() - 60 * 24 * 60 * 60 * 1000).toISOString();
+      const observations = [
+        { id: 1, entityName: 'a', type: 'session-request', title: 'Public expired', narrative: '', facts: [], filesModified: [], concepts: [], tokens: 10, createdAt: expiredDate, projectId: 'project-a' },
+        { id: 2, entityName: 'b', type: 'session-request', title: 'Private expired', narrative: '', facts: [], filesModified: [], concepts: [], tokens: 10, createdAt: expiredDate, projectId: 'project-a', visibility: 'personal', createdByAgentId: 'agent-a' },
+      ];
+      await fs.writeFile(path.join(tmpDir, 'observations.json'), JSON.stringify(observations));
+      await initObservationStore(tmpDir);
+
+      const result = await archiveExpired(tmpDir, now, undefined, 'project-a', { projectId: 'project-a' });
+
+      expect(result).toEqual({ archived: 1, remaining: 0 });
+      const all = await getObservationStore().loadAll();
+      expect(all.find((observation) => observation.id === 1)?.status).toBe('archived');
+      expect(all.find((observation) => observation.id === 2)?.status ?? 'active').toBe('active');
+    });
+
     it('archives a project in bounded ID-cursor batches without loading the shared table', async () => {
       const now = new Date();
       const expiredDate = new Date(now.getTime() - 60 * 24 * 60 * 60 * 1000).toISOString();

--- a/tests/memory/visibility.test.ts
+++ b/tests/memory/visibility.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+  canManageObservation,
+  canReadObservation,
+  filterReadableObservations,
+  resolveObservationVisibility,
+} from '../../src/memory/visibility.js';
+
+describe('observation visibility policy', () => {
+  const owner = 'agent-owner';
+  const recipient = 'agent-recipient';
+  const other = 'agent-other';
+  const projectReader = { projectId: 'project-a' };
+  const ownerReader = { projectId: 'project-a', agentId: owner, isTeamMember: true };
+  const recipientReader = { projectId: 'project-a', agentId: recipient, isTeamMember: true };
+  const otherReader = { projectId: 'project-a', agentId: other, isTeamMember: true };
+
+  it('keeps legacy records project-visible after upgrade', () => {
+    const legacy = { projectId: 'project-a' };
+
+    expect(resolveObservationVisibility(legacy)).toBe('project');
+    expect(canReadObservation(legacy, projectReader)).toBe(true);
+  });
+
+  it('fails closed for personal records without an owner identity', () => {
+    const personal = { projectId: 'project-a', visibility: 'personal' as const, createdByAgentId: owner };
+
+    expect(canReadObservation(personal, projectReader)).toBe(false);
+    expect(canReadObservation(personal, ownerReader)).toBe(true);
+    expect(canReadObservation(personal, otherReader)).toBe(false);
+  });
+
+  it('allows an explicit targeted-handoff recipient to read but not alter a personal record', () => {
+    const handoff = {
+      projectId: 'project-a',
+      visibility: 'personal' as const,
+      createdByAgentId: owner,
+      sharedWithAgentIds: [recipient],
+    };
+
+    expect(canReadObservation(handoff, ownerReader)).toBe(true);
+    expect(canReadObservation(handoff, recipientReader)).toBe(true);
+    expect(canReadObservation(handoff, otherReader)).toBe(false);
+    expect(canManageObservation(handoff, ownerReader)).toBe(true);
+    expect(canManageObservation(handoff, recipientReader)).toBe(false);
+  });
+
+  it('requires active same-project team membership for team records', () => {
+    const teamRecord = { projectId: 'project-a', visibility: 'team' as const, createdByAgentId: owner };
+
+    expect(canReadObservation(teamRecord, recipientReader)).toBe(true);
+    expect(canReadObservation(teamRecord, { projectId: 'project-a', agentId: recipient, isTeamMember: false })).toBe(false);
+    expect(canReadObservation(teamRecord, { projectId: 'project-b', agentId: recipient, isTeamMember: true })).toBe(false);
+  });
+
+  it('keeps global search limited to project-visible records', () => {
+    const records = [
+      { projectId: 'project-a', visibility: 'project' as const, title: 'project fact' },
+      { projectId: 'project-a', visibility: 'team' as const, title: 'team handoff' },
+      { projectId: 'project-a', visibility: 'personal' as const, createdByAgentId: owner, title: 'private note' },
+    ];
+
+    expect(filterReadableObservations(records, {}).map((record) => record.title)).toEqual(['project fact']);
+  });
+});

--- a/tests/orchestrate/memorix-bridge.test.ts
+++ b/tests/orchestrate/memorix-bridge.test.ts
@@ -1,5 +1,24 @@
-import { describe, it, expect } from 'vitest';
-import { sanitizeErrorPattern, hashErrorPattern } from '../../src/orchestrate/memorix-bridge.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { storeObservation } = vi.hoisted(() => ({
+  storeObservation: vi.fn(),
+}));
+
+vi.mock('../../src/memory/observations.js', () => ({ storeObservation }));
+
+import {
+  hashErrorPattern,
+  sanitizeErrorPattern,
+  storeFixExhausted,
+  storePipelineSummary,
+  storeTaskCompletion,
+  storeVerifiedFix,
+} from '../../src/orchestrate/memorix-bridge.js';
+
+beforeEach(() => {
+  storeObservation.mockReset();
+  storeObservation.mockResolvedValue(undefined);
+});
 
 describe('sanitizeErrorPattern', () => {
   it('should replace Windows absolute paths', () => {
@@ -59,5 +78,73 @@ describe('hashErrorPattern', () => {
     const h1 = hashErrorPattern('Error in C:\\Users\\alice\\project\\src\\file.ts:42:10');
     const h2 = hashErrorPattern('Error in C:\\Users\\bob\\project\\src\\file.ts:99:5');
     expect(h1).toBe(h2);
+  });
+});
+
+describe('automatic bridge admission', () => {
+  it('keeps a verified orchestration fix as a candidate until Code Memory qualifies it', async () => {
+    storeVerifiedFix({
+      projectId: 'org/repo',
+      gate: 'test',
+      errorOutput: 'src/auth.ts:42:10 expected 200, received 401',
+      fixDescription: 'Updated session validation and reran the focused test.',
+      fixAttempt: 1,
+      maxAttempts: 3,
+      passed: true,
+    });
+
+    await vi.waitFor(() => expect(storeObservation).toHaveBeenCalledTimes(1));
+    expect(storeObservation).toHaveBeenCalledWith(expect.objectContaining({
+      admissionState: 'candidate',
+      admissionReason: expect.stringContaining('awaits current Code Memory qualification'),
+    }));
+  });
+
+  it('keeps exhausted fix evidence as a candidate rather than auto-delivering it', async () => {
+    storeFixExhausted({
+      projectId: 'org/repo',
+      gate: 'compile',
+      errorOutput: 'src/index.ts:9:3 error TS2304',
+      fixDescription: 'Tried the available import paths.',
+      fixAttempt: 3,
+      maxAttempts: 3,
+      passed: false,
+    });
+
+    await vi.waitFor(() => expect(storeObservation).toHaveBeenCalledTimes(1));
+    expect(storeObservation).toHaveBeenCalledWith(expect.objectContaining({
+      admissionState: 'candidate',
+    }));
+  });
+
+  it('keeps task completion as an ephemeral trace and pipeline summary as a candidate', async () => {
+    storeTaskCompletion({
+      projectId: 'org/repo',
+      pipelineId: 'pipeline-1',
+      taskId: 'task-1',
+      taskDescription: 'Fix session timeout',
+      agentName: 'codex',
+      durationMs: 1_000,
+      tailOutput: 'Focused tests passed.',
+    });
+    await vi.waitFor(() => expect(storeObservation).toHaveBeenCalledTimes(1));
+    expect(storeObservation).toHaveBeenLastCalledWith(expect.objectContaining({
+      admissionState: 'ephemeral',
+      valueCategory: 'ephemeral',
+    }));
+
+    storePipelineSummary({
+      projectId: 'org/repo',
+      pipelineId: 'pipeline-1',
+      goal: 'Fix session timeout',
+      totalTasks: 2,
+      completed: 2,
+      failed: 0,
+      elapsedMs: 2_000,
+    });
+    await vi.waitFor(() => expect(storeObservation).toHaveBeenCalledTimes(2));
+    expect(storeObservation).toHaveBeenLastCalledWith(expect.objectContaining({
+      admissionState: 'candidate',
+    }));
   });
 });

--- a/tests/orchestrate/memorix-bridge.test.ts
+++ b/tests/orchestrate/memorix-bridge.test.ts
@@ -1,14 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { storeObservation } = vi.hoisted(() => ({
+const { storeObservation, searchObservations } = vi.hoisted(() => ({
   storeObservation: vi.fn(),
+  searchObservations: vi.fn(),
 }));
 
 vi.mock('../../src/memory/observations.js', () => ({ storeObservation }));
+vi.mock('../../src/store/orama-store.js', () => ({ searchObservations }));
 
 import {
   hashErrorPattern,
   sanitizeErrorPattern,
+  searchKnownFixes,
+  searchLessons,
   storeFixExhausted,
   storePipelineSummary,
   storeTaskCompletion,
@@ -18,6 +22,8 @@ import {
 beforeEach(() => {
   storeObservation.mockReset();
   storeObservation.mockResolvedValue(undefined);
+  searchObservations.mockReset();
+  searchObservations.mockResolvedValue([]);
 });
 
 describe('sanitizeErrorPattern', () => {
@@ -97,7 +103,13 @@ describe('automatic bridge admission', () => {
     expect(storeObservation).toHaveBeenCalledWith(expect.objectContaining({
       admissionState: 'candidate',
       admissionReason: expect.stringContaining('awaits current Code Memory qualification'),
+      visibility: 'personal',
     }));
+    const write = storeObservation.mock.calls[0][0];
+    expect(write.visibilityReader).toEqual({
+      projectId: 'org/repo',
+      agentId: write.createdByAgentId,
+    });
   });
 
   it('keeps exhausted fix evidence as a candidate rather than auto-delivering it', async () => {
@@ -114,7 +126,13 @@ describe('automatic bridge admission', () => {
     await vi.waitFor(() => expect(storeObservation).toHaveBeenCalledTimes(1));
     expect(storeObservation).toHaveBeenCalledWith(expect.objectContaining({
       admissionState: 'candidate',
+      visibility: 'personal',
     }));
+    const write = storeObservation.mock.calls[0][0];
+    expect(write.visibilityReader).toEqual({
+      projectId: 'org/repo',
+      agentId: write.createdByAgentId,
+    });
   });
 
   it('keeps task completion as an ephemeral trace and pipeline summary as a candidate', async () => {
@@ -131,7 +149,13 @@ describe('automatic bridge admission', () => {
     expect(storeObservation).toHaveBeenLastCalledWith(expect.objectContaining({
       admissionState: 'ephemeral',
       valueCategory: 'ephemeral',
+      visibility: 'personal',
     }));
+    let write = storeObservation.mock.calls[0][0];
+    expect(write.visibilityReader).toEqual({
+      projectId: 'org/repo',
+      agentId: write.createdByAgentId,
+    });
 
     storePipelineSummary({
       projectId: 'org/repo',
@@ -145,6 +169,37 @@ describe('automatic bridge admission', () => {
     await vi.waitFor(() => expect(storeObservation).toHaveBeenCalledTimes(2));
     expect(storeObservation).toHaveBeenLastCalledWith(expect.objectContaining({
       admissionState: 'candidate',
+      visibility: 'personal',
+    }));
+    write = storeObservation.mock.calls[1][0];
+    expect(write.visibilityReader).toEqual({
+      projectId: 'org/repo',
+      agentId: write.createdByAgentId,
+    });
+  });
+
+  it('uses an unbound project reader before injecting automatic lessons', async () => {
+    searchObservations.mockResolvedValue([
+      {
+        id: 7,
+        title: 'Known fix',
+        narrative: 'Use the focused verification command.',
+        type: 'problem-solution',
+        score: 0.9,
+        admissionState: 'qualified',
+      },
+    ]);
+
+    await expect(searchKnownFixes('test failed', 'org/repo')).resolves.toHaveLength(1);
+    expect(searchObservations).toHaveBeenLastCalledWith(expect.objectContaining({
+      projectId: 'org/repo',
+      reader: { projectId: 'org/repo' },
+    }));
+
+    await expect(searchLessons('fix the failing test', 'org/repo')).resolves.toContain('Known fix');
+    expect(searchObservations).toHaveBeenLastCalledWith(expect.objectContaining({
+      projectId: 'org/repo',
+      reader: { projectId: 'org/repo' },
     }));
   });
 });

--- a/tests/runtime/observation-qualification.integration.test.ts
+++ b/tests/runtime/observation-qualification.integration.test.ts
@@ -1,0 +1,88 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/embedding/provider.js', () => ({
+  getEmbeddingProvider: async () => null,
+  isVectorSearchAvailable: async () => false,
+  isEmbeddingExplicitlyDisabled: () => true,
+  resetProvider: () => {},
+}));
+
+import { getObservation, initObservations, storeObservation } from '../../src/memory/observations.js';
+import { MaintenanceJobStore } from '../../src/runtime/maintenance-jobs.js';
+import { createProjectMaintenanceHandler } from '../../src/runtime/project-maintenance.js';
+import { resetObservationStore } from '../../src/store/obs-store.js';
+import { resetDb } from '../../src/store/orama-store.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+
+let sandbox = '';
+let projectRoot = '';
+let dataDir = '';
+
+beforeEach(async () => {
+  sandbox = await fs.mkdtemp(path.join(tmpdir(), 'memorix-observation-qualification-'));
+  projectRoot = path.join(sandbox, 'repo');
+  dataDir = path.join(sandbox, 'data');
+  await fs.mkdir(path.join(projectRoot, 'src'), { recursive: true });
+  await fs.writeFile(
+    path.join(projectRoot, 'src', 'auth.ts'),
+    'export function verifySession(token: string) { return token.length > 0; }\n',
+    'utf8',
+  );
+  await resetDb();
+  await initObservations(dataDir);
+});
+
+afterEach(async () => {
+  resetObservationStore();
+  closeAllDatabases();
+  await resetDb();
+  if (sandbox) await fs.rm(sandbox, { recursive: true, force: true });
+});
+
+describe('automatic observation qualification', () => {
+  it('keeps a hook capture out of automatic delivery until a later Code Memory scan binds it', async () => {
+    const { observation } = await storeObservation({
+      entityName: 'auth',
+      type: 'what-changed',
+      title: 'Hook observed session verification edit',
+      narrative: 'Changed src/auth.ts to update session verification.',
+      filesModified: ['src/auth.ts'],
+      projectId: 'org/repo',
+      source: 'agent',
+      sourceDetail: 'hook',
+      valueCategory: 'contextual',
+      admissionState: 'candidate',
+      admissionReason: 'file mutation awaits Code Memory qualification',
+    });
+
+    expect(getObservation(observation.id, 'org/repo')?.admissionState).toBe('candidate');
+
+    const queue = new MaintenanceJobStore(dataDir);
+    const handler = createProjectMaintenanceHandler('org/repo', dataDir, projectRoot);
+    await handler({
+      id: 'refresh-code-memory',
+      projectId: 'org/repo',
+      kind: 'codegraph-refresh',
+      dedupeKey: 'codegraph-refresh',
+      payload: {},
+      status: 'running',
+      attempts: 1,
+      maxAttempts: 8,
+      runAfter: Date.now(),
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    });
+
+    const qualification = queue.list({ projectId: 'org/repo' })
+      .find((job) => job.kind === 'observation-qualify');
+    expect(qualification).toBeDefined();
+    await handler(qualification!);
+
+    expect(getObservation(observation.id, 'org/repo')).toMatchObject({
+      admissionState: 'qualified',
+    });
+  });
+});

--- a/tests/runtime/project-maintenance.test.ts
+++ b/tests/runtime/project-maintenance.test.ts
@@ -10,8 +10,10 @@ const getVectorStatus = vi.fn();
 const archiveExpiredBatch = vi.fn();
 const codeStoreInit = vi.fn();
 const latestSnapshot = vi.fn();
+const codeStatus = vi.fn();
+const listObservationRefs = vi.fn();
 const CodeGraphStore = vi.fn(function CodeGraphStoreMock() {
-  return { init: codeStoreInit, latestSnapshot };
+  return { init: codeStoreInit, latestSnapshot, status: codeStatus, listObservationRefs };
 });
 const refreshProjectLite = vi.fn();
 const backfillMissingObservationCodeRefs = vi.fn();
@@ -26,6 +28,8 @@ const ClaimStore = vi.fn(function ClaimStoreMock() {
 const bindObservationToCode = vi.fn();
 const deriveLowRiskClaimsFromObservation = vi.fn();
 const requalifyClaimsForCodeState = vi.fn();
+const updateObservationAdmission = vi.fn();
+const qualifyCandidateFromCurrentCode = vi.fn();
 const queueEnqueue = vi.fn();
 
 vi.mock('../../src/embedding/provider.js', () => ({
@@ -35,6 +39,11 @@ vi.mock('../../src/embedding/provider.js', () => ({
 vi.mock('../../src/memory/observations.js', () => ({
   backfillVectorEmbeddings,
   getVectorStatus,
+  updateObservationAdmission,
+}));
+
+vi.mock('../../src/memory/admission.js', () => ({
+  qualifyCandidateFromCurrentCode,
 }));
 
 vi.mock('../../src/memory/retention.js', () => ({
@@ -83,6 +92,9 @@ describe('createProjectMaintenanceHandler', () => {
     getResolvedConfig.mockReturnValue({ codegraph: { excludePatterns: ['generated/**'] } });
     getObservationStore.mockReturnValue({ loadByProject, getById });
     latestSnapshot.mockReturnValue({ id: 'snapshot-a' });
+    codeStatus.mockReturnValue({ indexedAt: '2026-07-24T00:00:00.000Z' });
+    listObservationRefs.mockReturnValue([]);
+    qualifyCandidateFromCurrentCode.mockReturnValue(undefined);
     queueEnqueue.mockReset();
   });
 
@@ -203,6 +215,49 @@ describe('createProjectMaintenanceHandler', () => {
       expect.anything(),
     );
     expect(queueEnqueue).toHaveBeenCalledWith(expect.objectContaining({ kind: 'knowledge-compile' }));
+    expect(result).toEqual({ action: 'complete' });
+  });
+
+  it('qualifies a candidate only after current Code Memory references exist', async () => {
+    const candidate = {
+      id: 43,
+      projectId: 'project-a',
+      entityName: 'auth',
+      type: 'what-changed',
+      title: 'Hook observed auth edit',
+      narrative: 'Changed src/auth.ts.',
+      facts: [],
+      filesModified: ['src/auth.ts'],
+      source: 'agent',
+      sourceDetail: 'hook',
+      valueCategory: 'contextual',
+      admissionState: 'candidate',
+      status: 'active',
+      createdAt: '2026-07-23T00:00:00.000Z',
+    };
+    loadByProject.mockResolvedValue([candidate]);
+    bindObservationToCode.mockResolvedValue([]);
+    listObservationRefs.mockReturnValue([{ status: 'current' }]);
+    qualifyCandidateFromCurrentCode.mockReturnValue({
+      admissionState: 'qualified',
+      admissionReason: 'automatic record qualified against 1 current Code Memory reference(s)',
+    });
+
+    const result = await createProjectMaintenanceHandler('project-a', 'C:/memorix-data')(
+      makeJob({ kind: 'observation-qualify' as any, payload: { limit: 10 } }),
+    );
+
+    expect(bindObservationToCode).toHaveBeenCalledWith(expect.anything(), candidate);
+    expect(qualifyCandidateFromCurrentCode).toHaveBeenCalledWith({
+      observation: candidate,
+      currentCodeReferenceCount: 1,
+    });
+    expect(updateObservationAdmission).toHaveBeenCalledWith(expect.objectContaining({
+      observationId: 43,
+      projectId: 'project-a',
+      expectedState: 'candidate',
+      admissionState: 'qualified',
+    }));
     expect(result).toEqual({ action: 'complete' });
   });
 

--- a/tests/sdk/memory-client.test.ts
+++ b/tests/sdk/memory-client.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { MemoryClient, createMemoryClient } from '../../src/sdk.js';
 import { initObservationStore, resetObservationStore } from '../../src/store/obs-store.js';
-import { initObservations, prepareSearchIndex, getAllObservations, getObservation } from '../../src/memory/observations.js';
+import { initObservations, prepareSearchIndex, getAllObservations, getObservation, storeObservation } from '../../src/memory/observations.js';
 import { resetDb } from '../../src/store/orama-store.js';
 import { resetProvider } from '../../src/embedding/provider.js';
 import { resetConfigCache } from '../../src/config.js';
@@ -160,6 +160,47 @@ describe('MemoryClient (unit)', () => {
 
     await client.store({ entityName: 'a', type: 'discovery', title: 'One', narrative: 'n' });
     expect(await client.count()).toBe(1);
+
+    await client.close();
+  });
+
+  it('keeps personal observations outside the default SDK reader and write scope', async () => {
+    const client = new MemoryClient('test/project', testDir, dataDir);
+    await client._init(true);
+
+    const { observation: shared } = await client.store({
+      entityName: 'shared',
+      type: 'decision',
+      title: 'Project-shared decision',
+      narrative: 'All project readers can use this decision.',
+    });
+    const { observation: personal } = await storeObservation({
+      entityName: 'private',
+      type: 'discovery',
+      title: 'Private operator note',
+      narrative: 'An unbound SDK client must not expose or alter this note.',
+      projectId: 'test/project',
+      topicKey: 'private/operator-note',
+      visibility: 'personal',
+      createdByAgentId: 'private-agent',
+    });
+
+    expect(await client.get(personal.id)).toBeUndefined();
+    expect((await client.getAll()).map((observation) => observation.id)).toEqual([shared.id]);
+    expect(await client.count()).toBe(1);
+    expect((await client.search({ query: 'private operator note' })).map((result) => result.id)).not.toContain(personal.id);
+
+    const resolveResult = await client.resolve([personal.id]);
+    expect(resolveResult.resolved).toEqual([]);
+    expect(resolveResult.notFound).toContain(personal.id);
+
+    await expect(client.store({
+      entityName: 'private',
+      type: 'discovery',
+      title: 'Guessed private update',
+      narrative: 'This must not overwrite the private record.',
+      topicKey: 'private/operator-note',
+    })).rejects.toThrow('write scope');
 
     await client.close();
   });

--- a/tests/store/sqlite-store.test.ts
+++ b/tests/store/sqlite-store.test.ts
@@ -80,6 +80,23 @@ describe('SqliteBackend CRUD', () => {
     expect(all[0].type).toBe('discovery');
   });
 
+  it('round-trips control-plane admission metadata', async () => {
+    const obs = makeObs({
+      id: 1,
+      entityName: 'auth',
+      projectId: 'test/proj',
+      admissionState: 'candidate',
+      admissionReason: 'file mutation awaits Code Memory qualification',
+    });
+    await store.insert(obs);
+
+    const [stored] = await store.loadAll();
+    expect(stored).toMatchObject({
+      admissionState: 'candidate',
+      admissionReason: 'file mutation awaits Code Memory qualification',
+    });
+  });
+
   it('update modifies an existing observation', async () => {
     const obs = makeObs({ id: 1, entityName: 'e', projectId: 'p', title: 'Original' });
     await store.insert(obs);

--- a/tests/team/handoff.test.ts
+++ b/tests/team/handoff.test.ts
@@ -81,6 +81,8 @@ describe('createHandoffArtifact', () => {
     expect(call.valueCategory).toBe('core'); // immune to archival
     expect(call.sourceDetail).toBe('explicit');
     expect(call.createdByAgentId).toBe(a1.agent_id);
+    expect(call.visibility).toBe('personal');
+    expect(call.sharedWithAgentIds).toEqual([a2.agent_id]);
     expect(call.filesModified).toEqual(['src/auth.ts']);
     expect(call.concepts).toContain('handoff');
     expect(call.concepts).toContain('authentication');
@@ -130,6 +132,8 @@ describe('createHandoffArtifact', () => {
     );
 
     expect(result.toAgentId).toBeUndefined();
+    expect(mock.calls[0].visibility).toBe('team');
+    expect(mock.calls[0].sharedWithAgentIds).toBeUndefined();
 
     // Each non-sender agent gets their own recipient-specific message
     const inbox2 = store.getInbox('proj1', a2.agent_id);

--- a/tests/tui/data-scope.test.ts
+++ b/tests/tui/data-scope.test.ts
@@ -50,9 +50,10 @@ beforeEach(async () => {
     { id: 3, entityName: 'auth', type: 'discovery', title: 'Old entry', narrative: 'Resolved', facts: [], projectId: PROJECT_A, status: 'resolved', createdAt: '2024-06-01T00:00:00Z' },
     { id: 4, entityName: 'billing', type: 'decision', title: 'Use Stripe', narrative: 'Stripe billing', facts: [], projectId: PROJECT_B, status: 'active', createdAt: '2025-01-03T00:00:00Z' },
     { id: 5, entityName: 'billing', type: 'gotcha', title: 'Webhook retry', narrative: 'Retry logic', facts: [], projectId: PROJECT_B, status: 'active', createdAt: '2025-01-04T00:00:00Z' },
+    { id: 6, entityName: 'auth', type: 'discovery', title: 'Private operator note', narrative: 'Not visible to an unbound TUI.', facts: [], projectId: PROJECT_A, status: 'active', createdAt: '2025-01-05T00:00:00Z', visibility: 'personal', createdByAgentId: 'private-agent' },
   ];
   await obsStore.bulkReplace(observations as any);
-  await obsStore.saveIdCounter(6);
+  await obsStore.saveIdCounter(7);
 
   await initSessionStore(dataDir);
   const sessStore = getSessionStore();

--- a/tests/wiki/generator.test.ts
+++ b/tests/wiki/generator.test.ts
@@ -98,6 +98,16 @@ describe('Filtering: isEligible', () => {
     expect(isEligible(obs, PROJECT_ID)).toBe(false);
   });
 
+  it('excludes an automatic candidate until it is qualified', () => {
+    const candidate = makeObs({
+      sourceDetail: 'hook',
+      admissionState: 'candidate',
+      admissionReason: 'file mutation awaits Code Memory qualification',
+    });
+    expect(isEligible(candidate, PROJECT_ID)).toBe(false);
+    expect(isEligible({ ...candidate, admissionState: 'qualified' }, PROJECT_ID)).toBe(true);
+  });
+
   it('includes core valueCategory', () => {
     const obs = makeObs({ valueCategory: 'core' });
     expect(isEligible(obs, PROJECT_ID)).toBe(true);


### PR DESCRIPTION
## Summary
- complete the direct CLI control plane with project and actor scoping
- add explicit CLI identities for personal and team memory access
- align Workbench/TUI and transfer exports with observation visibility
- add file/stdin transfer paths, command guides, docs, and release notes

## Verification
- npm test
- npm run lint
- npm run build
- npm pack --dry-run
- compiled CLI help and scope smoke