### PR TITLE
fix(embedding): keep CLI writes responsive during slow backfill

### DIFF
--- a/src/cli/commands/operator-shared.ts
+++ b/src/cli/commands/operator-shared.ts
@@ -110,7 +110,10 @@ export async function getCliProjectContext(options?: CliContextOptions): Promise
   } catch {
     // CLI reads remain available even if optional background maintenance metadata fails.
   }
-  await initObservations(dataDir);
+  await initObservations(dataDir, {
+    embeddingWriteMode: 'deferred',
+    projectRoot: project.rootPath,
+  });
   await initSessionStore(dataDir);
   const teamStore = await initTeamStore(dataDir);
 

--- a/src/memory/observations.ts
+++ b/src/memory/observations.ts
@@ -49,6 +49,17 @@ let observations: Observation[] = [];
 let nextId = 1;
 let projectDir: string | null = null;
 let searchIndexPrepared = false;
+export type ObservationEmbeddingWriteMode = 'background' | 'deferred';
+
+export interface ObservationRuntimeOptions {
+  /** Defer remote/local embedding to a detached worker for short-lived CLI writes. */
+  embeddingWriteMode?: ObservationEmbeddingWriteMode;
+  /** Git root used by the detached vector worker. */
+  projectRoot?: string;
+}
+
+let embeddingWriteMode: ObservationEmbeddingWriteMode = 'background';
+let embeddingWorkerProjectRoot: string | undefined;
 
 // ── Vector-missing tracking ──────────────────────────────────────
 // Tracks observation IDs whose async embedding write failed or was skipped.
@@ -106,7 +117,10 @@ function vectorBackfillError(error: unknown): string {
   return sanitizeCredentials(normalizeEmbeddingFailure(error).message).slice(0, 1_000);
 }
 
