### PR TITLE
feat(memcode): harden Pi overlay for 1.2.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Dependencies & Build
 node_modules/
+.npm-cache/
 dist/
 *.tgz
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.6] - 2026-07-27
+
+### Added
+- **Truthful Memcode command discovery** -- The interactive command list and editor autocomplete now derive from the same executable Pi-compatible command registry. Memorix-native `/memory` actions, including nested completion after `/memory `, are available without advertising dead commands.
+- **Deterministic memory resolution** -- `/memory delete <id>` now resolves the selected project-memory entry instead of only showing a candidate list.
+- **Pi-compatible shell session context** -- Model-initiated Memcode bash calls now receive current `PI_SESSION_ID`, `PI_SESSION_FILE`, `PI_PROVIDER`, `PI_MODEL`, and `PI_REASONING_LEVEL` metadata. Extensions can explicitly disable this exposure.
+- **Maintainer Pi-upstream audit** -- Added a pinned upstream manifest, `npm run audit:pi-upstream`, and a documented review policy. The read-only audit detects GitHub compare truncation and falls back to a full official Git-tree comparison.
+
+### Fixed
+- **No misleading terminal actions** -- Removed stale, non-dispatched TUI entries and unreachable `/git` actions, including the former implicit stage-all commit path.
+- **Memcode release identity** -- Version-check and user-agent internals now identify the published Memorix/Memcode package rather than incorrectly calling it a Pi release; bundled `memcode --version` now reports the installed Memorix release instead of an internal workspace version.
+- **Task-flag parity** -- `memorix context --task "..."` now works without a redundant positional task argument.
+- **Plugin release metadata** -- All shipped versioned plugin manifests now match the published Memorix release, including Claude Code, Codex, Copilot, Gemini CLI, OpenClaw, Oh-my-Pi, and Pi.
+- **Complete Node SQLite fallback** -- The supported Node built-in SQLite fallback now matches the transaction variants and permissive named-parameter behavior Memorix uses with `better-sqlite3`. Team task claims, Knowledge Workspace review, and other row-object writes no longer fail when the optional native binding is unavailable.
+
 ## [1.2.5] - 2026-07-27
 
 ### Added

--- a/docs/MEMCODE.md
+++ b/docs/MEMCODE.md
@@ -31,9 +31,10 @@ Both routes enter the same TUI.
 | Shared project memory | memcode reads and writes the same Memorix memory pool as MCP-connected agents |
 | Automatic capture | prompts, tool calls, assistant output, and session lifecycle feed the Memorix memory pipeline |
 | Session continuity | continue, resume, fork, name, export, and inspect coding sessions |
-| Model control | provider/model flags, `/model switch`, thinking levels, scoped model cycling |
+| Model control | provider/model flags, `/model`, thinking levels, scoped model cycling |
 | Tool control | read, bash, edit, write, grep, find, ls plus allow/deny lists |
-| Memory commands | `/memory status`, `/memory search`, `/memory show`, `/memory stats`, `/memory hooks` |
+| Shell context | model-initiated bash calls receive Pi-compatible `PI_*` session and model metadata |
+| Memory commands | `/memory status`, `/memory search`, `/memory show`, `/memory stats`, `/memory hooks`, `/memory delete <id>` |
 | Extensions | user/project skills, prompt templates, themes, and extension packages |
 | Scriptable modes | interactive TUI, print mode, JSON event stream, and RPC mode |
 
@@ -75,18 +76,18 @@ memcode @README.md @src/index.ts "what should change before release?"
 Common slash commands:
 
 ```text
-/help             show available commands
-/model switch     switch model or thinking profile
+/commands         show available commands
+/model            switch model or filter the model picker
 /memory status    inspect Memorix runtime and memory health
 /memory search    search shared project memory
 /memory show      browse stored memories
 /memory hooks     inspect hook state
+/memory delete 7  resolve memory entry 7
 /resume           resume a previous session
 /tree             navigate the session tree
 /fork             fork the current session
-/git status       show working-tree status
-/git diff         inspect a file diff
-/config           open configuration
+/settings         open configuration
+/quit             exit memcode
 ```
 
 The TUI is designed for normal coding-agent work: keep a session open, let the agent inspect files and run commands, then resume later without re-explaining the project.

--- a/docs/PI_UPSTREAM.md
+++ b/docs/PI_UPSTREAM.md
@@ -1,0 +1,59 @@
+# Pi Upstream Policy
+
+`packages/memcode` is a Memorix-native overlay on the Pi coding-agent
+runtime. Pi remains the general coding harness; Memorix adds only shared
+project memory, project identity, native hook capture, and context recovery.
+
+This repository does not silently track Pi's `main` branch and it does not use
+an automatic source overwrite. A released Memorix version is the supported,
+tested update unit for end users.
+
+## What Users Update
+
+- `memcode update --self` updates the published Memorix/memcode release.
+- `memcode update --extensions` updates installed skills, prompts, themes, and
+  extension packages through the normal Pi-compatible package path.
+- `memcode update <source>` updates one installed extension package.
+
+Those commands do not replace the core agent runtime with an unreviewed Pi
+release.
+
+## What Maintainers Review
+
+The pinned base and package mapping live in
+[`packages/memcode/pi-upstream.json`](../packages/memcode/pi-upstream.json).
+Run this from a clean, isolated branch:
+
+```powershell
+npm run audit:pi-upstream
+npm run audit:pi-upstream -- --head v0.82.1 --json
+```
+
+The audit calls the official GitHub compare API, groups changed files by the
+four forked packages, and highlights paths that overlap with Memcode's native
+integration surface. When GitHub's anonymous API limit is exhausted, it safely
+uses an already-authenticated local `gh api` session without reading or printing
+its token. It only reports. It never fetches source into the worktree, rewrites
+files, or changes the pinned base.
+
+GitHub compare exposes at most 300 file entries. When that cap is reached, the
+audit falls back to a recursive Git-tree comparison of the two official refs,
+so package and overlay counts still cover the full path set. If either tree is
+also truncated, it emits a warning: inspect the complete upstream range and
+release notes before selecting a port.
+
+## Adoption Rule
+
+1. Start with an isolated `codex/` branch and inspect the audit report.
+2. Decide feature by feature whether it belongs to Pi's general harness or
+   Memorix's native memory layer.
+3. Port only compatible runtime behavior. Do not add a second implementation
+   when Pi already owns the behavior.
+4. Preserve Memorix-specific memory, hook, and project-identity behavior.
+5. Run focused tests, package builds, and a user-facing memcode smoke before
+   publishing a Memorix release.
+
+Examples: upstream session environment metadata is compatible and useful to
+Memcode, so 1.2.6 adopts the exact `PI_*` contract for model-initiated bash
+calls. A local llama.cpp model manager is a broader Pi product surface and is
+not imported merely to chase upstream version parity.

--- a/docs/dev-log/progress.txt
+++ b/docs/dev-log/progress.txt
@@ -280,3 +280,39 @@
   the supported baseline.
 - See [1.2.2 Memory Control Plane](../1.2.2-MEMORY-CONTROL-PLANE.md) for
   phases, acceptance gates, non-goals, and release criteria.
+
+## 1.2.6 Pi Overlay Integrity
+- Replaced the stale Memcode TUI command list with one registry derived from
+  the executable Pi-compatible built-ins plus Memorix-native memory actions.
+  `/commands` and editor completion no longer advertise non-dispatched `/git`,
+  `/help`, `/config`, or synthetic session commands; nested `/memory `
+  completion is available in the live input path.
+- Made `/memory delete <id>` execute the intended project-memory resolution,
+  including fresh project-store initialization. The no-argument form remains a
+  safe list-and-select prompt.
+- Adopted Pi's current model-initiated bash session contract without changing
+  general harness behavior: Memcode supplies current `PI_*` session/model
+  metadata by default, removes stale inherited values, and lets an extension
+  opt out explicitly.
+- Added a pinned, read-only Pi upstream audit manifest and maintainer command.
+  Large upstream comparisons fall back from GitHub's capped file list to a
+  recursive official Git-tree diff before any manual adoption decision.
+- Completed the Node built-in SQLite compatibility path instead of treating it
+  as a degraded happy-path fallback: prepared statements now accept complete
+  row objects like `better-sqlite3`, and synchronous transactions implement
+  deferred, immediate, and exclusive entry points. This unblocks task claims,
+  coordination, and Knowledge Workspace review when the optional native module
+  is absent.
+- Release polish: bundled `memcode --version` resolves the verified public
+  Memorix package version; `memorix context --task "..."` no longer requires a
+  redundant positional argument; and every shipped versioned plugin manifest
+  is aligned with the public release version.
+- Final verification after the last Memcode change: `npm run lint`, the root
+  production build, the root test suite, and the complete Memcode suite all
+  passed. The Memcode suite reported 158 passing files / 1474 passing tests
+  (with its 5 opt-in skipped files / 43 skipped tests). Pi upstream audit
+  through `v0.82.1` also passed.
+- A fresh isolated installation of the final tarball verified `memorix` and
+  `memcode` version parity, all seven versioned plugin manifests, both Context
+  CLI forms, and a real stdio MCP handshake: 43 tools were discoverable and
+  `memorix_project_context` returned an Autopilot Brief.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.2.5",
+      "version": "1.2.6",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,
@@ -63,6 +63,7 @@
     "test:e2e": "vitest run tests/e2e/",
     "benchmark:codegraph": "node scripts/benchmark-codegraph-provider.cjs",
     "benchmark:retrieval": "npm run build && node scripts/benchmark-retrieval.mjs",
+    "audit:pi-upstream": "node scripts/pi-upstream-audit.mjs",
     "lint": "tsc --noEmit",
     "prepublishOnly": "npm run build && npm test"
   },

--- a/packages/memcode/README.md
+++ b/packages/memcode/README.md
@@ -27,9 +27,10 @@ Both routes enter the same memcode TUI.
 | Native project memory | memcode reads and writes the same Memorix memory pool as MCP-connected agents |
 | Hook capture | prompts, tool calls, assistant output, and session lifecycle feed the Memorix hook pipeline |
 | Session continuity | continue, resume, fork, name, export, and inspect coding sessions |
-| Model control | provider/model flags, `/model switch`, thinking levels, scoped model cycling |
+| Model control | provider/model flags, `/model`, thinking levels, scoped model cycling |
 | Tool control | read, bash, edit, write, grep, find, ls plus allow/deny lists |
-| Memory commands | `/memory status`, `/memory search`, `/memory show`, `/memory stats`, `/memory hooks` |
+| Shell context | model-initiated bash calls receive Pi-compatible `PI_*` session and model metadata |
+| Memory commands | `/memory status`, `/memory search`, `/memory show`, `/memory stats`, `/memory hooks`, `/memory delete <id>` |
 | Extensions | user/project skills, prompt templates, themes, and extension packages |
 | Scriptable modes | interactive TUI, print mode, JSON event stream, and RPC mode |
 
@@ -67,18 +68,18 @@ memcode @README.md @src/index.ts "what should change before release?"
 Common slash commands:
 
 ```text
-/help             show available commands
-/model switch     switch model or thinking profile
+/commands         show available commands
+/model            switch model or filter the model picker
 /memory status    inspect Memorix runtime and memory health
 /memory search    search shared project memory
 /memory show      browse stored memories
 /memory hooks     inspect native hook state
+/memory delete 7  resolve memory entry 7
 /resume           resume a previous session
 /tree             navigate the session tree
 /fork             fork the current session
-/git status       show working-tree status
-/git diff         inspect a file diff
-/config           open configuration
+/settings         open configuration
+/quit             exit memcode
 ```
 
 The TUI works like a normal coding agent: keep a session open, let the agent inspect files and run commands, then resume later without re-explaining the project.

