### PR TITLE
fix: harden vector recovery and Codex setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.8] - 2026-07-27
+
+### Fixed
+- **Recoverable vector backfill** -- Temporary embedding or index failures no longer exhaust a shared background job. Memorix keeps one diagnosable retry with bounded backoff, batches provider requests, and lets a later healthy MCP session resume the same recovery work instead of accumulating permanent failures.
+- **Accurate vector status outside MCP** -- The standalone dashboard and HTTP control plane no longer present an unhydrated in-memory index as a healthy `0 / 0` result. They now explicitly say that vector status belongs to the active MCP session when they cannot observe it.
+- **Codex plugin ownership** -- Agent Doctor recognizes the enabled Codex plugin as the owner of `memorix serve`, reports first-use hook approval as a host consent step instead of a broken install, and avoids suggesting a redundant config repair.
+- **Safe Codex migration** -- `memorix setup --agent codex --global` removes only the known old source-path Memorix MCP entry after the official plugin installation succeeds. Custom user-managed MCP entries remain untouched.
+
 ## [1.2.7] - 2026-07-27
 
 ### Added

--- a/docs/dev-log/progress.txt
+++ b/docs/dev-log/progress.txt
@@ -339,3 +339,28 @@
   isolated Claude Code handoff/continuation smoke. `npm publish --dry-run
   --ignore-scripts` accepted the public 1.2.7 tarball; the full prepublish
   build/test path is covered by the root release gates above.
