### PR TITLE
fix(distribution): restore registry-ready Docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,34 @@ jobs:
       - name: Verify the optional SQLite runtime loads on Node 26
         run: >-
           node -e "const Database = require('better-sqlite3'); const db = new Database(':memory:'); const row = db.prepare('select 1 as value').get(); db.close(); if (row.value !== 1) process.exit(1);"
+
+  docker-control-plane:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build the published HTTP control-plane image
+        run: docker build --tag memorix:ci .
+      - name: Verify the image starts and becomes healthy
+        run: |
+          set -euo pipefail
+          docker run --detach --rm --name memorix-ci -p 3211:3211 memorix:ci
+          for attempt in {1..30}; do
+            if curl --fail --silent --show-error http://127.0.0.1:3211/health; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker logs memorix-ci
+          exit 1
+      - name: Remove the verification container
+        if: always()
+        run: docker rm --force memorix-ci || true
+
+  mcp-registry-metadata:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm run check:mcp-registry

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Publish to npm
+name: Publish to npm and MCP Registry
 
 on:
   workflow_dispatch:
@@ -17,8 +17,25 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: npm
       - run: npm ci
+      - run: npm run check:mcp-registry
       - run: npm run build
       - run: npm test
       - run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Install the official MCP Registry publisher
+        env:
+          MCP_PUBLISHER_VERSION: 1.8.0
+        run: |
+          set -euo pipefail
+          archive="mcp-publisher_linux_amd64.tar.gz"
+          base_url="https://github.com/modelcontextprotocol/registry/releases/download/v${MCP_PUBLISHER_VERSION}"
+          curl --fail --location --silent --show-error --output "$archive" "$base_url/$archive"
+          curl --fail --location --silent --show-error --output checksums.txt "$base_url/registry_${MCP_PUBLISHER_VERSION}_checksums.txt"
+          grep " $archive$" checksums.txt | sha256sum --check --
+          tar --extract --gzip --file "$archive"
+          install --mode 0755 mcp-publisher /usr/local/bin/mcp-publisher
+      - name: Publish to the official MCP Registry
+        run: |
+          mcp-publisher login github-oidc
+          mcp-publisher publish server.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,10 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 COPY package*.json ./
+COPY packages/ai/package.json ./packages/ai/package.json
+COPY packages/agent-core/package.json ./packages/agent-core/package.json
+COPY packages/tui/package.json ./packages/tui/package.json
+COPY packages/memcode/package.json ./packages/memcode/package.json
 RUN npm ci
 
 FROM deps AS build
@@ -23,6 +27,10 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 COPY package*.json ./
+COPY packages/ai/package.json ./packages/ai/package.json
+COPY packages/agent-core/package.json ./packages/agent-core/package.json
+COPY packages/tui/package.json ./packages/tui/package.json
+COPY packages/memcode/package.json ./packages/memcode/package.json
 RUN npm ci --omit=dev
 
 FROM node:22-bookworm-slim AS runtime

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -321,7 +321,13 @@ npm publish --access public
 
 Notes:
 
-- `prepublishOnly` runs build + test, but does not contact live model catalog APIs
+- `prepublishOnly` synchronizes and checks Registry metadata, then runs build + test; it does not contact live model catalog APIs
+- `server.json` is the official MCP Registry record. Keep it synchronized with
+  `package.json` by running `npm run sync:mcp-registry`; verify it with
+  `npm run check:mcp-registry` before a release.
+- The GitHub publish workflow publishes npm first, then uses GitHub OIDC to
+  publish the same verified version to the official MCP Registry. It does not
+  require a Registry token or private key in repository secrets.
 - `@memorix/ai`, `@memorix/agent-core`, `@memorix/tui`, and `@memorix/memcode` are internal workspaces. Their code is bundled into the root `memorix` distribution and they must stay `private` unless the project deliberately establishes an owned npm scope and a separate package-support contract.
 - npm publish is usually manual, especially when 2FA is enabled
 - GitHub release automation should not be treated as a substitute for manual runtime validation

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "memorix",
+  "mcpName": "io.github.AVIDS2/memorix",
   "version": "1.2.9",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
