### PR TITLE
perf(retrieval): make search profiles deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.5] - 2026-07-27
+
+### Added
+- **Explicit retrieval profiles** -- Search now accepts `fast`, `balanced` (default), or `thorough` through the CLI, MCP, and SDK. Fast is fully local, balanced keeps optional LLM work out of everyday retrieval, and thorough explicitly opts into configured LLM query refinement.
+- **Reproducible retrieval evidence** -- Added `npm run benchmark:retrieval` for a clearly-labelled hot in-process SDK lexical benchmark with p50/p95/p99 output. It does not present CLI startup, MCP transport, remote embedding, or LLM latency as the same metric.
+
+### Changed
+- **Lighter read-only CLI path** -- Memory search, detail, timeline, recent, graph context, and help no longer create session bookkeeping or maintenance-target metadata. Identity and visibility checks remain unchanged.
+
+### Fixed
+- **Completed searches no longer retain timeout watchdogs** -- Embedding, rerank, MCP search, and maintenance timeout paths share a helper that clears the timer when work settles. This removes the avoidable CLI exit delay caused by an already-completed optional rerank.
+- **OpenRouter lane isolation** -- An embedding-only `OPENROUTER_API_KEY` no longer silently enables the memory LLM lane. It remains valid for a memory LLM only when that lane explicitly selects an OpenRouter provider or base URL.
+
 ## [1.2.4] - 2026-07-26
 
 ### Added

--- a/docs/1.2.5-RETRIEVAL-PERFORMANCE.md
+++ b/docs/1.2.5-RETRIEVAL-PERFORMANCE.md
@@ -1,0 +1,85 @@
+# 1.2.5 Retrieval Performance and Reliability
+
+## Goal
+
+Make retrieval predictable for both people and agents:
+
+- a normal search must not wait on optional LLM work;
+- a finished search must not leave a timeout timer alive and delay CLI exit;
+- embedding credentials must not silently become LLM credentials;
+- measured performance claims must identify the exact runtime being measured.
+
+This release improves the existing local SQLite + in-process Orama design. It
+does not introduce a daemon-only retrieval path, a new vector database, or a
+cross-process shared Orama index.
+
+## Retrieval Profiles
+
+| Profile | Use case | Local retrieval | Embeddings | LLM query rewrite / rerank |
+| --- | --- | --- | --- | --- |
+| `fast` | Scripts, probes, latency-sensitive agents | Yes | No | No |
+| `balanced` (default) | Everyday memory search | Yes | When configured | No |
+| `thorough` | An explicit, higher-quality investigation | Yes | When configured | Yes, only with an explicit memory LLM lane |
+
+`fast` never makes a network request and uses non-fuzzy lexical matching without
+vector payloads or fuzzy typo expansion. `balanced` preserves semantic vector
+search, typo tolerance, and intent-aware ranking but keeps optional LLM
+enrichment out of the default critical path.
+`thorough` is opt-in because it can add provider latency and cost.
+
+The profile is available through the SDK, `memorix memory search --quality`,
+the top-level `memorix search --quality` shortcut, and the `memorix_search` MCP
+tool. Existing callers that omit it receive `balanced` behavior.
+
+## Configuration Lanes
+
+Memorix has separate agent, memory-LLM, and embedding lanes. In particular:
+
+- `OPENROUTER_API_KEY` remains a compatible fallback for an embedding endpoint
+  hosted by OpenRouter.
+- It is not a generic memory-LLM credential.
+- It may supply the memory-LLM key only when `[memory.llm] provider =
+  "openrouter"`, or that lane explicitly points at an OpenRouter base URL.
+
+This prevents an embedding-only configuration from unexpectedly enabling LLM
+query rewriting or reranking.
+
+## Timeout Contract
+
+Every timeout helper must clear its timer when the protected operation settles.
+That applies to embedding requests, LLM reranking, MCP tool budgets, and
+background maintenance. This prevents a completed CLI command from being kept
+alive solely by a timeout watchdog while preserving a real deadline for a
+genuinely stalled operation.
+
+Timeouts still bound callers; they do not cancel a provider request that lacks
+an abort signal. The caller receives the fallback/error immediately, while the
+underlying request is allowed to settle safely in the background.
+
+## Evidence Protocol
+
+`npm run benchmark:retrieval` measures hot, in-process lexical retrieval with
+embeddings and LLM work disabled. It reports index-build time plus separate
+p50/p95/p99 values for a specific lookup and a broad query over a deterministic
+synthetic corpus. The two query shapes are intentionally not averaged together.
+
+It is deliberately not an end-to-end CLI, MCP, remote embedding, or LLM
+benchmark. Those paths have different startup, IPC, network, and provider
+costs and must be reported separately.
+
+Example:
+
+```powershell
+npm run build
+npm run benchmark:retrieval -- --records 1000 --runs 100
+```
+
+## Verification Gates
+
+1. Focused timeout, config, semantic-search, CLI, SDK, and MCP tests pass.
+2. The packaged CLI smoke verifies `fast`, default `balanced`, and
+   `thorough` argument handling without changing stored data.
+3. The MCP smoke verifies the `quality` schema and confirms no completed
+   search leaves a watchdog timer behind.
+4. Benchmark output is retained as evidence with its mode and machine context,
+   never presented as a universal latency guarantee.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -14,6 +14,24 @@ Memorix is designed to be light for everyday memory use and explicit about heavi
 
 The default memory path uses local SQLite as the canonical store and Orama for search/indexing. No cloud service is required.
 
+## Retrieval Profiles
+
+| Profile | Default? | Network work | Best fit |
+| --- | --- | --- | --- |
+| `fast` | No | Never | Scripts, probes, latency-sensitive agent steps |
+| `balanced` | Yes | Optional embedding only | Everyday search |
+| `thorough` | No | Optional embedding plus explicitly enabled memory LLM work | A deliberate deep investigation |
+
+Use `--quality fast|balanced|thorough` with `memorix memory search` or
+`memorix search`; the `memorix_search` MCP tool and SDK expose the same field.
+`fast` is fully local. `balanced` keeps optional LLM query rewriting and
+reranking out of the normal search path. `thorough` is opt-in because it can
+add provider latency and cost.
+
+`OPENROUTER_API_KEY` may provide an API key for an OpenRouter embedding endpoint.
+It does not enable the memory-LLM lane unless that lane explicitly selects
+OpenRouter through its provider or base URL.
+
 ## Interactive and Maintenance Boundaries
 
 MCP transport readiness is separate from full search-index readiness. The first