--- a/packages/memcode/pi-upstream.json
+++ b/packages/memcode/pi-upstream.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "upstream": {
+    "repository": "earendil-works/pi",
+    "baseline": "v0.79.0"
+  },
+  "packages": [
+    {
+      "name": "ai",
+      "upstreamPrefix": "packages/ai/",
+      "memorixPath": "packages/ai/"
+    },
+    {
+      "name": "agent-core",
+      "upstreamPrefix": "packages/agent/",
+      "memorixPath": "packages/agent-core/"
+    },
+    {
+      "name": "tui",
+      "upstreamPrefix": "packages/tui/",
+      "memorixPath": "packages/tui/"
+    },
+    {
+      "name": "memcode",
+      "upstreamPrefix": "packages/coding-agent/",
+      "memorixPath": "packages/memcode/"
+    }
+  ],
+  "overlayWatchPaths": [
+    {
+      "name": "Memorix command and memory integration",
+      "upstreamPaths": [
+        "packages/coding-agent/src/core/slash-commands.ts",
+        "packages/coding-agent/src/modes/interactive/interactive-mode.ts",
+        "packages/coding-agent/src/core/agent-session.ts",
+        "packages/coding-agent/src/core/system-prompt.ts"
+      ]
+    },
+    {
+      "name": "Memcode extension and shell integration",
+      "upstreamPaths": [
+        "packages/coding-agent/src/core/extensions/runner.ts",
+        "packages/coding-agent/src/core/extensions/types.ts",
+        "packages/coding-agent/src/core/tools/bash.ts",
+        "packages/coding-agent/src/core/tools/index.ts"
+      ]
+    }
+  ]
+}

--- a/packages/memcode/src/config.ts
+++ b/packages/memcode/src/config.ts
@@ -452,6 +452,30 @@ interface PackageJson {
 	};
 }
 