@@ -33,6 +34,7 @@
   "files": [
     "dist",
     "src",
+    "server.json",
     "!src/**/*.js",
     "!src/**/*.js.map",
     "!src/**/*.d.ts",
@@ -63,9 +65,11 @@
     "test:e2e": "vitest run tests/e2e/",
     "benchmark:codegraph": "node scripts/benchmark-codegraph-provider.cjs",
     "benchmark:retrieval": "npm run build && node scripts/benchmark-retrieval.mjs",
+    "sync:mcp-registry": "node scripts/sync-mcp-registry-manifest.mjs",
+    "check:mcp-registry": "node scripts/check-mcp-registry-manifest.mjs",
     "audit:pi-upstream": "node scripts/pi-upstream-audit.mjs",
     "lint": "tsc --noEmit",
-    "prepublishOnly": "npm run build && npm test"
+    "prepublishOnly": "npm run sync:mcp-registry && npm run check:mcp-registry && npm run build && npm test"
   },
   "keywords": [
     "mcp",

--- a/scripts/check-mcp-registry-manifest.mjs
+++ b/scripts/check-mcp-registry-manifest.mjs
@@ -1,0 +1,57 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const packageJson = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'));
+const manifest = JSON.parse(await readFile(join(root, 'server.json'), 'utf8'));
+const failures = [];
+
+const npmPackage = manifest.packages?.find(
+  (entry) => entry.registryType === 'npm' && entry.identifier === packageJson.name,
+);
+
+if (manifest.$schema !== 'https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json') {
+  failures.push('server.json must use the supported official MCP Registry schema.');
+}
+
+if (manifest.name !== packageJson.mcpName) {
+  failures.push('server.json name must match package.json mcpName.');
+}
+
+if (manifest.version !== packageJson.version) {
+  failures.push('server.json version must match package.json version.');
+}
+
+if (!npmPackage) {
+  failures.push(`server.json must contain an npm package entry for ${packageJson.name}.`);
+} else {
+  if (npmPackage.version !== packageJson.version) {
+    failures.push('server.json npm package version must match package.json version.');
+  }
+
+  if (npmPackage.transport?.type !== 'stdio') {
+    failures.push('Memorix Registry metadata must describe the stdio transport.');
+  }
+
+  const startsStdioServer = npmPackage.packageArguments?.some(
+    (argument) => argument.type === 'positional' && argument.value === 'serve',
+  );
+  if (!startsStdioServer) {
+    failures.push('Memorix Registry metadata must invoke the memorix serve command.');
+  }
+}
+
+if (typeof manifest.description !== 'string' || manifest.description.length === 0 || manifest.description.length > 100) {
+  failures.push('server.json description must be non-empty and at most 100 characters.');
+}
+
+if (!Array.isArray(packageJson.files) || !packageJson.files.includes('server.json')) {
+  failures.push('package.json files must include server.json.');
+}
+
+if (failures.length > 0) {
+  throw new Error(`MCP Registry metadata check failed:\n- ${failures.join('\n- ')}`);
+}
+
+console.log(`MCP Registry metadata is ready for ${manifest.name}@${manifest.version}.`);

--- a/scripts/sync-mcp-registry-manifest.mjs
+++ b/scripts/sync-mcp-registry-manifest.mjs
@@ -1,0 +1,36 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const packagePath = join(root, 'package.json');
+const manifestPath = join(root, 'server.json');
+
+const packageJson = JSON.parse(await readFile(packagePath, 'utf8'));
+const manifest = JSON.parse(await readFile(manifestPath, 'utf8'));
+
+if (typeof packageJson.mcpName !== 'string' || packageJson.mcpName.length === 0) {
+  throw new Error('package.json must declare mcpName before the Registry manifest can be synchronized.');
+}
+
+const npmPackage = manifest.packages?.find(
+  (entry) => entry.registryType === 'npm' && entry.identifier === packageJson.name,
+);
+
+if (!npmPackage) {
+  throw new Error(`server.json must contain an npm package entry for ${packageJson.name}.`);
+}
+
+manifest.name = packageJson.mcpName;
+manifest.version = packageJson.version;
+npmPackage.version = packageJson.version;
+
+const next = `${JSON.stringify(manifest, null, 2)}\n`;
+const current = await readFile(manifestPath, 'utf8');
+
+if (current !== next) {
+  await writeFile(manifestPath, next, 'utf8');
+  console.log(`Synchronized server.json for memorix@${packageJson.version}.`);
+} else {
+  console.log(`server.json already matches memorix@${packageJson.version}.`);
+}

--- a/server.json
+++ b/server.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.AVIDS2/memorix",
+  "title": "Memorix",
+  "description": "Local-first persistent project memory for AI coding agents across MCP clients and sessions.",
+  "repository": {
+    "url": "https://github.com/AVIDS2/memorix",
+    "source": "github"
+  },
+  "version": "1.2.9",
+  "websiteUrl": "https://github.com/AVIDS2/memorix#readme",
+  "icons": [
+    {
+      "src": "https://raw.githubusercontent.com/AVIDS2/memorix/main/assets/logo.png",
+      "mimeType": "image/png",
+      "sizes": [
+        "1024x1024"
+      ]
+    }
+  ],
+  "packages": [
+    {
+      "registryType": "npm",
+      "identifier": "memorix",
+      "version": "1.2.9",
+      "runtimeHint": "npx",
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "serve"
+        }
+      ],
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}

