### PR TITLE
docs: replace broken third-party listing links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-![MCP Toplist](https://mcptoplist.com/badge/io.github.AVIDS2%2Fmemorix.svg)
-
 <p align="center">
   <img src="https://raw.githubusercontent.com/AVIDS2/memorix/main/assets/readme-hero.svg" alt="Memorix" width="720">
 </p>
@@ -17,6 +15,10 @@
   <a href="https://github.com/AVIDS2/memorix/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/AVIDS2/memorix/ci.yml?style=for-the-badge&label=CI&logo=github" alt="CI"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-2563eb?style=for-the-badge" alt="license"></a>
   <a href="https://github.com/AVIDS2/memorix"><img src="https://img.shields.io/github/stars/AVIDS2/memorix?style=for-the-badge&logo=github&color=facc15" alt="stars"></a>
+</p>
+
+<p align="center">
+  <a href="https://registry.modelcontextprotocol.io/v0/servers?search=io.github.AVIDS2%2Fmemorix">Listed in the official MCP Registry</a>
 </p>
 
 <p align="center">
@@ -493,5 +495,3 @@ Memorix draws from the MCP ecosystem and prior memory projects such as mcp-memor
 <h2 id="license"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-license.svg"><img src="assets/tags/section-license.svg" alt="License" height="32" /></picture></h2>
 
 [Apache 2.0](LICENSE)
-
-[![Star History Chart](https://api.star-history.com/image?repos=AVIDS2/memorix&type=Date)](https://star-history.com/#AVIDS2/memorix&Date)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,6 +18,10 @@
 </p>
 
 <p align="center">
+  <a href="https://registry.modelcontextprotocol.io/v0/servers?search=io.github.AVIDS2%2Fmemorix">已收录至官方 MCP Registry</a>
+</p>
+
+<p align="center">
   <strong>共享项目记忆</strong> | <strong>MCP</strong> | <strong>Git Memory</strong> | <strong>Reasoning Memory</strong> | <strong>插件包</strong> | <strong>编排</strong>
 </p>
 
@@ -489,5 +493,3 @@ Memorix 借鉴了 MCP 生态和 mcp-memory-service、MemCP、claude-mem、Mem0 �
 <h2 id="license"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-license.svg"><img src="assets/tags/section-license.svg" alt="License" height="32" /></picture></h2>
 
 [Apache 2.0](LICENSE)
-
-[![Star History Chart](https://api.star-history.com/image?repos=AVIDS2/memorix&type=Date)](https://star-history.com/#AVIDS2/memorix&Date)

--- a/tests/release-contract.test.ts
+++ b/tests/release-contract.test.ts
@@ -24,10 +24,12 @@ describe('release contract', () => {
     expect(workflow).not.toContain('npm publish --workspace @memorix/');
   });
 
-  it('keeps the live Star History image at the end of both READMEs', async () => {
+  it('links both READMEs to the official MCP Registry without stale listing images', async () => {
     for (const readme of ['README.md', 'README.zh-CN.md']) {
       const content = await readFile(path.join(repoRoot, readme), 'utf-8');
-      expect(content.trimEnd()).toMatch(/\[!\[Star History Chart\]\(https:\/\/api\.star-history\.com\/image\?repos=AVIDS2\/memorix&type=Date\)\]\(https:\/\/star-history\.com\/#AVIDS2\/memorix&Date\)$/);
+      expect(content).toContain('https://registry.modelcontextprotocol.io/v0/servers?search=io.github.AVIDS2%2Fmemorix');
+      expect(content).not.toContain('mcptoplist.com');
+      expect(content).not.toContain('api.star-history.com');
     }
   });
 });


### PR DESCRIPTION
## Summary
- replace the broken MCP Toplist rank badge with the official MCP Registry listing
- remove Star History image URLs that currently return HTTP 500 and require an interactive GitHub token flow

## Verification
- git diff --check`n- official Registry query returns io.github.AVIDS2/memorix as active and latest
- confirmed no stale MCP Toplist or Star History image URLs remain in either README