### PR TITLE
chore(release): 1.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.10] - 2026-07-28
+
+### Added
+- **Official MCP Registry publication path** -- Ships the checked `server.json` manifest and a GitHub OIDC publication step that runs after npm succeeds. This release is the first package version eligible for official Registry registration.
+
+### Fixed
+- **Codex plugin ownership** -- `memorix setup --agent codex --global` now uses Codex's personal marketplace plugin path and never creates project-local `.codex` configuration as a fallback. Custom user MCP configuration stays untouched; legacy Memorix files are migrated only after Codex confirms the plugin is enabled.
+- **Glama-compatible Docker build** -- Docker now installs every workspace dependency set before compiling. CI builds and starts the HTTP control-plane image, so a future container regression is caught on the pull request instead of by an external registry scan.
+
 ## [1.2.9] - 2026-07-28
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.2.9",
+      "version": "1.2.10",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memorix",
   "mcpName": "io.github.AVIDS2/memorix",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AVIDS2/memorix",
     "source": "github"
   },
-  "version": "1.2.9",
+  "version": "1.2.10",
   "websiteUrl": "https://github.com/AVIDS2/memorix#readme",
   "icons": [
     {
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "memorix",
-      "version": "1.2.9",
+      "version": "1.2.10",
       "runtimeHint": "npx",
       "packageArguments": [
         {


### PR DESCRIPTION
## Release 1.2.10

Publishes the first package version eligible for official MCP Registry registration.

### Includes
- Codex global setup ownership fix from #155.
- Glama-compatible workspace Docker build and registry metadata path from #156.
- Version synchronization for all supported agent plugins and `server.json`.

### Verified locally
- `npm ci`
- `npm run lint`
- `npm run build`
- `npm test` (245 files passed, 1 live-embedding test skipped)
- `npm run check:mcp-registry`
- Built tarball contains `server.json`, reports `1.2.10`, completes MCP stdio handshake, lists 44 tools, and serves `memorix_project_context`.

Publishing remains gated on green CI for this commit.