### PR TITLE
fix(memory): rank handoff-shaped observations in L2 and rank resumption queries

### DIFF
--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -19,7 +19,14 @@ import { getSessionStore } from '../store/session-store.js';
 import { KnowledgeGraphManager } from './graph.js';
 import { redactCredentials, sanitizeCredentials } from './secret-filter.js';
 
-const PRIORITY_TYPES = new Set(['gotcha', 'decision', 'problem-solution', 'trade-off', 'discovery']);
+// Types eligible for L2 "Key Project Memories" injection. `session-request` and
+// `what-changed` belong here for handoff continuity: the former carries the task's
+// original goal, the latter what actually moved — both are exactly what a resuming
+// agent needs, and excluding them made deliberate handoff notes unreachable.
+const PRIORITY_TYPES = new Set([
+  'gotcha', 'decision', 'problem-solution', 'trade-off', 'discovery',
+  'session-request', 'what-changed',
+]);
 const TYPE_EMOJI: Record<string, string> = {
   'gotcha': '[DISCOVERY]',
   'decision': '[WHY]',
@@ -37,19 +44,24 @@ const TYPE_WEIGHTS: Record<string, number> = {
   'decision': 5.5,
   'problem-solution': 5.25,
   'trade-off': 4.75,
+  'session-request': 4.5,
   'discovery': 4.25,
+  'what-changed': 4,
 };
+// Markers that identify a memory as a demo/scratch artifact rather than real
+// working context. These are TITLE conventions — see isNoiseObservation.
+//
+// Deliberately excluded: 验证 / 兼容 / compat / 交接 / handoff. Those are ordinary
+// engineering vocabulary, not noise signals. Matching them silently dropped real
+// memories: any Chinese note about verification or compatibility, and any handoff
+// note that merely named a handoff tool, disappeared from session context with no
+// diagnostic. A noise filter must not veto the words its users normally write.
 const NOISE_PATTERNS = [
   /\[测试\]/i,
   /\[test\]/i,
-  /验证/i,
-  /兼容/i,
-  /\bcompat(?:ibility)?\b/i,
   /\bdemo\b/i,
   /展示/i,
   /全能力/i,
-  /handoff/i,
-  /交接/i,
   /for_memmcp_test/i,
   /\bbenchmark\b/i,
   /\bsandbox\b/i,
@@ -167,8 +179,13 @@ function isCommandTrace(obs: Observation): boolean {
 }
 
 function isNoiseObservation(obs: Observation): boolean {
-  const text = stringifyObservation(obs, false);
-  return NOISE_PATTERNS.some((pattern) => pattern.test(text)) || isCommandTrace(obs);
+  // Match the title only. Demo/scratch markers are a titling convention, so scanning
+  // the narrative/facts/concepts produced false positives on real memories that merely
+  // *mentioned* one of these words in prose — and because this filter runs before the
+  // PRIORITY_TYPES check and drops the observation outright (not a score penalty), a
+  // single unlucky word in a long narrative made the whole memory unreachable.
+  const title = obs.title ?? '';
+  return NOISE_PATTERNS.some((pattern) => pattern.test(title)) || isCommandTrace(obs);
 }
 
 function isSystemSelfObservation(obs: Observation): boolean {

--- a/src/search/intent-detector.ts
+++ b/src/search/intent-detector.ts
@@ -12,7 +12,7 @@ import type { ObservationType } from '../types.js';
 
 // ─── Types ───
 
-export type QueryIntent = 'why' | 'when' | 'how' | 'what_changed' | 'problem' | 'general';
+export type QueryIntent = 'why' | 'when' | 'how' | 'what_changed' | 'problem' | 'state' | 'general';
 
 export interface IntentResult {
   /** Detected intent category */
@@ -39,6 +39,30 @@ interface IntentPattern {
 }
 
 const INTENT_PATTERNS: IntentPattern[] = [
+  {
+    // Resumption queries — "where were we", "what's left". Weighted just above the
+    // others because these are asked at handoff time, when returning the current
+    // state matters more than returning the best semantic match.
+    intent: 'state',
+    patterns: [
+      /\bprogress\b/i,
+      /\bstatus\b/i,
+      /\bremaining\b/i,
+      /\bnext steps?\b/i,
+      /\bwhere (?:did|are) we\b/i,
+      /\bpick(?:ing)? up\b/i,
+      /\bresume\b/i,
+      /\bto-?do\b/i,
+      /进度/,
+      /做到哪/,
+      /下一步/,
+      /待办/,
+      /剩下/,
+      /继续/,
+      /接着做/,
+    ],
+    weight: 1.1,
+  },
   {
     intent: 'why',
     patterns: [
@@ -139,6 +163,12 @@ const INTENT_PATTERNS: IntentPattern[] = [
 // ─── Type Boost Maps ───
 
 const INTENT_TYPE_BOOSTS: Record<QueryIntent, Partial<Record<ObservationType, number>>> = {
+  state: {
+    'session-request': 2.5,
+    'what-changed': 2.0,
+    'discovery': 1.5,
+    'problem-solution': 1.2,
+  },
   why: {
     'decision': 3.0,
     'why-it-exists': 3.0,
@@ -198,6 +228,14 @@ const INTENT_SOURCE_BOOSTS: Partial<Record<QueryIntent, Partial<Record<'agent' |
 };
 
 const INTENT_FIELD_BOOSTS: Partial<Record<QueryIntent, Record<string, number>>> = {
+  state: {
+    title: 3,           // State notes are titled by topic — the title carries the signal
+    entityName: 1.5,
+    narrative: 2,
+    facts: 2.5,         // Progress lines usually live in facts
+    concepts: 1,
+    filesModified: 0.5,
+  },
   why: {
     title: 2,
     entityName: 1.5,

--- a/tests/search/intent-detector.test.ts
+++ b/tests/search/intent-detector.test.ts
@@ -123,4 +123,27 @@ describe('applyIntentBoost', () => {
     // Higher confidence → higher boost
     expect(highBoosted).toBeGreaterThanOrEqual(lowBoosted);
   });
+
+  describe('state intent (resumption queries)', () => {
+    it('detects English resumption phrasing', () => {
+      expect(detectQueryIntent('what is the progress and what are the next steps').intent).toBe('state');
+      expect(detectQueryIntent('where did we leave off, anything remaining?').intent).toBe('state');
+    });
+
+    it('detects Chinese resumption phrasing', () => {
+      expect(detectQueryIntent('现在进度怎么样，下一步做什么').intent).toBe('state');
+      expect(detectQueryIntent('上次做到哪了，还剩下什么待办').intent).toBe('state');
+    });
+
+    it('prefers the types that carry handoff state', () => {
+      const intent = detectQueryIntent('当前进度如何，下一步待办是什么');
+      const sessionRequest = applyIntentBoost(1.0, 'session-request', intent);
+      const howItWorks = applyIntentBoost(1.0, 'how-it-works', intent);
+      expect(sessionRequest).toBeGreaterThan(howItWorks);
+    });
+
+    it('leaves unrelated queries alone', () => {
+      expect(detectQueryIntent('why did we choose this database').intent).toBe('why');
+    });
+  });
 });


### PR DESCRIPTION
Two upstream-portable fixes:

## session.ts

- PRIORITY_TYPES now includes 'session-request' and 'what-changed'. Without this, deliberate handoff notes (the goal of the prior task and what actually moved) were filtered out of the L2 'Key Project Memories' injection block — exactly the block an agent reads first when resuming.
- NOISE_PATTERNS no longer matches '验证', '兼容', /compat/, 'handoff', '交接'. These are ordinary engineering vocabulary, not noise signals.
- isNoiseObservation now matches the title only. Scanning narrative/facts/concepts produced false positives that dropped real memories outright (not a score penalty).

## intent-detector.ts

Adds a 'state' intent for resumption queries (progress / next steps / 进度 / 下一步 / etc.) and matching INTENT_TYPE_BOOSTS / INTENT_FIELD_BOOSTS. The pinned channel loads its state regardless of this ranking, but the intent boost keeps the semantic pipeline aligned with handoff-shaped types — so an agent that asks 'what's left' gets the right answer without needing a pinned prefix.

Tests cover both English and Chinese resumption phrasing.

Supersedes PR #135 in scope: only the upstream-portable pieces remain. The deterministic pinned-state channel and the Stop-hook state reminder stay on a downstream branch.