### PR TITLE
fix(session): enforce visibility in handoff context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.3] - 2026-07-25
+
+### Fixed
+- **Session context now respects observation visibility** -- Automatic session handoff and manual session-context reads in the CLI, MCP server, and Workbench apply the caller's project, team, and personal-memory reader. A new identity cannot receive another agent's personal observations through session startup.
+- **Identity before handoff** -- CLI and MCP coordination sessions establish their explicit identity before assembling prior context, so an owner's own personal records remain available while a newly joined agent fails closed.
+- **Graph-side disclosure guard** -- Agent-facing session handoff no longer derives graph-neighbor hints from graph relations that do not yet carry observation visibility metadata.
+
 ## [1.2.2] - 2026-07-25
 
 ### Added

--- a/docs/dev-log/progress.txt
+++ b/docs/dev-log/progress.txt
@@ -4,15 +4,25 @@
 > older notes when they conflict.
 
 ## Current State
-- Phase: 1.2.2 memory-control-plane admission and visibility implementation
-- Branch: `codex/1.2.2-memory-control-plane`
+- Phase: 1.2.3 session-context visibility hotfix
+- Branch: `codex/1.2.3-session-visibility`
 - Last updated: 2026-07-25
-- Released baseline: `memorix@1.2.1`, tag `v1.2.1`, `origin/main` at
-  `1b5bf7f`.
-- Goal: make the 1.2 multi-dimensional evidence layer behave as one bounded,
-  explainable control plane. A task Workset, hook handoff, lifecycle refresh,
-  and provider capability result must share evidence qualification, delivery
-  budgets, and privacy-safe receipts.
+- Released baseline: `memorix@1.2.2`, tag `v1.2.2`, `origin/main` at
+  `2a7ebc7`.
+- Goal: close the agent-facing session-context visibility boundary before
+  further control-plane work.
+
+## 1.2.3 Session Context Visibility Hotfix
+- A real installed-package CLI smoke found that a second coordination identity
+  could receive the first identity's personal observation in automatic session
+  context. The root cause was a reader-less core session-context call.
+- `getSessionContext()` now accepts an `ObservationReader`; CLI, MCP, and TUI
+  session entry points pass their resolved caller identity. Alias-backed
+  project-visible records remain readable, while personal/team records fail
+  closed.
+- Graph-neighbor routing is omitted whenever a reader is present because graph
+  relations are not yet visibility-scoped. Core, CLI, MCP, and alias regression
+  tests cover the boundary.
 
 ## 1.1.13 Closeout
 - Codex setup now stamps plugin versions and doctor distinguishes bundle,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/src/cli/commands/session.ts
