### PR TITLE
docs: restore MCP Toplist badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 
 <p align="center">
   <a href="https://registry.modelcontextprotocol.io/v0/servers?search=io.github.AVIDS2%2Fmemorix">Listed in the official MCP Registry</a>
+  <br>
+  <img src="https://mcptoplist.com/badge/io.github.AVIDS2%2Fmemorix.svg" alt="MCP Toplist ranking">
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,6 +19,8 @@
 
 <p align="center">
   <a href="https://registry.modelcontextprotocol.io/v0/servers?search=io.github.AVIDS2%2Fmemorix">已收录至官方 MCP Registry</a>
+  <br>
+  <img src="https://mcptoplist.com/badge/io.github.AVIDS2%2Fmemorix.svg" alt="MCP Toplist ranking">
 </p>
 
 <p align="center">

--- a/tests/release-contract.test.ts
+++ b/tests/release-contract.test.ts
@@ -24,11 +24,11 @@ describe('release contract', () => {
     expect(workflow).not.toContain('npm publish --workspace @memorix/');
   });
 
-  it('links both READMEs to the official MCP Registry without stale listing images', async () => {
+  it('links both READMEs to the official MCP Registry and verified Toplist badge', async () => {
     for (const readme of ['README.md', 'README.zh-CN.md']) {
       const content = await readFile(path.join(repoRoot, readme), 'utf-8');
       expect(content).toContain('https://registry.modelcontextprotocol.io/v0/servers?search=io.github.AVIDS2%2Fmemorix');
-      expect(content).not.toContain('mcptoplist.com');
+      expect(content).toContain('https://mcptoplist.com/badge/io.github.AVIDS2%2Fmemorix.svg');
       expect(content).not.toContain('api.star-history.com');
       expect(content).toContain('https://github.com/AVIDS2/memorix/stargazers');
       expect(content).toContain('assets/star-history-light.svg');


### PR DESCRIPTION
## Summary
- restore the verified MCP Toplist badge in both README variants
- retain the official MCP Registry link as the authoritative listing signal
- update the release contract so the badge cannot disappear accidentally

## Verification
- `npm test -- tests/release-contract.test.ts`
- live badge endpoint returned `MCP Toplist: Top 1% of 94,230`