### PR TITLE
fix: unify retention state and keep session resume lightweight

### DIFF
--- a/src/cli/commands/serve-http.ts
+++ b/src/cli/commands/serve-http.ts
@@ -24,21 +24,7 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { ObservationStore } from '../../store/obs-store.js';
 import { resolveToolProfile } from '../../server/tool-profile.js';
 import { scopeKnowledgeGraphToProject } from '../../memory/graph-scope.js';
-import { isImmune } from '../../memory/retention.js';
-import type { MemorixDocument } from '../../types.js';
-
-/**
- * Adapt a raw loaded observation into the MemorixDocument shape isImmune expects.
- * Raw Observation.concepts is a string[] at runtime; isImmune calls .split on it,
- * so concepts must be joined to a string before the call (Gap #7 runtime fix).
- */
-function toImmuneDoc(obs: unknown): MemorixDocument {
-  const o = obs as Record<string, unknown>;
-  return {
-    ...o,
-    concepts: Array.isArray(o.concepts) ? o.concepts.join(', ') : ((o.concepts as string) ?? ''),
-  } as unknown as MemorixDocument;
-}
+import { projectObservationRetention, summarizeRetentionProjections } from '../../memory/retention.js';
 import { canManageObservation, filterReadableObservations } from '../../memory/visibility.js';
 
 export const DEFAULT_SESSION_TIMEOUT_MS = 30 * 60 * 1000;