+++ b/src/cli/commands/session.ts
@@ -32,7 +32,7 @@ export default defineCommand({
     const asJson = !!args.json;
 
     try {
-      const { project, dataDir, teamStore } = await getCliProjectContext({
+      const { project, dataDir, teamStore, reader } = await getCliProjectContext({
         projectRoot: args.projectRoot as string | undefined,
       });
 
@@ -46,11 +46,6 @@ export default defineCommand({
             emitError('use requires --agent or --agentType so Memorix can activate a coordination identity.', asJson);
             return;
           }
-          const result = await startSession(dataDir, project.id, {
-            sessionId: args.sessionId as string | undefined,
-            agent: args.agent as string | undefined,
-          });
-
           const shouldJoinTeam = !!args.joinTeam;
           let agentRecord: ReturnType<typeof teamStore.registerAgent> | null = null;
           let teamJoinNotice: string | null = null;
@@ -71,6 +66,19 @@ export default defineCommand({
           } else if (shouldJoinTeam) {
             teamJoinNotice = 'Coordination join skipped: provide --agent or --agentType to create a coordination identity.';
           }
+
+          const contextReader = agentRecord
+            ? {
+                projectId: project.id,
+                agentId: agentRecord.agent_id,
+                isTeamMember: agentRecord.status === 'active',
+              }
+            : reader;
+          const result = await startSession(dataDir, project.id, {
+            sessionId: args.sessionId as string | undefined,
+            agent: args.agent as string | undefined,
+            reader: contextReader,
+          });
 
           let identityActivated = false;
           if (args.use && agentRecord) {
@@ -178,7 +186,7 @@ export default defineCommand({
         case 'context': {
           const limit = parsePositiveInt(args.limit as string | undefined, 3);
           const [context, sessions] = await Promise.all([
-            getSessionContext(dataDir, project.id, limit),
+            getSessionContext(dataDir, project.id, limit, reader),
             listSessions(dataDir, project.id),
           ]);
           const active = sessions.filter((session) => session.status === 'active').length;

--- a/src/cli/tui/session-service.ts
+++ b/src/cli/tui/session-service.ts
@@ -53,12 +53,13 @@ export async function getSessionState(projectId?: string): Promise<SessionState>
 
 export async function bindSession(): Promise<SessionState> {
   try {
-    const proj = await resolveProject();
-    if (!proj) return { status: 'error', error: 'No project detected' };
+    const { getTuiOperatorContext } = await import('./operator-context.js');
+    const { project: proj, reader } = await getTuiOperatorContext();
 
     const { startSession } = await import('../../memory/session.js');
     const { session, previousContext } = await startSession(proj.rootPath, proj.id, {
       agent: 'memorix-tui',
+      reader,
     });
 
     return {

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -11,7 +11,7 @@
  * - Cross-agent session awareness (all agents share session data)
  */
 
-import type { Observation, Session } from '../types.js';
+import type { Observation, ObservationReader, Session } from '../types.js';
 import { isEligibleForAutomaticDelivery } from './admission.js';
 import { classifyLayer } from './disclosure-policy.js';
 import { resolveAliases } from '../project/aliases.js';
@@ -19,6 +19,7 @@ import { getObservationStore } from '../store/obs-store.js';
 import { getSessionStore } from '../store/session-store.js';
 import { KnowledgeGraphManager } from './graph.js';
 import { redactCredentials, sanitizeCredentials } from './secret-filter.js';
+import { canReadObservation } from './visibility.js';
 
 const PRIORITY_TYPES = new Set(['gotcha', 'decision', 'problem-solution', 'trade-off', 'discovery']);
 const TYPE_EMOJI: Record<string, string> = {
@@ -242,7 +243,7 @@ export function scoreObservationForSessionContext(obs: Observation, projectToken
 export async function startSession(
   projectDir: string,
   projectId: string,
-  opts?: { sessionId?: string; agent?: string },
+  opts?: { sessionId?: string; agent?: string; reader?: ObservationReader },
 ): Promise<{ session: Session; previousContext: string }> {
   const sessionId = opts?.sessionId || generateSessionId();
   const now = new Date().toISOString();
@@ -256,7 +257,7 @@ export async function startSession(
   };
 
   // Load previous context before creating new session
-  const previousContext = await getSessionContext(projectDir, projectId);
+  const previousContext = await getSessionContext(projectDir, projectId, 3, opts?.reader);
 
   // Atomic rollover: complete all active sessions for this project's aliases
   // and insert the new session in a single SQLite transaction.
@@ -306,17 +307,31 @@ export async function endSession(
  *   Key Memories   — durable explicit working context (L2)
  *   Session History— orientation log
  *   L3 Evidence    — pointers to git-memory and hook traces (on-demand)
+ *
+ * When a reader is supplied, automatic observation delivery follows that
+ * identity's visibility boundary. Omit it only for trusted maintenance paths.
  */
 export async function getSessionContext(
   projectDir: string,
   projectId: string,
   limit: number = 3,
+  reader?: ObservationReader,
 ): Promise<string> {
   const aliasSet = await resolveProjectIds(projectId);
   const [sessions, allObs] = await Promise.all([
     loadAliasSessions(aliasSet),
     loadAliasActiveObservations(aliasSet),
   ]);
+  const readableObs = reader
+    ? allObs.filter((observation) => {
+        // Aliases represent one project across moved/renamed worktrees. Preserve
+        // that project equivalence while still enforcing the caller's identity.
+        const observationReader = reader.projectId && aliasSet.has(observation.projectId)
+          ? { ...reader, projectId: observation.projectId }
+          : reader;
+        return canReadObservation(observation, observationReader);
+      })
+    : allObs;
   /** Check if a session summary contains noise/system-self content */
   const isNoisySummary = (summary: string | undefined): boolean => {
     if (!summary) return false;
@@ -329,7 +344,7 @@ export async function getSessionContext(
     .sort((a, b) => new Date(b.endedAt || b.startedAt).getTime() - new Date(a.endedAt || a.startedAt).getTime())
     .slice(0, limit);
 
-  if (projectSessions.length === 0 && allObs.length === 0) {
+  if (projectSessions.length === 0 && readableObs.length === 0) {
     return '';
   }
 
@@ -337,7 +352,7 @@ export async function getSessionContext(
   const projectTokens = tokenizeProjectId(projectId);
 
   // ── Partition project observations by disclosure layer ─────────────
-  const projectObs = allObs
+  const projectObs = readableObs
     .filter((obs) => !isNoiseObservation(obs) && !isSystemSelfObservation(obs));
 
   // L2: durable working context (explicit/undefined/core), priority types only
@@ -392,11 +407,11 @@ export async function getSessionContext(
   // Active entities enrich the section when it is shown but do not open it alone.
   const hasL1Content = l1HookObs.length > 0 || l3GitCount > 0;
   if (hasL1Content) {
-    // Graph neighbor routing hint: 1-hop neighbors of activeEntities from the
-    // knowledge graph. Routing only — no query expansion, no rerank, no 2-hop
-    // traversal. Silently skipped if graph is absent, empty, or throws.
+    // Graph relations do not yet carry observation visibility metadata, so an
+    // agent-facing reader must not use them as an indirect disclosure channel.
+    // Trusted maintenance paths retain the existing routing hint.
     let graphNeighbors: string[] = [];
-    if (activeEntities.length > 0) {
+    if (!reader && activeEntities.length > 0) {
       try {
         const graphMgr = new KnowledgeGraphManager(projectDir);
         await graphMgr.init();

--- a/src/server.ts
+++ b/src/server.ts
@@ -3614,7 +3614,6 @@ export async function createMemorixServer(
       if (unresolved) return unresolved;
 
       const { startSession } = await import('./memory/session.js');
-      const result = await startSession(projectDir, project.id, { sessionId, agent });
 
       const llmStatus = isLLMEnabled()
         ? `LLM enhanced mode: ${getLLMConfig()?.provider}/${getLLMConfig()?.model} (fact extraction + auto-dedup active)`
@@ -3689,6 +3688,12 @@ export async function createMemorixServer(
           teamJoinNotice = 'Coordination join skipped: pass `agent` or `agentType` to create a coordination identity.';
         }
       } catch { /* team auto-registration is best-effort */ }
+
+      const result = await startSession(projectDir, project.id, {
+        sessionId,
+        agent,
+        reader: getObservationReader(),
+      });
 
       const lines = [
         `[OK] Session started: ${result.session.id}`,
@@ -3825,7 +3830,7 @@ export async function createMemorixServer(
     async ({ limit }) => {
       const safeLimit = limit != null ? coerceNumber(limit, 3) : 3;
       const { getSessionContext, listSessions } = await import('./memory/session.js');
-      const context = await getSessionContext(projectDir, project.id, safeLimit);
+      const context = await getSessionContext(projectDir, project.id, safeLimit, getObservationReader());
       const sessions = await listSessions(projectDir, project.id);
 
       const activeSessions = sessions.filter(s => s.status === 'active');

--- a/tests/cli/identity-command.test.ts
+++ b/tests/cli/identity-command.test.ts
@@ -187,4 +187,49 @@ describe('CLI identity control plane', () => {
     expect(status.exitCode).toBe(0);
     expect(JSON.parse(status.stdout).identity.agentId).toBe(startPayload.agent.agentId);
   });
+
+  it('does not inject a prior CLI identity personal memory when a new coordination session starts', async () => {
+    const shared = await runCommand(memoryCommand, {
+      _: ['store'],
+      text: 'The shared release checklist requires a package smoke test.',
+      title: 'Project release checklist',
+      json: true,
+    });
+    expect(shared.exitCode).toBe(0);
+
+    const owner = await runCommand(identityCommand, {
+      _: ['join'],
+      agentType: 'codex',
+      instanceId: 'private-owner-terminal',
+      name: 'Private owner terminal',
+      json: true,
+    });
+    expect(owner.exitCode).toBe(0);
+
+    const privateMemory = await runCommand(memoryCommand, {
+      _: ['store'],
+      text: 'Only the owner should see this migration credential checklist.',
+      title: 'Owner-only session memory',
+      visibility: 'personal',
+      json: true,
+    });
+    expect(privateMemory.exitCode).toBe(0);
+
+    const cleared = await runCommand(identityCommand, { _: ['clear'], json: true });
+    expect(cleared.exitCode).toBe(0);
+
+    const foreignSession = await runCommand(sessionCommand, {
+      _: ['start'],
+      agent: 'Foreign release terminal',
+      agentType: 'claude-code',
+      instanceId: 'foreign-release-terminal',
+      joinTeam: true,
+      use: true,
+      json: true,
+    });
+    expect(foreignSession.exitCode).toBe(0);
+    const payload = JSON.parse(foreignSession.stdout);
+    expect(payload.previousContext).toContain('Project release checklist');
+    expect(payload.previousContext).not.toContain('Owner-only session memory');
+  });
 });

--- a/tests/integration/visibility-boundary.test.ts
+++ b/tests/integration/visibility-boundary.test.ts
@@ -74,6 +74,30 @@ describe('MCP observation visibility boundary', () => {
       const idB = agentId(await startB({ agent: 'visibility-b', agentType: 'claude-code', joinTeam: true }));
       agentId(await startC({ agent: 'visibility-c', agentType: 'windsurf', joinTeam: true }));
 
+      const storeA = getHandler(first.server as any, 'memorix_store');
+      const privateSessionMemory = await storeA({
+        entityName: 'private-session',
+        type: 'gotcha',
+        title: 'Owner-only session context',
+        narrative: 'This private observation must never be injected into another agent session.',
+        visibility: 'personal',
+      });
+      expect(privateSessionMemory.isError).not.toBe(true);
+
+      const foreignSession = text(await startC({
+        agent: 'visibility-c',
+        agentType: 'windsurf',
+        joinTeam: true,
+      }));
+      expect(foreignSession).not.toContain('Owner-only session context');
+
+      const ownerSession = text(await startA({
+        agent: 'visibility-a',
+        agentType: 'codex',
+        joinTeam: true,
+      }));
+      expect(ownerSession).toContain('Owner-only session context');
+
       const handoffA = getHandler(first.server as any, 'memorix_handoff');
       const created = await handoffA({
         fromAgentId: idA,

--- a/tests/memory/session.test.ts
+++ b/tests/memory/session.test.ts
@@ -115,6 +115,38 @@ describe('Session Lifecycle', () => {
   });
 
   describe('getSessionContext', () => {
+    it('does not inject personal observations into a different agent session', async () => {
+      await storeObservation({
+        entityName: 'migration',
+        type: 'decision',
+        title: 'Project-visible migration policy',
+        narrative: 'All migrations must have a rollback plan.',
+        projectId: PROJECT_ID,
+      });
+      await storeObservation({
+        entityName: 'migration',
+        type: 'decision',
+        title: 'Owner-only migration checklist',
+        narrative: 'This private checklist must not cross agent identities.',
+        projectId: PROJECT_ID,
+        visibility: 'personal',
+        createdByAgentId: 'owner-agent',
+      });
+
+      const foreign = await startSession(testDir, PROJECT_ID, {
+        sessionId: 'foreign-session',
+        reader: { projectId: PROJECT_ID, agentId: 'foreign-agent', isTeamMember: true },
+      });
+      expect(foreign.previousContext).toContain('Project-visible migration policy');
+      expect(foreign.previousContext).not.toContain('Owner-only migration checklist');
+
+      const owner = await startSession(testDir, PROJECT_ID, {
+        sessionId: 'owner-session',
+        reader: { projectId: PROJECT_ID, agentId: 'owner-agent', isTeamMember: true },
+      });
+      expect(owner.previousContext).toContain('Owner-only migration checklist');
+    });
+
     it('loads only the current project aliases instead of scanning global sessions and observations', async () => {
       await storeObservation({
         entityName: 'current',
@@ -402,11 +434,26 @@ describe('Session Lifecycle', () => {
         narrative: 'Found via alias',
         projectId: ALIAS_A,
       });
+      await storeObservation({
+        entityName: 'auth',
+        type: 'gotcha',
+        title: 'Aliased private gotcha',
+        narrative: 'This stays with its owner across project aliases.',
+        projectId: ALIAS_A,
+        visibility: 'personal',
+        createdByAgentId: 'alias-owner',
+      });
 
-      // Query context under ALIAS_B
-      const context = await getSessionContext(testDir, ALIAS_B);
+      // Query context under ALIAS_B through a different agent identity. The
+      // project-visible record crosses the alias, while the personal one does not.
+      const context = await getSessionContext(testDir, ALIAS_B, 3, {
+        projectId: ALIAS_B,
+        agentId: 'alias-reader',
+        isTeamMember: true,
+      });
       expect(context).toContain('Alias context test');
       expect(context).toContain('Cross-agent gotcha');
+      expect(context).not.toContain('Aliased private gotcha');
     });
 
     it('should auto-close aliased active sessions on new start', async () => {


### PR DESCRIPTION
## Summary
- apply the resolved observation reader to automatic and manual session context
- establish CLI/MCP coordination identity before assembling handoff context
- fail closed for graph-neighbor hints until graph relations have visibility metadata

## Regression coverage
- core session reader and alias boundary
- CLI identity handoff boundary
- MCP team-server handoff boundary
- real built CLI smoke: project record visible, owner personal record hidden from a new identity and recoverable by its owner

## Verification
- npm run lint
- npm run build
- npm test
- npm pack --dry-run