### PR TITLE
chore(release): publish 1.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.9] - 2026-07-28
+
+### Fixed
+- **One retention truth across the product** -- Dashboard, HTTP control-plane, and background cleanup now use the same canonical retention projection. Permanent, active, stale, and archive-ready memory states no longer disagree across surfaces.
+- **More useful session continuation** -- Resume and handoff-shaped requests prioritize the prior task, what changed, and remaining work without treating ordinary verification or compatibility language as disposable noise. Delivery stays bounded rather than replaying a transcript.
+- **Responsive CLI writes with remote embeddings** -- `memorix memory store` now persists the memory and queues durable vector work before starting a detached backfill worker. A slow embedding API no longer keeps a one-shot CLI command open; lexical recall remains available while vector search catches up.
+
 ## [1.2.8] - 2026-07-27
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.2.8",
+      "version": "1.2.9",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [


### PR DESCRIPTION
## Release\n\nPrepares Memorix 1.2.9 from the already-merged retention/session continuity and responsive CLI embedding backfill fixes.\n\n## Validation\n\n- 
pm run lint\n- 
pm run build\n- 
pm test -- --reporter=dot\n- 
pm pack --dry-run --json\n- Fresh F: drive tarball install: memorix --version and memorix context --json\n\nThe package artifact includes dist/vector-backfill-runner.js.