### PR TITLE
fix(docs): use canonical MCP Toplist badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![MCP Toplist](https://mcptoplist.com/badge/glama%2FAVIDS2%2Fmemorix.svg)](https://mcptoplist.com/server/glama%2FAVIDS2%2Fmemorix)
+![MCP Toplist](https://mcptoplist.com/badge/io.github.AVIDS2%2Fmemorix.svg)
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/AVIDS2/memorix/main/assets/readme-hero.svg" alt="Memorix" width="720">


### PR DESCRIPTION
## Summary
- switch the badge to MCP Toplist's current canonical io.github.AVIDS2/memorix identifier
- remove the broken server-detail link, which currently redirects to a 404 upstream

## Verification
- git diff --check`n- fetched the canonical badge: HTTP 200 with Top 1% rank text