@@ -775,20 +761,7 @@ export default defineCommand({
           await initGraphStore(statsDataDir);
           const graph = { entities: getGraphStore().loadEntities(), relations: getGraphStore().loadRelations() };
 
-          const observations = await loadDashboardProjectObservations(statsDataDir, statsProjectId, 'active') as Array<{
-            type?: string;
-            id?: number;
-            title?: string;
-            entityName?: string;
-            createdAt?: string;
-            source?: string;
-            commitHash?: string;
-            filesModified?: string[];
-            relatedEntities?: string[];
-            status?: string;
-            importance?: number;
-            accessCount?: number;
-          }>;
+          const observations = await loadDashboardProjectObservations(statsDataDir, statsProjectId, 'active');
           const statsStore = await getDashboardObservationStore(statsDataDir);
           const nextId = await statsStore.loadIdCounter();
           const typeCounts: Record<string, number> = {};
@@ -826,20 +799,17 @@ export default defineCommand({
             filesModified: o.filesModified,
           }));
 
-          let retentionSummary = { active: 0, stale: 0, archive: 0, immune: 0 };
-          for (const obs of observations) {
-            const age = now - new Date(obs.createdAt || now).getTime();
-            const ageHours = age / (1000 * 60 * 60);
-            const importance = obs.importance ?? 5;
-            const accessCount = obs.accessCount ?? 0;
-            const lambda = 0.01;
-            const score = Math.min(importance * Math.exp(-lambda * ageHours) + Math.min(accessCount * 0.5, 3), 10);
-            const immune = isImmune(toImmuneDoc(obs));
-            if (immune) retentionSummary.immune++;
-            if (score >= 3) retentionSummary.active++;
-            else if (score >= 1) retentionSummary.stale++;
-            else retentionSummary.archive++;
-          }
+          const retention = summarizeRetentionProjections(
+            observations
+              .filter((observation) => observation.type !== 'probe')
+              .map((observation) => projectObservationRetention(observation, { referenceTime: new Date(now) })),
+          );
+          const retentionSummary = {
+            active: retention.active,
+            stale: retention.stale,
+            archive: retention.archiveCandidates,
+            immune: retention.immune,
+          };
 
           const sorted = [...observations].filter(o => o.type !== 'probe').sort((a, b) => (b.id || 0) - (a.id || 0)).slice(0, 10);
 
@@ -974,26 +944,38 @@ export default defineCommand({
 
         if (apiPath === '/retention') {
           const { projectId: retProjectId, dataDir: retDataDir } = await resolveRequestProject(url);
-          const observations = await loadDashboardProjectObservations(retDataDir, retProjectId, 'active') as Array<{ id?: number; title?: string; type?: string; importance?: number; accessCount?: number; lastAccessedAt?: string; createdAt?: string; entityName?: string }>;
-          const now = Date.now();
-          const scored = observations.map(obs => {
-            const age = now - new Date(obs.createdAt || now).getTime();
-            const ageHours = age / (1000 * 60 * 60);
-            const importance = obs.importance ?? 5;
-            const accessCount = obs.accessCount ?? 0;
-            const lambda = 0.01;
-            const decayScore = importance * Math.exp(-lambda * ageHours);
-            const accessBonus = Math.min(accessCount * 0.5, 3);
-            const score = Math.min(decayScore + accessBonus, 10);
-            const immune = isImmune(toImmuneDoc(obs));
-            return { id: obs.id, title: obs.title, type: obs.type, entityName: obs.entityName, score: Math.round(score * 100) / 100, isImmune: immune, ageHours: Math.round(ageHours * 10) / 10, accessCount };
+          const observations = await loadDashboardProjectObservations(retDataDir, retProjectId, 'active');
+          const referenceTime = new Date();
+          const rows = observations
+            .filter((observation) => observation.type !== 'probe')
+            .map((observation) => ({
+              observation,
+              retention: projectObservationRetention(observation, { referenceTime }),
+            }))
+            .sort((a, b) => b.retention.displayScore - a.retention.displayScore);
+          const summary = summarizeRetentionProjections(rows.map((row) => row.retention));
+          const items = rows.map(({ observation, retention }) => ({
+            id: observation.id,
+            title: observation.title,
+            type: observation.type,
+            entityName: observation.entityName,
+            score: retention.displayScore,
+            isImmune: retention.immune,
+            zone: retention.zone,
+            ageHours: retention.ageHours,
+            accessCount: retention.accessCount,
+            effectiveRetentionDays: retention.effectiveRetentionDays,
+            immunityReason: retention.immunityReason,
+          }));
+          sendJson({
+            summary: {
+              active: summary.active,
+              stale: summary.stale,
+              archive: summary.archiveCandidates,
+              immune: summary.immune,
+            },
+            items,
           });
-          scored.sort((a, b) => b.score - a.score);
-          const activeCount = scored.filter(s => s.score >= 3).length;
-          const staleCount = scored.filter(s => s.score < 3 && s.score >= 1).length;
-          const archiveCount = scored.filter(s => s.score < 1).length;
-          const immuneCount = scored.filter(s => s.isImmune).length;
-          sendJson({ summary: { active: activeCount, stale: staleCount, archive: archiveCount, immune: immuneCount }, items: scored });
           return;
         }
 

--- a/src/cli/commands/serve-http.ts
+++ b/src/cli/commands/serve-http.ts
@@ -24,6 +24,21 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { ObservationStore } from '../../store/obs-store.js';
 import { resolveToolProfile } from '../../server/tool-profile.js';
 import { scopeKnowledgeGraphToProject } from '../../memory/graph-scope.js';
+import { isImmune } from '../../memory/retention.js';
+import type { MemorixDocument } from '../../types.js';
+
+/**
+ * Adapt a raw loaded observation into the MemorixDocument shape isImmune expects.
+ * Raw Observation.concepts is a string[] at runtime; isImmune calls .split on it,
+ * so concepts must be joined to a string before the call (Gap #7 runtime fix).
+ */
+function toImmuneDoc(obs: unknown): MemorixDocument {
+  const o = obs as Record<string, unknown>;
+  return {
+    ...o,
+    concepts: Array.isArray(o.concepts) ? o.concepts.join(', ') : ((o.concepts as string) ?? ''),
+  } as unknown as MemorixDocument;
+}
 import { canManageObservation, filterReadableObservations } from '../../memory/visibility.js';
 
 export const DEFAULT_SESSION_TIMEOUT_MS = 30 * 60 * 1000;
@@ -819,8 +834,8 @@ export default defineCommand({
             const accessCount = obs.accessCount ?? 0;
             const lambda = 0.01;
             const score = Math.min(importance * Math.exp(-lambda * ageHours) + Math.min(accessCount * 0.5, 3), 10);
-            const isImmune = importance >= 8 || obs.type === 'gotcha' || obs.type === 'decision';
-            if (isImmune) retentionSummary.immune++;
+            const immune = isImmune(toImmuneDoc(obs));
+            if (immune) retentionSummary.immune++;
             if (score >= 3) retentionSummary.active++;
             else if (score >= 1) retentionSummary.stale++;
             else retentionSummary.archive++;
@@ -970,8 +985,8 @@ export default defineCommand({
             const decayScore = importance * Math.exp(-lambda * ageHours);
             const accessBonus = Math.min(accessCount * 0.5, 3);
             const score = Math.min(decayScore + accessBonus, 10);
-            const isImmune = importance >= 8 || obs.type === 'gotcha' || obs.type === 'decision';
-            return { id: obs.id, title: obs.title, type: obs.type, entityName: obs.entityName, score: Math.round(score * 100) / 100, isImmune, ageHours: Math.round(ageHours * 10) / 10, accessCount };
+            const immune = isImmune(toImmuneDoc(obs));
+            return { id: obs.id, title: obs.title, type: obs.type, entityName: obs.entityName, score: Math.round(score * 100) / 100, isImmune: immune, ageHours: Math.round(ageHours * 10) / 10, accessCount };
           });
           scored.sort((a, b) => b.score - a.score);
           const activeCount = scored.filter(s => s.score >= 3).length;

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -23,22 +23,9 @@ import { resetDotenv } from '../config/dotenv-loader.js';
 import { initProjectRoot } from '../config/yaml-loader.js';
 import { clearProjectRoot } from '../config/yaml-loader.js';
 import { scopeKnowledgeGraphToProject } from '../memory/graph-scope.js';
-import { isImmune } from '../memory/retention.js';
-
-/**
- * Adapt a raw loaded observation into the MemorixDocument shape isImmune expects.
- * Raw Observation.concepts is a string[] at runtime; isImmune calls .split on it,
- * so concepts must be joined to a string before the call (Gap #7 runtime fix).
- */
-function toImmuneDoc(obs: unknown): MemorixDocument {
-    const o = obs as Record<string, unknown>;
-    return {
-        ...o,
-        concepts: Array.isArray(o.concepts) ? o.concepts.join(', ') : ((o.concepts as string) ?? ''),
-    } as unknown as MemorixDocument;
-}
+import { projectObservationRetention, summarizeRetentionProjections } from '../memory/retention.js';
 import { canManageObservation, filterReadableObservations } from '../memory/visibility.js';
-import type { Observation, MemorixDocument } from '../types.js';
+import type { Observation } from '../types.js';
 
 // MIME types for static file serving
 const MIME_TYPES: Record<string, string> = {
@@ -263,7 +250,7 @@ async function handleApi(
                 const observations = filterDashboardObservations(
                     await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' }),
                     effectiveProjectId,
-                ) as Array<{ type?: string; id?: number; createdAt?: string; title?: string; entityName?: string; relatedEntities?: string[]; status?: string }>;
+                );
                 const nextId = await getObservationStore().loadIdCounter();
 
                 // Project-scoped graph counts (must match /api/graph and /api/export)
@@ -304,21 +291,18 @@ async function handleApi(
                     filesModified: (o as any).filesModified,
                 }));
 
-                // Retention summary
-                let retentionSummary = { active: 0, stale: 0, archive: 0, immune: 0 };
-                for (const obs of observations) {
-                    const age = now - new Date((obs as any).createdAt || now).getTime();
-                    const ageHours = age / (1000 * 60 * 60);
-                    const importance = (obs as any).importance ?? 5;
-                    const accessCount = (obs as any).accessCount ?? 0;
-                    const lambda = 0.01;
-                    const score = Math.min(importance * Math.exp(-lambda * ageHours) + Math.min(accessCount * 0.5, 3), 10);
-                    const immune = isImmune(toImmuneDoc(obs));
-                    if (immune) retentionSummary.immune++;
-                    if (score >= 3) retentionSummary.active++;
-                    else if (score >= 1) retentionSummary.stale++;
-                    else retentionSummary.archive++;
-                }
+                const retentionReferenceTime = new Date(now);
+                const retention = summarizeRetentionProjections(
+                    observations
+                        .filter((observation) => observation.type !== 'probe')
+                        .map((observation) => projectObservationRetention(observation, { referenceTime: retentionReferenceTime })),
+                );
+                const retentionSummary = {
+                    active: retention.active,
+                    stale: retention.stale,
+                    archive: retention.archiveCandidates,
+                    immune: retention.immune,
+                };
 
                 // Recent observations (last 10, exclude probe)
                 const sorted = [...observations].filter(o => o.type !== 'probe')
@@ -413,55 +397,38 @@ async function handleApi(
                 const observations = filterDashboardObservations(
                     await getObservationStore().loadByProject(effectiveProjectId, { status: 'active' }),
                     effectiveProjectId,
-                ) as Array<{
-                    id?: number;
-                    title?: string;
-                    type?: string;
-                    importance?: number;
-                    accessCount?: number;
-                    lastAccessedAt?: string;
-                    createdAt?: string;
-                    entityName?: string;
-                }>;
+                );
 
-                const now = Date.now();
-                // Exclude probe from retention display -- not durable knowledge
-                const scored = observations.filter(obs => obs.type !== 'probe').map((obs) => {
-                    const age = now - new Date(obs.createdAt || now).getTime();
-                    const ageHours = age / (1000 * 60 * 60);
-                    const importance = obs.importance ?? 5;
-                    const accessCount = obs.accessCount ?? 0;
-
-                    // Exponential decay: score = importance * e^(-λt) + access_bonus
-                    const lambda = 0.01;
-                    const decayScore = importance * Math.exp(-lambda * ageHours);
-                    const accessBonus = Math.min(accessCount * 0.5, 3);
-                    const score = Math.min(decayScore + accessBonus, 10);
-
-                    const immune = isImmune(toImmuneDoc(obs));
-
-                    return {
-                        id: obs.id,
-                        title: obs.title,
-                        type: obs.type,
-                        entityName: obs.entityName,
-                        score: Math.round(score * 100) / 100,
-                        isImmune: immune,
-                        ageHours: Math.round(ageHours * 10) / 10,
-                        accessCount,
-                    };
-                });
-
-                // Sort by score descending
-                scored.sort((a, b) => b.score - a.score);
-
-                const activeCount = scored.filter((s) => s.score >= 3).length;
-                const staleCount = scored.filter((s) => s.score < 3 && s.score >= 1).length;
-                const archiveCount = scored.filter((s) => s.score < 1).length;
-                const immuneCount = scored.filter((s) => s.isImmune).length;
+                const referenceTime = new Date();
+                const rows = observations
+                    .filter((observation) => observation.type !== 'probe')
+                    .map((observation) => ({
+                        observation,
+                        retention: projectObservationRetention(observation, { referenceTime }),
+                    }))
+                    .sort((a, b) => b.retention.displayScore - a.retention.displayScore);
+                const summary = summarizeRetentionProjections(rows.map((row) => row.retention));
+                const scored = rows.map(({ observation, retention }) => ({
+                    id: observation.id,
+                    title: observation.title,
+                    type: observation.type,
+                    entityName: observation.entityName,
+                    score: retention.displayScore,
+                    isImmune: retention.immune,
+                    zone: retention.zone,
+                    ageHours: retention.ageHours,
+                    accessCount: retention.accessCount,
+                    effectiveRetentionDays: retention.effectiveRetentionDays,
+                    immunityReason: retention.immunityReason,
+                }));
 
                 sendJson(res, {
-                    summary: { active: activeCount, stale: staleCount, archive: archiveCount, immune: immuneCount },
+                    summary: {
+                        active: summary.active,
+                        stale: summary.stale,
+                        archive: summary.archiveCandidates,
+                        immune: summary.immune,
+                    },
                     items: scored,
                 });
                 break;

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -23,8 +23,22 @@ import { resetDotenv } from '../config/dotenv-loader.js';
 import { initProjectRoot } from '../config/yaml-loader.js';
 import { clearProjectRoot } from '../config/yaml-loader.js';
 import { scopeKnowledgeGraphToProject } from '../memory/graph-scope.js';
+import { isImmune } from '../memory/retention.js';
+
+/**
+ * Adapt a raw loaded observation into the MemorixDocument shape isImmune expects.
+ * Raw Observation.concepts is a string[] at runtime; isImmune calls .split on it,
+ * so concepts must be joined to a string before the call (Gap #7 runtime fix).
+ */
+function toImmuneDoc(obs: unknown): MemorixDocument {
+    const o = obs as Record<string, unknown>;
+    return {
+        ...o,
+        concepts: Array.isArray(o.concepts) ? o.concepts.join(', ') : ((o.concepts as string) ?? ''),
+    } as unknown as MemorixDocument;
+}
 import { canManageObservation, filterReadableObservations } from '../memory/visibility.js';
-import type { Observation } from '../types.js';
+import type { Observation, MemorixDocument } from '../types.js';
 
 // MIME types for static file serving
 const MIME_TYPES: Record<string, string> = {
@@ -299,8 +313,8 @@ async function handleApi(
                     const accessCount = (obs as any).accessCount ?? 0;
                     const lambda = 0.01;
                     const score = Math.min(importance * Math.exp(-lambda * ageHours) + Math.min(accessCount * 0.5, 3), 10);
-                    const isImmune = importance >= 8 || obs.type === 'gotcha' || obs.type === 'decision';
-                    if (isImmune) retentionSummary.immune++;
+                    const immune = isImmune(toImmuneDoc(obs));
+                    if (immune) retentionSummary.immune++;
                     if (score >= 3) retentionSummary.active++;
                     else if (score >= 1) retentionSummary.stale++;
                     else retentionSummary.archive++;
@@ -424,8 +438,7 @@ async function handleApi(
                     const accessBonus = Math.min(accessCount * 0.5, 3);
                     const score = Math.min(decayScore + accessBonus, 10);
 
-                    // Immune if importance >= 8 or type is 'gotcha' or 'decision'
-                    const isImmune = importance >= 8 || obs.type === 'gotcha' || obs.type === 'decision';
+                    const immune = isImmune(toImmuneDoc(obs));
 
                     return {
                         id: obs.id,
@@ -433,7 +446,7 @@ async function handleApi(
                         type: obs.type,
                         entityName: obs.entityName,
                         score: Math.round(score * 100) / 100,
-                        isImmune,
+                        isImmune: immune,
                         ageHours: Math.round(ageHours * 10) / 10,
                         accessCount,
                     };

--- a/src/memory/retention.ts
+++ b/src/memory/retention.ts
@@ -319,6 +319,40 @@ export interface RetentionExplanation {
   summary: string;
 }
 
+/** Access metadata maintained outside the persisted observation record. */
+export type ObservationAccessMap = ReadonlyMap<number, {
+  accessCount: number;
+  lastAccessedAt: string;
+}>;
+
+/**
+ * One canonical retention result for a persisted observation.
+ *
+ * Consumers should use this projection instead of recreating a local decay
+ * formula. That keeps the UI, HTTP control plane, and archive worker aligned
+ * on the same retention state.
+ */
+export interface RetentionProjection extends RetentionExplanation {
+  relevance: RelevanceScore;
+  /** A backwards-compatible 0-10 display value derived from relevance. */
+  displayScore: number;
+  ageHours: number;
+  accessCount: number;
+  lastAccessedAt: string;
+}
+
+export interface ObservationRetentionProjectionOptions {
+  referenceTime?: Date;
+  accessMap?: ObservationAccessMap;
+}
+
+export interface RetentionProjectionSummary {
+  active: number;
+  stale: number;
+  archiveCandidates: number;
+  immune: number;
+}
+
 /**
  * Produce a structured explanation of why an observation has its current
  * retention posture.  Designed for operator-facing reporting.
@@ -371,27 +405,16 @@ export function explainRetention(
   };
 }
 
-// ── Auto-Archive ────────────────────────────────────────────────────
-
-export interface ArchiveExpiredBatchOptions {
-  projectId: string;
-  afterId?: number;
-  limit?: number;
-  referenceTime?: Date;
-  accessMap?: Map<number, { accessCount: number; lastAccessedAt: string }>;
-  /** Omit only for trusted background maintenance. */
-  reader?: ObservationReader;
-}
-
-export interface ArchiveExpiredBatchResult {
-  archived: number;
-  scanned: number;
-  nextCursor?: number;
-}
-
-function toRetentionDocument(
+/**
+ * Convert a stored observation into the search/retention document shape.
+ *
+ * Observation fields such as concepts are arrays, while the retrieval schema
+ * intentionally stores them as strings. Centralising that conversion prevents
+ * callers from accidentally feeding raw observations into retention helpers.
+ */
+export function toRetentionDocument(
   obs: Observation,
-  accessMap?: Map<number, { accessCount: number; lastAccessedAt: string }>,
+  accessMap?: ObservationAccessMap,
 ): MemorixDocument {
   const access = accessMap?.get(obs.id);
   return {
@@ -418,6 +441,62 @@ function toRetentionDocument(
   };
 }
 
+/** Build the canonical retention result used by every Observation consumer. */
+export function projectObservationRetention(
+  observation: Observation,
+  options: ObservationRetentionProjectionOptions = {},
+): RetentionProjection {
+  const document = toRetentionDocument(observation, options.accessMap);
+  const relevance = calculateRelevance(document, options.referenceTime);
+  const explanation = explainRetention(document, options.referenceTime);
+
+  return {
+    ...explanation,
+    relevance,
+    displayScore: Math.round(Math.min(10, relevance.totalScore * 10) * 100) / 100,
+    ageHours: Math.round(relevance.ageDays * 24 * 10) / 10,
+    accessCount: document.accessCount,
+    lastAccessedAt: document.lastAccessedAt,
+  };
+}
+
+/** Summarise canonical projections without reimplementing retention thresholds. */
+export function summarizeRetentionProjections(
+  projections: readonly Pick<RetentionProjection, 'zone' | 'immune'>[],
+): RetentionProjectionSummary {
+  let active = 0;
+  let stale = 0;
+  let archiveCandidates = 0;
+  let immune = 0;
+
+  for (const projection of projections) {
+    if (projection.zone === 'active') active++;
+    else if (projection.zone === 'stale') stale++;
+    else archiveCandidates++;
+    if (projection.immune) immune++;
+  }
+
+  return { active, stale, archiveCandidates, immune };
+}
+
+// ── Auto-Archive ────────────────────────────────────────────────────
+
+export interface ArchiveExpiredBatchOptions {
+  projectId: string;
+  afterId?: number;
+  limit?: number;
+  referenceTime?: Date;
+  accessMap?: ObservationAccessMap;
+  /** Omit only for trusted background maintenance. */
+  reader?: ObservationReader;
+}
+
+export interface ArchiveExpiredBatchResult {
+  archived: number;
+  scanned: number;
+  nextCursor?: number;
+}
+
 /**
  * Archive one bounded page of a project's active memories. The caller owns the
  * cursor, which makes the operation safe to run from a durable maintenance job.
@@ -438,10 +517,10 @@ export async function archiveExpiredBatch(
   const scanned = hasMore ? page.slice(0, limit) : page;
   const candidateIds = scanned
     .filter((observation) => !options.reader || canManageObservation(observation, options.reader))
-    .filter((observation) => getRetentionZone(
-      toRetentionDocument(observation, options.accessMap),
-      options.referenceTime,
-    ) === 'archive-candidate')
+    .filter((observation) => projectObservationRetention(observation, {
+      accessMap: options.accessMap,
+      referenceTime: options.referenceTime,
+    }).zone === 'archive-candidate')
     .map((observation) => observation.id);
 
   const archived = candidateIds.length === 0
@@ -474,7 +553,7 @@ export async function archiveExpiredBatch(
 export async function archiveExpired(
   projectDir: string,
   referenceTime?: Date,
-  accessMap?: Map<number, { accessCount: number; lastAccessedAt: string }>,
+  accessMap?: ObservationAccessMap,
   projectId?: string,
   reader?: ObservationReader,
 ): Promise<{ archived: number; remaining: number }> {
@@ -512,9 +591,8 @@ export async function archiveExpired(
     const archivedIds: number[] = [];
 
     for (const obs of activeObs) {
-      const doc = toRetentionDocument(obs, accessMap);
-      const zone = getRetentionZone(doc, referenceTime);
-      if (zone === 'archive-candidate') {
+      const retention = projectObservationRetention(obs, { accessMap, referenceTime });
+      if (retention.zone === 'archive-candidate') {
         archivedIds.push(obs.id);
       }
     }

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -21,7 +21,18 @@ import { KnowledgeGraphManager } from './graph.js';
 import { redactCredentials, sanitizeCredentials } from './secret-filter.js';
 import { canReadObservation } from './visibility.js';
 
-const PRIORITY_TYPES = new Set(['gotcha', 'decision', 'problem-solution', 'trade-off', 'discovery']);
+// Types eligible for L2 "Key Project Memories" injection. Session requests carry
+// the original goal and change records carry the latest outcome, so both matter
+// when an agent resumes work after a handoff.
+const PRIORITY_TYPES = new Set([
+  'gotcha',
+  'decision',
+  'problem-solution',
+  'trade-off',
+  'discovery',
+  'session-request',
+  'what-changed',
+]);
 const RESUME_TYPES = new Set([
   'gotcha',
   'decision',
@@ -31,7 +42,6 @@ const RESUME_TYPES = new Set([
   'how-it-works',
   'what-changed',
   'reasoning',
-  'session-request',
 ]);
 const TYPE_EMOJI: Record<string, string> = {
   'gotcha': '[DISCOVERY]',
@@ -50,19 +60,24 @@ const TYPE_WEIGHTS: Record<string, number> = {
   'decision': 5.5,
   'problem-solution': 5.25,
   'trade-off': 4.75,
+  'session-request': 4.5,
   'discovery': 4.25,
+  'what-changed': 4,
 };
+// Markers that identify a memory as a demo/scratch artifact rather than real
+// working context. These are TITLE conventions — see isNoiseObservation.
+//
+// Deliberately excluded: 验证 / 兼容 / compat / 交接 / handoff. Those are ordinary
+// engineering vocabulary, not noise signals. Matching them silently dropped real
+// memories: any Chinese note about verification or compatibility, and any handoff
+// note that merely named a handoff tool, disappeared from session context with no
+// diagnostic. A noise filter must not veto the words its users normally write.
 const NOISE_PATTERNS = [
   /\[测试\]/i,
   /\[test\]/i,
-  /验证/i,
-  /兼容/i,
-  /\bcompat(?:ibility)?\b/i,
   /\bdemo\b/i,
   /展示/i,
   /全能力/i,
-  /handoff/i,
-  /交接/i,
   /for_memmcp_test/i,
   /\bbenchmark\b/i,
   /\bsandbox\b/i,
@@ -180,8 +195,13 @@ function isCommandTrace(obs: Observation): boolean {
 }
 
 function isNoiseObservation(obs: Observation): boolean {
-  const text = stringifyObservation(obs, false);
-  return NOISE_PATTERNS.some((pattern) => pattern.test(text)) || isCommandTrace(obs);
+  // Match the title only. Demo/scratch markers are a titling convention, so scanning
+  // the narrative/facts/concepts produced false positives on real memories that merely
+  // *mentioned* one of these words in prose — and because this filter runs before the
+  // PRIORITY_TYPES check and drops the observation outright (not a score penalty), a
+  // single unlucky word in a long narrative made the whole memory unreachable.
+  const title = obs.title ?? '';
+  return NOISE_PATTERNS.some((pattern) => pattern.test(title)) || isCommandTrace(obs);
 }
 
 function isSystemSelfObservation(obs: Observation): boolean {

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -341,6 +341,42 @@ export async function getSessionResumeBrief(
   };
 }
 
+const AUTO_RESUME_SUMMARY_LIMIT = 480;
+const AUTO_RESUME_TITLE_LIMIT = 180;
+
+function compactResumeText(text: string, limit: number): string {
+  const normalized = text.replace(/\s+/g, ' ').trim();
+  return normalized.length <= limit ? normalized : `${normalized.slice(0, Math.max(0, limit - 3)).trimEnd()}...`;
+}
+
+/**
+ * Render the bounded automatic delivery form of a resume brief.
+ *
+ * Full session context remains available through getSessionContext() and
+ * individual memory details remain on demand. Automatic session start gets an
+ * index, not a transcript, so it cannot crowd out the new task's context.
+ */
+export function renderSessionResumeCard(brief: SessionResumeBrief): string {
+  if (!brief.previousSession && brief.memories.length === 0) return '';
+
+  const lines = ['## Memorix Resume'];
+  if (brief.previousSession) {
+    const agent = brief.previousSession.agent ? ` (${brief.previousSession.agent})` : '';
+    lines.push(`Previous session: ${brief.previousSession.id}${agent}`);
+    lines.push(compactResumeText(brief.previousSession.summary, AUTO_RESUME_SUMMARY_LIMIT));
+  }
+
+  if (brief.memories.length > 0) {
+    lines.push('', 'Relevant memory references:');
+    for (const memory of brief.memories) {
+      lines.push(`- #${memory.id} [${memory.type}] ${compactResumeText(memory.title, AUTO_RESUME_TITLE_LIMIT)}`);
+    }
+    lines.push('Read a listed memory only when its title is relevant to the current task.');
+  }
+
+  return lines.join('\n');
+}
+
 export function scoreObservationForSessionContext(obs: Observation, projectTokens: string[], now = Date.now()): number {
   let score = TYPE_WEIGHTS[obs.type] ?? 1;
   const text = stringifyObservation(obs);
@@ -404,7 +440,7 @@ export function scoreObservationForSessionContext(obs: Observation, projectToken
  * so the agent can resume work without re-explaining everything.
  */
 export async function startSession(
-  projectDir: string,
+  _projectDir: string,
   projectId: string,
   opts?: { sessionId?: string; agent?: string; reader?: ObservationReader },
 ): Promise<{ session: Session; previousContext: string }> {
@@ -419,8 +455,11 @@ export async function startSession(
     agent: opts?.agent,
   };
 
-  // Load previous context before creating new session
-  const previousContext = await getSessionContext(projectDir, projectId, 3, opts?.reader);
+  // Automatic delivery stays intentionally small. The explicit context tool can
+  // still provide the expanded packet when an agent chooses to inspect it.
+  const previousContext = renderSessionResumeCard(
+    await getSessionResumeBrief(projectId, undefined, opts?.reader),
+  );
 
   // Atomic rollover: complete all active sessions for this project's aliases
   // and insert the new session in a single SQLite transaction.

--- a/src/search/intent-detector.ts
+++ b/src/search/intent-detector.ts
@@ -12,7 +12,7 @@ import type { ObservationType } from '../types.js';
 
 // ─── Types ───
 
-export type QueryIntent = 'why' | 'when' | 'how' | 'what_changed' | 'problem' | 'general';
+export type QueryIntent = 'why' | 'when' | 'how' | 'what_changed' | 'problem' | 'state' | 'general';
 
 export interface IntentResult {
   /** Detected intent category */
@@ -39,6 +39,30 @@ interface IntentPattern {
 }
 
 const INTENT_PATTERNS: IntentPattern[] = [
+  {
+    // Resumption queries — "where were we", "what's left". Weighted just above the
+    // others because these are asked at handoff time, when returning the current
+    // state matters more than returning the best semantic match.
+    intent: 'state',
+    patterns: [
+      /\bprogress\b/i,
+      /\bstatus\b/i,
+      /\bremaining\b/i,
+      /\bnext steps?\b/i,
+      /\bwhere (?:did|are) we\b/i,
+      /\bpick(?:ing)? up\b/i,
+      /\bresume\b/i,
+      /\bto-?do\b/i,
+      /进度/,
+      /做到哪/,
+      /下一步/,
+      /待办/,
+      /剩下/,
+      /继续/,
+      /接着做/,
+    ],
+    weight: 1.1,
+  },
   {
     intent: 'why',
     patterns: [
@@ -139,6 +163,12 @@ const INTENT_PATTERNS: IntentPattern[] = [
 // ─── Type Boost Maps ───
 
 const INTENT_TYPE_BOOSTS: Record<QueryIntent, Partial<Record<ObservationType, number>>> = {
+  state: {
+    'session-request': 2.5,
+    'what-changed': 2.0,
+    'discovery': 1.5,
+    'problem-solution': 1.2,
+  },
   why: {
     'decision': 3.0,
     'why-it-exists': 3.0,
@@ -198,6 +228,14 @@ const INTENT_SOURCE_BOOSTS: Partial<Record<QueryIntent, Partial<Record<'agent' |
 };
 
 const INTENT_FIELD_BOOSTS: Partial<Record<QueryIntent, Record<string, number>>> = {
+  state: {
+    title: 3,           // State notes are titled by topic — the title carries the signal
+    entityName: 1.5,
+    narrative: 2,
+    facts: 2.5,         // Progress lines usually live in facts
+    concepts: 1,
+    filesModified: 0.5,
+  },
   why: {
     title: 2,
     entityName: 1.5,

--- a/src/server.ts
+++ b/src/server.ts
@@ -3637,7 +3637,7 @@ export async function createMemorixServer(
   /**
    * memorix_session_start — Start a new coding session
    *
-   * Creates a session record and returns context from previous sessions.
+   * Creates a session record and returns a compact continuation card.
    * This is the entry point for session-aware memory management.
    */
   server.registerTool(
@@ -3645,10 +3645,10 @@ export async function createMemorixServer(
     {
       title: 'Start Session',
       description:
-        'Start a new coding session. Returns context from previous sessions so you can resume work seamlessly. ' +
-        'Call this at the beginning of a session to track activity and get injected context. ' +
+        'Start a new coding session. Returns a compact continuation card with the latest handoff and a few memory references. ' +
+        'Call this at the beginning of a session to track activity; retrieve a referenced memory only when it is relevant. ' +
         'Any previous active session for this project will be auto-closed. ' +
-        'By default this is lightweight: it binds the project, opens a session, and injects context only. ' +
+        'By default this is lightweight: it binds the project, opens a session, and avoids dumping full history into the new context. ' +
         'Coordination identity is opt-in via `joinTeam: true` or a separate `team_manage` join call.\n\n' +
         'IMPORTANT for HTTP/control-plane mode: pass `projectRoot` with the absolute path to your ' +
         'workspace root (e.g., the directory open in your IDE). Memorix uses this to detect the git ' +
@@ -3851,7 +3851,7 @@ export async function createMemorixServer(
       } catch { /* mini-skills not available yet — skip */ }
 
       if (result.previousContext) {
-        lines.push('---', '[TASK] **Context from previous sessions:**', '', result.previousContext);
+        lines.push('---', '[TASK] **Continuation card:**', '', result.previousContext);
       } else {
         lines.push('No previous session context found. This appears to be a fresh project.');
       }

--- a/tests/http/retention-immune-parity.test.ts
+++ b/tests/http/retention-immune-parity.test.ts
@@ -7,8 +7,13 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { isImmune } from '../../src/memory/retention.js';
-import type { MemorixDocument } from '../../src/types.js';
+import {
+  isImmune,
+  projectObservationRetention,
+  summarizeRetentionProjections,
+  toRetentionDocument,
+} from '../../src/memory/retention.js';
+import type { MemorixDocument, Observation } from '../../src/types.js';
 
 function makeDoc(overrides: Partial<MemorixDocument> = {}): MemorixDocument {
   return {
@@ -34,6 +39,23 @@ function makeDoc(overrides: Partial<MemorixDocument> = {}): MemorixDocument {
   };
 }
 
+function makeObservation(overrides: Partial<Observation> = {}): Observation {
+  return {
+    id: 1,
+    entityName: 'test',
+    type: 'decision',
+    title: 'Test',
+    narrative: 'Test narrative',
+    facts: [],
+    filesModified: [],
+    concepts: [],
+    tokens: 50,
+    createdAt: new Date().toISOString(),
+    projectId: 'test',
+    ...overrides,
+  };
+}
+
 describe('Retention immunity parity (Gap #7)', () => {
   it('bare gotcha (no core, no protected tags, low access) is NOT immune', () => {
     const doc = makeDoc({ type: 'gotcha', valueCategory: '', concepts: '', accessCount: 0 });
@@ -55,32 +77,57 @@ describe('Retention immunity parity (Gap #7)', () => {
     expect(isImmune(doc)).toBe(false);
   });
 
-  // --- Runtime shape guard (Gap #7 blocker) ---------------------------------
-  // Raw loaded Observation.concepts is a string[] at runtime. isImmune calls
-  // .split on concepts, so passing a raw array throws. Callsites use this same
-  // adapter to join concepts to a string first.
-  function toImmuneDoc(obs: unknown): MemorixDocument {
-    const o = obs as Record<string, unknown>;
-    return {
-      ...o,
-      concepts: Array.isArray(o.concepts) ? o.concepts.join(', ') : ((o.concepts as string) ?? ''),
-    } as unknown as MemorixDocument;
-  }
-
-  it('raw array concepts passed directly to isImmune THROWS (why the adapter exists)', () => {
+  it('raw array concepts passed directly to isImmune throws', () => {
     const raw = { ...makeDoc({ type: 'gotcha', accessCount: 0 }), concepts: ['foo', 'bar'] } as unknown as MemorixDocument;
     expect(() => isImmune(raw)).toThrow();
   });
 
-  it('callsite adapter joins string[] concepts: does NOT throw and gotcha is NOT immune', () => {
-    const raw = { type: 'gotcha', accessCount: 0, valueCategory: '', concepts: ['foo', 'bar'] };
-    let result: boolean | undefined;
-    expect(() => { result = isImmune(toImmuneDoc(raw)); }).not.toThrow();
-    expect(result).toBe(false);
+  it('central adapter joins string[] concepts: does not throw and gotcha is not immune', () => {
+    const raw = makeObservation({ type: 'gotcha', concepts: ['foo', 'bar'] });
+    expect(() => isImmune(toRetentionDocument(raw))).not.toThrow();
+    expect(isImmune(toRetentionDocument(raw))).toBe(false);
   });
 
-  it('callsite adapter preserves protected tags in string[] concepts (immune)', () => {
-    const raw = { type: 'gotcha', accessCount: 0, valueCategory: '', concepts: ['pinned', 'foo'] };
-    expect(isImmune(toImmuneDoc(raw))).toBe(true);
+  it('central projection preserves protected tags and canonical lifecycle state', () => {
+    const referenceTime = new Date('2026-07-27T00:00:00.000Z');
+    const raw = makeObservation({
+      type: 'gotcha',
+      concepts: ['pinned', 'foo'],
+      createdAt: new Date('2025-01-01T00:00:00.000Z').toISOString(),
+    });
+
+    const projection = projectObservationRetention(raw, { referenceTime });
+    expect(projection.immune).toBe(true);
+    expect(projection.zone).toBe('active');
+    expect(projection.accessCount).toBe(0);
+  });
+
+  it('summarizes lifecycle zones instead of applying display-score thresholds', () => {
+    const referenceTime = new Date('2026-07-27T00:00:00.000Z');
+    const projections = [
+      projectObservationRetention(makeObservation({
+        id: 1,
+        type: 'decision',
+        valueCategory: 'core',
+        createdAt: '2025-01-01T00:00:00.000Z',
+      }), { referenceTime }),
+      projectObservationRetention(makeObservation({
+        id: 2,
+        type: 'session-request',
+        createdAt: '2026-05-01T00:00:00.000Z',
+      }), { referenceTime }),
+      projectObservationRetention(makeObservation({
+        id: 3,
+        type: 'how-it-works',
+        createdAt: '2026-06-10T00:00:00.000Z',
+      }), { referenceTime }),
+    ];
+
+    expect(summarizeRetentionProjections(projections)).toEqual({
+      active: 1,
+      stale: 1,
+      archiveCandidates: 1,
+      immune: 1,
+    });
   });
 });

--- a/tests/http/retention-immune-parity.test.ts
+++ b/tests/http/retention-immune-parity.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Retention immunity parity test (Gap #7)
+ *
+ * Guards that HTTP/dashboard callsites use the canonical isImmune() from
+ * retention.ts instead of stale inline `importance >= 8 || type === gotcha/decision`
+ * checks. A bare gotcha/decision must NOT be permanently immune.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isImmune } from '../../src/memory/retention.js';
+import type { MemorixDocument } from '../../src/types.js';
+
+function makeDoc(overrides: Partial<MemorixDocument> = {}): MemorixDocument {
+  return {
+    id: 'obs-1',
+    observationId: 1,
+    entityName: 'test',
+    type: 'decision',
+    title: 'Test',
+    narrative: 'Test narrative',
+    facts: '',
+    filesModified: '',
+    concepts: '',
+    tokens: 50,
+    createdAt: new Date().toISOString(),
+    projectId: 'test',
+    accessCount: 0,
+    lastAccessedAt: '',
+    status: 'active',
+    source: 'agent',
+    sourceDetail: '',
+    valueCategory: '',
+    ...overrides,
+  };
+}
+
+describe('Retention immunity parity (Gap #7)', () => {
+  it('bare gotcha (no core, no protected tags, low access) is NOT immune', () => {
+    const doc = makeDoc({ type: 'gotcha', valueCategory: '', concepts: '', accessCount: 0 });
+    expect(isImmune(doc)).toBe(false);
+  });
+
+  it('bare decision is NOT immune (stale inline check wrongly said true)', () => {
+    const doc = makeDoc({ type: 'decision', valueCategory: '', concepts: '', accessCount: 0 });
+    expect(isImmune(doc)).toBe(false);
+  });
+
+  it('core valueCategory observation IS immune', () => {
+    const doc = makeDoc({ type: 'gotcha', valueCategory: 'core' });
+    expect(isImmune(doc)).toBe(true);
+  });
+
+  it('probe observation is NOT immune', () => {
+    const doc = makeDoc({ type: 'probe', valueCategory: 'core', accessCount: 99, concepts: 'pinned' });
+    expect(isImmune(doc)).toBe(false);
+  });
+
+  // --- Runtime shape guard (Gap #7 blocker) ---------------------------------
+  // Raw loaded Observation.concepts is a string[] at runtime. isImmune calls
+  // .split on concepts, so passing a raw array throws. Callsites use this same
+  // adapter to join concepts to a string first.
+  function toImmuneDoc(obs: unknown): MemorixDocument {
+    const o = obs as Record<string, unknown>;
+    return {
+      ...o,
+      concepts: Array.isArray(o.concepts) ? o.concepts.join(', ') : ((o.concepts as string) ?? ''),
+    } as unknown as MemorixDocument;
+  }
+
+  it('raw array concepts passed directly to isImmune THROWS (why the adapter exists)', () => {
+    const raw = { ...makeDoc({ type: 'gotcha', accessCount: 0 }), concepts: ['foo', 'bar'] } as unknown as MemorixDocument;
+    expect(() => isImmune(raw)).toThrow();
+  });
+
+  it('callsite adapter joins string[] concepts: does NOT throw and gotcha is NOT immune', () => {
+    const raw = { type: 'gotcha', accessCount: 0, valueCategory: '', concepts: ['foo', 'bar'] };
+    let result: boolean | undefined;
+    expect(() => { result = isImmune(toImmuneDoc(raw)); }).not.toThrow();
+    expect(result).toBe(false);
+  });
+
+  it('callsite adapter preserves protected tags in string[] concepts (immune)', () => {
+    const raw = { type: 'gotcha', accessCount: 0, valueCategory: '', concepts: ['pinned', 'foo'] };
+    expect(isImmune(toImmuneDoc(raw))).toBe(true);
+  });
+});

--- a/tests/memory/session.test.ts
+++ b/tests/memory/session.test.ts
@@ -92,6 +92,33 @@ describe('Session Lifecycle', () => {
       expect(sessions).toHaveLength(1);
       expect(sessions[0].id).toBe('persist-test');
     });
+
+    it('returns a bounded resume card instead of auto-injecting full history', async () => {
+      await storeObservation({
+        entityName: 'release',
+        type: 'decision',
+        title: 'Keep the release verification gate',
+        narrative: `MEMORY_BODY_SHOULD_NOT_AUTO_INJECT ${'detail '.repeat(400)}`,
+        projectId: PROJECT_ID,
+      });
+      await startSession(testDir, PROJECT_ID, { sessionId: 'previous-session' });
+      await endSession(
+        testDir,
+        'previous-session',
+        `Continue release verification. ${'summary '.repeat(400)} SESSION_TAIL_SHOULD_NOT_AUTO_INJECT`,
+      );
+
+      const resumed = await startSession(testDir, PROJECT_ID, { sessionId: 'resumed-session' });
+      const expanded = await getSessionContext(testDir, PROJECT_ID);
+
+      expect(resumed.previousContext).toContain('## Memorix Resume');
+      expect(resumed.previousContext).toContain('Keep the release verification gate');
+      expect(resumed.previousContext).not.toContain('MEMORY_BODY_SHOULD_NOT_AUTO_INJECT');
+      expect(resumed.previousContext).not.toContain('SESSION_TAIL_SHOULD_NOT_AUTO_INJECT');
+      expect(resumed.previousContext.length).toBeLessThan(1_000);
+      expect(expanded).toContain('## Key Project Memories');
+      expect(expanded).toContain('Keep the release verification gate');
+    });
   });
 
   describe('endSession', () => {

--- a/tests/search/intent-detector.test.ts
+++ b/tests/search/intent-detector.test.ts
@@ -123,4 +123,27 @@ describe('applyIntentBoost', () => {
     // Higher confidence → higher boost
     expect(highBoosted).toBeGreaterThanOrEqual(lowBoosted);
   });
+
+  describe('state intent (resumption queries)', () => {
+    it('detects English resumption phrasing', () => {
+      expect(detectQueryIntent('what is the progress and what are the next steps').intent).toBe('state');
+      expect(detectQueryIntent('where did we leave off, anything remaining?').intent).toBe('state');
+    });
+
+    it('detects Chinese resumption phrasing', () => {
+      expect(detectQueryIntent('现在进度怎么样，下一步做什么').intent).toBe('state');
+      expect(detectQueryIntent('上次做到哪了，还剩下什么待办').intent).toBe('state');
+    });
+
+    it('prefers the types that carry handoff state', () => {
+      const intent = detectQueryIntent('当前进度如何，下一步待办是什么');
+      const sessionRequest = applyIntentBoost(1.0, 'session-request', intent);
+      const howItWorks = applyIntentBoost(1.0, 'how-it-works', intent);
+      expect(sessionRequest).toBeGreaterThan(howItWorks);
+    });
+
+    it('leaves unrelated queries alone', () => {
+      expect(detectQueryIntent('why did we choose this database').intent).toBe('why');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- brings in the canonical immunity fix from #142, then centralizes the complete retention projection so archive maintenance, standalone Dashboard, and HTTP control-plane Dashboard all use the same lifecycle result
- returns zone, retention duration, and immunity reason from the retention endpoints while retaining the existing 0-10 display score
- brings in #144's handoff ranking and state-query intent, then changes automatic session start from a history dump to a bounded continuation card with on-demand detail

## Contributor provenance
- 57b0062 is a git cherry-pick -x of FBISiri's #142 fix. The new projection refactor is a separate follow-up commit, not a replacement presented as original work.
- 4e4312 is a git cherry-pick -x of #144, submitted by Tom-Ma-Ming. Its source commit uses a local-style email, so GitHub may not automatically connect the contribution graph; the source PR is intentionally retained here.

## Verification
- 
pm run lint`n- 
pm test - 243 files / 2727 tests passed; 1 intentionally skipped live embedding test
- 
pm run build`n- real isolated CLI smoke: session start/end/start returned the bounded resume card
- real control-plane smoke: /api/retention and /api/stats agreed on retention state