+
+## 1.2.8 Vector Recovery and Codex Installation Clarity
+- Reworked vector backfill failure handling so transient provider or local
+  index failures leave one durable, diagnosable retry with bounded backoff
+  instead of consuming the maintenance retry budget in each new MCP process.
+  Healthy work clears stale diagnostics, revives an old failed vector job when
+  needed, and resolves superseded historical failure rows once recovery is
+  complete. Provider calls are batched while process-local Orama writes remain
+  serialized.
+- Corrected dashboard and HTTP control-plane vector reporting. A process that
+  does not own a hydrated MCP search index now states that vector status belongs
+  to the active MCP session rather than showing a misleading green `0 / 0`.
+- Corrected Codex install diagnostics: an enabled official Codex plugin owns
+  its `.mcp.json` `memorix serve` endpoint, while first-use hook approval is an
+  explicit host consent step rather than a broken installation. Plugin setup
+  removes only the legacy source-path `memorix` entry after successful plugin
+  installation; custom user-managed MCP entries are preserved.
+- Release verification: focused regression tests (96 assertions), `npm run
+  lint`, production build, and the full root test suite (all passed, 280s).
+  A live OpenRouter `qwen/qwen3-embedding-8b` batch returned two 4096d vectors.
+  An isolated tarball install reported CLI version `1.2.8`; its stdio MCP
+  handshake exposed 44 tools and completed `memorix_project_context`, and its
+  CLI `context --json` path returned a structured Workset. `npm pack --dry-run`
+  and `npm publish --dry-run --ignore-scripts` both accepted the final tarball
+  without manifest normalization warnings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.2.7",
+      "version": "1.2.8",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,
@@ -11,8 +11,8 @@
     "packages/memcode"
   ],
   "bin": {
-    "memorix": "./dist/cli/index.js",
-    "memcode": "./dist/cli/memcode.js"
+    "memorix": "dist/cli/index.js",
+    "memcode": "dist/cli/memcode.js"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/src/cli/commands/agent-integrations.ts
+++ b/src/cli/commands/agent-integrations.ts
@@ -26,6 +26,8 @@ export interface AgentMcpCheck {
   exists: boolean;
   status: AgentIntegrationStatus;
   issues: string[];
+  /** This endpoint is supplied by an enabled Codex plugin, not config.toml. */
+  managedByPlugin?: boolean;
   server?: {
     transport: 'stdio' | 'http';
     command?: string;
@@ -229,6 +231,10 @@ function codexPluginPath(): string {
   return `${homedir()}/.codex/plugins/${CODEX_PLUGIN_NAME}`;
 }
 
+function codexPluginMcpPath(): string {
+  return `${codexPluginPath()}/.mcp.json`;
+}
+
 function codexMarketplacePath(): string {
   return `${homedir()}/.agents/plugins/marketplace.json`;
 }
@@ -267,6 +273,7 @@ async function inspectCodexPluginBundle(): Promise<AgentPluginCheck> {
   const pluginPath = codexPluginPath();
   const manifestPath = `${pluginPath}/.codex-plugin/plugin.json`;
   const hooksPath = `${pluginPath}/hooks/hooks.json`;
+  const mcpPath = codexPluginMcpPath();
   if (!existsSync(pluginPath)) {
     return {
       scope: 'global',
@@ -316,6 +323,20 @@ async function inspectCodexPluginBundle(): Promise<AgentPluginCheck> {
   const issues: string[] = [];
   if (version !== getCliVersion()) issues.push('codex-plugin-version-mismatch');
   if (manifest.hooks !== './hooks/hooks.json') issues.push('codex-hook-manifest-missing');
+
+  if (!existsSync(mcpPath)) {
+    issues.push('codex-plugin-mcp-manifest-missing');
+  } else {
+    try {
+      const mcpConfig = asRecord(JSON.parse(await readFile(mcpPath, 'utf-8')));
+      const server = coerceMcpServer('memorix', asRecord(mcpConfig?.mcpServers)?.memorix);
+      if (!server || !isRecommendedStdioServer(server)) {
+        issues.push('codex-plugin-mcp-manifest-invalid');
+      }
+    } catch {
+      issues.push('codex-plugin-mcp-manifest-unreadable');
+    }
+  }
 
   let declared: string[] = [];
   if (!existsSync(hooksPath)) {
@@ -479,7 +500,9 @@ async function inspectCodexHookTrust(): Promise<AgentPluginCheck> {
     kind: 'hook-trust',
     path: configPath,
     exists: true,
-    status: issues.length > 0 ? 'repairable' : 'ok',
+    // Codex records hook approval only after the user has reviewed it. Memorix
+    // must not treat an intentional, host-owned consent step as a broken setup.
+    status: issues.length > 0 ? 'skipped' : 'ok',
     issues,
     hookTrust: { trusted, expected: [...CODEX_HOOK_STATE_NAMES] },
   };
@@ -562,7 +585,7 @@ function getClaudeLocalConfigPath(): string {
   return `${homedir()}/.claude.json`;
 }
 
-function coerceClaudeLocalServer(name: string, value: unknown): MCPServerEntry | null {
+function coerceMcpServer(name: string, value: unknown): MCPServerEntry | null {
   const entry = asRecord(value);
   if (!entry) return null;
   const args = Array.isArray(entry.args) ? entry.args.map(String) : [];
@@ -626,7 +649,7 @@ async function inspectClaudeLocalMcp(projectRoot: string): Promise<AgentMcpCheck
   }
 
   const servers = asRecord(localProject.project.mcpServers);
-  const server = coerceClaudeLocalServer('memorix', servers?.memorix);
+  const server = coerceMcpServer('memorix', servers?.memorix);
   if (!server) {
     return {
       scope: 'local',
@@ -683,6 +706,59 @@ async function installClaudeLocalMcpConfig(projectRoot: string): Promise<void> {
   await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, 'utf-8');
 }
 
+async function inspectCodexPluginMcp(): Promise<AgentMcpCheck | null> {
+  const runtime = inspectCodexPluginRuntime();
+  if (!runtime.runtime?.installed || !runtime.runtime.enabled) return null;
+
+  const mcpPath = codexPluginMcpPath();
+  if (!existsSync(mcpPath)) {
+    return {
+      scope: 'global',
+      path: mcpPath,
+      exists: false,
+      status: 'repairable',
+      issues: ['codex-plugin-mcp-manifest-missing'],
+      managedByPlugin: true,
+    };
+  }
+
+  try {
+    const config = asRecord(JSON.parse(await readFile(mcpPath, 'utf-8')));
+    const server = coerceMcpServer('memorix', asRecord(config?.mcpServers)?.memorix);
+    if (!server) {
+      return {
+        scope: 'global',
+        path: mcpPath,
+        exists: true,
+        status: 'repairable',
+        issues: ['codex-plugin-mcp-manifest-invalid'],
+        managedByPlugin: true,
+      };
+    }
+    const issues: string[] = [];
+    if (looksLikeStaleMemorixCommand(server)) issues.push('stale-command-path');
+    if (!isRecommendedStdioServer(server)) issues.push('nonstandard-mcp-command');
+    return {
+      scope: 'global',
+      path: mcpPath,
+      exists: true,
+      status: issues.length > 0 ? 'repairable' : 'ok',
+      issues,
+      managedByPlugin: true,
+      server: sanitizeServer(server),
+    };
+  } catch {
+    return {
+      scope: 'global',
+      path: mcpPath,
+      exists: true,
+      status: 'repairable',
+      issues: ['codex-plugin-mcp-manifest-unreadable'],
+      managedByPlugin: true,
+    };
+  }
+}
+
 async function inspectMcp(agent: AgentName, projectRoot: string, scope: AgentIntegrationScope): Promise<AgentIntegrationEntry['mcp']> {
   if (!isMcpConfigAgent(agent)) {
     return { status: 'skipped', issues: ['mcp-managed-by-package'], checks: [] };
@@ -695,6 +771,14 @@ async function inspectMcp(agent: AgentName, projectRoot: string, scope: AgentInt
     if (agent === 'claude' && targetScope === 'local') {
       checks.push(await inspectClaudeLocalMcp(projectRoot));
       continue;
+    }
+
+    if (agent === 'codex' && targetScope === 'global') {
+      const pluginCheck = await inspectCodexPluginMcp();
+      if (pluginCheck) {
+        checks.push(pluginCheck);
+        continue;
+      }
     }
 
     const configPath = adapter.getConfigPath(targetScope === 'project' ? projectRoot : undefined);
@@ -872,11 +956,20 @@ export function formatAgentIntegrationReport(report: AgentIntegrationReport): st
     lines.push(`${entry.agent}: ${status}`);
     if (entry.mcp.issues.length > 0) lines.push(`  MCP: ${entry.mcp.issues.join(', ')}`);
     if (entry.guidance.issues.length > 0) lines.push(`  Guidance: ${entry.guidance.issues.join(', ')}`);
-    if (entry.plugin.issues.length > 0) lines.push(`  Plugin: ${entry.plugin.issues.join(', ')}`);
+    const hookTrustPending = entry.plugin.issues.includes('codex-hook-trust-pending');
+    const pluginIssues = entry.plugin.issues.filter((issue) => issue !== 'codex-hook-trust-pending');
+    if (pluginIssues.length > 0) lines.push(`  Plugin: ${pluginIssues.join(', ')}`);
+    if (hookTrustPending) {
+      lines.push('  Hooks: waiting for Codex approval on first use; MCP remains available.');
+    }
   }
 
   lines.push('');
-  lines.push(`Repair: ${report.repairCommand}`);
+  if (report.summary.missing > 0 || report.summary.repairable > 0) {
+    lines.push(`Repair: ${report.repairCommand}`);
+  } else {
+    lines.push('No file repair needed.');
+  }
   return lines.join('\n');
 }
 
@@ -899,6 +992,10 @@ export async function repairAgentIntegrations(options: {
     if (isMcpConfigAgent(entry.agent)) {
       for (const check of entry.mcp.checks) {
         if (check.status === 'ok' || check.status === 'skipped') continue;
+        if (check.managedByPlugin) {
+          skipped.push(`${entry.agent}:mcp:${check.scope}:plugin-managed`);
+          continue;
+        }
         if (check.status === 'missing' && !canInstallMissing) {
           skipped.push(`${entry.agent}:mcp:${check.scope}:missing`);
           continue;

--- a/src/cli/commands/serve-http.ts
+++ b/src/cli/commands/serve-http.ts
@@ -839,10 +839,21 @@ export default defineCommand({
             };
           } catch { /* best effort */ }
 
-          let vectorStatus = { total: 0, missing: 0, missingIds: [] as number[], backfillRunning: false };
+          let vectorStatus = {
+            available: false,
+            total: 0,
+            missing: 0,
+            missingIds: [] as number[],
+            backfillRunning: false,
+          };
           try {
-            const { getVectorStatus } = await import('../../memory/observations.js');
-            vectorStatus = getVectorStatus(statsProjectId);
+            const { getSearchIndexStatus, getVectorStatus } = await import('../../memory/observations.js');
+            // The HTTP control plane has a different module graph from stdio MCP.
+            // Only report vector counts when this process actually owns a hydrated
+            // index; an empty singleton must not look like a healthy 0/0 state.
+            if (getSearchIndexStatus(statsProjectId).prepared) {
+              vectorStatus = { available: true, ...getVectorStatus(statsProjectId) };
+            }
           } catch { /* best effort */ }
 
           // Real search mode from the last actual search execution

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -484,6 +484,40 @@ function mergeTomlMcpConfig(existingContent: string | null, generatedContent: st
   return `${parts.join('\n\n')}\n`;
 }
 
+function isLegacyCodexMemorixNodeServer(server: MCPServerEntry): boolean {
+  if (server.name !== 'memorix' || server.command.trim().toLowerCase() !== 'node') return false;
+  const startsMemorixStdio = server.args.some((arg) => arg.trim().toLowerCase() === 'serve');
+  const sourceEntry = server.args.some((arg) => {
+    const normalized = arg.replace(/\\/g, '/').toLowerCase();
+    return /\/memorix\/dist\/cli\/index\.(?:[cm]?js)$/.test(normalized);
+  });
+  return startsMemorixStdio && sourceEntry;
+}
+
+/**
+ * Codex plugins now own Memorix stdio MCP registration. Remove only the old
+ * source-path form emitted by pre-plugin setup, never a user's custom server.
+ */
+export async function removeLegacyCodexMemorixMcpConfig(
+  configPath = path.join(homedir(), '.codex', 'config.toml'),
+): Promise<{ configPath: string; removed: boolean }> {
+  let existingContent: string;
+  try {
+    existingContent = await readFile(configPath, 'utf-8');
+  } catch {
+    return { configPath, removed: false };
+  }
+
+  const adapter = new CodexMCPAdapter();
+  const legacyServer = adapter.parse(existingContent).find(isLegacyCodexMemorixNodeServer);
+  if (!legacyServer) return { configPath, removed: false };
+
+  let nextContent = removeTomlSection(existingContent, 'mcp_servers.memorix.env');
+  nextContent = removeTomlSection(nextContent, 'mcp_servers.memorix');
+  await writeFile(configPath, nextContent ? `${nextContent}\n` : '', 'utf-8');
+  return { configPath, removed: true };
+}
+
 function mergeYamlMcpConfig(existingContent: string | null, generatedContent: string): string {
   let existing: Record<string, unknown> = {};
   try {
@@ -1091,6 +1125,16 @@ export async function installAgentSetup(agent: AgentName, plan: SetupPlan, globa
       const install = tryInstallCodexPlugin();
       if (install.ok) p.log.success(install.message);
       else p.log.warn(install.message);
+      if (install.ok) {
+        try {
+          const migration = await removeLegacyCodexMemorixMcpConfig();
+          if (migration.removed) {
+            p.log.info(`codex: removed legacy source-path MCP config from ${migration.configPath}`);
+          }
+        } catch {
+          p.log.warn('codex: plugin installed, but the legacy MCP config could not be checked');
+        }
+      }
     } else if (agent === 'claude' && result.marketplaceRoot) {
       const install = tryInstallClaudePlugin(result.marketplaceRoot);
       if (install.ok) p.log.success(install.message);

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -351,6 +351,17 @@ async function handleApi(
                     sourceCounts,
                     recentObservations: sorted,
                     embedding: embeddingStatus,
+                    // A standalone dashboard has no access to an active MCP
+                    // process's in-memory Orama index. Keep this explicit so the
+                    // UI never presents an empty local singleton as a healthy
+                    // all-vectors-indexed result.
+                    vectorStatus: {
+                        available: false,
+                        total: 0,
+                        missing: 0,
+                        missingIds: [],
+                        backfillRunning: false,
+                    },
                     storage: storageInfo,
                     maintenance,
                     ...(lifecycle ? { lifecycle } : {}),

--- a/src/dashboard/static/app.js
+++ b/src/dashboard/static/app.js
@@ -216,6 +216,7 @@ const i18n = {
     backfillPending: 'Backfill Pending',
     vectorsMissing: 'vectors missing',
     noBackfillNeeded: 'All vectors indexed',
+    vectorStatusSessionLocal: 'Active MCP session',
     providerReady: 'Ready',
     providerUnavailable: 'Unavailable',
     providerDisabled: 'Disabled (BM25 only)',
@@ -647,6 +648,7 @@ const i18n = {
     backfillPending: '回填待处理',
     vectorsMissing: '条向量缺失',
     noBackfillNeeded: '所有向量已索引',
+    vectorStatusSessionLocal: '由活动 MCP 会话统计',
     providerReady: '就绪',
     providerUnavailable: '不可用',
     providerDisabled: '已禁用 (仅 BM25)',
@@ -1357,6 +1359,9 @@ async function loadDashboard() {
     : pendingProposals > 0
       ? { color: 'var(--accent-blue)', text: `${pendingProposals} ${t('pendingProposals')}` }
       : { color: 'var(--accent-green)', text: t('knowledgeReady') };
+  // Standalone dashboards and older control planes do not own the MCP process's
+  // in-memory index. Absence of a proof is not proof that every vector exists.
+  const vectorStatusAvailable = stats.vectorStatus?.available === true;
 
   const typeIcons = {
     'session-request': '<span class="iconify" data-icon="lucide:target" style="color:#f87171;"></span>', gotcha: '<span class="iconify" data-icon="lucide:alert-octagon" style="color:#ef4444;"></span>', 'problem-solution': '<span class="iconify" data-icon="lucide:lightbulb" style="color:#fbbf24;"></span>',
@@ -1418,8 +1423,8 @@ async function loadDashboard() {
             </div>
             <div>
               <div style="font-size:11px;color:var(--text-muted);margin-bottom:4px;">${t('backfillPending')}</div>
-              <div style="font-size:14px;font-weight:600;color:${(stats.vectorStatus?.missing || 0) > 0 ? 'var(--accent-amber)' : 'var(--accent-green)'};">
-                ${(stats.vectorStatus?.missing || 0) > 0 ? stats.vectorStatus.missing + ' ' + t('vectorsMissing') : t('noBackfillNeeded')}
+              <div style="font-size:14px;font-weight:600;color:${!vectorStatusAvailable ? 'var(--text-muted)' : (stats.vectorStatus?.missing || 0) > 0 ? 'var(--accent-amber)' : 'var(--accent-green)'};">
+                ${!vectorStatusAvailable ? t('vectorStatusSessionLocal') : (stats.vectorStatus?.missing || 0) > 0 ? stats.vectorStatus.missing + ' ' + t('vectorsMissing') : t('noBackfillNeeded')}
               </div>
             </div>
             <div>

--- a/src/memory/observations.ts
+++ b/src/memory/observations.ts
@@ -102,6 +102,10 @@ function normalizeEmbeddingFailure(error: unknown): { key: string; message: stri
   };
 }
 
+function vectorBackfillError(error: unknown): string {
+  return sanitizeCredentials(normalizeEmbeddingFailure(error).message).slice(0, 1_000);
+}
+
 function queueVectorBackfill(projectId: string): void {
   const dataDir = projectDir;
   if (!dataDir) return;
@@ -1202,6 +1206,7 @@ export async function backfillVectorEmbeddings(options: {
   attempted: number;
   succeeded: number;
   failed: number;
+  lastError?: string;
 }> {
   if (vectorBackfillRunning) {
     return { attempted: 0, succeeded: 0, failed: 0 };
@@ -1218,19 +1223,63 @@ export async function backfillVectorEmbeddings(options: {
   let succeeded = 0;
   let failed = 0;
   let lastFailure: string | undefined;
+  const recordFailure = (message: string): void => {
+    // A single batch may have several symptoms after one root cause. Preserve
+    // the first one so an informative provider/index error is not overwritten
+    // by later missing-result fallout.
+    if (!lastFailure) lastFailure = message;
+  };
+
+  const candidates: Array<{ id: number; observation: Observation; text: string }> = [];
+  for (const id of ids) {
+    const observation = observationById.get(id);
+    if (!observation) {
+      vectorMissingIds.delete(id);
+      continue;
+    }
+    candidates.push({
+      id,
+      observation,
+      text: [observation.title, observation.narrative, ...observation.facts].join(' '),
+    });
+  }
 
   try {
-    for (const id of ids) {
-      const obs = observationById.get(id);
-      if (!obs) {
-        vectorMissingIds.delete(id);
-        continue;
-      }
+    if (candidates.length === 0) {
+      return { attempted: ids.length, succeeded, failed };
+    }
 
-      const text = [obs.title, obs.narrative, ...obs.facts].join(' ');
-      try {
-        const embedding = await generateEmbedding(text);
-        if (embedding) {
+    let embeddings: number[][] | null = null;
+    try {
+      const provider = await getEmbeddingProvider();
+      if (!provider) {
+        if (isEmbeddingExplicitlyDisabled()) {
+          for (const candidate of candidates) vectorMissingIds.delete(candidate.id);
+        } else {
+          recordFailure('embedding provider unavailable');
+          failed += candidates.length;
+        }
+      } else {
+        // API providers batch and cache this efficiently; local providers can use
+        // their native batch path. Index writes stay sequential because Orama is
+        // process-local mutable state.
+        embeddings = await provider.embedBatch(candidates.map((candidate) => candidate.text));
+      }
+    } catch (error) {
+      recordFailure(vectorBackfillError(error));
+      failed += candidates.length;
+    }
+
+    if (embeddings) {
+      for (let index = 0; index < candidates.length; index++) {
+        const { id, observation: obs } = candidates[index];
+        const embedding = embeddings[index];
+        if (!embedding || embedding.length === 0) {
+          recordFailure('embedding provider returned no vector');
+          failed++;
+          continue;
+        }
+        try {
           if (!isVectorCompatibleWithCurrentIndex(embedding)) {
             await upgradeVectorSchemaAfterFirstEmbedding(embedding);
           }
@@ -1239,7 +1288,7 @@ export async function backfillVectorEmbeddings(options: {
             console.error(
               `[memorix] Backfill embedding mismatch for obs-${id}: provider returned ${embedding.length}d, index expects ${vectorDimensions ?? 'unknown'}d (kept in queue)`,
             );
-            lastFailure = `dimension mismatch: provider returned ${embedding.length}d, index expects ${vectorDimensions ?? 'unknown'}d`;
+            recordFailure(`dimension mismatch: provider returned ${embedding.length}d, index expects ${vectorDimensions ?? 'unknown'}d`);
             failed++;
             continue;
           }
@@ -1277,17 +1326,10 @@ export async function backfillVectorEmbeddings(options: {
           await insertObservation(doc);
           vectorMissingIds.delete(id);
           succeeded++;
-        } else if (isEmbeddingExplicitlyDisabled()) {
-          // Embedding explicitly off — nothing to backfill from
-          vectorMissingIds.delete(id);
-        } else {
-          // Provider temporarily unavailable — keep in queue for next backfill cycle
-          lastFailure = 'embedding provider unavailable';
+        } catch (error) {
+          recordFailure(vectorBackfillError(error));
           failed++;
         }
-      } catch (err) {
-        lastFailure = err instanceof Error ? err.message : String(err);
-        failed++;
       }
     }
   } finally {
@@ -1301,5 +1343,10 @@ export async function backfillVectorEmbeddings(options: {
     };
   }
 
-  return { attempted: ids.length, succeeded, failed };
+  return {
+    attempted: ids.length,
+    succeeded,
+    failed,
+    ...(lastFailure ? { lastError: lastFailure } : {}),
+  };
 }

--- a/src/runtime/maintenance-jobs.ts
+++ b/src/runtime/maintenance-jobs.ts
@@ -67,7 +67,18 @@ export interface MaintenanceJobSummary {
 
 export type MaintenanceJobRunResult =
   | { action: 'complete' }
-  | { action: 'reschedule'; delayMs: number; resetAttempts?: boolean; payload?: Record<string, unknown> };
+  | {
+    action: 'reschedule';
+    delayMs: number;
+    resetAttempts?: boolean;
+    payload?: Record<string, unknown>;
+    /** Keep recoverable work out of the immediate pending queue during a cooldown. */
+    status?: 'pending' | 'retry';
+    /** Persist a sanitized diagnostic without consuming the job's retry budget. */
+    lastError?: string;
+    /** Clear a stale transient diagnostic after the job makes progress. */
+    clearLastError?: boolean;
+  };
 
 export type MaintenanceJobHandler = (
   job: MaintenanceJob,
@@ -160,6 +171,12 @@ export class MaintenanceJobStore {
       `).get(input.projectId, input.kind, dedupeKey);
 
       if (existing) {
+        // A vector backfill in cooldown is a circuit-breaker state. A new MCP
+        // process must not pull it forward and recreate the original retry storm.
+        if (input.kind === 'vector-backfill' && existing.status === 'retry') {
+          this.commit();
+          return rowToJob(existing);
+        }
         const nextRunAfter = Math.min(Number(existing.run_after), runAfter);
         this.db.prepare(`
           UPDATE maintenance_jobs
@@ -169,6 +186,30 @@ export class MaintenanceJobStore {
         const updated = this.getRow(existing.id)!;
         this.commit();
         return rowToJob(updated);
+      }
+
+      // Older releases exhausted vector jobs on transient provider/index errors.
+      // Reuse one failed record so the next healthy session recovers work instead
+      // of adding another permanent failure row for the same project.
+      if (input.kind === 'vector-backfill') {
+        const failed = this.db.prepare(`
+          SELECT * FROM maintenance_jobs
+          WHERE project_id = ? AND kind = ? AND dedupe_key = ? AND status = 'failed'
+          ORDER BY updated_at DESC
+          LIMIT 1
+        `).get(input.projectId, input.kind, dedupeKey);
+        if (failed) {
+          this.db.prepare(`
+            UPDATE maintenance_jobs
+            SET status = 'pending', attempts = 0, max_attempts = ?, run_after = ?,
+                payload_json = ?, lease_owner = NULL, lease_expires_at = NULL,
+                last_error = NULL, completed_at = NULL, updated_at = ?
+            WHERE id = ?
+          `).run(maxAttempts, runAfter, payloadJson, now, failed.id);
+          const revived = this.getRow(failed.id)!;
+          this.commit();
+          return rowToJob(revived);
+        }
       }
 
       const id = randomUUID();
@@ -361,19 +402,55 @@ export class MaintenanceJobStore {
   reschedule(
     id: string,
     workerId: string,
-    options: { delayMs: number; resetAttempts?: boolean; payload?: Record<string, unknown>; now?: number },
+    options: {
+      delayMs: number;
+      resetAttempts?: boolean;
+      payload?: Record<string, unknown>;
+      status?: 'pending' | 'retry';
+      lastError?: string;
+      clearLastError?: boolean;
+      now?: number;
+    },
   ): MaintenanceJob | undefined {
     const now = options.now ?? Date.now();
     const delayMs = Number.isFinite(options.delayMs) ? Math.max(0, Math.floor(options.delayMs)) : 0;
     const payloadJson = options.payload === undefined ? null : JSON.stringify(options.payload);
+    const status = options.status === 'retry' ? 'retry' : 'pending';
+    const hasLastError = options.lastError !== undefined;
+    const lastError = hasLastError ? errorText(options.lastError) : null;
     this.db.prepare(`
       UPDATE maintenance_jobs
-      SET status = 'pending', run_after = ?, attempts = CASE WHEN ? THEN 0 ELSE attempts END,
+      SET status = ?, run_after = ?, attempts = CASE WHEN ? THEN 0 ELSE attempts END,
           payload_json = COALESCE(?, payload_json),
+          last_error = CASE
+            WHEN ? THEN NULL
+            WHEN ? THEN ?
+            ELSE last_error
+          END,
           lease_owner = NULL, lease_expires_at = NULL, updated_at = ?
       WHERE id = ? AND status = 'running' AND lease_owner = ?
-    `).run(now + delayMs, options.resetAttempts ? 1 : 0, payloadJson, now, id, workerId);
+    `).run(
+      status,
+      now + delayMs,
+      options.resetAttempts ? 1 : 0,
+      payloadJson,
+      options.clearLastError ? 1 : 0,
+      hasLastError ? 1 : 0,
+      lastError,
+      now,
+      id,
+      workerId,
+    );
     return this.get(id);
+  }
+
+  resolveFailedVectorBackfills(projectId: string, dedupeKey = 'vector-backfill', now = Date.now()): number {
+    const result = this.db.prepare(`
+      UPDATE maintenance_jobs
+      SET status = 'completed', completed_at = ?, updated_at = ?
+      WHERE project_id = ? AND kind = 'vector-backfill' AND dedupe_key = ? AND status = 'failed'
+    `).run(now, now, projectId, dedupeKey);
+    return Number(result.changes ?? 0);
   }
 
   fail(id: string, workerId: string, error: unknown, now = Date.now()): MaintenanceJob | undefined {
@@ -486,6 +563,9 @@ export class MaintenanceJobWorker {
             delayMs: result.delayMs,
             resetAttempts: result.resetAttempts,
             payload: result.payload,
+            status: result.status,
+            lastError: result.lastError,
+            clearLastError: result.clearLastError,
             now,
           });
           return { state: 'rescheduled', job: updated };

--- a/src/runtime/project-maintenance.ts
+++ b/src/runtime/project-maintenance.ts
@@ -1,6 +1,7 @@
-import type {
-  MaintenanceJobHandler,
-  MaintenanceJobRunResult,
+import {
+  MaintenanceJobStore,
+  type MaintenanceJobHandler,
+  type MaintenanceJobRunResult,
 } from './maintenance-jobs.js';
 import { runMaintenanceInChildProcess } from './isolated-maintenance.js';
 import {
@@ -18,12 +19,41 @@ const DEFAULT_CODEGRAPH_MAX_FILES = 5_000;
 const DEFAULT_CLAIM_DERIVATION_BATCH_SIZE = 100;
 const DEFAULT_OBSERVATION_QUALIFICATION_BATCH_SIZE = 100;
 const VECTOR_RETRY_DELAY_MS = 5_000;
+const VECTOR_FAILURE_BASE_RETRY_DELAY_MS = 60_000;
+const VECTOR_FAILURE_MAX_RETRY_DELAY_MS = 15 * 60_000;
 const DEDUP_PER_PAIR_TIMEOUT_MS = 5_000;
 
 function vectorBatchSize(payload: Record<string, unknown>): number {
   const value = payload.limit;
   if (typeof value !== 'number' || !Number.isFinite(value)) return DEFAULT_VECTOR_BATCH_SIZE;
   return Math.min(100, Math.max(1, Math.floor(value)));
+}
+
+function vectorBackfillFailureStreak(payload: Record<string, unknown>): number {
+  const value = payload.vectorBackfillFailureStreak;
+  return typeof value === 'number' && Number.isFinite(value)
+    ? Math.min(16, Math.max(0, Math.floor(value)))
+    : 0;
+}
+
+function vectorBackfillRetryDelayMs(streak: number): number {
+  return Math.min(
+    VECTOR_FAILURE_MAX_RETRY_DELAY_MS,
+    VECTOR_FAILURE_BASE_RETRY_DELAY_MS * (2 ** Math.max(0, streak - 1)),
+  );
+}
+
+function withoutVectorBackfillFailureStreak(payload: Record<string, unknown>): Record<string, unknown> {
+  const { vectorBackfillFailureStreak: _streak, ...rest } = payload;
+  return rest;
+}
+
+function resolveSupersededVectorFailures(projectDir: string, projectId: string): void {
+  try {
+    new MaintenanceJobStore(projectDir).resolveFailedVectorBackfills(projectId);
+  } catch {
+    // Health cleanup must never block the live memory path.
+  }
 }
 
 function retentionBatchSize(payload: Record<string, unknown>): number {
@@ -498,23 +528,50 @@ export function createProjectMaintenanceHandler(
 
     const { backfillVectorEmbeddings, getVectorStatus } = await import('../memory/observations.js');
     const before = getVectorStatus(projectId);
-    if (before.missing === 0) return { action: 'complete' };
+    if (before.missing === 0) {
+      resolveSupersededVectorFailures(projectDir, projectId);
+      return { action: 'complete' };
+    }
 
     const result = await backfillVectorEmbeddings({
       projectId,
       limit: vectorBatchSize(job.payload),
     });
     const after = getVectorStatus(projectId);
-    if (after.missing === 0) return { action: 'complete' };
-
-    if (result.failed > 0 && result.succeeded === 0) {
-      throw new Error(`vector backfill made no progress (${result.failed}/${result.attempted} failed)`);
+    if (after.missing === 0) {
+      resolveSupersededVectorFailures(projectDir, projectId);
+      return { action: 'complete' };
     }
 
+    if (result.failed > 0 && result.succeeded === 0) {
+      const streak = vectorBackfillFailureStreak(job.payload) + 1;
+      return {
+        action: 'reschedule',
+        status: 'retry',
+        delayMs: vectorBackfillRetryDelayMs(streak),
+        // This is a recoverable provider/index state, not a terminal job error.
+        // Keeping one retry row prevents new MCP processes from creating a storm.
+        resetAttempts: true,
+        payload: {
+          ...job.payload,
+          vectorBackfillFailureStreak: streak,
+        },
+        lastError: result.lastError ?? `vector backfill made no progress (${result.failed}/${result.attempted} failed)`,
+      };
+    }
+
+    const priorFailureStreak = vectorBackfillFailureStreak(job.payload);
+    const payload = withoutVectorBackfillFailureStreak(job.payload);
     return {
       action: 'reschedule',
       delayMs: result.attempted === 0 ? VECTOR_RETRY_DELAY_MS : 0,
       resetAttempts: result.succeeded > 0,
+      ...(result.succeeded > 0 ? {
+        ...(priorFailureStreak > 0 ? { payload } : {}),
+        ...(result.failed > 0 && result.lastError
+          ? { lastError: result.lastError }
+          : priorFailureStreak > 0 ? { clearLastError: true } : {}),
+      } : {}),
     };
   };
 }

--- a/tests/cli/agent-doctor.test.ts
+++ b/tests/cli/agent-doctor.test.ts
@@ -151,7 +151,8 @@ describe('agent doctor and repair', () => {
     }, null, 2), 'utf-8');
   }
 
-  function writeCurrentCodexPluginSetup() {
+  function writeCurrentCodexPluginSetup(options: { trustedHooks?: boolean } = {}) {
+    const trustedHooks = options.trustedHooks ?? true;
     const pluginPath = path.join(sandboxRoot, '.codex', 'plugins', 'memorix');
     mkdirSync(path.join(pluginPath, '.codex-plugin'), { recursive: true });
     mkdirSync(path.join(pluginPath, 'hooks'), { recursive: true });
@@ -171,7 +172,12 @@ describe('agent doctor and repair', () => {
         Stop: [],
       },
     }, null, 2), 'utf-8');
-    writeFileSync(path.join(sandboxRoot, '.codex', 'config.toml'), [
+    writeFileSync(path.join(pluginPath, '.mcp.json'), JSON.stringify({
+      mcpServers: {
+        memorix: { command: 'memorix', args: ['serve'] },
+      },
+    }, null, 2), 'utf-8');
+    const hookTrust = [
       '[hooks.state."memorix@personal:hooks/hooks.json:session_start:0:0"]',
       'trusted_hash = "sha256:test"',
       '[hooks.state."memorix@personal:hooks/hooks.json:user_prompt_submit:0:0"]',
@@ -182,7 +188,10 @@ describe('agent doctor and repair', () => {
       'trusted_hash = "sha256:test"',
       '[hooks.state."memorix@personal:hooks/hooks.json:stop:0:0"]',
       'trusted_hash = "sha256:test"',
-    ].join('\n'), 'utf-8');
+    ];
+    writeFileSync(path.join(sandboxRoot, '.codex', 'config.toml'), trustedHooks
+      ? hookTrust.join('\n')
+      : '[plugins."memorix@personal"]\nenabled = true\n', 'utf-8');
     writeFileSync(path.join(sandboxRoot, '.agents', 'plugins', 'marketplace.json'), JSON.stringify({
       name: 'personal',
       plugins: [{
@@ -190,6 +199,22 @@ describe('agent doctor and repair', () => {
         source: { source: 'local', path: './.codex/plugins/memorix' },
       }],
     }, null, 2), 'utf-8');
+  }
+
+  function writeCurrentCodexGuidance() {
+    const codexDir = path.join(sandboxRoot, '.codex');
+    mkdirSync(codexDir, { recursive: true });
+    writeFileSync(path.join(codexDir, 'AGENTS.md'), [
+      '# Memorix - Agent Instructions for Codex',
+      '',
+      '## Memory Autopilot',
+      '',
+      '- Default first step for non-trivial coding work: call `memorix_project_context` with the user task.',
+      '- Continuation fallback is mandatory: `memorix resume "<task>"` for prior work.',
+      '- Do not call more Memorix retrieval tools after a complete brief.',
+      '- For read-only work, do not call `memorix_store` unless the user asks to preserve a record.',
+      '',
+    ].join('\n'), 'utf-8');
   }
 
   function mockCodexPluginList(enabled = true) {
@@ -362,6 +387,42 @@ describe('agent doctor and repair', () => {
     ]));
     expect(codex.plugin.checks[2].runtime).toMatchObject({ installed: true, enabled: true });
     expect(codex.plugin.checks[3].hookTrust.trusted).toHaveLength(5);
+    expect(codex.mcp).toMatchObject({ status: 'ok', issues: [] });
+    expect(codex.mcp.checks[0]).toMatchObject({
+      managedByPlugin: true,
+      server: { command: 'memorix', args: ['serve'] },
+    });
+  });
+
+  it('uses the enabled Codex plugin MCP before hooks receive user trust', async () => {
+    writeCurrentCodexPluginSetup({ trustedHooks: false });
+    writeCurrentCodexGuidance();
+    mockCodexPluginList(true);
+
+    const result = await runCommand(doctorCommand, {
+      _: ['agents'],
+      agent: 'codex',
+      scope: 'global',
+      json: true,
+    });
+
+    const parsed = JSON.parse(result.stdout);
+    const codex = parsed.agents.entries.find((entry: any) => entry.agent === 'codex');
+
+    expect(codex.mcp).toMatchObject({ status: 'ok', issues: [] });
+    expect(codex.plugin.status).toBe('ok');
+    expect(codex.plugin.issues).toContain('codex-hook-trust-pending');
+    expect(parsed.agents.summary).toMatchObject({ ok: 1, repairable: 0 });
+
+    const humanResult = await runCommand(doctorCommand, {
+      _: ['agents'],
+      agent: 'codex',
+      scope: 'global',
+      json: false,
+    });
+    expect(humanResult.stdout).toContain('Hooks: waiting for Codex approval on first use; MCP remains available.');
+    expect(humanResult.stdout).toContain('No file repair needed.');
+    expect(humanResult.stdout).not.toContain('Repair:');
   });
 
   it('doctor agents reports a disabled Codex plugin as repairable', async () => {

--- a/tests/cli/setup-command.test.ts
+++ b/tests/cli/setup-command.test.ts
@@ -17,6 +17,7 @@ import {
   installOpenClawBundlePackage,
   installPiPackage,
   installPluginPackage,
+  removeLegacyCodexMemorixMcpConfig,
   getSetupAgentTargets,
 } from '../../src/cli/commands/setup.js';
 
@@ -591,6 +592,61 @@ describe('setup MCP config installer', () => {
       expect(content).toContain('command = "memorix"');
       expect(content).toContain('args = ["serve"]');
       expect(content).not.toContain('command = "old"');
+    } finally {
+      await cleanup(tmpDir);
+    }
+  });
+
+  it('migrates only the legacy Codex source-path MCP server after plugin setup', async () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const configPath = path.join(tmpDir, 'config.toml');
+      await fs.writeFile(
+        configPath,
+        [
+          '[mcp_servers.other]',
+          'command = "other"',
+          'args = []',
+          '',
+          '[mcp_servers.memorix]',
+          'command = "node"',
+          'args = ["E:/work/memorix/dist/cli/index.js", "serve"]',
+          '',
+          '[mcp_servers.memorix.env]',
+          'LEGACY_FLAG = "1"',
+          '',
+        ].join('\n'),
+        'utf-8',
+      );
+
+      const result = await removeLegacyCodexMemorixMcpConfig(configPath);
+      const content = await fs.readFile(configPath, 'utf-8');
+
+      expect(result).toMatchObject({ configPath, removed: true });
+      expect(content).toContain('[mcp_servers.other]');
+      expect(content).not.toContain('[mcp_servers.memorix]');
+      expect(content).not.toContain('LEGACY_FLAG');
+    } finally {
+      await cleanup(tmpDir);
+    }
+  });
+
+  it('does not remove a user-managed Codex memorix MCP server', async () => {
+    const tmpDir = makeTmpDir();
+    try {
+      const configPath = path.join(tmpDir, 'config.toml');
+      const customConfig = [
+        '[mcp_servers.memorix]',
+        'command = "node"',
+        'args = ["C:/tools/custom-memorix-server.js", "serve"]',
+        '',
+      ].join('\n');
+      await fs.writeFile(configPath, customConfig, 'utf-8');
+
+      const result = await removeLegacyCodexMemorixMcpConfig(configPath);
+
+      expect(result).toMatchObject({ configPath, removed: false });
+      expect(await fs.readFile(configPath, 'utf-8')).toBe(customConfig);
     } finally {
       await cleanup(tmpDir);
     }

--- a/tests/integration/dashboard-project-scope.test.ts
+++ b/tests/integration/dashboard-project-scope.test.ts
@@ -214,6 +214,9 @@ describe('Standalone Dashboard Project Scope', () => {
 
     expect(body.observations).toBe(2);
     expect(body.nextId).toBe(8);
+    // Standalone Dashboard cannot inspect an MCP process-local Orama index.
+    // It must not claim the project has a fully indexed vector corpus.
+    expect(body.vectorStatus).toMatchObject({ available: false, total: 0, missing: 0 });
   });
 
   it('GET /api/maintenance exposes project-scoped background work state', async () => {

--- a/tests/integration/embedding-live.test.ts
+++ b/tests/integration/embedding-live.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { getEmbeddingProvider, resetProvider } from '../../src/embedding/provider.js';
+
+const runLive = process.env.MEMORIX_RUN_LIVE_EMBEDDING_TESTS === '1';
+
+describe.skipIf(!runLive)('live embedding provider', () => {
+  afterEach(() => {
+    resetProvider();
+  });
+
+  it('returns one compatible vector for each batch input', async () => {
+    const provider = await getEmbeddingProvider();
+    expect(provider).not.toBeNull();
+
+    const vectors = await provider!.embedBatch([
+      'memorix live batch smoke alpha',
+      'memorix live batch smoke beta',
+    ]);
+
+    expect(vectors).toHaveLength(2);
+    expect(vectors.every((vector) => vector.length === provider!.dimensions)).toBe(true);
+  }, 60_000);
+});

--- a/tests/memory/vector-stability.test.ts
+++ b/tests/memory/vector-stability.test.ts
@@ -260,6 +260,45 @@ describe('Vector Stability', () => {
     expect(getVectorMissingIds()).toContain(observation.id);
   });
 
+  it('backfills queued observations through one provider batch request', async () => {
+    const oramaStore = await import('../../src/store/orama-store.js');
+    const embeddingProvider = await import('../../src/embedding/provider.js');
+    const vector = [0.1, 0.2, 0.3];
+    const embedBatch = vi.fn().mockResolvedValue([vector]);
+
+    vi.mocked(oramaStore.generateEmbedding).mockResolvedValue(null);
+    vi.mocked(oramaStore.getVectorDimensions).mockReturnValue(3);
+    vi.mocked(embeddingProvider.isEmbeddingExplicitlyDisabled).mockReturnValue(false);
+    vi.mocked(embeddingProvider.getEmbeddingProvider).mockResolvedValue({
+      name: 'api-test',
+      dimensions: 3,
+      embed: vi.fn(),
+      embedBatch,
+    });
+
+    const { storeObservation, backfillVectorEmbeddings, getVectorMissingIds } =
+      await import('../../src/memory/observations.ts');
+    const { observation } = await storeObservation({
+      entityName: 'batched-backfill',
+      type: 'gotcha',
+      title: 'Batched vector recovery',
+      narrative: 'The retry lane should use the provider batch endpoint.',
+      projectId: 'test/vector-batch',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(getVectorMissingIds()).toContain(observation.id);
+
+    const result = await backfillVectorEmbeddings({ projectId: 'test/vector-batch', limit: 1 });
+
+    expect(embedBatch).toHaveBeenCalledTimes(1);
+    expect(embedBatch).toHaveBeenCalledWith([
+      'Batched vector recovery The retry lane should use the provider batch endpoint.',
+    ]);
+    expect(result).toMatchObject({ attempted: 1, succeeded: 1, failed: 0 });
+    expect(getVectorMissingIds()).not.toContain(observation.id);
+  });
+
   it('backfill keeps items queued when the generated embedding dimensions do not match the index', async () => {
     const oramaStore = await import('../../src/store/orama-store.js');
 

--- a/tests/runtime/maintenance-jobs.test.ts
+++ b/tests/runtime/maintenance-jobs.test.ts
@@ -120,6 +120,104 @@ describe('MaintenanceJobStore', () => {
     expect(failed?.lastError).not.toContain('sk-abcdefghijklmnopqrstuvwxyz123456');
   });
 
+  it('keeps vector recovery in cooldown when another MCP process enqueues the same work', async () => {
+    const store = new MaintenanceJobStore(dataDir);
+    const job = store.enqueue({
+      projectId: 'project-a',
+      kind: 'vector-backfill',
+      dedupeKey: 'vectors',
+      payload: { limit: 12 },
+      now: 1_000,
+    });
+    const worker = new MaintenanceJobWorker(store, async () => ({
+      action: 'reschedule' as const,
+      status: 'retry' as const,
+      delayMs: 60_000,
+      resetAttempts: true,
+      payload: { limit: 12, vectorBackfillFailureStreak: 1 },
+      lastError: 'provider unavailable',
+    }), { workerId: 'vector-worker', leaseMs: 100 });
+
+    await worker.runOnce(1_000);
+    const cooled = store.get(job.id)!;
+    const duplicate = store.enqueue({
+      projectId: 'project-a',
+      kind: 'vector-backfill',
+      dedupeKey: 'vectors',
+      payload: { limit: 12 },
+      now: 2_000,
+    });
+
+    expect(cooled).toMatchObject({
+      status: 'retry',
+      attempts: 0,
+      lastError: 'provider unavailable',
+      payload: { limit: 12, vectorBackfillFailureStreak: 1 },
+    });
+    expect(duplicate).toMatchObject({
+      id: job.id,
+      status: 'retry',
+      runAfter: cooled.runAfter,
+      payload: { limit: 12, vectorBackfillFailureStreak: 1 },
+    });
+  });
+
+  it('revives one failed vector backfill instead of adding another failed row', () => {
+    const store = new MaintenanceJobStore(dataDir);
+    const job = store.enqueue({
+      projectId: 'project-a',
+      kind: 'vector-backfill',
+      dedupeKey: 'vectors',
+      maxAttempts: 1,
+      now: 1_000,
+    });
+    store.claimNext({ workerId: 'worker-a', now: 1_000, leaseMs: 100 });
+    expect(store.fail(job.id, 'worker-a', new Error('old transient failure'), 1_100)?.status).toBe('failed');
+
+    const revived = store.enqueue({
+      projectId: 'project-a',
+      kind: 'vector-backfill',
+      dedupeKey: 'vectors',
+      payload: { limit: 12 },
+      now: 2_000,
+    });
+
+    expect(revived).toMatchObject({
+      id: job.id,
+      status: 'pending',
+      attempts: 0,
+      payload: { limit: 12 },
+    });
+    expect(revived.lastError).toBeUndefined();
+  });
+
+  it('resolves historical vector failures after a later backfill completes', () => {
+    const store = new MaintenanceJobStore(dataDir);
+    const failed = store.enqueue({
+      projectId: 'project-a',
+      kind: 'vector-backfill',
+      dedupeKey: 'vectors',
+      maxAttempts: 1,
+      now: 1_000,
+    });
+    store.claimNext({ workerId: 'worker-a', now: 1_000, leaseMs: 100 });
+    expect(store.fail(failed.id, 'worker-a', new Error('old provider failure'), 1_100)?.status).toBe('failed');
+
+    const unrelated = store.enqueue({
+      projectId: 'project-b',
+      kind: 'vector-backfill',
+      dedupeKey: 'vectors',
+      maxAttempts: 1,
+      now: 1_000,
+    });
+    store.claimNext({ workerId: 'worker-b', now: 1_000, leaseMs: 100 });
+    expect(store.fail(unrelated.id, 'worker-b', new Error('other project failure'), 1_100)?.status).toBe('failed');
+
+    expect(store.resolveFailedVectorBackfills('project-a', 'vectors', 2_000)).toBe(1);
+    expect(store.get(failed.id)).toMatchObject({ status: 'completed', completedAt: 2_000 });
+    expect(store.get(unrelated.id)?.status).toBe('failed');
+  });
+
   it('prunes completed history after its retention window without deleting failed diagnostics', () => {
     const store = new MaintenanceJobStore(dataDir);
     const completed = store.enqueue({

--- a/tests/runtime/project-maintenance.test.ts
+++ b/tests/runtime/project-maintenance.test.ts
@@ -110,6 +110,29 @@ describe('createProjectMaintenanceHandler', () => {
     expect(result).toEqual({ action: 'reschedule', delayMs: 0, resetAttempts: true });
   });
 
+  it('keeps a no-progress vector batch in durable cooldown with its real diagnostic', async () => {
+    getVectorStatus
+      .mockReturnValueOnce({ missing: 3 })
+      .mockReturnValueOnce({ missing: 3 });
+    backfillVectorEmbeddings.mockResolvedValue({
+      attempted: 2,
+      succeeded: 0,
+      failed: 2,
+      lastError: 'Embedding API timed out; using BM25 until embedding recovers',
+    });
+
+    const result = await createProjectMaintenanceHandler('project-a', 'C:/memorix-data')(makeJob());
+
+    expect(result).toEqual({
+      action: 'reschedule',
+      status: 'retry',
+      delayMs: 60_000,
+      resetAttempts: true,
+      payload: { limit: 2, vectorBackfillFailureStreak: 1 },
+      lastError: 'Embedding API timed out; using BM25 until embedding recovers',
+    });
+  });
+
   it('completes vector work immediately when embeddings are explicitly disabled', async () => {
     isEmbeddingExplicitlyDisabled.mockReturnValue(true);
 


### PR DESCRIPTION
## Summary
- Make vector backfill recoverable across short-lived MCP processes, with bounded retry backoff and useful diagnostics.
- Report vector index health honestly when dashboard/control-plane processes do not own the active MCP index.
- Treat the enabled Codex plugin as the MCP owner, keep hook approval host-owned, and safely remove only legacy source-path configuration after plugin installation.
- Add a guarded live OpenRouter embedding smoke and align all published plugin manifests with 1.2.8.

## Verification
- npm run lint
- npm run build
- npm test
- MEMORIX_RUN_LIVE_EMBEDDING_TESTS=1 vitest run tests/integration/embedding-live.test.ts
- npm pack --dry-run
- npm publish --dry-run --ignore-scripts
- isolated tarball CLI and stdio MCP smoke