-function queueVectorBackfill(projectId: string): void {
+function queueVectorBackfill(
+  projectId: string,
+  options: { detachedWorker?: boolean; projectRoot?: string } = {},
+): void {
   const dataDir = projectDir;
   if (!dataDir) return;
   void import('../runtime/maintenance-jobs.js')
@@ -117,6 +131,19 @@ function queueVectorBackfill(projectId: string): void {
         dedupeKey: 'vector-backfill',
         payload: { limit: 12 },
       });
+      if (options.detachedWorker && options.projectRoot) {
+        void import('../runtime/vector-backfill-runner.js')
+          .then(({ launchDetachedVectorBackfill }) => {
+            launchDetachedVectorBackfill({
+              projectId,
+              projectRoot: options.projectRoot!,
+              dataDir,
+            });
+          })
+          .catch(() => {
+            // The durable queue remains available to a later MCP session.
+          });
+      }
     })
     .catch(() => {
       // Memory writes remain durable even when the optional maintenance queue is unavailable.
@@ -199,7 +226,12 @@ async function upgradeVectorSchemaAfterFirstEmbedding(embedding: number[]): Prom
  * Initialize the observations manager with a project directory.
  * Auto-initializes the ObservationStore if not already set.
  */
-export async function initObservations(dir: string): Promise<void> {
+export async function initObservations(
+  dir: string,
+  options: ObservationRuntimeOptions = {},
+): Promise<void> {
+  embeddingWriteMode = options.embeddingWriteMode ?? 'background';
+  embeddingWorkerProjectRoot = options.projectRoot;
   if (projectDir === dir) return;
   await initObservationStore(dir);
   const store = getObservationStore();
@@ -208,6 +240,70 @@ export async function initObservations(dir: string): Promise<void> {
   projectDir = dir;
   searchIndexPrepared = false;
   vectorSchemaUpgradePromise = null;
+}
+
+function scheduleObservationEmbedding(input: {
+  observationId: number;
+  projectId: string;
+  searchableText: string;
+  doc: MemorixDocument;
+}): void {
+  const { observationId, projectId, searchableText, doc } = input;
+  vectorMissingIds.add(observationId);
+
+  // A network fetch keeps Node's event loop alive even when its Promise is not
+  // awaited. One-shot CLI commands therefore persist first and let a detached
+  // worker consume the same durable queue.
+  if (embeddingWriteMode === 'deferred') {
+    if (isEmbeddingExplicitlyDisabled()) {
+      vectorMissingIds.delete(observationId);
+      return;
+    }
+    queueVectorBackfill(projectId, {
+      detachedWorker: true,
+      projectRoot: embeddingWorkerProjectRoot,
+    });
+    return;
+  }
+
+  void generateEmbedding(searchableText).then(async (embedding) => {
+    if (embedding) {
+      if (!isVectorCompatibleWithCurrentIndex(embedding)) {
+        await upgradeVectorSchemaAfterFirstEmbedding(embedding);
+      }
+      if (!isVectorCompatibleWithCurrentIndex(embedding)) {
+        const vectorDimensions = getVectorDimensions();
+        console.error(
+          `[memorix] Embedding dimension mismatch for obs-${observationId}: provider returned ${embedding.length}d, index expects ${vectorDimensions ?? 'unknown'}d (kept in backfill queue)`,
+        );
+        queueVectorBackfill(projectId);
+        return;
+      }
+      try {
+        await removeObservation(makeOramaObservationId(projectId, observationId));
+        await insertObservation(Object.assign({}, doc, { embedding }));
+        vectorMissingIds.delete(observationId);
+      } catch {
+        console.error(`[memorix] Embedding index update failed for obs-${observationId} (kept in backfill queue)`);
+        queueVectorBackfill(projectId);
+      }
+    } else if (isEmbeddingExplicitlyDisabled()) {
+      vectorMissingIds.delete(observationId);
+    } else {
+      queueVectorBackfill(projectId);
+      logEmbeddingFailureOnce(
+        'provider-unavailable',
+        `[memorix] Embedding provider unavailable (using BM25 until embedding recovers; queued obs-${observationId} for retry)`,
+      );
+    }
+  }).catch((err) => {
+    queueVectorBackfill(projectId);
+    const failure = normalizeEmbeddingFailure(err);
+    logEmbeddingFailureOnce(
+      failure.key,
+      `[memorix] Async embedding failed (using BM25 until embedding recovers; queued obs-${observationId} for retry): ${failure.message}`,
+    );
+  });
 }
 
 /**
@@ -507,49 +603,11 @@ export async function storeObservation(input: {
     queueClaimDerivation(observation);
   }
 
-  // Generate embedding async (fire-and-forget) — never blocks MCP response
-  // Track in vectorMissingIds until embedding is successfully written.
-  const obsId = observation.id;
-  vectorMissingIds.add(obsId);
-  const searchableText = [input.title, input.narrative, ...(input.facts ?? [])].join(' ');
-  generateEmbedding(searchableText).then(async (embedding) => {
-    if (embedding) {
-      if (!isVectorCompatibleWithCurrentIndex(embedding)) {
-        await upgradeVectorSchemaAfterFirstEmbedding(embedding);
-      }
-      if (!isVectorCompatibleWithCurrentIndex(embedding)) {
-        const vectorDimensions = getVectorDimensions();
-        console.error(
-          `[memorix] Embedding dimension mismatch for obs-${obsId}: provider returned ${embedding.length}d, index expects ${vectorDimensions ?? 'unknown'}d (kept in backfill queue)`,
-        );
-        queueVectorBackfill(input.projectId);
-        return;
-      }
-      try {
-        const { removeObservation: removeObs } = await import('../store/orama-store.js');
-        await removeObs(makeOramaObservationId(input.projectId, obsId));
-        await insertObservation(Object.assign({}, doc, { embedding }));
-        vectorMissingIds.delete(obsId);
-      } catch {
-        console.error(`[memorix] Embedding index update failed for obs-${obsId} (kept in backfill queue)`);
-        queueVectorBackfill(input.projectId);
-      }
-    } else if (isEmbeddingExplicitlyDisabled()) {
-      vectorMissingIds.delete(obsId);
-    } else {
-      queueVectorBackfill(input.projectId);
-      logEmbeddingFailureOnce(
-        'provider-unavailable',
-        `[memorix] Embedding provider unavailable (using BM25 until embedding recovers; queued obs-${obsId} for retry)`,
-      );
-    }
-  }).catch((err) => {
-    queueVectorBackfill(input.projectId);
-    const failure = normalizeEmbeddingFailure(err);
-    logEmbeddingFailureOnce(
-      failure.key,
-      `[memorix] Async embedding failed (using BM25 until embedding recovers; queued obs-${obsId} for retry): ${failure.message}`,
-    );
+  scheduleObservationEmbedding({
+    observationId: observation.id,
+    projectId: input.projectId,
+    searchableText: [input.title, input.narrative, ...(input.facts ?? [])].join(' '),
+    doc,
   });
 
   return { observation, upserted: false };
@@ -678,40 +736,11 @@ async function upsertObservation(
     queueClaimDerivation(existing);
   }
 
-  // Generate embedding async (fire-and-forget) — never blocks MCP response
-  const searchableText = [input.title, input.narrative, ...(input.facts ?? [])].join(' ');
-  const obsId = existing.id;
-  vectorMissingIds.add(obsId);
-  generateEmbedding(searchableText).then(async (embedding) => {
-    if (embedding) {
-      if (!isVectorCompatibleWithCurrentIndex(embedding)) {
-        await upgradeVectorSchemaAfterFirstEmbedding(embedding);
-      }
-      if (!isVectorCompatibleWithCurrentIndex(embedding)) {
-        queueVectorBackfill(existing.projectId);
-        return;
-      }
-      try {
-        const { removeObservation: removeObs } = await import('../store/orama-store.js');
-        await removeObs(makeOramaObservationId(existing.projectId, obsId));
-        await insertObservation(Object.assign({}, doc, { embedding }));
-        vectorMissingIds.delete(obsId);
-      } catch {
-        // Embedding index update failed — observation still persisted without vector
-        queueVectorBackfill(existing.projectId);
-      }
-    } else if (isEmbeddingExplicitlyDisabled()) {
-      vectorMissingIds.delete(obsId);
-    } else {
-      queueVectorBackfill(existing.projectId);
-    }
-  }).catch((err) => {
-    queueVectorBackfill(existing.projectId);
-    const failure = normalizeEmbeddingFailure(err);
-    logEmbeddingFailureOnce(
-      failure.key,
-      `[memorix] Async embedding failed (using BM25 until embedding recovers; queued obs-${obsId} for retry): ${failure.message}`,
-    );
+  scheduleObservationEmbedding({
+    observationId: existing.id,
+    projectId: existing.projectId,
+    searchableText: [input.title, input.narrative, ...(input.facts ?? [])].join(' '),
+    doc,
   });
 
   return existing;

--- a/src/runtime/vector-backfill-runner.ts
+++ b/src/runtime/vector-backfill-runner.ts
@@ -1,0 +1,144 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { loadDotenv } from '../config/dotenv-loader.js';
+import { initProjectRoot } from '../config/yaml-loader.js';
+import { prepareSearchIndex, initObservations } from '../memory/observations.js';
+import { sanitizeCredentials } from '../memory/secret-filter.js';
+import { initObservationStore } from '../store/obs-store.js';
+import { getDeferredCachedVectorHydration } from '../store/orama-store.js';
+import { closeAllDatabases } from '../store/sqlite-db.js';
+import { MaintenanceJobStore, MaintenanceJobWorker } from './maintenance-jobs.js';
+import { createProjectMaintenanceHandler } from './project-maintenance.js';
+
+export interface VectorBackfillRequest {
+  projectId: string;
+  projectRoot: string;
+  dataDir: string;
+}
+
+export interface VectorBackfillLauncherOptions {
+  runnerPath?: string;
+  exists?: (path: string) => boolean;
+  spawn?: typeof spawn;
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+/** Resolve the standalone worker next to either the library or CLI bundle. */
+export function resolveVectorBackfillRunnerPath(moduleUrl = import.meta.url): string {
+  const moduleDir = path.dirname(fileURLToPath(moduleUrl));
+  const distDir = path.basename(moduleDir) === 'cli'
+    ? path.dirname(moduleDir)
+    : path.basename(moduleDir) === 'runtime' && path.basename(path.dirname(moduleDir)) === 'src'
+      ? path.join(path.dirname(path.dirname(moduleDir)), 'dist')
+      : moduleDir;
+  return path.join(distDir, 'vector-backfill-runner.js');
+}
+
+/** Parse the internal request passed from a short-lived CLI process. */
+export function parseVectorBackfillRequest(raw: string): VectorBackfillRequest {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new Error('Vector backfill runner received invalid JSON input');
+  }
+
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    !isNonEmptyString((value as VectorBackfillRequest).projectId) ||
+    !isNonEmptyString((value as VectorBackfillRequest).projectRoot) ||
+    !isNonEmptyString((value as VectorBackfillRequest).dataDir) ||
+    !path.isAbsolute((value as VectorBackfillRequest).projectRoot) ||
+    !path.isAbsolute((value as VectorBackfillRequest).dataDir)
+  ) {
+    throw new Error('Vector backfill runner received an invalid request');
+  }
+
+  return {
+    projectId: (value as VectorBackfillRequest).projectId,
+    projectRoot: (value as VectorBackfillRequest).projectRoot,
+    dataDir: (value as VectorBackfillRequest).dataDir,
+  };
+}
+
+/**
+ * Start a detached one-shot worker. The caller has already persisted the
+ * observation and durable vector job, so failure to start is recoverable by a
+ * later MCP or control-plane session.
+ */
+export function launchDetachedVectorBackfill(
+  request: VectorBackfillRequest,
+  options: VectorBackfillLauncherOptions = {},
+): boolean {
+  const runnerPath = options.runnerPath ?? resolveVectorBackfillRunnerPath();
+  const exists = options.exists ?? existsSync;
+  if (!exists(runnerPath)) return false;
+
+  try {
+    const child = (options.spawn ?? spawn)(process.execPath, [runnerPath], {
+      cwd: request.projectRoot,
+      detached: true,
+      stdio: 'ignore',
+      // The request contains only local project metadata, never credentials.
+      // Environment transport avoids a live stdin pipe keeping the CLI alive.
+      env: { ...process.env, MEMORIX_VECTOR_BACKFILL_REQUEST: JSON.stringify(request) },
+      windowsHide: true,
+    }) as ChildProcess;
+    child.once?.('error', () => {});
+    child.unref();
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Run one durable vector-backfill job without sharing the CLI event loop. */
+export async function executeVectorBackfill(request: VectorBackfillRequest) {
+  initProjectRoot(request.projectRoot);
+  loadDotenv(request.projectRoot);
+  await initObservationStore(request.dataDir);
+  await initObservations(request.dataDir);
+  await prepareSearchIndex();
+  await getDeferredCachedVectorHydration()?.catch(() => {});
+
+  const worker = new MaintenanceJobWorker(
+    new MaintenanceJobStore(request.dataDir),
+    createProjectMaintenanceHandler(request.projectId, request.dataDir, request.projectRoot),
+    { projectId: request.projectId, kinds: ['vector-backfill'] },
+  );
+  return worker.runOnce();
+}
+
+async function readStdin(): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let raw = '';
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => { raw += chunk; });
+    process.stdin.once('error', reject);
+    process.stdin.once('end', () => resolve(raw));
+  });
+}
+
+export async function main(): Promise<void> {
+  try {
+    const raw = process.env.MEMORIX_VECTOR_BACKFILL_REQUEST ?? await readStdin();
+    await executeVectorBackfill(parseVectorBackfillRequest(raw));
+  } catch (error) {
+    const detail = sanitizeCredentials(error instanceof Error ? error.message : String(error));
+    process.stderr.write(`[memorix] vector backfill worker failed: ${detail}\n`);
+    process.exitCode = 1;
+  } finally {
+    closeAllDatabases();
+  }
+}
+
+if (process.argv[1] && process.argv[1].endsWith('vector-backfill-runner.js')) {
+  void main();
+}