+/**
+ * The bundled Memcode runtime has its own internal workspace manifest. When
+ * it is launched through the public Memorix package, report the public
+ * package version instead so update checks and `memcode --version` agree.
+ */
+export function resolveMemcodeVersion(
+	runtimePackage: Pick<PackageJson, "version">,
+	memorixPackageRoot = process.env.MEMORIX_PACKAGE_ROOT,
+): string {
+	const root = memorixPackageRoot?.trim();
+	if (root) {
+		try {
+			const bundledPackage = JSON.parse(readFileSync(join(resolve(root), "package.json"), "utf-8")) as PackageJson;
+			if (bundledPackage.name === "memorix" && bundledPackage.version?.trim()) {
+				return bundledPackage.version.trim();
+			}
+		} catch {
+			// The root hint is optional. Fall back to the runtime manifest when it is unavailable or invalid.
+		}
+	}
+
+	return runtimePackage.version?.trim() || "0.0.0";
+}
+
 let pkg: PackageJson = {};
 try {
 	pkg = JSON.parse(readFileSync(getPackageJsonPath(), "utf-8")) as PackageJson;
@@ -465,7 +489,7 @@ export const PACKAGE_NAME: string = pkg.name || "@memorix/memcode";
 export const APP_NAME: string = piConfigName || "memcode";
 export const APP_TITLE: string = piConfigName ? APP_NAME : "memcode";
 export const CONFIG_DIR_NAME: string = pkg.piConfig?.configDir || ".memorix";
-export const VERSION: string = pkg.version || "0.0.0";
+export const VERSION: string = resolveMemcodeVersion(pkg);
 
 // e.g., MEMCODE_CODING_AGENT_DIR
 export const ENV_AGENT_DIR = `${APP_NAME.toUpperCase()}_CODING_AGENT_DIR`;

--- a/packages/memcode/src/core/extensions/runner.ts
+++ b/packages/memcode/src/core/extensions/runner.ts
@@ -644,6 +644,10 @@ export class ExtensionRunner {
 				runner.assertActive();
 				return getModel();
 			},
+			get thinkingLevel() {
+				runner.assertActive();
+				return runner.runtime.getThinkingLevel();
+			},
 			isIdle: () => {
 				runner.assertActive();
 				return runner.isIdleFn();

--- a/packages/memcode/src/core/extensions/types.ts
+++ b/packages/memcode/src/core/extensions/types.ts
@@ -312,6 +312,8 @@ export interface ExtensionContext {
 	modelRegistry: ModelRegistry;
 	/** Current model (may be undefined) */
 	model: Model<any> | undefined;
+	/** Current thinking level, when provided by the session runtime. */
+	thinkingLevel?: ThinkingLevel;
 	/** Whether the agent is idle (not streaming) */
 	isIdle(): boolean;
 	/** The current abort signal, or undefined when the agent is not streaming. */

--- a/packages/memcode/src/core/tools/bash.ts
+++ b/packages/memcode/src/core/tools/bash.ts
@@ -15,7 +15,7 @@ import {
 	trackDetachedChildPid,
 	untrackDetachedChildPid,
 } from "../../utils/shell.ts";
-import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.ts";
+import type { ExtensionContext, ToolDefinition, ToolRenderResultOptions } from "../extensions/types.ts";
 import { OutputAccumulator } from "./output-accumulator.ts";
 import { getTextOutput, invalidArgText, str } from "./render-utils.ts";
 import { wrapToolDefinition } from "./tool-definition-wrapper.ts";
@@ -133,8 +133,36 @@ export interface BashSpawnContext {
 
 export type BashSpawnHook = (context: BashSpawnContext) => BashSpawnContext;
 
-function resolveSpawnContext(command: string, cwd: string, spawnHook?: BashSpawnHook): BashSpawnContext {
-	const baseContext: BashSpawnContext = { command, cwd, env: { ...getShellEnv() } };
+function resolveSpawnContext(
+	command: string,
+	cwd: string,
+	spawnHook: BashSpawnHook | undefined,
+	exposeSessionEnvironment: boolean,
+	ctx: ExtensionContext | undefined,
+): BashSpawnContext {
+	const env = { ...getShellEnv() };
+
+	// Avoid leaking stale metadata when memcode is launched from another session.
+	delete env.PI_SESSION_ID;
+	delete env.PI_SESSION_FILE;
+	delete env.PI_PROVIDER;
+	delete env.PI_MODEL;
+	delete env.PI_REASONING_LEVEL;
+
+	const sessionManager = ctx?.sessionManager;
+	if (exposeSessionEnvironment && sessionManager && typeof sessionManager.getSessionId === "function") {
+		const sessionId = sessionManager.getSessionId();
+		if (sessionId) env.PI_SESSION_ID = sessionId;
+		const sessionFile = sessionManager.getSessionFile?.();
+		if (sessionFile) env.PI_SESSION_FILE = sessionFile;
+		if (ctx?.model) {
+			env.PI_PROVIDER = ctx.model.provider;
+			env.PI_MODEL = ctx.model.id;
+		}
+		if (ctx?.thinkingLevel) env.PI_REASONING_LEVEL = ctx.thinkingLevel;
+	}
+
+	const baseContext: BashSpawnContext = { command, cwd, env };
 	return spawnHook ? spawnHook(baseContext) : baseContext;
 }
 
@@ -145,6 +173,8 @@ export interface BashToolOptions {
 	commandPrefix?: string;
 	/** Optional explicit shell path from settings */
 	shellPath?: string;
+	/** Expose current Pi-compatible session metadata as PI_* environment variables. Default: true. */
+	exposeSessionEnvironment?: boolean;
 	/** Hook to adjust command, cwd, or env before execution */
 	spawnHook?: BashSpawnHook;
 }
@@ -273,6 +303,7 @@ export function createBashToolDefinition(
 	const ops = options?.operations ?? createLocalBashOperations({ shellPath: options?.shellPath });
 	const commandPrefix = options?.commandPrefix;
 	const spawnHook = options?.spawnHook;
+	const exposeSessionEnvironment = options?.exposeSessionEnvironment ?? true;
 	const shellGuidance =
 		process.platform === "win32"
 			? "On Windows, prefer PowerShell-compatible commands, `rg`, and scoped `Get-ChildItem`/`Select-String`; quote paths and never run Unix root scans like `find /`."
@@ -285,16 +316,25 @@ export function createBashToolDefinition(
 			process.platform === "win32"
 				? "Execute Windows shell commands; prefer rg/Get-ChildItem/Select-String and scoped paths"
 				: "Execute scoped shell commands; prefer rg over grep/find where available",
+		promptGuidelines: exposeSessionEnvironment
+			? ["Inspect PI_* environment variables for current model and session details."]
+			: undefined,
 		parameters: bashSchema,
 		async execute(
 			_toolCallId,
 			{ command, timeout }: { command: string; timeout?: number },
-			signal?: AbortSignal,
-			onUpdate?,
-			_ctx?,
+			signal: AbortSignal | undefined,
+			onUpdate,
+			ctx,
 		) {
 			const resolvedCommand = commandPrefix ? `${commandPrefix}\n${command}` : command;
-			const spawnContext = resolveSpawnContext(resolvedCommand, cwd, spawnHook);
+			const spawnContext = resolveSpawnContext(
+				resolvedCommand,
+				cwd,
+				spawnHook,
+				exposeSessionEnvironment,
+				ctx,
+			);
 			const output = new OutputAccumulator({ tempFilePrefix: "memcode-bash" });
 			let updateTimer: NodeJS.Timeout | undefined;
 			let updateDirty = false;

--- a/packages/memcode/src/modes/interactive/interactive-mode.ts
+++ b/packages/memcode/src/modes/interactive/interactive-mode.ts
@@ -98,9 +98,9 @@ import { getCwdRelativePath } from "../../utils/paths.ts";
 import { getPiUserAgent } from "../../utils/pi-user-agent.ts";
 import { killTrackedDetachedChildren } from "../../utils/shell.ts";
 import { ensureTool } from "../../utils/tools-manager.ts";
-import { checkForNewPiVersion, type LatestPiRelease } from "../../utils/version-check.ts";
+import { checkForNewMemcodeVersion, type LatestMemcodeRelease } from "../../utils/version-check.ts";
 import { MEMORY_COMMANDS, type MemoryCommandResult } from "../../tui/commands/memory-commands.ts";
-import { getTuiSlashCommandRows } from "../../tui/command-registry.ts";
+import { getTuiSlashCommandRows, TUI_SLASH_COMMANDS } from "../../tui/command-registry.ts";
 import { createViewportWheelInputListener } from "./mouse-wheel.ts";
 import {
 	ActivityStatus,
@@ -553,7 +553,7 @@ export class InteractiveMode {
 	}
 
 	private getBuiltInCommandConflictDiagnostics(extensionRunner: ExtensionRunner): ResourceDiagnostic[] {
-		const builtinNames = new Set(BUILTIN_SLASH_COMMANDS.map((command) => command.name));
+		const builtinNames = new Set(TUI_SLASH_COMMANDS.map((command) => command.name.slice(1)));
 		return extensionRunner
 			.getRegisteredCommands()
 			.filter((command) => builtinNames.has(command.name))
@@ -568,9 +568,10 @@ export class InteractiveMode {
 	}
 
 	private createBaseAutocompleteProvider(): AutocompleteProvider {
-		// Define commands for autocomplete
-		const slashCommands: SlashCommand[] = BUILTIN_SLASH_COMMANDS.map((command) => ({
-			name: command.name,
+		// Keep actual editor autocomplete on the same executable command registry
+		// used by `/commands`; this includes Memorix-native memory subcommands.
+		const slashCommands: SlashCommand[] = TUI_SLASH_COMMANDS.map((command) => ({
+			name: command.name.slice(1),
 			description: command.description,
 		}));
 
@@ -603,6 +604,25 @@ export class InteractiveMode {
 					description: item.provider,
 				}));
 			};
+		}
+
+		const memoryCommand = slashCommands.find((command) => command.name === "memory");
+		if (memoryCommand) {
+			const memorySubcommands = TUI_SLASH_COMMANDS.filter((command) => command.name.startsWith("/memory ")).map(
+				(command) => ({
+					value: command.name.slice("/memory ".length),
+					label: command.name.slice("/memory ".length),
+					description: command.description,
+				}),
+			);
+			memoryCommand.getArgumentCompletions = (prefix: string): AutocompleteItem[] =>
+				fuzzyFilter(memorySubcommands, prefix, (command) => `${command.value} ${command.description}`).map(
+					(command) => ({
+						value: command.value,
+						label: command.label,
+						description: command.description,
+					}),
+				);
 		}
 
 		// Convert prompt templates to SlashCommand format for autocomplete
@@ -856,7 +876,7 @@ export class InteractiveMode {
 		await this.init();
 
 		// Start version check asynchronously
-		checkForNewPiVersion(this.version).then((newRelease) => {
+		checkForNewMemcodeVersion(this.version).then((newRelease) => {
 			if (newRelease) {
 				this.showNewVersionNotification(newRelease);
 			}
@@ -4084,7 +4104,7 @@ export class InteractiveMode {
 		this.ui.requestRender();
 	}
 
-	showNewVersionNotification(release: LatestPiRelease): void {
+	showNewVersionNotification(release: LatestMemcodeRelease): void {
 		const action = theme.fg("accent", `${APP_NAME} update`);
 		const updateInstruction = theme.fg("muted", `New version ${release.version} is available. Run `) + action;
 		const changelogUrl = "https://github.com/AVIDS2/memorix/releases/latest";
@@ -5928,7 +5948,7 @@ export class InteractiveMode {
 			"| `/memory show` | List recent project memories |",
 			"| `/memory diff` | Show recent memory changes |",
 			"| `/memory promote` | Store the last assistant response as memory |",
-			"| `/memory delete` | Resolve a memory entry |",
+			"| `/memory delete <id>` | Resolve a memory entry |",
 			"",
 			"Production path: search first to recover context, promote only durable decisions/fixes, use stats to spot stale or missing project memory.",
 		].filter((line): line is string => line !== undefined);

--- a/packages/memcode/src/package-manager-cli.ts
+++ b/packages/memcode/src/package-manager-cli.ts
@@ -16,7 +16,7 @@ import { DefaultPackageManager } from "./core/package-manager.ts";
 import { SettingsManager } from "./core/settings-manager.ts";
 import { hasProjectTrustInputs, ProjectTrustStore } from "./core/trust-manager.ts";
 import { spawnProcess } from "./utils/child-process.ts";
-import { getLatestPiRelease, isNewerPackageVersion } from "./utils/version-check.ts";
+import { getLatestMemcodeRelease, isNewerPackageVersion } from "./utils/version-check.ts";
 import {
 	cleanupWindowsSelfUpdateQuarantine,
 	quarantineWindowsNativeDependencies,
@@ -367,7 +367,7 @@ async function getSelfUpdatePlan(force: boolean): Promise<SelfUpdatePlan> {
 	}
 
 	try {
-		const latestRelease = await getLatestPiRelease(VERSION);
+		const latestRelease = await getLatestMemcodeRelease(VERSION);
 		const packageName = latestRelease?.packageName ?? PACKAGE_NAME;
 		if (!latestRelease || packageName !== PACKAGE_NAME || isNewerPackageVersion(latestRelease.version, VERSION)) {
 			return { packageName, shouldRun: true, ...(latestRelease?.note ? { note: latestRelease.note } : {}) };

--- a/packages/memcode/src/tui/command-registry.ts
+++ b/packages/memcode/src/tui/command-registry.ts
@@ -1,3 +1,5 @@
+import { BUILTIN_SLASH_COMMANDS } from "../core/slash-commands.ts";
+
 export type TuiSlashCommandMode = "no-arg" | "selector" | "text-input";
 
 export interface TuiSlashCommandEntry {
@@ -26,36 +28,44 @@ export function getTuiSlashCommandRows(): TuiSlashCommandRow[] {
 	}));
 }
 
-export const TUI_SLASH_COMMANDS: readonly TuiSlashCommandEntry[] = [
-	{ name: "/clear", description: "Clear conversation history", mode: "no-arg" },
-	{ name: "/help", description: "Show available commands", mode: "no-arg" },
-	{ name: "/vim", description: "Toggle vim keybindings", mode: "no-arg" },
-	{ name: "/doctor", description: "Run diagnostic checks", mode: "no-arg" },
-	{ name: "/inspect", description: "Inspect last assistant message", mode: "no-arg" },
-	{ name: "/clone", description: "Clone current session", mode: "no-arg" },
-	{ name: "/git status", description: "Show git working-tree status", mode: "no-arg" },
+const BUILTIN_COMMAND_MODES: Readonly<Partial<Record<string, TuiSlashCommandMode>>> = {
+	commands: "text-input",
+	settings: "selector",
+	model: "selector",
+	"scoped-models": "selector",
+	export: "text-input",
+	import: "text-input",
+	name: "text-input",
+	fork: "selector",
+	tree: "selector",
+	trust: "selector",
+	login: "selector",
+	logout: "selector",
+	compact: "text-input",
+	resume: "selector",
+};
+
+const MEMORIX_MEMORY_SUBCOMMANDS: readonly TuiSlashCommandEntry[] = [
 	{ name: "/memory status", description: "Show native Memorix runtime status", mode: "no-arg" },
-	{ name: "/memory stats", description: "Show memory statistics", mode: "no-arg" },
-	{ name: "/memory hooks", description: "Show native hook status", mode: "no-arg" },
-	{ name: "/memory diff", description: "Show pending memory changes", mode: "no-arg" },
-	{ name: "/session export", description: "Export session to file", mode: "no-arg" },
-	{ name: "/session", description: "Show current session info", mode: "no-arg" },
-	{ name: "/config", description: "Open configuration", mode: "no-arg" },
-	{ name: "/exit", description: "Exit memcode", mode: "no-arg" },
-	{ name: "/session load", description: "Load a saved session", mode: "selector" },
-	{ name: "/session delete", description: "Delete a saved session", mode: "selector" },
-	{ name: "/session new", description: "Create a new session", mode: "selector" },
-	{ name: "/resume", description: "Resume a previous session", mode: "selector" },
-	{ name: "/tree", description: "Navigate the session tree", mode: "selector" },
-	{ name: "/fork", description: "Fork session at a point", mode: "selector" },
-	{ name: "/memory show", description: "Browse stored memories", mode: "selector" },
-	{ name: "/memory delete", description: "Delete a memory", mode: "selector" },
-	{ name: "/memory promote", description: "Promote a memory to permanent", mode: "selector" },
-	{ name: "/model switch", description: "Switch AI model", mode: "selector" },
-	{ name: "/theme", description: "Switch color theme", mode: "selector" },
-	{ name: "/git commit", description: "Create a git commit", mode: "selector" },
-	{ name: "/memory search", description: "Search memories by query", mode: "text-input" },
-	{ name: "/remember", description: "Store a new memory", mode: "text-input" },
-	{ name: "/label", description: "Label the current session", mode: "text-input" },
-	{ name: "/git diff", description: "Show diff for a file", mode: "text-input" },
-] as const;
+	{ name: "/memory stats", description: "Show project memory statistics", mode: "no-arg" },
+	{ name: "/memory hooks", description: "Show native hook capture status", mode: "no-arg" },
+	{ name: "/memory search", description: "Search shared project memory", mode: "text-input" },
+	{ name: "/memory show", description: "List recent project memories", mode: "no-arg" },
+	{ name: "/memory diff", description: "Show recent project memory changes", mode: "no-arg" },
+	{ name: "/memory promote", description: "Promote the last agent response to memory", mode: "no-arg" },
+	{ name: "/memory delete", description: "Resolve a project memory entry by ID", mode: "text-input" },
+];
+
+/**
+ * The autocomplete and `/commands` surface must only advertise commands that
+ * InteractiveMode can execute. Generic commands derive from the canonical
+ * Pi-compatible built-in registry; Memorix adds only its native memory verbs.
+ */
+export const TUI_SLASH_COMMANDS: readonly TuiSlashCommandEntry[] = [
+	...BUILTIN_SLASH_COMMANDS.map((command) => ({
+		name: `/${command.name}`,
+		description: command.description,
+		mode: BUILTIN_COMMAND_MODES[command.name] ?? "no-arg",
+	})),
+	...MEMORIX_MEMORY_SUBCOMMANDS,
+];

--- a/packages/memcode/src/tui/commands/memory-commands.ts
+++ b/packages/memcode/src/tui/commands/memory-commands.ts
@@ -7,7 +7,7 @@
  *   /memory show      — list recent memories (returns picker items)
  *   /memory diff      — show memory changes from current session
  *   /memory promote   — promote last AI response to a stored memory
- *   /memory delete    — show memories for deletion (returns picker items)
+ *   /memory delete ID — resolve one memory from active search
  *
  * Each handler calls the appropriate memorix core function via importFromMemorix
  * and returns structured results (toasts, messages, picker items) for the TUI
@@ -366,7 +366,15 @@ async function handlePromote(_args: string, ctx: MemoryCommandContext): Promise<
 
 // ── /memory delete ─────────────────────────────────────────────────────────
 
-async function handleDelete(_args: string, ctx: MemoryCommandContext): Promise<MemoryCommandResult> {
+async function handleDelete(args: string, ctx: MemoryCommandContext): Promise<MemoryCommandResult> {
+	const requestedId = args.trim();
+	if (requestedId) {
+		if (!/^\d+$/.test(requestedId)) {
+			return { toast: { msg: "Usage: /memory delete <id>", type: "error" } };
+		}
+		return executeDelete(Number.parseInt(requestedId, 10), ctx);
+	}
+
 	try {
 		const { projectId } = await prepareMemoryProject(ctx.cwd, { searchIndex: true });
 		const compactSearch = await getCompactSearch();
@@ -383,7 +391,7 @@ async function handleDelete(_args: string, ctx: MemoryCommandContext): Promise<M
 		}));
 
 		return {
-			message: "Select a memory to delete (resolves it from active search):",
+			message: "Use `/memory delete <id>` to resolve a memory from active search:",
 			items,
 		};
 	} catch (err) {
@@ -463,6 +471,7 @@ async function handleStatus(_args: string, ctx: MemoryCommandContext): Promise<M
 
 export async function executeDelete(id: number, ctx: MemoryCommandContext): Promise<MemoryCommandResult> {
 	try {
+		await prepareMemoryProject(ctx.cwd);
 		const resolveObservations = await getResolveObservations();
 		const result = await resolveObservations([id], "resolved");
 

--- a/packages/memcode/src/tui/components/slash-commands.tsx
+++ b/packages/memcode/src/tui/components/slash-commands.tsx
@@ -2,8 +2,8 @@
  * Slash command system for the memcode TUI.
  *
  * Defines three execution modes:
- *   - "no-arg":    Execute directly (e.g. /clear, /help, /vim)
- *   - "selector":  Show a picker for choices (e.g. /model switch, /theme)
+ *   - "no-arg":    Execute directly (e.g. /commands, /memory status)
+ *   - "selector":  Show a picker for choices (e.g. /model, /settings)
  *   - "text-input": Fill the input with the command prefix (e.g. /memory search)
  *
  * The CommandPicker component renders a filtered, keyboard-navigable
@@ -25,7 +25,7 @@ export type CommandMode = "no-arg" | "selector" | "text-input";
 
 /** Definition of a single slash command. */
 export interface Command {
-	/** Full command name including leading slash (e.g. "/clear", "/model switch"). */
+	/** Full command name including leading slash (e.g. "/commands", "/model"). */
 	name: string;
 	/** Human-readable description shown alongside the command. */
 	description: string;

--- a/packages/memcode/src/tui/integrations/git.ts
+++ b/packages/memcode/src/tui/integrations/git.ts
@@ -1,23 +1,13 @@
 /**
- * Git integration for the memcode TUI.
+ * Minimal Git metadata for the memcode TUI header.
  *
- * Provides:
- *   - getGitInfo(cwd)    — branch, dirty flag, ahead/behind counts
- *   - getGitDiff(cwd)    — staged + unstaged diff summary
- *   - hasDirtyFiles(cwd) — quick boolean check
- *   - getGitDiffContext   — compact diff context for LLM auto-injection
- *   - GIT_COMMANDS       — /git slash-command handlers
- *
- * Uses simple-git (already installed as a dependency).
+ * InteractiveMode owns the executable command surface. Keep this module free
+ * of slash-command declarations so autocomplete and dispatch cannot drift.
  */
 
 import { simpleGit, type SimpleGit, type StatusResult } from "simple-git";
 
-// ============================================================================
-// Types
-// ============================================================================
-
-/** Core git state for the header display and context injection. */
+/** Core git state for the header display. */
 export interface GitInfo {
 	branch: string;
 	dirty: boolean;
@@ -26,46 +16,10 @@ export interface GitInfo {
 	behind: number;
 }
 
-/** Structured diff summary for /git diff display. */
-export interface GitDiffSummary {
-	staged: DiffEntry[];
-	unstaged: DiffEntry[];
-	totalInsertions: number;
-	totalDeletions: number;
-}
-
-/** A single file diff entry. */
-export interface DiffEntry {
-	file: string;
-	insertions: number;
-	deletions: number;
-	status: string;
-}
-
-/** Handler map for /git subcommands. */
-export interface GitCommandHandlers {
-	"git status": () => Promise<string>;
-	"git diff": (file?: string) => Promise<string>;
-	"git commit": (message?: string) => Promise<string>;
-}
-
-/** Slash command definition (matches the Command interface from slash-commands.tsx). */
-interface GitSlashCommand {
-	name: string;
-	description: string;
-	mode: "no-arg" | "selector" | "text-input";
-}
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-/** Create a simple-git instance scoped to cwd, with error boundary. */
 function git(cwd: string): SimpleGit {
 	return simpleGit(cwd);
 }
 
-/** Translate StatusResult file groups into a DiffEntry-style count. */
 function countDirtyFiles(status: StatusResult): number {
 	return (
 		status.modified.length +
@@ -77,308 +31,23 @@ function countDirtyFiles(status: StatusResult): number {
 	);
 }
 
-// ============================================================================
-// Public API
-// ============================================================================
-
 /**
- * Fetch branch name, dirty state, and ahead/behind tracking info.
- *
- * Returns a safe default ({ branch: "n/a", dirty: false }) when cwd is not
- * inside a git repository.
+ * Fetch branch and working-tree state for the header.
+ * Returns a safe neutral value when cwd is not inside a Git repository.
  */
 export async function getGitInfo(cwd: string): Promise<GitInfo> {
 	try {
-		const g = git(cwd);
-		const branch = (await g.revparse(["--abbrev-ref", "HEAD"])).trim();
-		const status = await g.status();
-
-		let ahead = 0;
-		let behind = 0;
-		if (status.tracking) {
-			ahead = status.ahead;
-			behind = status.behind;
-		}
-
-		const dirtyCount = countDirtyFiles(status);
-		return { branch, dirty: dirtyCount > 0, dirtyCount, ahead, behind };
+		const instance = git(cwd);
+		const branch = (await instance.revparse(["--abbrev-ref", "HEAD"])).trim();
+		const status = await instance.status();
+		return {
+			branch,
+			dirty: countDirtyFiles(status) > 0,
+			dirtyCount: countDirtyFiles(status),
+			ahead: status.tracking ? status.ahead : 0,
+			behind: status.tracking ? status.behind : 0,
+		};
 	} catch {
 		return { branch: "n/a", dirty: false, dirtyCount: 0, ahead: 0, behind: 0 };
 	}
-}
-
-/**
- * Get a structured diff summary of staged and unstaged changes.
- *
- * Returns { staged, unstaged, totalInsertions, totalDeletions }.
- * Each entry includes file path, +/- counts, and a short status code.
- */
-export async function getGitDiff(cwd: string): Promise<GitDiffSummary> {
-	try {
-		const g = git(cwd);
-		const diffSummary = await g.diffSummary();
-		const status = await g.status();
-
-		const stagedSet = new Set(status.staged);
-		const staged: DiffEntry[] = [];
-		const unstaged: DiffEntry[] = [];
-
-		for (const file of diffSummary.files) {
-			const entry: DiffEntry = {
-				file: file.file,
-				insertions: "insertions" in file ? (file as any).insertions : 0,
-				deletions: "deletions" in file ? (file as any).deletions : 0,
-				status: fileTypeLabel(file),
-			};
-			if (stagedSet.has(file.file)) {
-				staged.push(entry);
-			} else {
-				unstaged.push(entry);
-			}
-		}
-
-		return {
-			staged,
-			unstaged,
-			totalInsertions: diffSummary.insertions,
-			totalDeletions: diffSummary.deletions,
-		};
-	} catch {
-		return { staged: [], unstaged: [], totalInsertions: 0, totalDeletions: 0 };
-	}
-}
-
-/**
- * Quick boolean check for dirty working tree.
- * Returns false when cwd is not a git repo.
- */
-export async function hasDirtyFiles(cwd: string): Promise<boolean> {
-	try {
-		const status = await git(cwd).status();
-		return countDirtyFiles(status) > 0;
-	} catch {
-		return false;
-	}
-}
-
-/**
- * Build a compact git-diff context string for LLM auto-injection.
- *
- * When the working tree is dirty, returns a short block listing changed files
- * and a truncated unified diff (max ~2000 chars) to attach to the user prompt.
- * Returns "" when clean.
- */
-export async function getGitDiffContext(cwd: string): Promise<string> {
-	try {
-		const g = git(cwd);
-		const status = await g.status();
-		const dirtyCount = countDirtyFiles(status);
-		if (dirtyCount === 0) return "";
-
-		const branch = (await g.revparse(["--abbrev-ref", "HEAD"])).trim();
-
-		// Collect changed file names
-		const changedFiles = [
-			...status.modified,
-			...status.not_added,
-			...status.deleted,
-			...status.staged,
-			...status.renamed.map((r) => r.to),
-		];
-		const uniqueFiles = [...new Set(changedFiles)];
-
-		// Get truncated diff (limit to avoid context bloat)
-		let diffText = "";
-		try {
-			const fullDiff = await g.diff();
-			diffText = fullDiff.length > 2000
-				? fullDiff.slice(0, 2000) + "\n... (truncated)"
-				: fullDiff;
-		} catch {
-			// diff may fail in edge cases; proceed with file list only
-		}
-
-		const lines = [
-			`<git-context branch="${branch}" dirty-files="${dirtyCount}">`,
-			"Changed files:",
-			...uniqueFiles.map((f) => `  ${f}`),
-		];
-		if (diffText) {
-			lines.push("", "Diff (truncated):", "```diff", diffText, "```");
-		}
-		lines.push("</git-context>");
-		return lines.join("\n");
-	} catch {
-		return "";
-	}
-}
-
-// ============================================================================
-// /git command handlers
-// ============================================================================
-
-/**
- * Create handlers for /git slash commands.
- *
- * @param cwd - working directory for git operations (should match runtime.cwd)
- * @param addMessage - callback to inject a system/assistant message into the TUI
- * @param sendMessage - callback to send a user message to the LLM (for /git commit)
- */
-export function createGitCommandHandlers(
-	cwd: string,
-	addMessage: (role: "assistant", content: string) => void,
-	sendMessage: (text: string) => Promise<void>,
-): GitCommandHandlers {
-	return {
-		async "git status"(): Promise<string> {
-			try {
-				const g = git(cwd);
-				const status = await g.status();
-				const branch = status.current ?? "detached";
-
-				const lines: string[] = [];
-				lines.push(`**Git Status** (\`${branch}\`)`);
-				lines.push("");
-
-				if (status.ahead > 0 || status.behind > 0) {
-					const tracking = [];
-					if (status.ahead > 0) tracking.push(`${status.ahead} ahead`);
-					if (status.behind > 0) tracking.push(`${status.behind} behind`);
-					lines.push(`Tracking: ${tracking.join(", ")}`);
-					lines.push("");
-				}
-
-				if (status.staged.length > 0) {
-					lines.push(`**Staged (${status.staged.length}):**`);
-					for (const f of status.staged) lines.push(`  A ${f}`);
-					lines.push("");
-				}
-				if (status.modified.length > 0) {
-					lines.push(`**Modified (${status.modified.length}):**`);
-					for (const f of status.modified) lines.push(`  M ${f}`);
-					lines.push("");
-				}
-				if (status.not_added.length > 0) {
-					lines.push(`**Untracked (${status.not_added.length}):**`);
-					for (const f of status.not_added) lines.push(`  ? ${f}`);
-					lines.push("");
-				}
-				if (status.deleted.length > 0) {
-					lines.push(`**Deleted (${status.deleted.length}):**`);
-					for (const f of status.deleted) lines.push(`  D ${f}`);
-					lines.push("");
-				}
-				if (status.conflicted.length > 0) {
-					lines.push(`**Conflicted (${status.conflicted.length}):**`);
-					for (const f of status.conflicted) lines.push(`  ! ${f}`);
-					lines.push("");
-				}
-
-				const total = countDirtyFiles(status);
-				if (total === 0) {
-					lines.push("Working tree is clean.");
-				}
-
-				return lines.join("\n");
-			} catch (err) {
-				return `Error reading git status: ${err instanceof Error ? err.message : String(err)}`;
-			}
-		},
-
-		async "git diff"(file?: string): Promise<string> {
-			try {
-				const g = git(cwd);
-				const diffArgs = file ? [file] : [];
-				const diff = await g.diff(diffArgs);
-
-				if (!diff.trim()) {
-					// Check staged diff if unstaged is empty
-					const stagedDiff = await g.diff(["--cached", ...diffArgs]);
-					if (!stagedDiff.trim()) {
-						return "No changes to display.";
-					}
-					const truncated = stagedDiff.length > 4000
-						? stagedDiff.slice(0, 4000) + "\n... (truncated)"
-						: stagedDiff;
-					return `**Staged Diff:**\n\`\`\`diff\n${truncated}\n\`\`\``;
-				}
-
-				const truncated = diff.length > 4000
-					? diff.slice(0, 4000) + "\n... (truncated)"
-					: diff;
-				return `**Diff:**\n\`\`\`diff\n${truncated}\n\`\`\``;
-			} catch (err) {
-				return `Error reading git diff: ${err instanceof Error ? err.message : String(err)}`;
-			}
-		},
-
-		async "git commit"(message?: string): Promise<string> {
-			try {
-				const g = git(cwd);
-				const status = await g.status();
-
-				if (countDirtyFiles(status) === 0) {
-					return "Nothing to commit — working tree is clean.";
-				}
-
-				// Stage all changes
-				await g.add("-A");
-
-				if (message) {
-					// Direct commit with provided message
-					const result = await g.commit(message);
-					return `Committed ${result.summary.changes} file(s): "${message}"\n(${result.commit})`;
-				}
-
-				// No message provided — generate one via LLM
-				const diff = await g.diff(["--cached"]);
-				const diffPreview = diff.length > 3000
-					? diff.slice(0, 3000) + "\n... (truncated)"
-					: diff;
-
-				const prompt = [
-					"Generate a conventional commit message for these staged changes.",
-					"Use the format: type(scope): description",
-					"Keep the first line under 72 characters. Add a blank line and 1-2 sentence body if needed.",
-					"",
-					"Staged diff:",
-					"```diff",
-					diffPreview,
-					"```",
-				].join("\n");
-
-				// Send the commit-message generation request to the LLM
-				await sendMessage(prompt);
-				return "Generating commit message...";
-			} catch (err) {
-				return `Error during commit: ${err instanceof Error ? err.message : String(err)}`;
-			}
-		},
-	};
-}
-
-// ============================================================================
-// GIT_COMMANDS — slash command definitions
-// ============================================================================
-
-/**
- * Git-specific slash commands for the TUI command registry.
- *
- * Merge into the main COMMANDS array or use directly with
- * createGitCommandHandlers() for dispatch.
- */
-export const GIT_COMMANDS: readonly GitSlashCommand[] = [
-	{ name: "/git status", description: "Show git working-tree status",   mode: "no-arg" },
-	{ name: "/git diff",   description: "Show staged + unstaged diff",   mode: "text-input" },
-	{ name: "/git commit", description: "Stage all + generate commit msg", mode: "text-input" },
-];
-
-// ============================================================================
-// Internal helpers
-// ============================================================================
-
-/** Map simple-git's diff file entry to a short status label. */
-function fileTypeLabel(file: { binary: boolean }): string {
-	if (file.binary) return "binary";
-	return "text";
 }

--- a/packages/memcode/src/utils/pi-user-agent.ts
+++ b/packages/memcode/src/utils/pi-user-agent.ts
@@ -1,4 +1,7 @@
-export function getPiUserAgent(version: string): string {
+export function getMemcodeUserAgent(version: string): string {
 	const runtime = process.versions.bun ? `bun/${process.versions.bun}` : `node/${process.version}`;
 	return `memcode/${version} (${process.platform}; ${runtime}; ${process.arch})`;
 }
+
+/** @deprecated Use getMemcodeUserAgent. Retained for Pi-compatible extensions. */
+export const getPiUserAgent = getMemcodeUserAgent;

--- a/packages/memcode/src/utils/version-check.ts
+++ b/packages/memcode/src/utils/version-check.ts
@@ -1,13 +1,16 @@
-import { getPiUserAgent } from "./pi-user-agent.ts";
+import { getMemcodeUserAgent } from "./pi-user-agent.ts";
 
 const LATEST_VERSION_URL = "https://registry.npmjs.org/memorix/latest";
 const DEFAULT_VERSION_CHECK_TIMEOUT_MS = 10000;
 
-export interface LatestPiRelease {
+export interface LatestMemcodeRelease {
 	version: string;
 	packageName?: string;
 	note?: string;
 }
+
+/** @deprecated Use LatestMemcodeRelease. */
+export type LatestPiRelease = LatestMemcodeRelease;
 
 interface ParsedVersion {
 	major: number;
@@ -53,15 +56,15 @@ export function isNewerPackageVersion(candidateVersion: string, currentVersion: 
 	return candidateVersion.trim() !== currentVersion.trim();
 }
 
-export async function getLatestPiRelease(
+export async function getLatestMemcodeRelease(
 	currentVersion: string,
 	options: { timeoutMs?: number } = {},
-): Promise<LatestPiRelease | undefined> {
+): Promise<LatestMemcodeRelease | undefined> {
 	if (process.env.MEMCODE_SKIP_VERSION_CHECK || process.env.PI_SKIP_VERSION_CHECK || process.env.MEMCODE_OFFLINE || process.env.PI_OFFLINE) return undefined;
 
 	const response = await fetch(LATEST_VERSION_URL, {
 		headers: {
-			"User-Agent": getPiUserAgent(currentVersion),
+			"User-Agent": getMemcodeUserAgent(currentVersion),
 			accept: "application/json",
 		},
 		signal: AbortSignal.timeout(options.timeoutMs ?? DEFAULT_VERSION_CHECK_TIMEOUT_MS),
@@ -89,16 +92,16 @@ export async function getLatestPiRelease(
 	};
 }
 
-export async function getLatestPiVersion(
+export async function getLatestMemcodeVersion(
 	currentVersion: string,
 	options: { timeoutMs?: number } = {},
 ): Promise<string | undefined> {
-	return (await getLatestPiRelease(currentVersion, options))?.version;
+	return (await getLatestMemcodeRelease(currentVersion, options))?.version;
 }
 
-export async function checkForNewPiVersion(currentVersion: string): Promise<LatestPiRelease | undefined> {
+export async function checkForNewMemcodeVersion(currentVersion: string): Promise<LatestMemcodeRelease | undefined> {
 	try {
-		const latestRelease = await getLatestPiRelease(currentVersion);
+		const latestRelease = await getLatestMemcodeRelease(currentVersion);
 		if (latestRelease && isNewerPackageVersion(latestRelease.version, currentVersion)) {
 			return latestRelease;
 		}
@@ -107,3 +110,10 @@ export async function checkForNewPiVersion(currentVersion: string): Promise<Late
 		return undefined;
 	}
 }
+
+/** @deprecated Use getLatestMemcodeRelease. */
+export const getLatestPiRelease = getLatestMemcodeRelease;
+/** @deprecated Use getLatestMemcodeVersion. */
+export const getLatestPiVersion = getLatestMemcodeVersion;
+/** @deprecated Use checkForNewMemcodeVersion. */
+export const checkForNewPiVersion = checkForNewMemcodeVersion;

--- a/packages/memcode/test/bash-session-environment.test.ts
+++ b/packages/memcode/test/bash-session-environment.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, test } from "vitest";
+import type { ExtensionContext } from "../src/core/extensions/types.ts";
+import { createBashToolDefinition, type BashOperations } from "../src/core/tools/bash.ts";
+
+const PI_ENV_KEYS = ["PI_SESSION_ID", "PI_SESSION_FILE", "PI_PROVIDER", "PI_MODEL", "PI_REASONING_LEVEL"] as const;
+
+const originalPiEnvironment = Object.fromEntries(PI_ENV_KEYS.map((key) => [key, process.env[key]]));
+
+afterEach(() => {
+	for (const key of PI_ENV_KEYS) {
+		const originalValue = originalPiEnvironment[key];
+		if (originalValue === undefined) {
+			delete process.env[key];
+		} else {
+			process.env[key] = originalValue;
+		}
+	}
+});
+
+function createContext(): ExtensionContext {
+	return {
+		sessionManager: {
+			getSessionId: () => "session-123",
+			getSessionFile: () => "E:\\sessions\\session-123.jsonl",
+		},
+		model: { provider: "openrouter", id: "qwen/qwen3-coder" },
+		thinkingLevel: "high",
+	} as unknown as ExtensionContext;
+}
+
+function captureEnvironment(options?: Parameters<typeof createBashToolDefinition>[1]) {
+	let capturedEnvironment: NodeJS.ProcessEnv | undefined;
+	const operations: BashOperations = {
+		exec: async (_command, _cwd, { env }) => {
+			capturedEnvironment = env;
+			return { exitCode: 0 };
+		},
+	};
+	const tool = createBashToolDefinition(process.cwd(), { ...options, operations });
+	return {
+		tool,
+		getEnvironment: () => capturedEnvironment,
+	};
+}
+
+describe("bash session environment", () => {
+	test("exposes current session, model, and thinking metadata to LLM bash calls", async () => {
+		const seenByHook: NodeJS.ProcessEnv[] = [];
+		const { tool, getEnvironment } = captureEnvironment({
+			spawnHook: (context) => {
+				seenByHook.push(context.env);
+				return context;
+			},
+		});
+
+		await tool.execute("call-1", { command: "echo ok" }, undefined, undefined, createContext());
+
+		expect(getEnvironment()).toMatchObject({
+			PI_SESSION_ID: "session-123",
+			PI_SESSION_FILE: "E:\\sessions\\session-123.jsonl",
+			PI_PROVIDER: "openrouter",
+			PI_MODEL: "qwen/qwen3-coder",
+			PI_REASONING_LEVEL: "high",
+		});
+		expect(seenByHook[0]).toMatchObject(getEnvironment());
+		expect(tool.promptGuidelines).toContain("Inspect PI_* environment variables for current model and session details.");
+	});
+
+	test("does not leak stale PI metadata into a new call without a session context", async () => {
+		for (const key of PI_ENV_KEYS) {
+			process.env[key] = "stale";
+		}
+		const { tool, getEnvironment } = captureEnvironment();
+
+		await tool.execute("call-2", { command: "echo ok" });
+
+		for (const key of PI_ENV_KEYS) {
+			expect(getEnvironment()?.[key]).toBeUndefined();
+		}
+	});
+
+	test("allows extensions to disable session metadata exposure", async () => {
+		const { tool, getEnvironment } = captureEnvironment({ exposeSessionEnvironment: false });
+
+		await tool.execute("call-3", { command: "echo ok" }, undefined, undefined, createContext());
+
+		for (const key of PI_ENV_KEYS) {
+			expect(getEnvironment()?.[key]).toBeUndefined();
+		}
+		expect(tool.promptGuidelines).toBeUndefined();
+	});
+});

--- a/packages/memcode/test/config.test.ts
+++ b/packages/memcode/test/config.test.ts
@@ -8,6 +8,7 @@ import {
 	getSelfUpdateUnavailableInstruction,
 	getShareViewerUrl,
 	getUpdateInstruction,
+	resolveMemcodeVersion,
 } from "../src/config.ts";
 
 const execPathDescriptor = Object.getOwnPropertyDescriptor(process, "execPath");
@@ -70,6 +71,24 @@ describe("getShareViewerUrl", () => {
 		expect(getShareViewerUrl("abc123", "https://gist.github.com/user/abc123")).toBe(
 			"https://viewer.example/session/#abc123",
 		);
+	});
+});
+
+describe("resolveMemcodeVersion", () => {
+	test("uses the verified public Memorix package version for a bundled runtime", () => {
+		const root = mkdtempSync(join(tmpdir(), "memorix-runtime-root-"));
+		tempDir = root;
+		writeFileSync(join(root, "package.json"), JSON.stringify({ name: "memorix", version: "1.2.6" }), "utf-8");
+
+		expect(resolveMemcodeVersion({ version: "1.1.12" }, root)).toBe("1.2.6");
+	});
+
+	test("falls back to the runtime version when the root is not a Memorix package", () => {
+		const root = mkdtempSync(join(tmpdir(), "memcode-unverified-root-"));
+		tempDir = root;
+		writeFileSync(join(root, "package.json"), JSON.stringify({ name: "another-package", version: "9.9.9" }), "utf-8");
+
+		expect(resolveMemcodeVersion({ version: "1.1.12" }, root)).toBe("1.1.12");
 	});
 });
 

--- a/packages/memcode/test/interactive-mode-status.test.ts
+++ b/packages/memcode/test/interactive-mode-status.test.ts
@@ -717,6 +717,33 @@ describe("InteractiveMode.setupAutocompleteProvider", () => {
 	});
 });
 
+describe("InteractiveMode.createBaseAutocompleteProvider", () => {
+	test("offers executable Memorix memory subcommands in the real interactive editor", async () => {
+		const fakeThis = {
+			session: {
+				scopedModels: [],
+				modelRegistry: { getAvailable: () => [] },
+				promptTemplates: [],
+				extensionRunner: { getRegisteredCommands: () => [] },
+				resourceLoader: { getSkills: () => ({ skills: [] }) },
+			},
+			settingsManager: { getEnableSkillCommands: () => false },
+			skillCommands: new Map(),
+			sessionManager: { getCwd: () => process.cwd() },
+			fdPath: undefined,
+		};
+		const provider = (InteractiveMode as any).prototype.createBaseAutocompleteProvider.call(fakeThis);
+		const signal = new AbortController().signal;
+
+		const rootSuggestions = await provider.getSuggestions(["/memory"], 0, 7, { signal });
+		const nestedSuggestions = await provider.getSuggestions(["/memory "], 0, 8, { signal });
+
+		expect(rootSuggestions?.items.map((item: { value: string }) => item.value)).toContain("memory search");
+		expect(nestedSuggestions?.items.map((item: { value: string }) => item.value)).toContain("search");
+		expect(nestedSuggestions?.items.map((item: { value: string }) => item.value)).toContain("status");
+	});
+});
+
 describe("InteractiveMode.showLoadedResources", () => {
 	beforeAll(() => {
 		initTheme("dark");

--- a/packages/memcode/test/memorix-resolve.test.ts
+++ b/packages/memcode/test/memorix-resolve.test.ts
@@ -4,10 +4,9 @@ import {
 	importFromMemorix,
 	resetMemorixModuleRootForTests,
 } from "../src/core/memorix-resolve.ts";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 
 describe("importFromMemorix", () => {
 	let tempRoot: string | undefined;
@@ -27,14 +26,18 @@ describe("importFromMemorix", () => {
 		expect(mod.AGENT_SUPPORT_TIER.codex).toBe("extended");
 	});
 
-	test("prefers repo TypeScript sources over stale sibling js files", () => {
-		const currentDir = dirname(fileURLToPath(import.meta.url));
-		const projectRoot = join(currentDir, "..", "..", "..");
-		const tsSource = readFileSync(join(projectRoot, "src", "memory", "observations.ts"), "utf8");
-		const jsSource = readFileSync(join(projectRoot, "src", "memory", "observations.js"), "utf8");
+	test("prefers configured TypeScript sources over stale sibling js files", async () => {
+		tempRoot = mkdtempSync(join(tmpdir(), "memorix-source-precedence-"));
+		mkdirSync(join(tempRoot, "src", "memory"), { recursive: true });
+		writeFileSync(join(tempRoot, "src", "memory", "observations.ts"), "export const marker = 'fresh-source';");
+		writeFileSync(join(tempRoot, "src", "memory", "observations.js"), "export const marker = 'stale-sidecar';");
 
-		expect(tsSource).toContain("using BM25 until embedding recovers");
-		expect(jsSource).not.toContain("using BM25 until embedding recovers");
+		process.env.MEMORIX_PACKAGE_ROOT = tempRoot;
+		resetMemorixModuleRootForTests();
+
+		const mod = await importFromMemorix("memory/observations.js");
+
+		expect(mod.marker).toBe("fresh-source");
 	});
 
 	test("uses MEMORIX_PACKAGE_ROOT src files for npm-installed root package layouts", () => {

--- a/packages/memcode/test/memorix-runtime-context.test.ts
+++ b/packages/memcode/test/memorix-runtime-context.test.ts
@@ -99,11 +99,12 @@ describe("Memorix runtime context", () => {
 		expect(context.hooks.active).toBe(true);
 
 		const formatted = formatMemorixRuntimeStatus(context);
-		expect(formatted).toContain("Project: AVIDS2/memorix");
-		expect(formatted).toContain("Shared aliases: AVIDS2/memorix, local/memorix");
-		expect(formatted).toContain("Search: hybrid + LLM rerank");
-		expect(formatted).toContain("Embedding: api-text-embedding-v4 (1024d)");
-		expect(formatted).toContain("Memory LLM: openai/deepseek-chat");
-		expect(formatted).toContain("Native hooks: active");
+		expect(formatted).toContain("## Memorix Status");
+		expect(formatted).toContain("- Project: AVIDS2/memorix");
+		expect(formatted).toContain("- Memory: 2 active / 2 shared");
+		expect(formatted).toContain("- Search: semantic warming (BM25/fulltext until vectors finish)");
+		expect(formatted).toContain("- Embedding: api-text-embedding-v4 · 2/3 vectors · 1024d · backfill running");
+		expect(formatted).toContain("- Memory LLM: openai/deepseek-chat");
+		expect(formatted).toContain("- Hooks: active · user_prompt 2, agent_end 1");
 	});
 });

--- a/packages/memcode/test/memory-commands-runtime.test.ts
+++ b/packages/memcode/test/memory-commands-runtime.test.ts
@@ -5,6 +5,7 @@ const initObservations = vi.hoisted(() => vi.fn());
 const ensureFreshObservations = vi.hoisted(() => vi.fn());
 const prepareSearchIndex = vi.hoisted(() => vi.fn());
 const resolveMemorixProjectContext = vi.hoisted(() => vi.fn());
+const resolveObservations = vi.hoisted(() => vi.fn());
 
 vi.mock("../src/core/memorix-resolve.ts", () => ({
 	importFromMemorix: async (specifier: string) => {
@@ -16,6 +17,7 @@ vi.mock("../src/core/memorix-resolve.ts", () => ({
 				initObservations,
 				ensureFreshObservations,
 				prepareSearchIndex,
+				resolveObservations,
 			};
 		}
 		throw new Error(`Unexpected import: ${specifier}`);
@@ -57,5 +59,27 @@ describe("TUI /memory commands", () => {
 		});
 		expect(addMessage).toHaveBeenCalledWith("Found project memory");
 		expect(result.toast).toEqual({ msg: "1 result(s), ~4 tokens", type: "info" });
+	});
+
+	test("resolves an explicit memory ID instead of only listing deletion candidates", async () => {
+		initObservations.mockClear();
+		ensureFreshObservations.mockClear();
+		resolveMemorixProjectContext.mockResolvedValue({
+			canonicalId: "AVIDS2/memorix",
+			dataDir: "C:\\Users\\Lenovo\\.memorix\\data",
+		});
+		resolveObservations.mockResolvedValue({ resolved: [42], notFound: [] });
+		const toast = vi.fn();
+
+		const result = await MEMORY_COMMANDS.delete("42", {
+			cwd: "E:\\project\\memorix",
+			toast,
+			addMessage: vi.fn(),
+		});
+
+		expect(resolveObservations).toHaveBeenCalledWith([42], "resolved");
+		expect(initObservations).toHaveBeenCalledWith("C:\\Users\\Lenovo\\.memorix\\data");
+		expect(toast).toHaveBeenCalledWith("Memory #42 resolved", "success");
+		expect(result.toast).toEqual({ msg: "Deleted memory #42", type: "success" });
 	});
 });

--- a/packages/memcode/test/slash-command-registry.test.ts
+++ b/packages/memcode/test/slash-command-registry.test.ts
@@ -3,21 +3,44 @@ import { BUILTIN_SLASH_COMMANDS } from "../src/core/slash-commands.ts";
 import { getTuiSlashCommandsByMode, TUI_SLASH_COMMANDS } from "../src/tui/command-registry.ts";
 
 describe("TUI_SLASH_COMMANDS", () => {
-	test("contains the shared TUI-discoverable memory, git, and session commands", () => {
+	test("contains every executable built-in command for autocomplete", () => {
 		const names = TUI_SLASH_COMMANDS.map((command) => command.name);
 
-		expect(names).toContain("/memory hooks");
-		expect(names).toContain("/git status");
-		expect(names).toContain("/session export");
+		for (const command of BUILTIN_SLASH_COMMANDS) {
+			expect(names).toContain(`/${command.name}`);
+		}
 	});
 
-	test("stays aligned with the built-in interactive command surface for core slash commands", () => {
-		const builtinNames = new Set(BUILTIN_SLASH_COMMANDS.map((command) => `/${command.name}`));
+	test("contains the executable Memorix memory subcommands", () => {
+		const names = TUI_SLASH_COMMANDS.map((command) => command.name);
 
-		expect(builtinNames.has("/memory")).toBe(true);
-		expect(builtinNames.has("/session")).toBe(true);
-		expect(builtinNames.has("/model")).toBe(true);
-		expect(builtinNames.has("/tree")).toBe(true);
+		expect(names).toContain("/memory status");
+		expect(names).toContain("/memory stats");
+		expect(names).toContain("/memory hooks");
+		expect(names).toContain("/memory search");
+		expect(names).toContain("/memory show");
+		expect(names).toContain("/memory diff");
+		expect(names).toContain("/memory promote");
+		expect(names).toContain("/memory delete");
+	});
+
+	test("does not advertise legacy commands that interactive mode cannot execute", () => {
+		const names = new Set(TUI_SLASH_COMMANDS.map((command) => command.name));
+
+		for (const staleCommand of [
+			"/clear",
+			"/help",
+			"/config",
+			"/exit",
+			"/git status",
+			"/git diff",
+			"/git commit",
+			"/model switch",
+			"/remember",
+			"/session export",
+		]) {
+			expect(names.has(staleCommand)).toBe(false);
+		}
 	});
 
 	test("does not register duplicate TUI slash command names", () => {
@@ -27,8 +50,11 @@ describe("TUI_SLASH_COMMANDS", () => {
 
 	test("can filter TUI slash commands by mode from the shared registry", () => {
 		expect(getTuiSlashCommandsByMode("no-arg").some((command) => command.name === "/memory hooks")).toBe(true);
-		expect(getTuiSlashCommandsByMode("selector").some((command) => command.name === "/memory show")).toBe(true);
+		expect(getTuiSlashCommandsByMode("selector").some((command) => command.name === "/settings")).toBe(true);
 		expect(getTuiSlashCommandsByMode("text-input").some((command) => command.name === "/memory search")).toBe(
+			true,
+		);
+		expect(getTuiSlashCommandsByMode("text-input").some((command) => command.name === "/memory delete")).toBe(
 			true,
 		);
 	});

--- a/packages/memcode/test/slash-commands.test.ts
+++ b/packages/memcode/test/slash-commands.test.ts
@@ -18,12 +18,13 @@ describe("BUILTIN_SLASH_COMMANDS", () => {
 		expect(new Set(names).size).toBe(names.length);
 	});
 
-	test("keeps TUI-only discoverability commands separate from legacy built-ins", () => {
+	test("keeps only real Memorix subcommands separate from built-ins", () => {
 		const builtinNames = new Set(BUILTIN_SLASH_COMMANDS.map((command) => `/${command.name}`));
 		const tuiRows = getTuiSlashCommandRows();
 
 		expect(tuiRows.some((row) => row.name === "/memory hooks")).toBe(true);
-		expect(tuiRows.some((row) => row.name === "/git status")).toBe(true);
+		expect(tuiRows.some((row) => row.name === "/memory search")).toBe(true);
+		expect(tuiRows.some((row) => row.name === "/git status")).toBe(false);
 		expect(builtinNames.has("/memory")).toBe(true);
 		expect(builtinNames.has("/memory hooks")).toBe(false);
 	});

--- a/packages/memcode/test/version-check.test.ts
+++ b/packages/memcode/test/version-check.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-	checkForNewPiVersion,
+	checkForNewMemcodeVersion,
 	comparePackageVersions,
+	getLatestMemcodeRelease,
+	getLatestMemcodeVersion,
 	getLatestPiRelease,
-	getLatestPiVersion,
 	isNewerPackageVersion,
 } from "../src/utils/version-check.ts";
 
@@ -37,15 +38,15 @@ describe("version checks", () => {
 		const fetchMock = vi.fn(async () => Response.json({ version: "1.2.3" }));
 		vi.stubGlobal("fetch", fetchMock);
 
-		await expect(checkForNewPiVersion("1.2.3")).resolves.toBeUndefined();
-		await expect(checkForNewPiVersion("1.2.2")).resolves.toEqual({ version: "1.2.3" });
+		await expect(checkForNewMemcodeVersion("1.2.3")).resolves.toBeUndefined();
+		await expect(checkForNewMemcodeVersion("1.2.2")).resolves.toEqual({ version: "1.2.3" });
 	});
 
 	it("uses the npm registry version check api with a memcode user agent", async () => {
 		const fetchMock = vi.fn(async () => Response.json({ version: "1.2.4" }));
 		vi.stubGlobal("fetch", fetchMock);
 
-		await expect(getLatestPiVersion("1.2.3")).resolves.toBe("1.2.4");
+		await expect(getLatestMemcodeVersion("1.2.3")).resolves.toBe("1.2.4");
 		expect(fetchMock).toHaveBeenCalledWith(
 			"https://registry.npmjs.org/memorix/latest",
 			expect.objectContaining({
@@ -66,7 +67,7 @@ describe("version checks", () => {
 		);
 		vi.stubGlobal("fetch", fetchMock);
 
-		await expect(getLatestPiRelease("1.2.3")).resolves.toEqual({
+		await expect(getLatestMemcodeRelease("1.2.3")).resolves.toEqual({
 			packageName: "memorix",
 			version: "1.2.4",
 		});
@@ -76,7 +77,7 @@ describe("version checks", () => {
 		const fetchMock = vi.fn(async () => Response.json({ note: " **Read this** ", version: "1.2.4" }));
 		vi.stubGlobal("fetch", fetchMock);
 
-		await expect(getLatestPiRelease("1.2.3")).resolves.toEqual({ note: "**Read this**", version: "1.2.4" });
+		await expect(getLatestMemcodeRelease("1.2.3")).resolves.toEqual({ note: "**Read this**", version: "1.2.4" });
 	});
 
 	it("skips api calls when version checks are disabled", async () => {
@@ -84,7 +85,11 @@ describe("version checks", () => {
 		const fetchMock = vi.fn();
 		vi.stubGlobal("fetch", fetchMock);
 
-		await expect(getLatestPiVersion("1.2.3")).resolves.toBeUndefined();
+		await expect(getLatestMemcodeVersion("1.2.3")).resolves.toBeUndefined();
 		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
+	it("keeps deprecated Pi-named exports as compatibility aliases", () => {
+		expect(getLatestPiRelease).toBe(getLatestMemcodeRelease);
 	});
 });

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.1.0",
+  "version": "1.2.6",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.1.1",
+  "version": "1.2.6",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.1.1",
+  "version": "1.2.6",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.1.1",
+  "version": "1.2.6",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.1.1",
+  "version": "1.2.6",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.1.1",
+  "version": "1.2.6",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/scripts/pi-upstream-audit.mjs
+++ b/scripts/pi-upstream-audit.mjs
@@ -1,0 +1,313 @@
+#!/usr/bin/env node
+
+/*
+ * Read-only Pi upstream audit for the memcode overlay.
+ *
+ * This deliberately reports differences only. Core runtime updates remain a
+ * reviewed Memorix change: apply them in an isolated branch, keep native
+ * memory integration intact, and run the normal package verification gates.
+ */
+
+import { readFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const manifestPath = path.join(root, "packages", "memcode", "pi-upstream.json");
+const GITHUB_COMPARE_FILE_LIMIT = 300;
+const REQUEST_TIMEOUT_MS = 15_000;
+const REF_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._/-]*$/;
+const REPOSITORY_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+const execFileAsync = promisify(execFile);
+
+function assertRef(value, optionName) {
+	if (!REF_PATTERN.test(value)) {
+		throw new Error(`${optionName} must be a Git ref made of letters, numbers, dot, underscore, slash, or dash.`);
+	}
+	return value;
+}
+
+function assertRepository(value) {
+	if (!REPOSITORY_PATTERN.test(value)) {
+		throw new Error("Pi upstream manifest has an invalid repository value.");
+	}
+	return value;
+}
+
+function readOption(args, index, option) {
+	const value = args[index + 1];
+	if (!value || value.startsWith("--")) {
+		throw new Error(`${option} requires a value.`);
+	}
+	return value;
+}
+
+export function parsePiUpstreamAuditArgs(args) {
+	const options = { base: undefined, head: undefined, json: false, help: false };
+	for (let index = 0; index < args.length; index += 1) {
+		const arg = args[index];
+		if (arg === "--base") {
+			options.base = assertRef(readOption(args, index, arg), arg);
+			index += 1;
+			continue;
+		}
+		if (arg === "--head") {
+			options.head = assertRef(readOption(args, index, arg), arg);
+			index += 1;
+			continue;
+		}
+		if (arg === "--json") {
+			options.json = true;
+			continue;
+		}
+		if (arg === "--help" || arg === "-h") {
+			options.help = true;
+			continue;
+		}
+		throw new Error(`Unknown option: ${arg}`);
+	}
+	return options;
+}
+
+export function buildPiUpstreamAuditReport(compare, manifest, refs, options = {}) {
+	const files = Array.isArray(compare?.files)
+		? compare.files.filter((file) => typeof file?.filename === "string" && file.filename.length > 0)
+		: [];
+	const fileListMayBeTruncated = options.fileListMayBeTruncated ?? files.length >= GITHUB_COMPARE_FILE_LIMIT;
+	const packages = (manifest.packages ?? []).map((pkg) => ({
+		name: pkg.name,
+		upstreamPrefix: pkg.upstreamPrefix,
+		changedFiles: 0,
+		overlayFiles: [],
+	}));
+	const unmappedFiles = [];
+
+	for (const file of files) {
+		const bucket = packages.find((pkg) => file.filename.startsWith(pkg.upstreamPrefix));
+		if (!bucket) {
+			unmappedFiles.push(file.filename);
+			continue;
+		}
+
+		bucket.changedFiles += 1;
+		const areas = (manifest.overlayWatchPaths ?? [])
+			.filter((area) => area.upstreamPaths?.includes(file.filename))
+			.map((area) => area.name);
+		if (areas.length > 0) {
+			bucket.overlayFiles.push({ filename: file.filename, areas });
+		}
+	}
+
+	const warnings = [];
+	if (fileListMayBeTruncated) {
+		warnings.push("GitHub compare returns at most 300 changed files; inspect the full upstream range before merging.");
+	}
+
+	return {
+		upstream: {
+			repository: manifest.upstream.repository,
+			base: refs.base,
+			head: refs.head,
+		},
+		compare: {
+			aheadBy: typeof compare?.ahead_by === "number" ? compare.ahead_by : undefined,
+			totalCommits: typeof compare?.total_commits === "number" ? compare.total_commits : undefined,
+			filesSeen: files.length,
+			fileListMayBeTruncated,
+			fileSource: options.fileSource ?? "compare",
+		},
+		packages: packages.map(({ name, changedFiles, overlayFiles }) => ({ name, changedFiles, overlayFiles })),
+		unmappedFiles,
+		warnings,
+	};
+}
+
+export function diffPiGitTrees(baseTree, headTree) {
+	const indexTree = (entries) => {
+		const index = new Map();
+		for (const entry of entries ?? []) {
+			if (entry?.type !== "blob" || typeof entry.path !== "string" || typeof entry.sha !== "string") continue;
+			index.set(entry.path, { mode: entry.mode, sha: entry.sha });
+		}
+		return index;
+	};
+	const baseEntries = indexTree(baseTree);
+	const headEntries = indexTree(headTree);
+	const paths = new Set([...baseEntries.keys(), ...headEntries.keys()]);
+	const changes = [];
+
+	for (const filename of [...paths].sort((left, right) => left.localeCompare(right))) {
+		const before = baseEntries.get(filename);
+		const after = headEntries.get(filename);
+		if (!before && after) {
+			changes.push({ filename, status: "added" });
+			continue;
+		}
+		if (before && !after) {
+			changes.push({ filename, status: "removed" });
+			continue;
+		}
+		if (before?.sha !== after?.sha || before?.mode !== after?.mode) {
+			changes.push({ filename, status: "modified" });
+		}
+	}
+	return changes;
+}
+
+export function formatPiUpstreamAuditReport(report) {
+	const lines = [
+		"Pi upstream audit (read-only)",
+		`${report.upstream.repository}: ${report.upstream.base} -> ${report.upstream.head}`,
+		`${report.compare.aheadBy ?? "?"} commits ahead; ${report.compare.filesSeen} changed file entries seen.`,
+		"",
+		"Package impact:",
+	];
+
+	for (const pkg of report.packages) {
+		lines.push(`- ${pkg.name}: ${pkg.changedFiles} changed file(s)`);
+		for (const file of pkg.overlayFiles) {
+			lines.push(`  - review native overlay: ${file.filename} (${file.areas.join(", ")})`);
+		}
+	}
+
+	if (report.unmappedFiles.length > 0) {
+		lines.push("", `Unmapped upstream files: ${report.unmappedFiles.length}`);
+	}
+	for (const warning of report.warnings) {
+		lines.push("", `WARNING: ${warning}`);
+	}
+
+	lines.push(
+		"",
+		"This report never applies upstream code. Review the range, port selected changes in a branch, then run package tests and smoke checks.",
+	);
+	return lines.join("\n");
+}
+
+async function readManifest() {
+	const manifest = JSON.parse(await readFile(manifestPath, "utf8"));
+	assertRepository(manifest?.upstream?.repository);
+	assertRef(manifest?.upstream?.baseline, "manifest upstream.baseline");
+	if (!Array.isArray(manifest.packages) || manifest.packages.length === 0) {
+		throw new Error("Pi upstream manifest must define at least one package mapping.");
+	}
+	return manifest;
+}
+
+async function fetchGitHubJson(endpoint) {
+	const token = process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN;
+	const headers = {
+		Accept: "application/vnd.github+json",
+		"User-Agent": "memorix-pi-upstream-audit",
+		...(token ? { Authorization: `Bearer ${token}` } : {}),
+	};
+	let response;
+	try {
+		response = await fetch(`https://api.github.com${endpoint}`, {
+			headers,
+			signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+		});
+	} catch (error) {
+		if (token) throw error;
+		return fetchGitHubJsonWithGh(endpoint, error);
+	}
+	if (response.ok) {
+		return response.json();
+	}
+
+	const body = await response.text();
+	const error = new Error(`GitHub API ${response.status}: ${body.slice(0, 300) || response.statusText}`);
+	if (token || (response.status !== 403 && response.status !== 429)) {
+		throw error;
+	}
+	return fetchGitHubJsonWithGh(endpoint, error);
+}
+
+async function fetchGitHubJsonWithGh(endpoint, fetchError) {
+	try {
+		const { stdout } = await execFileAsync(
+			"gh",
+			["api", endpoint.replace(/^\//, ""), "--header", "Accept: application/vnd.github+json"],
+			{ windowsHide: true, maxBuffer: 10 * 1024 * 1024 },
+		);
+		return JSON.parse(stdout);
+	} catch (ghError) {
+		const fetchMessage = fetchError instanceof Error ? fetchError.message : String(fetchError);
+		const ghMessage = ghError instanceof Error ? ghError.message : String(ghError);
+		throw new Error(`${fetchMessage}\nAuthenticated gh fallback failed: ${ghMessage}`);
+	}
+}
+
+async function resolveHeadRef(repository, requestedHead) {
+	if (requestedHead) return requestedHead;
+	const release = await fetchGitHubJson(`/repos/${repository}/releases/latest`);
+	if (!release || typeof release.tag_name !== "string") {
+		throw new Error("GitHub latest-release response did not include a tag_name.");
+	}
+	return assertRef(release.tag_name, "latest release tag");
+}
+
+async function fetchGitTree(repository, ref) {
+	const commit = await fetchGitHubJson(`/repos/${repository}/commits/${encodeURIComponent(ref)}`);
+	const treeSha = commit?.commit?.tree?.sha;
+	if (typeof treeSha !== "string" || !treeSha) {
+		throw new Error(`GitHub commit response for ${ref} did not include a tree SHA.`);
+	}
+	const tree = await fetchGitHubJson(`/repos/${repository}/git/trees/${treeSha}?recursive=1`);
+	if (!Array.isArray(tree?.tree)) {
+		throw new Error(`GitHub tree response for ${ref} did not include entries.`);
+	}
+	return tree;
+}
+
+export async function runPiUpstreamAudit(options = {}) {
+	const manifest = await readManifest();
+	const repository = manifest.upstream.repository;
+	const base = options.base ?? manifest.upstream.baseline;
+	const head = await resolveHeadRef(repository, options.head);
+	let compare = await fetchGitHubJson(
+		`/repos/${repository}/compare/${encodeURIComponent(base)}...${encodeURIComponent(head)}`,
+	);
+	const compareFiles = Array.isArray(compare.files) ? compare.files : [];
+	if (compareFiles.length < GITHUB_COMPARE_FILE_LIMIT) {
+		return buildPiUpstreamAuditReport(compare, manifest, { base, head });
+	}
+
+	const [baseTree, headTree] = await Promise.all([fetchGitTree(repository, base), fetchGitTree(repository, head)]);
+	if (baseTree.truncated || headTree.truncated) {
+		return buildPiUpstreamAuditReport(compare, manifest, { base, head }, { fileListMayBeTruncated: true });
+	}
+
+	compare = { ...compare, files: diffPiGitTrees(baseTree.tree, headTree.tree) };
+	return buildPiUpstreamAuditReport(compare, manifest, { base, head }, {
+		fileSource: "git-tree",
+		fileListMayBeTruncated: false,
+	});
+}
+
+function printUsage() {
+	console.log(`Usage: npm run audit:pi-upstream -- [--base <ref>] [--head <ref>] [--json]
+
+Compare the pinned Pi baseline to an upstream release. With no --head, the
+official latest release is used. The command is read-only and does not merge or
+replace any source files.`);
+}
+
+async function main() {
+	const options = parsePiUpstreamAuditArgs(process.argv.slice(2));
+	if (options.help) {
+		printUsage();
+		return;
+	}
+	const report = await runPiUpstreamAudit(options);
+	console.log(options.json ? JSON.stringify(report, null, 2) : formatPiUpstreamAuditReport(report));
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+	main().catch((error) => {
+		console.error(error instanceof Error ? error.message : String(error));
+		process.exitCode = 1;
+	});
+}

--- a/src/cli/commands/context.ts
+++ b/src/cli/commands/context.ts
@@ -22,7 +22,11 @@ export default defineCommand({
   },
   args: {
     task: { type: 'string', description: 'Current task for context shaping' },
-    input: { type: 'positional', description: 'Current task for context shaping (ergonomic positional form)' },
+    input: {
+      type: 'positional',
+      description: 'Current task for context shaping (ergonomic positional form)',
+      required: false,
+    },
     resume: { type: 'boolean', description: 'Always include the bounded prior-work projection' },
     refresh: { type: 'string', description: 'Project scan policy: auto, always, or never' },
     json: { type: 'boolean', description: 'Emit machine-readable JSON output' },

--- a/src/store/bun-sqlite-compat.ts
+++ b/src/store/bun-sqlite-compat.ts
@@ -23,6 +23,26 @@ function isNativeBindingFailure(error: unknown): boolean {
 }
 
 function addCompatibility(db: any): any {
+  // Node's StatementSync is stricter than better-sqlite3: it rejects a
+  // parameter object with harmless extra keys. Memorix stores commonly pass a
+  // complete row object to statements that only use part of that row, so keep
+  // the established better-sqlite3 behavior on the fallback driver.
+  if (!db.__memorixPreparedStatementCompatibility) {
+    const prepare = db.prepare.bind(db);
+    db.prepare = function (...args: any[]) {
+      const statement = prepare(...args);
+      statement.setAllowBareNamedParameters?.(true);
+      statement.setAllowUnknownNamedParameters?.(true);
+      return statement;
+    };
+    Object.defineProperty(db, '__memorixPreparedStatementCompatibility', {
+      value: true,
+      configurable: false,
+      enumerable: false,
+      writable: false,
+    });
+  }
+
   // Bun and node:sqlite do not expose better-sqlite3's pragma helper.
   if (!db.pragma) {
     db.pragma = function (pragma: string, options?: { simple?: boolean }) {
@@ -37,15 +57,17 @@ function addCompatibility(db: any): any {
 
   // Stores use better-sqlite3's synchronous transaction factory. Keep nested
   // calls correct with savepoints instead of silently committing inner work.
+  // Match its callable transaction variants as well: default/deferred,
+  // immediate, and exclusive.
   if (!db.transaction) {
     let depth = 0;
     let sequence = 0;
     db.transaction = function <T>(fn: (...args: any[]) => T) {
-      return (...args: any[]): T => {
+      const run = (mode: 'DEFERRED' | 'IMMEDIATE' | 'EXCLUSIVE', args: any[]): T => {
         const outermost = depth === 0;
         const savepoint = `memorix_tx_${++sequence}`;
         if (outermost) {
-          db.exec('BEGIN IMMEDIATE');
+          db.exec(`BEGIN ${mode}`);
         } else {
           db.exec(`SAVEPOINT ${savepoint}`);
         }
@@ -77,6 +99,13 @@ function addCompatibility(db: any): any {
           throw error;
         }
       };
+
+      const transaction = (...args: any[]): T => run('DEFERRED', args);
+      transaction.default = transaction;
+      transaction.deferred = (...args: any[]): T => run('DEFERRED', args);
+      transaction.immediate = (...args: any[]): T => run('IMMEDIATE', args);
+      transaction.exclusive = (...args: any[]): T => run('EXCLUSIVE', args);
+      return transaction;
     };
   }
 

--- a/tests/cli/context-command.test.ts
+++ b/tests/cli/context-command.test.ts
@@ -3,6 +3,7 @@ import { execSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
+import { parseArgs } from 'citty';
 import codegraphCommand from '../../src/cli/commands/codegraph.js';
 import contextCommand from '../../src/cli/commands/context.js';
 import doctorCommand from '../../src/cli/commands/doctor.js';
@@ -109,6 +110,16 @@ describe('project context CLI commands', () => {
       projectId: 'local/repo',
     });
   }
+
+  it('accepts --task without requiring the ergonomic positional task', () => {
+    const args = parseArgs(
+      ['--task', 'prepare the release'],
+      contextCommand.args as Record<string, { type?: 'boolean' | 'string' | 'positional'; required?: boolean }>,
+    );
+
+    expect(args.task).toBe('prepare the release');
+    expect(args.input).toBeUndefined();
+  });
 
   it('auto-refreshes code memory when context runs before a manual scan', async () => {
     await seedMemoryOnly();

--- a/tests/integration/plugin-release-metadata.test.ts
+++ b/tests/integration/plugin-release-metadata.test.ts
@@ -1,0 +1,25 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { getCliVersion } from '../../src/cli/version.js';
+
+const versionedPluginManifests = [
+  'plugins/claude/memorix/.claude-plugin/plugin.json',
+  'plugins/codex/memorix/.codex-plugin/plugin.json',
+  'plugins/copilot/memorix/plugin.json',
+  'plugins/gemini/memorix/gemini-extension.json',
+  'plugins/omp/memorix/package.json',
+  'plugins/openclaw/memorix/.codex-plugin/plugin.json',
+  'plugins/pi/memorix/package.json',
+];
+
+describe('shipped plugin release metadata', () => {
+  it('keeps every versioned plugin manifest aligned with the published CLI release', async () => {
+    for (const manifestPath of versionedPluginManifests) {
+      const manifest = JSON.parse(await readFile(path.join(process.cwd(), manifestPath), 'utf-8')) as {
+        version?: unknown;
+      };
+      expect(manifest.version, manifestPath).toBe(getCliVersion());
+    }
+  });
+});

--- a/tests/maintainer/pi-upstream-audit.test.ts
+++ b/tests/maintainer/pi-upstream-audit.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "vitest";
+import { buildPiUpstreamAuditReport, diffPiGitTrees } from "../../scripts/pi-upstream-audit.mjs";
+
+const manifest = {
+	upstream: {
+		repository: "earendil-works/pi",
+		baseline: "v0.79.0",
+	},
+	packages: [
+		{ name: "ai", upstreamPrefix: "packages/ai/" },
+		{ name: "agent-core", upstreamPrefix: "packages/agent/" },
+		{ name: "tui", upstreamPrefix: "packages/tui/" },
+		{ name: "memcode", upstreamPrefix: "packages/coding-agent/" },
+	],
+	overlayWatchPaths: [
+		{
+			name: "Memorix command and memory integration",
+			upstreamPaths: [
+				"packages/coding-agent/src/core/slash-commands.ts",
+				"packages/coding-agent/src/modes/interactive/interactive-mode.ts",
+			],
+		},
+	],
+};
+
+describe("Pi upstream audit report", () => {
+	test("groups upstream changes by the forked package and flags native overlay touchpoints", () => {
+		const report = buildPiUpstreamAuditReport(
+			{
+				ahead_by: 4,
+				total_commits: 4,
+				files: [
+					{ filename: "packages/ai/src/models.ts", status: "modified" },
+					{ filename: "packages/coding-agent/src/core/slash-commands.ts", status: "modified" },
+					{ filename: "packages/coding-agent/src/core/tools/bash.ts", status: "added" },
+					{ filename: "docs/README.md", status: "modified" },
+				],
+			},
+			manifest,
+			{ base: "v0.79.0", head: "v0.82.1" },
+		);
+
+		expect(report.compare).toMatchObject({ aheadBy: 4, totalCommits: 4, filesSeen: 4, fileListMayBeTruncated: false });
+		expect(report.packages).toEqual([
+			{ name: "ai", changedFiles: 1, overlayFiles: [] },
+			{
+				name: "agent-core",
+				changedFiles: 0,
+				overlayFiles: [],
+			},
+			{ name: "tui", changedFiles: 0, overlayFiles: [] },
+			{
+				name: "memcode",
+				changedFiles: 2,
+				overlayFiles: [
+					{
+						filename: "packages/coding-agent/src/core/slash-commands.ts",
+						areas: ["Memorix command and memory integration"],
+					},
+				],
+			},
+		]);
+		expect(report.unmappedFiles).toEqual(["docs/README.md"]);
+	});
+
+	test("warns when GitHub's compare file list reaches its documented cap", () => {
+		const report = buildPiUpstreamAuditReport(
+			{
+				ahead_by: 301,
+				total_commits: 301,
+				files: Array.from({ length: 300 }, (_, index) => ({
+					filename: `packages/coding-agent/src/file-${index}.ts`,
+					status: "modified",
+				})),
+			},
+			manifest,
+			{ base: "v0.79.0", head: "v0.82.1" },
+		);
+
+		expect(report.compare.fileListMayBeTruncated).toBe(true);
+		expect(report.warnings).toContain("GitHub compare returns at most 300 changed files; inspect the full upstream range before merging.");
+	});
+
+	test("reconstructs a complete changed-path list from two Git trees when compare is capped", () => {
+		const changes = diffPiGitTrees(
+			[
+				{ path: "packages/ai/src/removed.ts", mode: "100644", type: "blob", sha: "old" },
+				{ path: "packages/coding-agent/src/core/tools/bash.ts", mode: "100644", type: "blob", sha: "before" },
+			],
+			[
+				{ path: "packages/ai/src/added.ts", mode: "100644", type: "blob", sha: "new" },
+				{ path: "packages/coding-agent/src/core/tools/bash.ts", mode: "100644", type: "blob", sha: "after" },
+			],
+		);
+
+		expect(changes).toEqual([
+			{ filename: "packages/ai/src/added.ts", status: "added" },
+			{ filename: "packages/ai/src/removed.ts", status: "removed" },
+			{ filename: "packages/coding-agent/src/core/tools/bash.ts", status: "modified" },
+		]);
+	});
+
+	test("does not retain the compare truncation warning after a complete tree fallback", () => {
+		const report = buildPiUpstreamAuditReport(
+			{
+				files: Array.from({ length: 301 }, (_, index) => ({
+					filename: `packages/ai/src/file-${index}.ts`,
+					status: "modified",
+				})),
+			},
+			manifest,
+			{ base: "v0.79.0", head: "v0.82.1" },
+			{ fileSource: "git-tree", fileListMayBeTruncated: false },
+		);
+
+		expect(report.compare).toMatchObject({ fileSource: "git-tree", fileListMayBeTruncated: false });
+		expect(report.warnings).toEqual([]);
+	});
+});

--- a/tests/store/node-sqlite-compat.test.ts
+++ b/tests/store/node-sqlite-compat.test.ts
@@ -13,7 +13,7 @@ describe('node:sqlite compatibility fallback', () => {
     resetSqliteDriverForTests();
   });
 
-  it('keeps the better-sqlite3 pragma and transaction contract on Node 22', () => {
+  it('keeps better-sqlite3 pragma, statement, and transaction contracts on Node 22', () => {
     process.env.MEMORIX_SQLITE_DRIVER = 'node';
     resetSqliteDriverForTests();
     const db = createDatabase(':memory:');
@@ -26,10 +26,21 @@ describe('node:sqlite compatibility fallback', () => {
       const write = db.transaction((values: string[]) => {
         for (const value of values) insert.run(value);
       });
-      write(['first', 'second']);
+      write(['default']);
+      write.deferred(['deferred']);
+      write.immediate(['immediate']);
+      write.exclusive(['exclusive']);
 
       expect(db.prepare('SELECT value FROM entries ORDER BY id').all())
-        .toEqual([{ value: 'first' }, { value: 'second' }]);
+        .toEqual([
+          { value: 'default' },
+          { value: 'deferred' },
+          { value: 'immediate' },
+          { value: 'exclusive' },
+        ]);
+
+      const lookup = db.prepare('SELECT @id AS id');
+      expect(lookup.get({ id: 7, projectId: 'unused-row-field' })).toEqual({ id: 7 });
     } finally {
       db.close();
     }


### PR DESCRIPTION
## Release scope
- Keep Memcode a minimal Pi overlay: native project memory only, no fake generic slash commands.
- Add Pi-compatible session metadata for model bash calls and a read-only upstream audit.
- Complete Node SQLite fallback parity and release metadata consistency.

## Verification
- npm run lint
- npm run build
- npm test
- packages/memcode: npm test
- npm run audit:pi-upstream -- --head v0.82.1 --json
- fresh tarball install with CLI and real stdio MCP smoke