@@ -58,6 +76,8 @@ On the release development machine used for this check, the healthy HTTP service
 | `MEMORIX_LLM_API_KEY` / `OPENAI_API_KEY` | unset | Enable LLM-backed enrichment, extraction, rerank, or skill generation |
 | `MEMORIX_LLM_TIMEOUT_MS` | `30000` (30 s) | Bound a single LLM-backed extraction/resolve call |
 | `MEMORIX_RERANK_TIMEOUT_MS` | provider default | Bound slow LLM rerank calls |
+| `memorix memory search --quality fast` | n/a | Force a fully local retrieval path for a latency-sensitive call |
+| `npm run benchmark:retrieval -- --records 1000 --runs 100` | n/a | Reproduce hot in-process lexical retrieval latency; not an end-to-end claim |
 | `[codegraph].max_file_bytes` | `2097152` | Raise only when a large file is intentional source that should enter Code Memory |
 | `memorix retention status` | report only | Inspect whether memory growth needs cleanup |
 | `memorix retention archive` | explicit | Archive expired memories when the project gets noisy |
@@ -71,6 +91,7 @@ On the release development machine used for this check, the healthy HTTP service
 - For Docker, use it when you want a managed HTTP service. Do not use image size alone as the runtime memory estimate.
 - For orchestrated subagent work, expect CPU and disk activity proportional to the spawned agents and verification commands.
 - For release checks, measure build/test/pack separately from idle service cost.
+- When comparing retrieval latency, report cold CLI, warm in-process SDK, MCP/HTTP, remote embedding, and LLM-enhanced paths separately. They have materially different costs.
 - When Dashboard shows queued or failed maintenance work, inspect
   `/api/maintenance` on that local dashboard before assuming a Code Memory scan
   or lifecycle task completed.
@@ -79,7 +100,7 @@ On the release development machine used for this check, the healthy HTTP service
 
 These are not release blockers, but they are reasonable future improvements:
 
-- Add a lightweight benchmark command that reports startup time, index size, SQLite size, and search latency.
+- Extend the retrieval benchmark with separately labelled cold CLI, MCP, and remote-provider cases when a release needs those comparisons.
 - Add dashboard-side performance telemetry for API latency and payload sizes.
 - Document recommended retention schedules for large projects.
 - Evaluate a persistent cross-process retrieval index only as a major-version

--- a/docs/dev-log/progress.txt
+++ b/docs/dev-log/progress.txt
@@ -4,14 +4,39 @@
 > older notes when they conflict.
 
 ## Current State
-- Phase: 1.2.4 persistent memory delivery release candidate
-- Branch: `codex/1.2.4-persistent-memory-delivery`
-- Last updated: 2026-07-26
-- Released baseline: `memorix@1.2.3`, tag `v1.2.3`, `origin/main` at
-  `03ceb6d`.
-- Goal: make the existing persistent memory layer deliver useful prior work
-  naturally across MCP and CLI without turning ordinary tasks into historical
-  context dumps.
+- Phase: 1.2.5 retrieval performance and reliability release candidate
+- Branch: `codex/1.2.5-retrieval-performance`
+- Last updated: 2026-07-27
+- Released baseline: `memorix@1.2.4`, tag `v1.2.4`, `origin/main` at
+  `24f3b9b`.
+- Goal: make ordinary retrieval deterministic and bounded without changing the
+  local SQLite + in-process Orama architecture.
+
+## 1.2.5 Retrieval Performance and Reliability
+- Retrieval now has three explicit profiles: `fast` is fully local, `balanced`
+  is the default vector-capable path without LLM query work, and `thorough`
+  explicitly opts into configured LLM query rewrite/reranking.
+- `OPENROUTER_API_KEY` remains an embedding fallback only. It activates the
+  memory LLM lane only when that lane explicitly names an OpenRouter provider
+  or base URL, preventing embedding-only configurations from adding hidden
+  network work to normal search.
+- Embedding, rerank, MCP search, and maintenance share one timeout helper that
+  clears watchdog timers after settlement. This removes the previously measured
+  avoidable CLI exit delay from a completed rerank path while preserving real
+  timeouts for stalled work.
+- Read-only memory CLI commands skip session-store and maintenance-target setup
+  while retaining the existing project/identity visibility boundary.
+- Local verification completed before release: TypeScript check; focused
+  timeout/config/search/CLI/SDK tests; a full serial suite that reached a
+  single stale Codex plugin-manifest version assertion, followed by its
+  dedicated passing recheck after the template was synced; production build;
+  package SDK benchmark; real CLI smoke; and an in-memory MCP client smoke
+  confirming `memorix_search.quality` and `fast` mode.
+- Current benchmark evidence on Windows/Node 22: a 1,000-record hot in-process
+  SDK lexical fixture measured specific lookup p50 44.603 ms / p95 96.085 ms
+  and broad-query p50 160.903 ms / p95 171.878 ms. This excludes CLI startup,
+  MCP transport, remote embeddings, and LLM work by design; the two query
+  shapes are reported separately rather than averaged into a marketing number.
 
 ## 1.2.4 Persistent Memory Delivery
 - Continuation is now a bounded delivery projection over existing sessions and

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,
@@ -62,6 +62,7 @@
     "test:llm-live": "MEMORIX_RUN_LIVE_LLM_TESTS=1 vitest run tests/integration/formation-llm-quality.test.ts",
     "test:e2e": "vitest run tests/e2e/",
     "benchmark:codegraph": "node scripts/benchmark-codegraph-provider.cjs",
