### PR TITLE
feat(ai): wire video input capability for MiniMax-M3

### DIFF
--- a/packages/ai/scripts/generate-models.ts
+++ b/packages/ai/scripts/generate-models.ts
@@ -66,6 +66,19 @@ const COPILOT_STATIC_HEADERS = {
 	"Copilot-Integration-Id": "vscode-chat",
 } as const;
 
+/**
+ * Build the input modality list for a MiniMax model from models.dev modality
+ * data. MiniMax models expose text, image, and (for newer models such as
+ * MiniMax-M3) video inputs through their Anthropic-compatible API, so we mirror
+ * whatever the upstream catalog reports instead of hard-coding a single pair.
+ */
+function buildMiniMaxInputModalities(input?: string[]): ("text" | "image" | "video")[] {
+	const modalities: ("text" | "image" | "video")[] = ["text"];
+	if (input?.includes("image")) modalities.push("image");
+	if (input?.includes("video")) modalities.push("video");
+	return modalities;
+}
+
 const KIMI_STATIC_HEADERS = {
 	"User-Agent": "KimiCLI/1.5",
 } as const;
@@ -1197,7 +1210,7 @@ async function loadModelsDevData(): Promise<Model<any>[]> {
 						// MiniMax's Anthropic-compatible API - SDK appends /v1/messages
 						baseUrl,
 						reasoning: m.reasoning === true,
-						input: m.modalities?.input?.includes("image") ? ["text", "image"] : ["text"],
+						input: buildMiniMaxInputModalities(m.modalities?.input),
 						cost: {
 							input: m.cost?.input || 0,
 							output: m.cost?.output || 0,

--- a/packages/ai/src/models.generated.ts
+++ b/packages/ai/src/models.generated.ts
@@ -6364,7 +6364,7 @@ export const MODELS = {
 			provider: "minimax",
 			baseUrl: "https://api.minimax.io/anthropic",
 			reasoning: true,
-			input: ["text", "image"],
+			input: ["text", "image", "video"],
 			cost: {
 				input: 0.3,
 				output: 1.2,
@@ -6417,7 +6417,7 @@ export const MODELS = {
 			provider: "minimax-cn",
 			baseUrl: "https://api.minimaxi.com/anthropic",
 			reasoning: true,
-			input: ["text", "image"],
+			input: ["text", "image", "video"],
 			cost: {
 				input: 0.3,
 				output: 1.2,

--- a/packages/ai/src/providers/amazon-bedrock.ts
+++ b/packages/ai/src/providers/amazon-bedrock.ts
@@ -42,6 +42,7 @@ import type {
 	Tool,
 	ToolCall,
 	ToolResultMessage,
+	VideoContent,
 } from "../types.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { parseStreamingJson } from "../utils/json-parse.ts";
@@ -663,11 +664,15 @@ function createRequiredTextBlock(text: string): ContentBlock.TextMember {
 	return createNonBlankTextBlock(text) ?? { text: EMPTY_TEXT_PLACEHOLDER };
 }
 
-function convertToolResultContent(content: (TextContent | ImageContent)[]): ToolResultContentBlock[] {
+function convertToolResultContent(content: (TextContent | ImageContent | VideoContent)[]): ToolResultContentBlock[] {
 	const result: ToolResultContentBlock[] = [];
 	for (const c of content) {
 		if (c.type === "image") {
 			result.push({ image: createImageBlock(c.mimeType, c.data) });
+		} else if (c.type === "video") {
+			// Bedrock video inputs are provider-specific and not wired here; downgrade
+			// to a placeholder note so the payload stays valid for image/text models.
+			result.push({ text: "(video omitted: bedrock does not support video tool results)" });
 		} else {
 			const textBlock = createNonBlankTextBlock(c.text);
 			if (textBlock) result.push(textBlock);

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -25,6 +25,7 @@ import type {
 	Tool,
 	ToolCall,
 	ToolResultMessage,
+	VideoContent,
 } from "../types.ts";
 import { AssistantMessageEventStream } from "../utils/event-stream.ts";
 import { headersToRecord } from "../utils/headers.ts";
@@ -107,32 +108,33 @@ const fromClaudeCodeName = (name: string, tools?: Tool[]) => {
 /**
  * Convert content blocks to Anthropic API format
  */
-function convertContentBlocks(content: (TextContent | ImageContent)[]):
-	| string
-	| Array<
-			| { type: "text"; text: string }
-			| {
-					type: "image";
-					source: {
-						type: "base64";
-						media_type: "image/jpeg" | "image/png" | "image/gif" | "image/webp";
-						data: string;
-					};
-			  }
-	  > {
+function convertContentBlocks(content: (TextContent | ImageContent | VideoContent)[]): string | ContentBlockParam[] {
 	// If only text blocks, return as concatenated string for simplicity
-	const hasImages = content.some((c) => c.type === "image");
-	if (!hasImages) {
+	const hasMedia = content.some((c) => c.type === "image" || c.type === "video");
+	if (!hasMedia) {
 		return sanitizeSurrogates(content.map((c) => (c as TextContent).text).join("\n"));
 	}
 
-	// If we have images, convert to content block array
-	const blocks = content.map((block) => {
+	// If we have media (images/video), convert to content block array
+	const blocks: ContentBlockParam[] = content.map((block) => {
 		if (block.type === "text") {
 			return {
 				type: "text" as const,
 				text: sanitizeSurrogates(block.text),
 			};
+		}
+		if (block.type === "video") {
+			// MiniMax's Anthropic-compatible API accepts base64 video sources; the
+			// @anthropic-ai/sdk type union does not yet include a video block, so cast
+			// through unknown to keep the SDK payload shape intact.
+			return {
+				type: "video",
+				source: {
+					type: "base64",
+					media_type: block.mimeType as "video/mp4" | "video/quicktime" | "video/webm",
+					data: block.data,
+				},
+			} as unknown as ContentBlockParam;
 		}
 		return {
 			type: "image" as const,
@@ -144,12 +146,12 @@ function convertContentBlocks(content: (TextContent | ImageContent)[]):
 		};
 	});
 
-	// If only images (no text), add placeholder text block
+	// If only media (no text), add placeholder text block
 	const hasText = blocks.some((b) => b.type === "text");
 	if (!hasText) {
 		blocks.unshift({
 			type: "text" as const,
-			text: "(see attached image)",
+			text: "(see attached media)",
 		});
 	}
 
@@ -1030,6 +1032,15 @@ function convertMessages(
 							type: "text",
 							text: sanitizeSurrogates(item.text),
 						};
+					} else if (item.type === "video") {
+						return {
+							type: "video",
+							source: {
+								type: "base64",
+								media_type: item.mimeType as "video/mp4" | "video/quicktime" | "video/webm",
+								data: item.data,
+							},
+						} as unknown as ContentBlockParam;
 					} else {
 						return {
 							type: "image",
@@ -1118,9 +1129,11 @@ function convertMessages(
 			toolResults.push({
 				type: "tool_result",
 				tool_use_id: msg.toolCallId,
-				content: convertContentBlocks(msg.content),
+				// MiniMax's Anthropic-compatible API accepts video in tool results;
+				// the SDK's ToolResultBlockParam.content type predates video support.
+				content: convertContentBlocks(msg.content) as ContentBlockParam[] | string,
 				is_error: msg.isError,
-			});
+			} as ContentBlockParam);
 
 			// Look ahead for consecutive toolResult messages
 			let j = i + 1;
@@ -1129,9 +1142,9 @@ function convertMessages(
 				toolResults.push({
 					type: "tool_result",
 					tool_use_id: nextMsg.toolCallId,
-					content: convertContentBlocks(nextMsg.content),
+					content: convertContentBlocks(nextMsg.content) as ContentBlockParam[] | string,
 					is_error: nextMsg.isError,
-				});
+				} as ContentBlockParam);
 				j++;
 			}
 
@@ -1154,7 +1167,7 @@ function convertMessages(
 				const lastBlock = lastMessage.content[lastMessage.content.length - 1];
 				if (
 					lastBlock &&
-					(lastBlock.type === "text" || lastBlock.type === "image" || lastBlock.type === "tool_result")
+					(lastBlock.type === "text" || lastBlock.type === "image" || (lastBlock as { type: string }).type === "video" || lastBlock.type === "tool_result")
 				) {
 					(lastBlock as any).cache_control = cacheControl;
 				}

--- a/packages/ai/src/providers/faux.ts
+++ b/packages/ai/src/providers/faux.ts
@@ -14,6 +14,7 @@ import type {
 	ToolCall,
 	ToolResultMessage,
 	Usage,
+	VideoContent,
 } from "../types.ts";
 import { createAssistantMessageEventStream } from "../utils/event-stream.ts";
 
@@ -133,7 +134,7 @@ function randomId(prefix: string): string {
 	return `${prefix}:${Date.now()}:${Math.random().toString(36).slice(2)}`;
 }
 
-function contentToText(content: string | Array<TextContent | ImageContent>): string {
+function contentToText(content: string | Array<TextContent | ImageContent | VideoContent>): string {
 	if (typeof content === "string") {
 		return content;
 	}
@@ -141,6 +142,9 @@ function contentToText(content: string | Array<TextContent | ImageContent>): str
 		.map((block) => {
 			if (block.type === "text") {
 				return block.text;
+			}
+			if (block.type === "video") {
+				return `[video:${block.mimeType}:${block.data.length}]`;
 			}
 			return `[image:${block.mimeType}:${block.data.length}]`;
 		})

--- a/packages/ai/src/providers/transform-messages.ts
+++ b/packages/ai/src/providers/transform-messages.ts
@@ -7,17 +7,26 @@ import type {
 	TextContent,
 	ToolCall,
 	ToolResultMessage,
+	VideoContent,
 } from "../types.ts";
 
 const NON_VISION_USER_IMAGE_PLACEHOLDER = "(image omitted: model does not support images)";
 const NON_VISION_TOOL_IMAGE_PLACEHOLDER = "(tool image omitted: model does not support images)";
+const NON_VISION_USER_VIDEO_PLACEHOLDER = "(video omitted: model does not support video)";
+const NON_VISION_TOOL_VIDEO_PLACEHOLDER = "(tool video omitted: model does not support video)";
 
-function replaceImagesWithPlaceholder(content: (TextContent | ImageContent)[], placeholder: string): TextContent[] {
+type MediaContent = TextContent | ImageContent | VideoContent;
+
+function replaceMediaWithPlaceholder(
+	content: MediaContent[],
+	dropType: "image" | "video",
+	placeholder: string,
+): TextContent[] {
 	const result: TextContent[] = [];
 	let previousWasPlaceholder = false;
 
 	for (const block of content) {
-		if (block.type === "image") {
+		if (block.type === dropType) {
 			if (!previousWasPlaceholder) {
 				result.push({ type: "text", text: placeholder });
 			}
@@ -25,31 +34,34 @@ function replaceImagesWithPlaceholder(content: (TextContent | ImageContent)[], p
 			continue;
 		}
 
-		result.push(block);
-		previousWasPlaceholder = block.text === placeholder;
+		result.push(block as TextContent);
+		previousWasPlaceholder = block.type === "text" && block.text === placeholder;
 	}
 
 	return result;
 }
 
-function downgradeUnsupportedImages<TApi extends Api>(messages: Message[], model: Model<TApi>): Message[] {
-	if (model.input.includes("image")) {
+function downgradeUnsupportedMedia<TApi extends Api>(messages: Message[], model: Model<TApi>): Message[] {
+	const supportsImage = model.input.includes("image");
+	const supportsVideo = model.input.includes("video");
+
+	if (supportsImage && supportsVideo) {
 		return messages;
 	}
 
 	return messages.map((msg) => {
 		if (msg.role === "user" && Array.isArray(msg.content)) {
-			return {
-				...msg,
-				content: replaceImagesWithPlaceholder(msg.content, NON_VISION_USER_IMAGE_PLACEHOLDER),
-			};
+			let content: MediaContent[] = msg.content;
+			if (!supportsImage) content = replaceMediaWithPlaceholder(content, "image", NON_VISION_USER_IMAGE_PLACEHOLDER);
+			if (!supportsVideo) content = replaceMediaWithPlaceholder(content, "video", NON_VISION_USER_VIDEO_PLACEHOLDER);
+			return { ...msg, content };
 		}
 
 		if (msg.role === "toolResult") {
-			return {
-				...msg,
-				content: replaceImagesWithPlaceholder(msg.content, NON_VISION_TOOL_IMAGE_PLACEHOLDER),
-			};
+			let content: MediaContent[] = msg.content;
+			if (!supportsImage) content = replaceMediaWithPlaceholder(content, "image", NON_VISION_TOOL_IMAGE_PLACEHOLDER);
+			if (!supportsVideo) content = replaceMediaWithPlaceholder(content, "video", NON_VISION_TOOL_VIDEO_PLACEHOLDER);
+			return { ...msg, content };
 		}
 
 		return msg;
@@ -68,7 +80,7 @@ export function transformMessages<TApi extends Api>(
 ): Message[] {
 	// Build a map of original tool call IDs to normalized IDs
 	const toolCallIdMap = new Map<string, string>();
-	const imageAwareMessages = downgradeUnsupportedImages(messages, model);
+	const imageAwareMessages = downgradeUnsupportedMedia(messages, model);
 
 	// First pass: transform messages (unsupported image downgrade, thinking blocks, tool call ID normalization)
 	const transformed = imageAwareMessages.map((msg) => {

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -254,6 +254,12 @@ export interface ImageContent {
 	mimeType: string; // e.g., "image/jpeg", "image/png"
 }
 
+export interface VideoContent {
+	type: "video";
+	data: string; // base64 encoded video data
+	mimeType: string; // e.g., "video/mp4", "video/quicktime", "video/webm"
+}
+
 export interface ToolCall {
 	type: "toolCall";
 	id: string;
@@ -281,7 +287,7 @@ export type StopReason = "stop" | "length" | "toolUse" | "error" | "aborted";
 
 export interface UserMessage {
 	role: "user";
-	content: string | (TextContent | ImageContent)[];
+	content: string | (TextContent | ImageContent | VideoContent)[];
 	timestamp: number; // Unix timestamp in milliseconds
 }
 
@@ -304,7 +310,7 @@ export interface ToolResultMessage<TDetails = any> {
 	role: "toolResult";
 	toolCallId: string;
 	toolName: string;
-	content: (TextContent | ImageContent)[]; // Supports text and images
+	content: (TextContent | ImageContent | VideoContent)[]; // Supports text, images, and video
 	details?: TDetails;
 	isError: boolean;
 	timestamp: number; // Unix timestamp in milliseconds
@@ -577,7 +583,7 @@ export interface Model<TApi extends Api> {
 	 * Missing keys use provider defaults. null marks a level as unsupported.
 	 */
 	thinkingLevelMap?: ThinkingLevelMap;
-	input: ("text" | "image")[];
+	input: ("text" | "image" | "video")[];
 	cost: {
 		input: number; // $/million tokens
 		output: number; // $/million tokens

--- a/packages/ai/test/minimax-models.test.ts
+++ b/packages/ai/test/minimax-models.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { getModel } from "../src/models.ts";
+
+describe("MiniMax models", () => {
+	it("registers MiniMax-M3 with text, image, and video input on the global endpoint", () => {
+		const model = getModel("minimax", "MiniMax-M3");
+
+		expect(model).toBeDefined();
+		expect(model.api).toBe("anthropic-messages");
+		expect(model.provider).toBe("minimax");
+		expect(model.baseUrl).toBe("https://api.minimax.io/anthropic");
+		expect(model.reasoning).toBe(true);
+		expect(model.input).toEqual(["text", "image", "video"]);
+		expect(model.contextWindow).toBe(1000000);
+		expect(model.maxTokens).toBe(128000);
+		expect(model.cost).toEqual({
+			input: 0.3,
+			output: 1.2,
+			cacheRead: 0.06,
+			cacheWrite: 0,
+		});
+	});
+
+	it("registers MiniMax-M3 with text, image, and video input on the China endpoint", () => {
+		const model = getModel("minimax-cn", "MiniMax-M3");
+
+		expect(model).toBeDefined();
+		expect(model.api).toBe("anthropic-messages");
+		expect(model.provider).toBe("minimax-cn");
+		expect(model.baseUrl).toBe("https://api.minimaxi.com/anthropic");
+		expect(model.reasoning).toBe(true);
+		expect(model.input).toEqual(["text", "image", "video"]);
+	});
+
+	it("keeps MiniMax-M2.7 as text-only", () => {
+		const model = getModel("minimax", "MiniMax-M2.7");
+
+		expect(model).toBeDefined();
+		expect(model.input).toEqual(["text"]);
+	});
+});

--- a/packages/ai/test/minimax-video-input.test.ts
+++ b/packages/ai/test/minimax-video-input.test.ts
@@ -1,0 +1,114 @@
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { describe, expect, it } from "vitest";
+import { getModel } from "../src/models.ts";
+import { streamAnthropic } from "../src/providers/anthropic.ts";
+import { transformMessages } from "../src/providers/transform-messages.ts";
+import type { Context, Message, Model } from "../src/types.ts";
+
+interface CapturedRequest {
+	body: Record<string, unknown>;
+}
+
+function getMiniMaxM3(baseUrl: string): Model<"anthropic-messages"> {
+	const model = getModel("minimax", "MiniMax-M3");
+	if (!model) {
+		throw new Error("MiniMax-M3 is not registered");
+	}
+	return { ...model, baseUrl };
+}
+
+async function readRequestBody(request: IncomingMessage): Promise<Record<string, unknown>> {
+	const chunks: Buffer[] = [];
+	for await (const chunk of request) {
+		chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+	}
+	return JSON.parse(Buffer.concat(chunks).toString("utf8")) as Record<string, unknown>;
+}
+
+function writeEmptySseResponse(response: ServerResponse): void {
+	response.writeHead(200, { "content-type": "text/event-stream" });
+	response.end();
+}
+
+async function captureRequest(context: Context): Promise<CapturedRequest> {
+	let capturedRequest: CapturedRequest | undefined;
+	const server = createServer(async (request, response) => {
+		capturedRequest = { body: await readRequestBody(request) };
+		writeEmptySseResponse(response);
+	});
+
+	await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+	const address = server.address() as AddressInfo;
+
+	try {
+		const stream = streamAnthropic(getMiniMaxM3(`http://127.0.0.1:${address.port}`), context, {
+			apiKey: "test-key",
+			cacheRetention: "none",
+		});
+		for await (const event of stream) {
+			if (event.type === "done" || event.type === "error") break;
+		}
+	} finally {
+		await new Promise<void>((resolve, reject) => {
+			server.close((error) => (error ? reject(error) : resolve()));
+		});
+	}
+
+	if (!capturedRequest) {
+		throw new Error("Anthropic-compatible request was not captured");
+	}
+	return capturedRequest;
+}
+
+describe("MiniMax M3 video input", () => {
+	it("sends base64 video blocks through the Anthropic-compatible request", async () => {
+		const request = await captureRequest({
+			messages: [
+				{
+					role: "user",
+					content: [
+						{ type: "text", text: "Describe this clip" },
+						{ type: "video", data: "dmlkZW8=", mimeType: "video/mp4" },
+					],
+					timestamp: Date.now(),
+				},
+			],
+		});
+
+		const messages = request.body.messages as Array<{ content: unknown }>;
+		expect(messages).toHaveLength(1);
+		expect(messages[0].content).toContainEqual({
+			type: "video",
+			source: { type: "base64", media_type: "video/mp4", data: "dmlkZW8=" },
+		});
+	});
+
+	it("downgrades only video for image-capable models that do not support video", () => {
+		const m3 = getMiniMaxM3("https://api.minimax.io/anthropic");
+		const imageOnlyModel: Model<"anthropic-messages"> = {
+			...m3,
+			id: "image-only-test-model",
+			input: ["text", "image"],
+		};
+		const messages: Message[] = [
+			{
+				role: "user",
+				content: [
+					{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" },
+					{ type: "video", data: "dmlkZW8=", mimeType: "video/mp4" },
+				],
+				timestamp: Date.now(),
+			},
+		];
+
+		const transformed = transformMessages(messages, imageOnlyModel);
+		expect(transformed[0]).toMatchObject({
+			role: "user",
+			content: [
+				{ type: "image", data: "aW1hZ2U=", mimeType: "image/png" },
+				{ type: "text", text: "(video omitted: model does not support video)" },
+			],
+		});
+	});
+});


### PR DESCRIPTION
Reason: MiniMax-M3 supports video input through its Anthropic-compatible API, but the registry and message pipeline only wired text and image.

## Changes

- Add a `VideoContent` block type and extend `Model.input` to allow `"video"` alongside `"text"` and `"image"`.
- Register `MiniMax-M3` with `input: ["text", "image", "video"]` on both the global (`minimax`) and China (`minimax-cn`) endpoints in `packages/ai/src/models.generated.ts`.
- Update `packages/ai/scripts/generate-models.ts` so MiniMax input modalities are derived from the upstream catalog (text, image, and video) instead of a hard-coded text/image pair; future video-capable MiniMax models will be registered correctly.
- Route base64 video blocks through the Anthropic provider (`convertContentBlocks` and `convertMessages`) so video content is sent to the API rather than dropped.
- Extend `transform-messages.ts` to downgrade video blocks to a placeholder for models that do not advertise video input, mirroring the existing image downgrade.
- Handle `VideoContent` in the Bedrock and faux providers so the expanded content union stays type-safe.
- Add `packages/ai/test/minimax-models.test.ts` asserting MiniMax-M3 advertises video input on both endpoints and MiniMax-M2.7 stays text-only.

## Checks

- `tsc --noEmit` (root) passes.
- `npx vitest run test/minimax-models.test.ts test/generate-models-fallback.test.ts test/transform-messages-copilot-openai-to-anthropic.test.ts test/anthropic-temperature-compat.test.ts` passes (14 tests).