--- a/tests/memory/vector-stability.test.ts
+++ b/tests/memory/vector-stability.test.ts
@@ -7,6 +7,11 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+const { enqueueVectorBackfill, launchDetachedVectorBackfill } = vi.hoisted(() => ({
+  enqueueVectorBackfill: vi.fn(),
+  launchDetachedVectorBackfill: vi.fn(),
+}));
+
 // Mock orama-store before importing observations
 vi.mock('../../src/store/orama-store.js', () => ({
   insertObservation: vi.fn().mockResolvedValue(undefined),
@@ -34,6 +39,18 @@ vi.mock('../../src/embedding/provider.js', () => ({
   resetProvider: vi.fn(),
 }));
 
+vi.mock('../../src/runtime/maintenance-jobs.js', () => ({
+  MaintenanceJobStore: class {
+    enqueue(input: unknown) {
+      enqueueVectorBackfill(input);
+    }
+  },
+}));
+
+vi.mock('../../src/runtime/vector-backfill-runner.js', () => ({
+  launchDetachedVectorBackfill,
+}));
+
 vi.mock('../../src/store/persistence.js', () => ({
   saveObservationsJson: vi.fn().mockResolvedValue(undefined),
   loadObservationsJson: vi.fn().mockResolvedValue([]),
@@ -59,6 +76,13 @@ const mockStore = {
   saveIdCounter: vi.fn(),
   getGeneration: vi.fn().mockReturnValue(1),
   ensureFresh: vi.fn().mockResolvedValue(false),
+  atomic: vi.fn().mockImplementation(async (fn: Function) => fn({
+    getGeneration: vi.fn().mockResolvedValue(1),
+    findByTopicKey: vi.fn().mockResolvedValue(undefined),
+    loadIdCounter: vi.fn().mockResolvedValue(1),
+    insert: vi.fn().mockResolvedValue(undefined),
+    saveIdCounter: vi.fn().mockResolvedValue(undefined),
+  })),
   transaction: vi.fn().mockImplementation(async (fn: Function) => fn({
     loadAll: vi.fn(),
     saveAll: vi.fn(),
@@ -67,6 +91,7 @@ const mockStore = {
     upsert: vi.fn(),
     remove: vi.fn(),
   })),
+  update: vi.fn().mockResolvedValue(undefined),
   close: vi.fn(),
   getBackendName: vi.fn().mockReturnValue('sqlite'),
 };
@@ -151,6 +176,44 @@ describe('Vector Stability', () => {
     const status = getVectorStatus();
     // The observation should be in the missing set since embedding failed
     expect(status.missing).toBeGreaterThanOrEqual(0);
+  });
+
+  it('defers a CLI write without starting a remote embedding request in the parent process', async () => {
+    const oramaStore = await import('../../src/store/orama-store.js');
+    const { initObservations, storeObservation, getVectorMissingIds } =
+      await import('../../src/memory/observations.js');
+
+    mockStore.loadAll.mockResolvedValue([]);
+    mockStore.loadIdCounter.mockResolvedValue(1);
+    await initObservations('/tmp/memorix-vector-cli-write', {
+      embeddingWriteMode: 'deferred',
+      projectRoot: 'E:/repo',
+    });
+    vi.mocked(oramaStore.generateEmbedding).mockImplementation(() => new Promise(() => {}));
+
+    const { observation } = await storeObservation({
+      entityName: 'cli-write',
+      type: 'decision',
+      title: 'CLI writes must not wait for embedding',
+      narrative: 'The durable memory record is visible immediately while vector work runs elsewhere.',
+      projectId: 'test/vector-cli-write',
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(oramaStore.generateEmbedding).not.toHaveBeenCalled();
+    expect(enqueueVectorBackfill).toHaveBeenCalledWith(expect.objectContaining({
+      projectId: 'test/vector-cli-write',
+      kind: 'vector-backfill',
+    }));
+    expect(launchDetachedVectorBackfill).toHaveBeenCalledWith({
+      projectId: 'test/vector-cli-write',
+      projectRoot: 'E:/repo',
+      dataDir: '/tmp/memorix-vector-cli-write',
+    });
+    expect(getVectorMissingIds('test/vector-cli-write')).toContain(observation.id);
+
+    await initObservations('/tmp/memorix-vector-default-write', { embeddingWriteMode: 'background' });
   });
 
   it('keeps obs in vectorMissingIds when provider is temporarily unavailable (not disabled)', async () => {

--- a/tests/runtime/vector-backfill-runner.test.ts
+++ b/tests/runtime/vector-backfill-runner.test.ts
@@ -1,0 +1,58 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  launchDetachedVectorBackfill,
+  parseVectorBackfillRequest,
+  resolveVectorBackfillRunnerPath,
+} from '../../src/runtime/vector-backfill-runner.js';
+
+describe('detached vector backfill runner', () => {
+  const request = {
+    projectId: 'AVIDS2/memorix',
+    projectRoot: path.resolve('work', 'memorix'),
+    dataDir: path.resolve('data', 'memorix'),
+  };
+
+  it('resolves the compiled worker beside both library and CLI bundles', () => {
+    const distDir = path.resolve('pkg', 'dist');
+    const expected = path.join(distDir, 'vector-backfill-runner.js');
+
+    expect(resolveVectorBackfillRunnerPath(pathToFileURL(path.join(distDir, 'index.js')).href)).toBe(expected);
+    expect(resolveVectorBackfillRunnerPath(pathToFileURL(path.join(distDir, 'cli', 'index.js')).href)).toBe(expected);
+  });
+
+  it('accepts only complete local worker requests', () => {
+    expect(parseVectorBackfillRequest(JSON.stringify(request))).toEqual(request);
+    expect(() => parseVectorBackfillRequest('{"projectId":"missing-paths"}')).toThrow(/invalid/i);
+    expect(() => parseVectorBackfillRequest('not json')).toThrow(/invalid json/i);
+  });
+
+  it('detaches the worker so a short-lived CLI never waits on an embedding request', () => {
+    const unref = vi.fn();
+    const spawn = vi.fn(() => ({ unref }));
+
+    const started = launchDetachedVectorBackfill(request, {
+      runnerPath: 'E:/pkg/dist/vector-backfill-runner.js',
+      exists: () => true,
+      spawn: spawn as never,
+    });
+
+    expect(started).toBe(true);
+    expect(spawn).toHaveBeenCalledWith(
+      process.execPath,
+      ['E:/pkg/dist/vector-backfill-runner.js'],
+      expect.objectContaining({
+        cwd: request.projectRoot,
+        detached: true,
+        stdio: 'ignore',
+        windowsHide: true,
+        env: expect.objectContaining({
+          MEMORIX_VECTOR_BACKFILL_REQUEST: JSON.stringify(request),
+        }),
+      }),
+    );
+    expect(unref).toHaveBeenCalledOnce();
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -16,6 +16,9 @@ export default defineConfig([
       // separate from the MCP host prevents graph scans and consolidation from
       // blocking an agent request on the main event loop.
       'maintenance-runner': 'src/runtime/maintenance-runner.ts',
+      // Short-lived CLI writes hand remote embedding work to this detached
+      // worker so a slow provider never holds the user's terminal open.
+      'vector-backfill-runner': 'src/runtime/vector-backfill-runner.ts',
     },
     format: ['esm'],
     target: 'node20',


### PR DESCRIPTION
## Summary
- persist CLI memory writes and enqueue a durable vector-backfill job before any embedding request
- run remote embedding work in a detached one-shot worker so a slow provider cannot hold a CLI command open
- keep MCP and long-lived SDK paths on the existing in-process asynchronous embedding behavior

## Verification
- `npm test` - 244 files / 2731 tests passed, 1 existing live-embedding test skipped
- `npm run lint`
- `npm run build`
- `npm pack --dry-run` confirms `dist/vector-backfill-runner.js` is packaged
- manual OpenRouter smoke completed a real `qwen/qwen3-embedding-8b` backfill
- controlled 4s-per-request OpenAI-compatible endpoint: the CLI exited in 2.494s while the vector job was still running, then completed and cached the vector