--- a/tests/cli/docker-deployment.test.ts
+++ b/tests/cli/docker-deployment.test.ts
@@ -18,6 +18,25 @@ describe('official Docker deployment artifacts', () => {
     expect(dockerfile).toMatch(/^USER\s+node\s*$/m);
   });
 
+  it('installs every workspace dependency set before each npm install', () => {
+    const dockerfile = readFileSync(dockerfilePath, 'utf8');
+    const workspaces = ['ai', 'agent-core', 'tui', 'memcode'];
+    const dependencyStages = dockerfile.split(/^FROM node:22-bookworm-slim AS /m).slice(1, 3);
+
+    expect(dependencyStages).toHaveLength(2);
+
+    for (const stage of dependencyStages) {
+      const installIndex = stage.indexOf('RUN npm ci');
+
+      expect(installIndex).toBeGreaterThan(-1);
+      for (const workspace of workspaces) {
+        const manifest = `COPY packages/${workspace}/package.json ./packages/${workspace}/package.json`;
+        expect(stage.indexOf(manifest)).toBeGreaterThan(-1);
+        expect(stage.indexOf(manifest)).toBeLessThan(installIndex);
+      }
+    }
+  });
+
   it('ships a compose file with port 3211 and a healthcheck', () => {
     expect(existsSync(composePath)).toBe(true);
 

--- a/tests/release/mcp-registry-metadata.test.ts
+++ b/tests/release/mcp-registry-metadata.test.ts
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, 'utf8')) as T;
+}
+
+interface RegistryPackage {
+  registryType: string;
+  identifier: string;
+  version: string;
+  transport: { type: string };
+  packageArguments?: Array<{ type: string; value?: string }>;
+}
+
+describe('MCP Registry release metadata', () => {
+  it('binds the published npm package to the official Registry record', () => {
+    const packageJson = readJson<{ name: string; version: string; mcpName: string; files: string[] }>(
+      join(process.cwd(), 'package.json'),
+    );
+    const manifest = readJson<{
+      $schema: string;
+      name: string;
+      version: string;
+      description: string;
+      packages: RegistryPackage[];
+    }>(join(process.cwd(), 'server.json'));
+    const npmPackage = manifest.packages.find(
+      (entry) => entry.registryType === 'npm' && entry.identifier === packageJson.name,
+    );
+
+    expect(packageJson.mcpName).toBe('io.github.AVIDS2/memorix');
+    expect(manifest.$schema).toBe('https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json');
+    expect(manifest.name).toBe(packageJson.mcpName);
+    expect(manifest.version).toBe(packageJson.version);
+    expect(manifest.description.length).toBeLessThanOrEqual(100);
+    expect(packageJson.files).toContain('server.json');
+    expect(npmPackage).toMatchObject({
+      version: packageJson.version,
+      transport: { type: 'stdio' },
+    });
+    expect(npmPackage?.packageArguments).toContainEqual({ type: 'positional', value: 'serve' });
+  });
+
+  it('keeps Registry publication behind npm publication and GitHub OIDC', () => {
+    const workflow = readFileSync(join(process.cwd(), '.github', 'workflows', 'publish.yml'), 'utf8');
+
+    expect(workflow).toContain('npm publish --provenance --access public');
+    expect(workflow).toContain('mcp-publisher login github-oidc');
+    expect(workflow).toContain('mcp-publisher publish server.json');
+    expect(workflow.indexOf('npm publish --provenance --access public')).toBeLessThan(
+      workflow.indexOf('mcp-publisher publish server.json'),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Install workspace manifests before each Docker dependency install so the Linux image can compile Memcode.
- Ship and verify the official MCP Registry manifest, including npm metadata binding and GitHub OIDC publication after npm succeeds.
- Add Docker, Registry metadata, package, and documentation safeguards.

## Verification
- npm run lint
- npm run build
- npm test (245 files / 2734 passed / 1 live embedding test skipped)
- no-cache Docker build, HTTP health check, and MCP initialize -> tools/list smoke
- stdio SDK smoke for node dist/cli/index.js serve
- npm pack --dry-run --json (server.json included)