+    "benchmark:retrieval": "npm run build && node scripts/benchmark-retrieval.mjs",
     "lint": "tsc --noEmit",
     "prepublishOnly": "npm run build && npm test"
   },

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/scripts/benchmark-retrieval.mjs
+++ b/scripts/benchmark-retrieval.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+
+/*
+ * Reproducible hot-path retrieval measurement.
+ *
+ * This exercises the public SDK in one process after seeding a temporary Git
+ * project. It intentionally uses the fast profile with embeddings disabled,
+ * so its numbers describe local lexical retrieval only, not CLI startup, MCP
+ * transport, remote embedding, or LLM provider latency.
+ */
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+function readPositiveOption(name, fallback, maximum) {
+  const index = process.argv.indexOf(name);
+  const raw = index >= 0 ? process.argv[index + 1] : undefined;
+  if (raw === undefined) return fallback;
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(value) || value <= 0 || value > maximum) {
+    throw new Error(`${name} must be an integer between 1 and ${maximum}.`);
+  }
+  return value;
+}
+
+function percentile(samples, fraction) {
+  const index = Math.min(samples.length - 1, Math.max(0, Math.ceil(samples.length * fraction) - 1));
+  return samples[index];
+}
+
+function uniqueLookupToken(index) {
+  let value = index;
+  let suffix = '';
+  do {
+    suffix = String.fromCharCode(97 + (value % 26)) + suffix;
+    value = Math.floor(value / 26) - 1;
+  } while (value >= 0);
+  return `lookupkey${suffix}`;
+}
+
+function summarize(samples) {
+  samples.sort((left, right) => left - right);
+  return {
+    min: Number(samples[0].toFixed(3)),
+    p50: Number(percentile(samples, 0.5).toFixed(3)),
+    p95: Number(percentile(samples, 0.95).toFixed(3)),
+    p99: Number(percentile(samples, 0.99).toFixed(3)),
+    max: Number(samples.at(-1).toFixed(3)),
+  };
+}
+
+async function measureSearch(client, runs, queryForRun) {
+  for (let index = 0; index < Math.min(20, runs); index += 1) {
+    await client.search({ query: queryForRun(index), quality: 'fast', limit: 10 });
+  }
+
+  const samples = [];
+  for (let index = 0; index < runs; index += 1) {
+    const started = performance.now();
+    await client.search({ query: queryForRun(index), quality: 'fast', limit: 10 });
+    samples.push(performance.now() - started);
+  }
+  return summarize(samples);
+}
+
+async function packageVersion() {
+  const pkg = JSON.parse(await readFile(path.join(root, 'package.json'), 'utf8'));
+  return pkg.version;
+}
+
+async function main() {
+  const records = readPositiveOption('--records', 1_000, 100_000);
+  const runs = readPositiveOption('--runs', 100, 10_000);
+  const sandbox = await mkdtemp(path.join(tmpdir(), 'memorix-retrieval-benchmark-'));
+  const projectRoot = path.join(sandbox, 'project');
+  const dataDir = path.join(sandbox, 'data');
+
+  process.env.MEMORIX_DATA_DIR = dataDir;
+  process.env.MEMORIX_EMBEDDING = 'off';
+
+  try {
+    const git = spawnSync('git', ['init', '--quiet', projectRoot], { encoding: 'utf8', windowsHide: true });
+    if (git.status !== 0) {
+      throw new Error(`git init failed: ${git.stderr || git.stdout || 'unknown error'}`);
+    }
+
+    const { createMemoryClient } = await import('../dist/sdk.js');
+    const client = await createMemoryClient({ projectRoot, silent: true });
+    const seedStarted = performance.now();
+
+    for (let index = 0; index < records; index += 1) {
+      const lookupToken = uniqueLookupToken(index);
+      await client.store({
+        entityName: `module-${index % 64}`,
+        type: index % 5 === 0 ? 'decision' : 'discovery',
+        title: `Retrieval benchmark record ${index}`,
+        narrative: `Module ${index % 64} recorded deterministic retrieval evidence for scenario ${index} with ${lookupToken}.`,
+        facts: [`scenario=${index}`, `module=${index % 64}`, lookupToken],
+        concepts: ['benchmark', 'retrieval', `module-${index % 64}`, lookupToken],
+      });
+    }
+    const seedAndIndexMs = performance.now() - seedStarted;
+
+    const specific = await measureSearch(client, runs, (index) => uniqueLookupToken(index % records));
+    const broad = await measureSearch(client, runs, () => 'retrieval evidence');
+    await client.close();
+
+    console.log(JSON.stringify({
+      version: await packageVersion(),
+      node: process.version,
+      platform: process.platform,
+      arch: process.arch,
+      records,
+      runs,
+      mode: 'hot in-process SDK lexical retrieval; fast profile; embeddings and LLM disabled',
+      seedAndIndexMs: Number(seedAndIndexMs.toFixed(3)),
+      latencyMs: {
+        specific,
+        broad,
+      },
+    }, null, 2));
+  } finally {
+    await rm(sandbox, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -7,8 +7,10 @@ import { canManageObservation, filterReadableObservations, resolveObservationVis
 import {
   coerceObservationStatus,
   coerceObservationType,
+  coerceRetrievalQuality,
   emitError,
   emitResult,
+  getCliReadContext,
   getCliProjectContext,
   parseCsvList,
   parsePositiveInt,
@@ -36,6 +38,7 @@ export default defineCommand({
     topicKey: { type: 'string', description: 'Stable topic key override' },
     action: { type: 'string', description: 'Secondary action for advanced memory commands' },
     limit: { type: 'string', description: 'Limit for search/recent output' },
+    quality: { type: 'string', description: 'Retrieval profile: fast, balanced (default), or thorough' },
     graphLimit: { type: 'string', description: 'Limit for graph-context output' },
     graphQuery: { type: 'string', description: 'Query for graph-context packet' },
     format: { type: 'string', description: 'Output format for graph-context: summary or prompt' },
@@ -56,7 +59,12 @@ export default defineCommand({
     const asJson = !!args.json;
 
     try {
-      const { project, dataDir, reader, identity } = await getCliProjectContext({ searchIndex: true });
+      const readOnlyActions = new Set(['', 'search', 'graph-context', 'recent', 'suggest-topic-key', 'detail', 'timeline']);
+      const needsSearchIndex = action === 'search' || action === 'detail' || action === 'timeline';
+      const context = readOnlyActions.has(action)
+        ? await getCliReadContext({ searchIndex: needsSearchIndex })
+        : await getCliProjectContext({ searchIndex: true });
+      const { project, dataDir, reader, identity } = context;
 
       switch (action) {
         case 'search': {
@@ -66,7 +74,8 @@ export default defineCommand({
             return;
           }
           const limit = parsePositiveInt(args.limit as string | undefined, 10);
-          const result = await compactSearch({ query, limit, projectId: project.id, reader });
+          const quality = coerceRetrievalQuality(args.quality as string | undefined);
+          const result = await compactSearch({ query, limit, quality, projectId: project.id, reader });
           emitResult({ project, entries: result.entries }, result.formatted, asJson);
           return;
         }
@@ -420,7 +429,7 @@ export default defineCommand({
           console.log('Memorix Memory Commands');
           console.log('');
           console.log('Usage:');
-          console.log('  memorix memory search --query "timeout bug" [--limit 10]');
+          console.log('  memorix memory search --query "timeout bug" [--limit 10] [--quality fast|balanced|thorough]');
           console.log('  memorix memory recent [--limit 10]');
           console.log('  memorix memory store --text "..." [--title "..."] [--type discovery] [--visibility project|personal|team]');
           console.log('  memorix memory suggest-topic-key --type decision --title "..."');

--- a/src/cli/commands/operator-shared.ts
+++ b/src/cli/commands/operator-shared.ts
@@ -9,9 +9,10 @@ import type {
   ObservationStatus,
   ObservationType,
   ObservationVisibility,
+  RetrievalQuality,
 } from '../../types.js';
 import { getCliInvocation } from '../invocation.js';
-import { resolveCliIdentity, type CliIdentity } from '../identity.js';
+import { loadCliIdentity, resolveCliIdentity, type CliIdentity } from '../identity.js';
 
 export interface CliProjectContext {
   project: ProjectInfo;
@@ -22,7 +23,24 @@ export interface CliProjectContext {
   identityWarning?: string;
 }
 
-export async function getCliProjectContext(options?: { searchIndex?: boolean; projectRoot?: string }): Promise<CliProjectContext> {
+export interface CliReadContext {
+  project: ProjectInfo;
+  dataDir: string;
+  reader: ObservationReader;
+  identity: CliIdentity | null;
+  identityWarning?: string;
+}
+
+interface CliContextOptions {
+  searchIndex?: boolean;
+  projectRoot?: string;
+}
+
+async function resolveCliProjectContext(options?: CliContextOptions): Promise<{
+  project: ProjectInfo;
+  dataDir: string;
+  invocation: ReturnType<typeof getCliInvocation>;
+}> {
   const invocation = getCliInvocation();
   const detection = detectProjectWithDiagnostics(
     options?.projectRoot
@@ -37,6 +55,51 @@ export async function getCliProjectContext(options?: { searchIndex?: boolean; pr
 
   const project = detection.project;
   const dataDir = await getProjectDataDir(project.id);
+  return { project, dataDir, invocation };
+}
+
+/**
+ * Read-only memory commands do not need session bookkeeping or maintenance
+ * target registration. Identity resolution remains intact so visibility rules
+ * stay identical to the full operator context.
+ */
+export async function getCliReadContext(options?: CliContextOptions): Promise<CliReadContext> {
+  const { project, dataDir, invocation } = await resolveCliProjectContext(options);
+  await initObservations(dataDir);
+
+  if (options?.searchIndex) {
+    await prepareSearchIndex();
+  }
+
+  const storedIdentity = await loadCliIdentity(dataDir, project.id);
+  if (!invocation.actorId && !storedIdentity) {
+    return {
+      project,
+      dataDir,
+      reader: { projectId: project.id },
+      identity: null,
+    };
+  }
+
+  const teamStore = await initTeamStore(dataDir);
+  const identity = await resolveCliIdentity({
+    project,
+    dataDir,
+    teamStore,
+    explicitActorId: invocation.actorId,
+  });
+
+  return {
+    project,
+    dataDir,
+    reader: identity.reader,
+    identity: identity.identity,
+    ...(identity.warning ? { identityWarning: identity.warning } : {}),
+  };
+}
+
+export async function getCliProjectContext(options?: CliContextOptions): Promise<CliProjectContext> {
+  const { project, dataDir, invocation } = await resolveCliProjectContext(options);
   try {
     const { MaintenanceTargetStore } = await import('../../runtime/maintenance-targets.js');
     new MaintenanceTargetStore(dataDir).register({
@@ -129,6 +192,7 @@ const OBSERVATION_TYPES: ObservationType[] = [
 ];
 
 const OBSERVATION_STATUSES: ObservationStatus[] = ['active', 'resolved', 'archived'];
+const RETRIEVAL_QUALITIES: RetrievalQuality[] = ['fast', 'balanced', 'thorough'];
 
 export function coerceObservationType(input?: string): ObservationType {
   const normalized = (input ?? 'discovery') as ObservationType;
@@ -146,6 +210,14 @@ export function coerceObservationStatus(input?: string): ObservationStatus {
     throw new Error(
       `Unknown observation status "${input}". Valid statuses: ${OBSERVATION_STATUSES.join(', ')}`,
     );
+  }
+  return normalized;
+}
+
+export function coerceRetrievalQuality(input?: string): RetrievalQuality {
+  const normalized = (input ?? 'balanced').trim().toLowerCase() as RetrievalQuality;
+  if (!RETRIEVAL_QUALITIES.includes(normalized)) {
+    throw new Error('quality must be fast, balanced, or thorough');
   }
   return normalized;
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -985,12 +985,14 @@ const main = defineCommand({
       args: {
         query: { type: 'positional', description: 'Search query', required: true },
         limit: { type: 'string', description: 'Maximum results' },
+        quality: { type: 'string', description: 'Retrieval profile: fast, balanced (default), or thorough' },
         json: { type: 'boolean', description: 'Emit machine-readable JSON output' },
       },
       async run({ args }) {
         await runMemoryShortcut('search', {
           query: args.query,
           limit: args.limit,
+          quality: args.quality,
           json: args.json,
         });
       },

--- a/src/config/resolved-config.ts
+++ b/src/config/resolved-config.ts
@@ -88,6 +88,27 @@ export function getResolvedConfig(options: ResolvedLaneOptions = {}): ResolvedMe
   const legacy = loadFileConfig();
   const embeddingBaseUrl = first(process.env.MEMORIX_EMBEDDING_BASE_URL, toml.embedding?.base_url, yaml.embedding?.baseUrl, legacy.embeddingApi?.baseUrl);
   const openRouterEmbeddingApiKey = isOpenRouterUrl(embeddingBaseUrl) ? process.env.OPENROUTER_API_KEY : undefined;
+  const memoryLlmProvider = first(
+    process.env.MEMORIX_LLM_PROVIDER,
+    toml.memory?.llm?.provider,
+    yaml.llm?.provider,
+    legacy.llm?.provider,
+  );
+  const memoryLlmModel = first(
+    process.env.MEMORIX_LLM_MODEL,
+    toml.memory?.llm?.model,
+    yaml.llm?.model,
+    legacy.llm?.model,
+  );
+  const memoryLlmBaseUrl = first(
+    process.env.MEMORIX_LLM_BASE_URL,
+    toml.memory?.llm?.base_url,
+    yaml.llm?.baseUrl,
+    legacy.llm?.baseUrl,
+  );
+  const openRouterMemoryLlmApiKey = isOpenRouterMemoryLane(memoryLlmProvider, memoryLlmBaseUrl)
+    ? process.env.OPENROUTER_API_KEY
+    : undefined;
 
   const resolved: ResolvedMemorixConfig = {
     agent: {
@@ -126,9 +147,9 @@ export function getResolvedConfig(options: ResolvedLaneOptions = {}): ResolvedMe
       autoCleanup: firstBool(toml.memory?.auto_cleanup, yaml.behavior?.autoCleanup),
       syncAdvisory: firstBool(toml.memory?.sync_advisory, yaml.behavior?.syncAdvisory),
       llm: {
-        provider: first(process.env.MEMORIX_LLM_PROVIDER, toml.memory?.llm?.provider, yaml.llm?.provider, legacy.llm?.provider),
-        model: first(process.env.MEMORIX_LLM_MODEL, toml.memory?.llm?.model, yaml.llm?.model, legacy.llm?.model),
-        baseUrl: first(process.env.MEMORIX_LLM_BASE_URL, toml.memory?.llm?.base_url, yaml.llm?.baseUrl, legacy.llm?.baseUrl),
+        provider: memoryLlmProvider,
+        model: memoryLlmModel,
+        baseUrl: memoryLlmBaseUrl,
         apiKey: first(
           process.env.MEMORIX_LLM_API_KEY,
           process.env.MEMORIX_API_KEY,
@@ -137,7 +158,7 @@ export function getResolvedConfig(options: ResolvedLaneOptions = {}): ResolvedMe
           legacy.llm?.apiKey,
           process.env.OPENAI_API_KEY,
           process.env.ANTHROPIC_API_KEY,
-          process.env.OPENROUTER_API_KEY,
+          openRouterMemoryLlmApiKey,
         ),
       },
     },
@@ -288,6 +309,10 @@ function isOpenRouterUrl(value: string | undefined): boolean {
   } catch {
     return /(^|\.)openrouter\.ai(?::|\/|$)/i.test(value);
   }
+}
+
+function isOpenRouterMemoryLane(provider: string | undefined, baseUrl: string | undefined): boolean {
+  return provider?.trim().toLowerCase() === 'openrouter' || isOpenRouterUrl(baseUrl);
 }
 
 function normalizeExternalContext(value: string | undefined): 'auto' | 'off' | undefined {

--- a/src/runtime/project-maintenance.ts
+++ b/src/runtime/project-maintenance.ts
@@ -9,6 +9,7 @@ import {
   enqueueObservationQualification,
   type MaintenanceQueue,
 } from './lifecycle.js';
+import { withTimeout } from '../timeout.js';
 
 const DEFAULT_VECTOR_BATCH_SIZE = 12;
 const DEFAULT_RETENTION_BATCH_SIZE = 100;
@@ -108,20 +109,6 @@ async function loadWorkspaceForMaintenance(
     loadKnowledgeWorkspace({ projectId, dataDir: projectDir, mode: 'local' }),
   ]);
   return versioned ?? local;
-}
-
-/**
- * Creates handlers for one initialized project runtime. The worker itself is
- * project-scoped so it never claims a different project's queued work.
- */
-function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
-  return new Promise<T>((resolve, reject) => {
-    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
-    promise.then(
-      (value) => { clearTimeout(timer); resolve(value); },
-      (error) => { clearTimeout(timer); reject(error); },
-    );
-  });
 }
 
 async function runAutomaticConsolidation(

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -26,6 +26,7 @@ import type {
   ProjectInfo,
   DetectionResult,
   ObservationReader,
+  RetrievalQuality,
 } from './types.js';
 import {
   canManageObservation,
@@ -90,6 +91,8 @@ export interface ClientSearchOptions {
   status?: ObservationStatus | 'all';
   /** Maximum results. Default: 20 */
   limit?: number;
+  /** Retrieval profile. Default: balanced. */
+  quality?: RetrievalQuality;
 }
 
 /** Result from resolving observations */
@@ -220,6 +223,7 @@ export class MemoryClient {
       type: options.type,
       source: options.source,
       status: options.status === 'all' ? undefined : (options.status ?? 'active'),
+      quality: options.quality,
       reader: this._reader,
     };
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -50,22 +50,12 @@ import type { ExistingMemory } from './llm/memory-manager.js';
 import { runFormation, getMetricsSummary, getBeforeAfterMetrics } from './memory/formation/index.js';
 import type { FormationConfig, SearchHit, FormedMemory, FormationStage, FormationStageEvent } from './memory/formation/types.js';
 import { parseFormationTimeoutMs } from './server/formation-timeout.js';
+import { withTimeout } from './timeout.js';
 
 // ── Timeout budgets for LLM-heavy paths ──────────────────────────
 const FORMATION_TIMEOUT_MS = parseFormationTimeoutMs(process.env.MEMORIX_FORMATION_TIMEOUT_MS); // Formation pipeline (extract+resolve+evaluate)
 const COMPACT_ON_WRITE_TIMEOUT_MS = 12_000; // Legacy compact-on-write fallback path
 const COMPRESSION_TIMEOUT_MS = 5_000;  // Narrative compression
-
-/** Race a promise against a timeout. Rejects with a descriptive Error on timeout. */
-function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
-  let timer: ReturnType<typeof setTimeout>;
-  return Promise.race([
-    promise,
-    new Promise<never>((_, reject) => {
-      timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
-    }),
-  ]).finally(() => clearTimeout(timer!));
-}
 
 function formatFormationStageDurations(stageDurationsMs: Partial<Record<FormationStage, number>>): string {
   const orderedStages: FormationStage[] = ['extract', 'resolve', 'evaluate'];
@@ -1310,6 +1300,9 @@ export async function createMemorixServer(
         source: z.enum(['agent', 'git', 'manual']).optional().describe(
           'Filter by memory source. "git" returns only commit-derived ground truth memories. Omit for all sources.',
         ),
+        quality: z.enum(['fast', 'balanced', 'thorough']).optional().default('balanced').describe(
+          'Retrieval profile: fast stays local, balanced uses configured embeddings, thorough explicitly permits optional LLM refinement.',
+        ),
         purpose: z.string().optional().describe(
           'Why this must expand beyond the latest Autopilot brief. Name the missing fact or the user\'s explicit request.',
         ),
@@ -1318,7 +1311,7 @@ export async function createMemorixServer(
         ),
       },
     },
-    async ({ query, limit, type, maxTokens, scope, since, until, status, source, purpose, force }) => {
+    async ({ query, limit, type, maxTokens, scope, since, until, status, source, quality, purpose, force }) => {
       if (scope !== 'global') {
         const unresolved = requireResolvedProject('search the current project');
         if (unresolved) return unresolved;
@@ -1346,18 +1339,15 @@ export async function createMemorixServer(
         projectId: scope === 'global' ? undefined : project.id,
         status: (status as 'active' | 'resolved' | 'archived' | 'all') ?? 'active',
         source: source as 'agent' | 'git' | 'manual' | undefined,
+        quality: quality as 'fast' | 'balanced' | 'thorough',
         reader: getObservationReader(scope === 'global' ? 'global' : 'project'),
       });
 
-      const timeoutPromise = new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error(`Search timeout after ${TIMEOUT_MS}ms`)), TIMEOUT_MS)
-      );
-
       let result;
       try {
-        result = await Promise.race([searchPromise, timeoutPromise]);
+        result = await withTimeout(searchPromise, TIMEOUT_MS, 'Search');
       } catch (error) {
-        if (error instanceof Error && error.message.includes('timeout')) {
+        if (error instanceof Error && /\btimeout\b|timed out/i.test(error.message)) {
           // Timeout: return empty result with error message
           return {
             content: [

--- a/src/store/orama-store.ts
+++ b/src/store/orama-store.ts
@@ -17,6 +17,7 @@ import { getEmbeddingProvider, type EmbeddingProvider } from '../embedding/provi
 import { calculateProjectAffinity, extractProjectKeywords, type AffinityContext, type MemoryContent } from './project-affinity.js';
 import { detectQueryIntent, applyIntentBoost } from '../search/intent-detector.js';
 import { maybeExpandSearchQuery } from '../search/query-expansion.js';
+import { withTimeout } from '../timeout.js';
 
 let db: AnyOrama | null = null;
 let dbInitPromise: Promise<AnyOrama> | null = null;
@@ -501,8 +502,12 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
   const t0 = perf ? performance.now() : 0;
   const mark = (label: string) => { if (perf) { const now = performance.now(); process.stderr.write(`  [search-perf] ${label}: ${(now - t0).toFixed(0)}ms\n`); } };
   const modeKey = options.projectId ?? SEARCH_MODE_DEFAULT_KEY;
-  lastSearchModeByProject.set(modeKey, embeddingEnabled ? 'hybrid' : 'fulltext');
+  const quality = options.quality ?? 'balanced';
   const database = await getDb();
+  lastSearchModeByProject.set(
+    modeKey,
+    quality === 'fast' ? 'fulltext (fast profile)' : embeddingEnabled ? 'hybrid' : 'fulltext',
+  );
 
   // Resolve project aliases — safety net for observations not yet migrated to canonical ID.
   // After migration, this is typically a single-element array matching options.projectId.
@@ -531,17 +536,28 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
   // Determine search mode: hybrid (with vector) or fulltext (default)
   const hasQuery = options.query && options.query.trim().length > 0;
   const originalQuery = options.query;
-  const tier = hasQuery ? classifyQueryTier(originalQuery!) : 'fast' as QueryTier;
+  // The fast profile is a bounded local probe, not a lower-quality spelling
+  // corrector. Skip query classification and the expensive recall enrichments
+  // it would otherwise inherit from the balanced path.
+  const tier = quality === 'fast' ? 'fast' as QueryTier : hasQuery ? classifyQueryTier(originalQuery!) : 'fast' as QueryTier;
   mark(`tier=${tier}`);
 
-  // Query expansion: only for heavy-tier (CJK) queries
-  const expandedEmbeddingQuery = tier === 'heavy' ? await maybeExpandSearchQuery(options.query!) : options.query;
+  // LLM quality work is explicit. It never runs on the default search path.
+  if (quality === 'thorough' && hasQuery) {
+    const { initLLM, isLLMEnabled } = await import('../llm/provider.js');
+    if (!isLLMEnabled()) initLLM();
+  }
+
+  // Query expansion: only for thorough heavy-tier (CJK) searches.
+  const expandedEmbeddingQuery = quality === 'thorough' && tier === 'heavy'
+    ? await maybeExpandSearchQuery(options.query!)
+    : options.query;
   mark('queryExpansion');
 
   // ── Intent-Aware Recall ──────────────────────────────────────
   // Detect query intent (why/when/how/what/problem) and adjust
   // field weights and type boosting accordingly.
-  const intentResult = hasQuery ? detectQueryIntent(originalQuery!) : null;
+  const intentResult = quality === 'fast' || !hasQuery ? null : detectQueryIntent(originalQuery!);
 
   // Orama's vector/hybrid search can leak cross-project hits even when `where`
   // is present, so always keep enough headroom for a deterministic post-filter.
@@ -565,20 +581,24 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
   let searchParams: Record<string, unknown> = {
     term: originalQuery,
     limit: requestLimit,
-    includeVectors: true,
+    // Fast search never uses vectors, so returning them only adds work and
+    // payload pressure to an explicitly latency-sensitive path.
+    includeVectors: quality !== 'fast',
     ...(Object.keys(filters).length > 0 ? { where: filters } : {}),
     // Search specific fields (not tokens, accessCount, etc.)
     properties: ['title', 'entityName', 'narrative', 'facts', 'concepts', 'filesModified'],
     // Field boosting: intent-aware or default
     boost: fieldBoost,
     // Fuzzy tolerance: allow 1-char typos for short queries, 2 for longer
-    ...(hasQuery ? { tolerance: originalQuery!.length > 6 ? 2 : 1 } : {}),
+    // Fuzzy matching is useful for ordinary recall, but grows sharply with
+    // corpus size. The fast profile deliberately uses exact lexical matching.
+    ...(hasQuery && quality !== 'fast' ? { tolerance: originalQuery!.length > 6 ? 2 : 1 } : {}),
   };
 
   // If embedding provider is available and query tier warrants it, use hybrid search
   // Fast-tier queries skip embedding entirely (fulltext is sufficient)
   let queryVector: number[] | null = null;
-  if (embeddingEnabled && hasQuery && tier !== 'fast') {
+  if (quality !== 'fast' && embeddingEnabled && hasQuery && tier !== 'fast') {
     try {
       const provider = await getEmbeddingProvider();
       if (provider) {
@@ -594,11 +614,11 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
         } else {
           // Embedding timeout: 15 seconds
           const EMBEDDING_TIMEOUT_MS = 15000;
-          const embedPromise = provider.embed(expandedEmbeddingQuery!);
-          const timeoutPromise = new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error(`Embedding timeout after ${EMBEDDING_TIMEOUT_MS}ms`)), EMBEDDING_TIMEOUT_MS)
+          queryVector = await withTimeout(
+            provider.embed(expandedEmbeddingQuery!),
+            EMBEDDING_TIMEOUT_MS,
+            'Embedding',
           );
-          queryVector = await Promise.race([embedPromise, timeoutPromise]);
           mark('embedding');
           // Detect CJK-heavy queries: BM25 can't tokenize Chinese/Japanese/Korean well
           const cjkRatio = (originalQuery!.match(/[\u4e00-\u9fff\u3040-\u309f\u30a0-\u30ff\uac00-\ud7af]/g) || []).length / originalQuery!.length;
@@ -946,9 +966,10 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
 
   // ── LLM Reranking (heavy-tier only) ────────────────────────────
   // Only triggered for heavy-tier queries with ambiguous top results.
-  // Fast and standard tiers skip entirely.
+  // Non-thorough profiles, fast, and standard tiers skip entirely.
   // Ambiguity check: top-2 scores within 30% → results are uncertain.
-  const shouldRerank = tier === 'heavy'
+  const shouldRerank = quality === 'thorough'
+    && tier === 'heavy'
     && hasQuery
     && intermediate.length > 2
     && (() => {
@@ -979,11 +1000,11 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
       // LLM rerank timeout: configurable via MEMORIX_RERANK_TIMEOUT_MS, default 5s
       const _parsedRerank = parseInt(process.env.MEMORIX_RERANK_TIMEOUT_MS || '', 10);
       const RERANK_TIMEOUT_MS = Number.isFinite(_parsedRerank) && _parsedRerank > 0 ? _parsedRerank : 5000;
-      const rerankPromise = rerankResults(originalQuery!, candidates);
-      const timeoutPromise = new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error(`LLM rerank timeout after ${RERANK_TIMEOUT_MS}ms`)), RERANK_TIMEOUT_MS)
+      const { reranked, usedLLM } = await withTimeout(
+        rerankResults(originalQuery!, candidates),
+        RERANK_TIMEOUT_MS,
+        'LLM rerank',
       );
-      const { reranked, usedLLM } = await Promise.race([rerankPromise, timeoutPromise]);
       mark(`rerank(usedLLM=${usedLLM})`);
       
       if (usedLLM) {

--- a/src/timeout.ts
+++ b/src/timeout.ts
@@ -1,0 +1,23 @@
+/**
+ * Run an operation with a bounded wait without leaving its watchdog alive.
+ *
+ * The underlying operation is not force-cancelled because many existing
+ * callers do not expose an AbortSignal. Its settlement is still observed so a
+ * late rejection is handled, while the caller receives the timeout promptly.
+ */
+export function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${label} timed out after ${ms}ms`)), ms);
+
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -239,6 +239,9 @@ export interface TimelineContext {
   after: IndexEntry[];
 }
 
+/** Retrieval work allowed for a search request. */
+export type RetrievalQuality = 'fast' | 'balanced' | 'thorough';
+
 /** Search options for the compact engine */
 export interface SearchOptions {
   query: string;
@@ -257,6 +260,11 @@ export interface SearchOptions {
   trackAccess?: boolean;
   /** Internal reader context for agent-facing visibility filtering. */
   reader?: ObservationReader;
+  /**
+   * `fast` stays fully local, `balanced` (default) permits embeddings, and
+   * `thorough` explicitly permits optional LLM query rewrite and reranking.
+   */
+  quality?: RetrievalQuality;
 }
 
 /** Topic key family heuristics for suggesting stable topic keys */

--- a/tests/cli/operator-surface.test.ts
+++ b/tests/cli/operator-surface.test.ts
@@ -356,6 +356,29 @@ describe('CLI operator surface', () => {
     expect(JSON.parse(typedDetail.stdout).documents[0].title).toBe('Positional memory');
   });
 
+  it('forwards an explicit fast retrieval profile through the memory CLI', async () => {
+    await runCommand(memoryCommand, {
+      _: ['store'],
+      text: 'Fast profile should avoid optional remote retrieval work.',
+      title: 'Fast retrieval contract',
+      entity: 'cli-memory',
+      type: 'decision',
+      json: true,
+    });
+
+    const search = await runCommand(memoryCommand, {
+      _: ['search'],
+      query: 'fast retrieval contract',
+      quality: 'fast',
+      json: true,
+    });
+
+    expect(search.exitCode).toBe(0);
+    expect(JSON.parse(search.stdout).entries[0].title).toBe('Fast retrieval contract');
+    const { getLastSearchMode } = await import('../../src/store/orama-store.js');
+    expect(getLastSearchMode('local/repo')).toContain('fast profile');
+  });
+
   it('audits project memory quality from the audit namespace', async () => {
     await runCommand(memoryCommand, {
       _: ['store'],

--- a/tests/config/resolved-config.test.ts
+++ b/tests/config/resolved-config.test.ts
@@ -36,6 +36,8 @@ const ENV_KEYS = [
   'MEMORIX_CODEGRAPH_EXTERNAL_COMMAND',
   'MEMORIX_CODEGRAPH_EXTERNAL_TIMEOUT_MS',
   'OPENAI_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'OPENROUTER_API_KEY',
 ];
 
 describe('resolved config', () => {
@@ -103,6 +105,34 @@ describe('resolved config', () => {
     process.env.MEMORIX_AGENT_API_KEY = 'agent-key';
 
     expect(getResolvedEmbeddingLane({ projectRoot: null, homeDir: HOME }).apiKey).toBeUndefined();
+  });
+
+  it('uses an OpenRouter key for its embedding lane without enabling the memory LLM lane', () => {
+    process.env.OPENROUTER_API_KEY = 'embedding-only-key';
+    writeFileSync(join(HOME, '.memorix', 'config.toml'), [
+      '[embedding]',
+      'provider = "api"',
+      'base_url = "https://openrouter.ai/api/v1"',
+    ].join('\n'), 'utf8');
+
+    const cfg = getResolvedConfig({ projectRoot: null, homeDir: HOME });
+
+    expect(cfg.embedding.apiKey).toBe('embedding-only-key');
+    expect(cfg.memory.llm.apiKey).toBeUndefined();
+  });
+
+  it('allows an OpenRouter key for an explicitly configured memory LLM lane', () => {
+    process.env.OPENROUTER_API_KEY = 'memory-openrouter-key';
+    process.env.MEMORIX_LLM_PROVIDER = 'openrouter';
+
+    expect(getResolvedMemoryLane({ projectRoot: null, homeDir: HOME }).llm.apiKey).toBe('memory-openrouter-key');
+  });
+
+  it('recognizes an explicit OpenRouter memory base URL without a provider label', () => {
+    process.env.OPENROUTER_API_KEY = 'memory-openrouter-base-url-key';
+    process.env.MEMORIX_LLM_BASE_URL = 'https://openrouter.ai/api/v1';
+
+    expect(getResolvedMemoryLane({ projectRoot: null, homeDir: HOME }).llm.apiKey).toBe('memory-openrouter-base-url-key');
   });
 
   it('returns memory LLM simple key from MEMORIX_API_KEY', () => {

--- a/tests/runtime/timeout.test.ts
+++ b/tests/runtime/timeout.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import { withTimeout } from '../../src/timeout.js';
+
+describe('withTimeout', () => {
+  it('clears its watchdog after a successful operation', async () => {
+    vi.useFakeTimers();
+    try {
+      await expect(withTimeout(Promise.resolve('ready'), 1_000, 'test')).resolves.toBe('ready');
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears its watchdog after an operation rejects', async () => {
+    vi.useFakeTimers();
+    try {
+      await expect(withTimeout(Promise.reject(new Error('failed')), 1_000, 'test')).rejects.toThrow('failed');
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('rejects with the supplied deadline and does not leave a live timer', async () => {
+    vi.useFakeTimers();
+    let finish!: () => void;
+    const operation = new Promise<void>((resolve) => { finish = resolve; });
+    const bounded = withTimeout(operation, 100, 'Search');
+    const timeoutExpectation = expect(bounded).rejects.toThrow('Search timed out after 100ms');
+
+    try {
+      await vi.advanceTimersByTimeAsync(100);
+      await timeoutExpectation;
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      finish();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/tests/search/orama-store-semantic.test.ts
+++ b/tests/search/orama-store-semantic.test.ts
@@ -268,7 +268,35 @@ describe('orama-store semantic hybrid search', () => {
     expect(entries[0]?.title).toContain('semantic retrieval weak');
   });
 
-  it('expands CJK natural-language queries to recover cross-lingual memories', async () => {
+  it('keeps default balanced CJK search free of LLM query expansion', async () => {
+    const { searchObservations } = await import('../../src/store/orama-store.js');
+
+    await searchObservations({
+      query: '语义检索为什么变弱',
+      projectId: 'AVIDS2/memorix',
+      limit: 5,
+      quality: 'balanced',
+    });
+
+    expect(mockCallLLM).not.toHaveBeenCalled();
+  });
+
+  it('keeps fast search on the bounded local retrieval path', async () => {
+    const { getLastSearchMode, searchObservations } = await import('../../src/store/orama-store.js');
+
+    await searchObservations({
+      query: '语义检索为什么变弱',
+      projectId: 'AVIDS2/memorix',
+      limit: 5,
+      quality: 'fast',
+    });
+
+    expect(mockInitLLM).not.toHaveBeenCalled();
+    expect(mockCallLLM).not.toHaveBeenCalled();
+    expect(getLastSearchMode('AVIDS2/memorix')).toBe('fulltext (fast profile)');
+  });
+
+  it('expands CJK natural-language queries in thorough mode to recover cross-lingual memories', async () => {
     const {
       insertObservation,
       makeOramaObservationId,
@@ -321,6 +349,7 @@ describe('orama-store semantic hybrid search', () => {
       query: '语义检索为什么变弱',
       projectId: 'AVIDS2/memorix',
       limit: 5,
+      quality: 'thorough',
     });
 
     expect(mockCallLLM).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- Add fast, balanced, and thorough retrieval profiles across SDK, CLI, and MCP.
- Keep default retrieval off the optional LLM critical path and make fast fully local.
- Clear timeout watchdogs on settlement; isolate OpenRouter embedding credentials from the memory LLM lane.
- Add reproducible specific-vs-broad retrieval benchmark evidence and a lighter read-only CLI path.

## Verification
- npm run lint
- Focused timeout, config, search, CLI, Codex hook, and MCP HTTP transport tests.
- Final npm tarball installed without optional better-sqlite3; real remember/search --quality fast smoke passed.
- 1,000-record hot SDK benchmark: specific p50 44.603ms / p95 96.085ms; broad p50 160.903ms / p95 171.878ms.

The serial full suite reached one stale Codex manifest version assertion; the template was synced and the dedicated Codex hook test then passed. The machine's parallel full-suite run is not stable for this repository's filesystem/Ink tests, so its unrelated timing failures are not used as release evidence.