### PR TITLE
feat(memory): add curated long-term memory architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.0] - 2026-07-30
+
+### Added
+- **Curated long-term memory** -- Added source-bound episodic, semantic, and procedural memory records with explicit `candidate -> qualified -> approved -> archived/superseded` lifecycle states, evidence references, audit events, and task-aware delivery.
+- **Deliberate local portability** -- A user may explicitly create a `user + portable` memory for reuse across projects on the same local installation. Project and team facts remain project-bound, and source-derived evidence can never be made portable.
+- **Long-term memory CLI** -- Added `memorix memory long-term list|show|add|promote|qualify|approve|archive|supersede` for reviewable lifecycle management without requiring an MCP connection.
+
+### Changed
+- **Bounded Worksets** -- Task context can now select up to three relevant qualified or approved long-term records, with source and lifecycle status preserved in the context receipt. Candidates, archived records, and superseded records are never injected.
+- **Low-noise agent guidance** -- Generated rules and shipped plugin skills tell agents to create long-term candidates only for stable facts, reusable procedures, or completed episodes; approval remains an explicit operator action.
+- **Bounded semantic recall** -- Keyword matching remains the deterministic first path. A configured embedding provider gets one 1.8-second, no-retry fallback only when no reviewed long-term item matched, so a slow remote service cannot turn context delivery into a long foreground wait.
+
+### Fixed
+- **Long-term CLI discoverability** -- `memorix memory` help now documents the existing `--title`, `--tags`, and `--applicability` fields for curated long-term records.
+
 ## [1.2.10] - 2026-07-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Memorix is more than a memory store. It also installs agent integrations, keeps 
 | --- | --- | --- |
 | Memory Autopilot | A bounded task Workset with start files, current memory, source-backed knowledge, workflow starts, cautions, and verification | `memorix context "..."`, `memorix resume "..."`, `memorix_project_context` |
 | Observation Memory | Searchable facts, fixes, gotchas, session summaries, and implementation notes scoped to the current Git project | `memorix memory`, MCP memory tools |
+| Curated Long-term Memory | Deliberately reviewed episodic, semantic, and procedural memory with source evidence. Only an explicitly portable user item can cross local projects | `memorix memory long-term` |
 | Code State and Code Memory | Versioned local code snapshots, file/symbol links, and freshness checks. The built-in Lite index is always honest about its limits; an already-indexed local CodeGraph can add a bounded semantic outline | `memorix codegraph`, automatic context refresh |
 | Git Memory | Commit-derived engineering facts that answer what changed, where, and why it matters | `memorix ingest commit`, git hook |
 | Reasoning Memory | Design rationale, alternatives, trade-offs, and risks that should survive beyond one chat | `memorix reasoning`, memory formation |
@@ -333,6 +334,11 @@ memorix identity join --agent-type codex --name codex-main
 memorix memory store --text "private investigation note" --visibility personal
 memorix task create --description "verify the release package"
 
+# Deliberate durable memory: create a candidate, then review it before it can enter a Workset.
+memorix memory long-term add --kind procedural --scope user --portability portable --title "Release verification preference" --text "Run focused tests and a packed-package smoke before publishing." --applicability "When publishing an npm package."
+memorix memory long-term qualify --id <id> --reason "The user explicitly confirmed this preference."
+memorix memory long-term approve --id <id> --reason "Reviewed for future local projects."
+
 memorix transfer export --format json --out ./.memorix-export.json
 memorix transfer import --file ./.memorix-export.json
 memorix reasoning search --query "why sqlite"
@@ -361,11 +367,14 @@ This opens memcode, a terminal coding agent that uses the same Memorix project m
 | Reasoning Memory | rationale, alternatives, constraints, risks | "Why did we choose this?" |
 | Git Memory | commit-derived engineering facts | "What changed and where?" |
 | Code Memory | files, symbols, import edges, and memory-to-code freshness | "Which current code should I inspect first?" |
+| Curated Long-term Memory | reviewed episodic events, stable facts, or reusable procedures with evidence | "What should this agent still know or do later?" |
 | Compact Continuity | recent host-native compact summaries or lifecycle markers | "What survived the last context compaction?" |
 
 Search is project-scoped by default. `scope="global"` searches across projects. The search boosts Git Memory for "what changed" questions and reasoning records for "why" questions.
 
-`memorix context "..."` is the default Memory Autopilot entry. It builds a compact task-lensed brief for agents: bugfix tasks lean toward tests and repros, release tasks lean toward package/changelog/build checks, onboarding tasks lean toward docs and entry points, and stale or unrelated memories stay in warning lanes instead of flooding the prompt. A normal new task does not receive an old-session dump. For an explicit continuation, `memorix resume "..."` adds only the latest useful session summary, up to three readable durable anchors, and at most one recent source-labelled host compact checkpoint. A checkpoint is lifecycle evidence, not durable memory or a transcript backup. Agents should read the suggested files before trusting stored memory.
+Long-term memory is deliberately not an automatic dump of every note. A source observation, Claim, workflow, session, and code snapshot keep their existing roles. An agent may ask `memorix_store` to create an additional long-term **candidate**, but candidates never enter task context. Use `memorix memory long-term qualify|approve|archive|supersede` to record the evidence-backed lifecycle. Only a manually created or user-confirmed `user + portable` item may be considered in another local project; project code, Git facts, tests, workflows, sessions, and observations cannot be promoted into portable user memory.
+
+`memorix context "..."` is the default Memory Autopilot entry. It builds a compact task-lensed brief for agents: bugfix tasks lean toward tests and repros, release tasks lean toward package/changelog/build checks, onboarding tasks lean toward docs and entry points, and stale or unrelated memories stay in warning lanes instead of flooding the prompt. A normal new task does not receive an old-session dump. For an explicit continuation, `memorix resume "..."` adds only the latest useful session summary, up to three readable durable anchors, and at most one recent source-labelled host compact checkpoint. A durable anchor carries a `durable:<id>` reference, so an agent can expand the full reviewed record through `memorix_detail` only when needed. Keyword matches stay primary; when no reviewed durable item matches and an embedding provider is configured, Memorix makes one 1.8-second, no-retry semantic fallback for paraphrases or cross-language tasks. A slow or unavailable provider simply leaves the normal keyword-only Workset intact. A checkpoint is lifecycle evidence, not durable memory or a transcript backup. Agents should read the suggested files before trusting stored memory.
 
 <h2 id="runtime-modes"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-runtime.svg"><img src="assets/tags/section-runtime.svg" alt="Runtime Modes" height="32" /></picture></h2>
 
@@ -377,6 +386,7 @@ Search is project-scoped by default. `scope="global"` searches across projects. 
 | Run shared HTTP MCP plus dashboard | `memorix background start` |
 | Debug HTTP MCP in the foreground | `memorix serve-http --port 3211` |
 | Inspect or manage memory directly | `memorix memory`, `memorix reasoning`, `memorix session`, `memorix ingest` |
+| Manage reviewed long-term memory | `memorix memory long-term list|show|add|promote|qualify|approve|archive|supersede` |
 | Inspect native compaction continuity | `memorix checkpoint list|show|context|archive` |
 | Use the interactive terminal memory control plane | `memorix workbench` |
 | Use the bundled terminal agent | `memorix` or `memcode` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -67,6 +67,7 @@ Memorix 不只是一个记忆库。它还负责安装 Agent 接入、保留有�
 | --- | --- | --- |
 | Memory Autopilot | 给新 Agent session 一份有预算的任务 Workset，包含起步文件、当前记忆、来源知识、工作流首步、风险提示和验证建议 | `memorix context "..."`、`memorix resume "..."`、`memorix_project_context` |
 | Observation Memory | 当前 Git 项目内可检索的事实、修复、坑点、session 摘要和实现记录 | `memorix memory`、MCP memory tools |
+| 受管理的长期记忆 | 有来源证据、可审核的情景/语义/程序记忆；只有明确标为可携带的用户记忆才可在本机跨项目使用 | `memorix memory long-term` |
 | Code State 和 Code Memory | 可版本化的本地代码快照、文件 / symbol 关联和 freshness 检查。内置 Lite 会如实说明边界；已有本地索引的 CodeGraph 可额外给出有预算的语义关系 | `memorix codegraph`、自动 context refresh |
 | Git Memory | 从 commit 中提取工程事实，回答改了什么、在哪里改、为什么重要 | `memorix ingest commit`、git hook |
 | Reasoning Memory | 保存设计原因、备选方案、trade-off 和风险，不让决策只留在一次聊天里 | `memorix reasoning`、memory formation |
@@ -333,6 +334,11 @@ memorix identity join --agent-type codex --name codex-main
 memorix memory store --text "个人排查笔记" --visibility personal
 memorix task create --description "验证发布包"
 
+# 有意沉淀长期记忆：先创建候选，再审核，审核前不会进入 Agent 的 Workset。
+memorix memory long-term add --kind procedural --scope user --portability portable --title "发布验证偏好" --text "发布 npm 包前运行 focused tests 和打包后的 package smoke。" --applicability "发布 npm 包时。"
+memorix memory long-term qualify --id <id> --reason "用户明确确认了这项偏好。"
+memorix memory long-term approve --id <id> --reason "已审核，可在本机其它项目中使用。"
+
 memorix transfer export --format json --out ./.memorix-export.json
 memorix transfer import --file ./.memorix-export.json
 memorix reasoning search --query "why sqlite"
@@ -361,11 +367,14 @@ memcode
 | Reasoning Memory | 原因、替代方案、约束、风险 | “当时为什么这么选？” |
 | Git Memory | 从 commit 提炼出的工程事实 | “最近改了什么，在哪些文件？” |
 | Code Memory | 文件、符号、import 关系、记忆到代码的新鲜度 | “现在应该先看哪些代码？” |
+| 受管理的长期记忆 | 有来源证据、经过审核的情景事件、稳定事实或可复用流程 | “以后还应记住什么、按什么方式做？” |
 | Compact Continuity | 最近一次宿主原生压缩的摘要或生命周期标记 | “上次上下文压缩后留下了什么？” |
 
 默认搜索当前项目。`scope="global"` 可以跨项目搜索。“改了什么”优先匹配 Git Memory，“为什么”优先匹配 reasoning / decision 记录。
 
-`memorix context "..."` 是默认的 Memory Autopilot 入口。它会按任务生成紧凑 brief：修 bug 时偏向测试和复现，发版时偏向 package/changelog/build 检查，接手项目时偏向文档和入口文件；过期或不相关的记忆只作为 warning，不会一股脑塞进 prompt。普通新任务不会自动得到旧会话的文本倾倒；明确要继续之前工作时，用 `memorix resume "..."`，只会补入最近一份有用的会话总结、最多三条当前可读的长期记忆锚点，以及最多一条带来源标识的近期宿主压缩检查点。检查点只是生命周期证据，不是长期记忆，也不是聊天记录备份。Agent 应该先读 suggested files，再相信历史记忆。
+长期记忆不是把所有笔记自动堆进去。Observation、Claim、工作流、session 和代码快照仍各自承担原来的职责。Agent 可以在 `memorix_store` 时要求额外生成长期记忆**候选**，但候选绝不会自动进入任务上下文；用 `memorix memory long-term qualify|approve|archive|supersede` 留下带证据的生命周期记录。只有人工创建或用户确认的 `user + portable` 记忆，才可能在同一台机器的其它项目中按任务相关性被使用；项目代码、Git 事实、测试、工作流、session 和 Observation 都不能被提升成可携带的用户记忆。
+
+`memorix context "..."` 是默认的 Memory Autopilot 入口。它会按任务生成紧凑 brief：修 bug 时偏向测试和复现，发版时偏向 package/changelog/build 检查，接手项目时偏向文档和入口文件；过期或不相关的记忆只作为 warning，不会一股脑塞进 prompt。普通新任务不会自动得到旧会话的文本倾倒；明确要继续之前工作时，用 `memorix resume "..."`，只会补入最近一份有用的会话总结、最多三条当前可读的长期记忆锚点，以及最多一条带来源标识的近期宿主压缩检查点。每个长期锚点都有 `durable:<id>` 引用，Agent 只在确实需要完整已审核记录时才通过 `memorix_detail` 展开。关键词仍优先；没有命中而且用户已配置 embedding 时，Memorix 才会做一次 1.8 秒、不重试的语义回退，用于模型改写或跨语言任务。服务变慢或不可用时，正常的关键词 Workset 会原样返回。检查点只是生命周期证据，不是长期记忆，也不是聊天记录备份。Agent 应该先读 suggested files，再相信历史记忆。
 
 <h2 id="运行模式"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-runtime.svg"><img src="assets/tags/section-runtime.svg" alt="运行模式" height="32" /></picture></h2>
 
@@ -377,6 +386,7 @@ memcode
 | 启动共享 HTTP MCP 和 Dashboard | `memorix background start` |
 | 前台调试 HTTP MCP | `memorix serve-http --port 3211` |
 | 直接检查或管理记忆 | `memorix memory`、`memorix reasoning`、`memorix session`、`memorix ingest` |
+| 管理已审核的长期记忆 | `memorix memory long-term list|show|add|promote|qualify|approve|archive|supersede` |
 | 检查原生上下文压缩连续性 | `memorix checkpoint list|show|context|archive` |
 | 使用交互式终端记忆控制台 | `memorix workbench` |
 | 使用内置终端 Agent | `memorix` 或 `memcode` |

--- a/docs/1.3-MEMORY-ARCHITECTURE.md
+++ b/docs/1.3-MEMORY-ARCHITECTURE.md
@@ -1,0 +1,236 @@
+# Memorix 1.3: Memory Architecture 2.0
+
+## Problem
+
+Memorix already captures useful project observations, code-state evidence,
+knowledge claims, wiki pages, workflows, sessions, and compaction checkpoints.
+Those records have different sources and lifecycles, but they are not yet
+expressed as one cognitive memory architecture. In particular, a `personal`
+observation still lives under one project and cannot safely become durable
+cross-project knowledge for the local user.
+
+Version 1.3 makes Memorix a local-first persistent memory system for coding
+agents. It does not replace the agent's context window or turn every note into
+a global profile. It supplies small, current, source-aware working context and
+keeps durable knowledge under explicit lifecycle control.
+
+## Goals
+
+1. Model durable memory with independent **kind**, **scope**, **state**, and
+   **evidence** dimensions.
+2. Add local-user durable memories that can be reused across projects without
+   silently exposing project facts to unrelated projects.
+3. Treat the existing Task Workset as derived working memory, not another
+   database or a transcript dump.
+4. Allow agents to capture a candidate through their normal memory write path,
+   while keeping qualification and approval explicit and inspectable through
+   the CLI.
+5. Include only bounded, task-relevant qualified or approved durable memory in
+   project context. A candidate, stale record, or unrelated user preference is
+   never injected merely because it exists.
+6. Preserve all existing Observation, Claim, Wiki, Workflow, Session, and
+   Code Memory behavior. The migration is additive and idempotent.
+
+## Non-goals
+
+- No cloud account, remote synchronization, organization directory, or
+  cross-machine identity system in 1.3.
+- No automatic export of source code, paths, Git facts, or project observations
+  into a user-global memory.
+- No claim that a graph alone makes information true. Graph links remain
+  navigational provenance, and source evidence remains authoritative.
+- No automatic execution of a stored procedure. Procedures advise a Workset;
+  existing workflow gates still control execution and verification.
+- No automated psychological profile or covert user tracking.
+
+## Mental Model
+
+The following axes are deliberately independent.
+
+| Axis | Values | Meaning |
+| --- | --- | --- |
+| Cognitive kind | `episodic`, `semantic`, `procedural` | What the durable item represents. |
+| Scope | `project`, `user`, `team` | Who may retrieve it and where it may travel. |
+| State | `candidate`, `qualified`, `approved`, `archived`, `superseded` | Whether it can be delivered and how much trust it carries. |
+| Source | `manual`, `agent`, `hook`, `git`, `test`, `code-state`, `workflow` | Where the supporting evidence came from. |
+| Portability | `project-bound`, `portable` | Whether a user item may be considered outside its origin project. |
+
+Working memory is not a fourth persisted record class. It is the temporary
+Task Workset assembled for one task from current code facts, continuation
+evidence, source-qualified knowledge, and relevant durable memories under a
+strict token budget.
+
+### Kinds
+
+- **Episodic**: a bounded event or handoff, such as a completed debugging
+  session and its verified result. Existing Sessions and compaction checkpoints
+  remain the canonical event sources.
+- **Semantic**: a source-backed fact, preference, or stable convention. Existing
+  Claims and reviewed Wiki pages remain project semantic truth; new long-term
+  memories cover deliberate user-scoped facts and portable conventions.
+- **Procedural**: a reusable way of working with applicability and verification
+  evidence. Existing canonical Workflows and Mini-Skills remain the project
+  procedure sources; the long-term layer can hold deliberately promoted user
+  procedures.
+
+## Canonical Storage
+
+1. `observations` remains the raw evidence ledger and legacy-compatible agent
+   write surface.
+2. `knowledge_claims`, Markdown Wiki pages, Workflows, Sessions, Code Graph
+   snapshots, and checkpoints remain their existing specialized stores.
+3. A new SQLite `long_term_memories` table stores curated cross-source memory
+   artifacts. Each item records its origin project, owner, scope, cognitive
+   kind, lifecycle state, evidence references, tags, and portability.
+4. A local installation identity is stored only on the local machine. It is a
+   random stable identifier unless `MEMORIX_USER_ID` is explicitly supplied.
+   It is never derived from a model prompt and is never transmitted by
+   Memorix.
+
+The new table does not copy all legacy observations on upgrade. Existing
+records keep their current behavior. Promotion creates a new artifact with
+references to its evidence, so no provenance is lost and no historical record
+becomes global by accident.
+
+## Lifecycle and Promotion
+
+```text
+raw observation / session / claim / workflow result
+                 |
+                 v
+          long-term candidate
+                 |
+          explicit qualify
+                 v
+      qualified durable memory
+                 |
+     explicit approval or review
+                 v
+       approved durable memory
+                 |
+       archive / supersede
+```
+
+- Agent-facing `memorix_store` may create an **additional candidate** when a
+  caller explicitly requests long-term capture. It always writes normal source
+  evidence first.
+- Candidate artifacts are visible to management commands but are excluded from
+  automatic task context.
+- Qualification requires at least one evidence reference. A semantic or
+  procedural item never becomes an unsupported text summary.
+- Approval is a separate deliberate operation. The CLI records the transition
+  and reason in the artifact audit trail.
+- Project code, Git, observation, test, and workflow evidence may support a
+  project-bound item. A portable user item rejects project-bound source kinds;
+  the operator must create it from user/manual evidence instead.
+
+## Scope and Privacy Rules
+
+| Scope | Default retrieval | Cross-project behavior |
+| --- | --- | --- |
+| `project` | Current project only | Never crosses automatically. |
+| `user` + `project-bound` | Origin project for the same local user | Does not cross. |
+| `user` + `portable` | Same local user, task-relevant only | May cross projects after explicit portable promotion. |
+| `team` | Explicit active project team only | Not cross-project in 1.3. |
+
+`personal` Observation visibility remains a project-local private sharing rule
+for backward compatibility. It is not renamed to `user`: a project-private
+observation and a user-level portable durable memory are intentionally
+different things.
+
+## Retrieval and Delivery
+
+Task Workset assembly combines existing project facts with a new long-term
+selection stage:
+
+1. Filter by owner, scope, project, portability, lifecycle state, and reader
+   capability before ranking.
+2. Rank only approved or qualified artifacts by task term overlap, kind fit,
+   validation recency, and explicit tag matches. If that produces no result
+   and the user has configured an embedding provider, one bounded semantic
+   fallback may compare the task with already-visible durable records. A slow,
+   unavailable, or disabled provider falls back to keyword-only retrieval.
+3. Include at most three short entries under a fixed sub-budget. Include title,
+   kind, scope, applicability, and a `durable:<id>` provenance reference, not
+   a long historical narrative. An agent can open that reference through the
+   existing `memorix_detail` route when it needs the full evidence-backed
+   record.
+4. Keep current code, dirty-worktree cautions, source-backed claims, and
+   verification evidence ahead of optional durable enrichment.
+5. Record selected and omitted durable memory in the delivery receipt without
+   exposing private content in diagnostics.
+
+The result is a useful memory directory for an agent, not an automatic history
+dump. An agent can request detail through the CLI when it needs more.
+
+### Semantic fallback budget
+
+Keyword matching is the deterministic first route. Only when no eligible long-term
+record matches may Memorix use the configured embedding provider for a small,
+scope-filtered semantic fallback. It has a strict 1.8-second request budget and
+no retry. Provider startup probing receives the same budget. Failure is silent
+from the agent's point of view: the normal lexical Workset is still delivered.
+This keeps semantic recall additive rather than making a remote API a dependency
+of task continuation.
+
+## Operator Surface
+
+The CLI is the complete management surface:
+
+```text
+memorix memory long-term list
+memorix memory long-term show --id <id>
+memorix memory long-term add --kind procedural --scope user --portability portable --title "Release verification preference" --text "Run focused tests and a packed-package smoke before publishing." --tags "release,verification" --applicability "When publishing an npm package."
+memorix memory long-term promote --from-observation <id> --kind semantic --scope project
+memorix memory long-term qualify --id <id> --reason "verified against focused test"
+memorix memory long-term approve --id <id> --reason "reviewed by operator"
+memorix memory long-term archive --id <id> --reason "no longer current"
+memorix memory long-term supersede --id <old-id> --superseded-by <qualified-id> --reason "replaced by the current procedure"
+```
+
+`memorix_store` gains optional long-term capture metadata for agents. This
+keeps the default MCP micro profile small: no additional MCP tool is necessary
+to capture a candidate or receive relevant working context. The CLI remains the
+inspection, promotion, and audit route.
+
+## Compatibility and Migration
+
+- SQLite creates the new table and indexes through an idempotent named schema
+  migration.
+- Existing records receive no data rewrite and remain project-visible under
+  their current legacy rules.
+- Missing local user identity means no user-memory retrieval; a write creates
+  the local identity lazily.
+- The new APIs fail closed for unavailable owner/team context. They never
+  broaden project visibility to compensate for missing identity.
+
+## Acceptance Criteria
+
+1. A normal Observation remains readable after the migration with unchanged
+   visibility and project behavior.
+2. A promoted project semantic memory appears in a task Workset only after
+   qualification.
+3. A portable user semantic memory created under one project can be selected in
+   another local project for the same owner, while a project-bound user memory
+   cannot.
+4. A portable promotion with code, Git, observation, test, or workflow source
+   evidence is rejected.
+5. Team memories are absent without explicit active team membership.
+6. Candidate, archived, superseded, and unrelated durable memories do not
+   appear in the agent-facing prompt.
+7. The Workset stays within its configured token budget and its receipt records
+   durable memory selection or omission.
+8. CLI JSON flows cover create, list, promote, qualify, approve, archive, and
+   cross-project retrieval.
+9. Type checking, focused tests, full test suite, package build, and an
+   installed-package CLI smoke all pass before publishing 1.3.0.
+
+## Research Basis
+
+This design uses the memory taxonomy and evidence discipline in
+`AI-Agents-in-Depth` (working / episodic / semantic / procedural memory), while
+keeping Memorix's current-source-first code-memory and proposal-first Knowledge
+Workspace principles. It takes AgentMemory's capture/consolidate/forget and
+token-budget lessons as inspiration, but does not adopt generic time-decay or
+automatic global slots for code facts. Source-qualified promotion and explicit
+portable scope are the safety boundary for a coding-agent memory system.

--- a/docs/AGENT_OPERATOR_PLAYBOOK.md
+++ b/docs/AGENT_OPERATOR_PLAYBOOK.md
@@ -50,11 +50,13 @@ For the 1.2 release line, the visible product shape is:
 
 ### CLI is the direct command surface; MCP is the integration layer
 
-For direct use, prefer `memorix ...` commands first. In the 1.2 line, the CLI covers session, memory, Code State, knowledge workspaces, reasoning, retention, formation, audit, transfer, skills, orchestration coordination, sync, ingest workflows, and the bundled terminal agent.
+For direct use, prefer `memorix ...` commands first. In the 1.3 line, the CLI covers session, memory, reviewed long-term memory, Code State, knowledge workspaces, reasoning, retention, formation, audit, transfer, skills, orchestration coordination, sync, ingest workflows, and the bundled terminal agent.
 
 Do not ask memory-only users to join coordination state. A lightweight session is enough for memory, retrieval, reasoning, and continuation. Use `joinTeam` / `team_manage(join)` only for explicit task/message/lock coordination or for CLI-agent work managed by `memorix orchestrate`.
 
 An unbound terminal is intentionally project-scoped: it reads and writes project-visible memory only. Use `memorix identity join --agent-type <agent>` or `memorix identity use --agent-id <id>` only when an operator explicitly needs personal/team memory or coordinated task actions. `memorix identity clear` removes that local selection; `--as <agent-id>` is the one-command script form and still requires an active member of the current project.
+
+Long-term memory is a reviewed layer, not a generic global note store. `memorix memory long-term add` creates a candidate; `qualify` and `approve` are explicit audit transitions before it can appear in a bounded task Workset. A project-derived observation, code fact, Git fact, test, session, Claim, or workflow stays project-bound. Only manual or user-confirmed `user + portable` records can cross local projects for the same local installation identity. When one is task-matched in a Workset, it is intentionally usable background even if its origin differs; use its `durable:<id>` reference with `memorix_detail` only when the full record is needed. Use `archive` or `supersede` when a durable item is no longer current.
 
 `--cwd <git-project>` is the canonical way to run direct CLI work from outside a repository. It changes the command's project anchor only; Git remains the source of truth for final project identity.
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -219,6 +219,7 @@ Important inputs:
 - optional `relatedCommits`
 - optional `relatedEntities`
 - optional `visibility`: `project` (default), `personal`, or `team`
+- optional `longTerm`: an explicit source-backed long-term candidate with `kind` (`episodic`, `semantic`, or `procedural`), an optional `scope` (`project`, `user`, or `team`), tags, and applicability
 
 Visibility controls who can retrieve a record through agent-facing memory
 tools. Normal memories default to `project`. `personal` and `team` writes
@@ -229,6 +230,13 @@ lets an agent overwrite a record outside its write scope.
 When the current Autopilot task is read-only or explicitly says not to modify
 files, `memorix_store` returns without writing. Use `overrideReadOnly: true`
 only when the user explicitly asks to preserve a record during that task.
+
+`longTerm` is deliberately opt-in. It stores the normal Observation first, then
+creates a separate candidate with an evidence reference. Candidates are not
+inserted into a Task Workset. Review them with `memorix memory long-term
+list|show|qualify|approve|archive|supersede`. Source-derived entries remain
+project-bound; only a manual or user-confirmed `user + portable` record created
+through the CLI may cross local projects for the same local installation.
 
 Example:
 
@@ -291,7 +299,7 @@ Global example:
 
 ### `memorix_detail`
 
-Fetch full observation detail.
+Fetch full observation, mini-skill, or curated long-term memory detail.
 
 After `memorix_project_context`, use `purpose` only for a named missing fact. Set `force: true` only when the user explicitly asks for the full underlying record already represented in the brief.
 
@@ -299,6 +307,10 @@ Supports two modes:
 
 - `ids` for current-project observations
 - `refs` for project-aware cross-project lookup
+- `typedRefs` for typed observation/skill refs and a `durable:<uuid>` reference
+  emitted by a Task Workset. A matching `user + portable` durable item is
+  intentionally reusable across local projects, but remains background guidance
+  rather than a current-project fact.
 
 Examples:
 
@@ -313,6 +325,13 @@ Examples:
   "refs": [
     { "id": 84, "projectId": "AVIDS2/test-memorix-demo" }
   ]
+}
+```
+
+```json
+{
+  "typedRefs": ["durable:9f3d9a6d-1111-4222-8333-abcdefabcdef"],
+  "purpose": "Need the full verified release procedure before publishing."
 }
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,11 +2,16 @@
 
 Memorix is an open-source cross-agent memory layer for coding agents via MCP.
 
-It combines three core memory layers:
+It combines three source-of-truth memory layers and a curated long-term memory layer:
 
 - **Observation Memory** for what changed and how things work
 - **Reasoning Memory** for why choices were made
 - **Git Memory** for engineering truth derived from commits
+- **Long-term Memory** for explicitly curated episodic, semantic, and procedural knowledge that should outlive a single project session
+
+Observation, reasoning, and Git records remain the canonical evidence. Long-term
+memory references that evidence and has its own lifecycle; it is not a second
+copy of every conversation or a global dump shared between unrelated projects.
 
 These layers are exposed through MCP tools, CLI workflows, and an HTTP service.
 
@@ -36,6 +41,7 @@ flowchart LR
         C2["Reasoning store"]
         C3["Git memory store"]
         C4["Session / team registry"]
+        C5["Curated long-term memory"]
     end
 
     subgraph Intelligence["Intelligence and Quality"]
@@ -65,6 +71,7 @@ flowchart LR
     B3 --> C2
     B3 --> C3
     B3 --> C4
+    B3 --> C5
 
     C1 --> D1
     C1 --> D2
@@ -74,6 +81,8 @@ flowchart LR
     C2 --> D3
     C3 --> D2
     C4 --> D3
+    C5 --> D4
+    C5 --> E1
 
     D1 --> E1
     D2 --> E1
@@ -114,6 +123,8 @@ Main pieces:
 - `src/memory/retention.ts`
 - `src/memory/graph.ts`
 - `src/memory/consolidation.ts`
+- `src/memory/long-term.ts`
+- `src/memory/long-term-store.ts`
 
 Responsibilities:
 
@@ -123,6 +134,8 @@ Responsibilities:
 - manage session state
 - retention, archive, and deduplication
 - knowledge graph entities and relations
+- curate long-lived episodes, facts, and procedures with source evidence,
+  qualification, approval, archival, and supersession
 
 ### Intelligence and Quality Layer
 
@@ -211,6 +224,26 @@ Git Memory turns commits into structured memory with source provenance:
 - extracted concepts
 
 This creates an engineering truth layer that complements human- or agent-authored observations.
+
+### Curated Long-term Memory
+
+Long-term memory holds a deliberately small set of records that remain useful
+after a project session ends:
+
+- **episodic**: a completed, reusable episode
+- **semantic**: a stable fact or principle
+- **procedural**: a repeatable workflow
+
+It is separate from ordinary observations so the two jobs do not get confused:
+
+- an observation records what happened in context;
+- a long-term record says that the fact or procedure has earned durable reuse.
+
+Each record is source-bound, auditable, and moves through
+`candidate -> qualified -> approved -> archived/superseded`. Candidates are
+never injected into an agent context. A record can be portable only when it is
+user-owned and based on explicit manual or user evidence; project, team, Git,
+session, code, and claim evidence never crosses that boundary.
 
 ---
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -13,9 +13,9 @@ Memorix is a TypeScript project built around:
 
 ## Current Development Baseline
 
-The current release work targets the **1.1 line** while package metadata may still show the last published patch version until the release commit is cut.
+The current release work targets the **1.3 line** while package metadata may still show the last published version until the release commit is cut.
 
-Contributors should assume the following areas are part of the 1.1 release line:
+Contributors should assume the following areas are part of the 1.3 release line:
 
 - shared memory across MCP clients, CLI, SDK, dashboard, hooks, and memcode
 - memcode uses Memorix project memory, hooks, `/memory` commands, resumable sessions, and model switching as the bundled terminal agent
@@ -26,6 +26,7 @@ Contributors should assume the following areas are part of the 1.1 release line:
 - notify-only auto-update by default with explicit install opt-in
 - dashboard config loading aligned with CLI/TUI status surfaces
 - the existing layered retrieval, retention, attribution, and compact output model
+- source-backed long-term memory with candidate, qualification, approval, archival, supersession, and explicit portable user scope
 
 ---
 

--- a/docs/MODULES.md
+++ b/docs/MODULES.md
@@ -1,7 +1,11 @@
 # Memorix 模块详解
 
-> 最后更新: 2026-03-09 (v1.0.0)
+> 最后更新: 2026-07-30 (v1.3.0)
 > 本文档详细记录每个模块的实现细节、关键算法和注意事项
+
+> 本文档中的早期 JSON/Orama 章节保留为历史模块说明。当前运行时的
+> SQLite 数据层和长期记忆生命周期以 `docs/ARCHITECTURE.md`、
+> `docs/1.3-MEMORY-ARCHITECTURE.md` 及对应源码为准。
 
 ---
 
@@ -145,6 +149,28 @@ Archive-candidate: age > 100% retention & !immune
 - 免疫的 observation 最低 relevance 为 0.5
 - `high` 重要性的 observation 也被视为免疫 — 这意味着 `gotcha`, `decision`, `trade-off` 永远不会被自动归档
 - `archiveExpired()` 可自动归档过期记忆，`deferredInit` 启动时自动执行
+
+---
+
+## 5. 长期记忆 (`memory/long-term.ts`, `memory/long-term-store.ts`)
+
+长期记忆不是把所有 observation 再复制一遍。它是由已有证据支撑、经过
+明确管理的少量长期知识，面向跨会话持续使用。
+
+| 维度 | 取值 | 含义 |
+|---|---|---|
+| 认知类型 | `episodic` / `semantic` / `procedural` | 完成经历、稳定事实、可复用流程 |
+| 范围 | `project` / `user` / `team` | 项目、同一安装的用户、显式团队 |
+| 生命周期 | `candidate` -> `qualified` -> `approved` -> `archived` / `superseded` | 候选不会自动注入；只有合格或已批准的记录才会进入受限 Workset |
+
+### 核心边界
+
+- 每条记录保存来源 observation 和生命周期事件，便于审计和追溯。
+- `portable` 只允许用户范围、并且来源是显式手工或用户输入的记录。
+- Git、代码、会话、项目、团队和模型生成的证据不能因为标记为长期记忆就跨项目共享。
+- 用户通过 `memorix memory long-term` 管理记录；MCP 的 `memorix_store`
+  只能创建候选，不会偷偷把日常对话升级成长期知识。
+- 检索遵守任务相关性和 token 预算，最多放入少量合格/批准记录，不回填完整历史。
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ The public docs are organized by user intent:
 | --- | --- |
 | CLI commands and MCP tools | [API_REFERENCE.md](API_REFERENCE.md) |
 | Memory Autopilot, Code State, and context packs | [API_REFERENCE.md § Memory Autopilot, Code State, and Context Packs](API_REFERENCE.md#memory-autopilot-code-state-and-context-packs), [1.2 Code State](1.2.0-CODE-STATE.md), and [1.2 Workset Retrieval](1.2.0-WORKSET-RETRIEVAL.md) |
+| Reviewed episodic, semantic, and procedural long-term memory | [1.3 Memory Architecture](1.3-MEMORY-ARCHITECTURE.md) |
 | Reviewable knowledge pages and workflow inheritance | [API_REFERENCE.md § Knowledge Workspace and Workflows](API_REFERENCE.md#knowledge-workspace-and-workflows), [1.2 Knowledge Workspace](1.2.0-KNOWLEDGE-WORKSPACE.md), and [1.2 Workflow Inheritance](1.2.0-WORKFLOW-INHERITANCE.md) |
 | Git-derived engineering memory | [GIT_MEMORY.md](GIT_MEMORY.md) |
 | Memory formation and quality pipeline | [MEMORY_FORMATION_PIPELINE.md](MEMORY_FORMATION_PIPELINE.md) |
@@ -87,6 +88,7 @@ The public docs are organized by user intent:
 | 1.2 task-shaped evidence selection | [1.2 Workset Retrieval](1.2.0-WORKSET-RETRIEVAL.md) |
 | 1.2 non-blocking refresh and maintenance contract | [1.2 Dynamic Lifecycle](1.2.0-DYNAMIC-LIFECYCLE.md) |
 | 1.2 honest Lite and optional semantic CodeGraph provider contract | [1.2 Provider Quality](1.2.0-PROVIDER-QUALITY.md) |
+| 1.3 long-term memory model, source boundary, and lifecycle | [1.3 Memory Architecture](1.3-MEMORY-ARCHITECTURE.md) |
 | Active context-control work | [1.2.2 Memory Control Plane](1.2.2-MEMORY-CONTROL-PLANE.md) |
 | Historical cloud sync and multi-agent research | [CLOUD_SYNC_AND_MULTI_AGENT_RESEARCH.md](CLOUD_SYNC_AND_MULTI_AGENT_RESEARCH.md) |
 | Known issues and old roadmap notes | [KNOWN_ISSUES_AND_ROADMAP.md](KNOWN_ISSUES_AND_ROADMAP.md) |
@@ -115,9 +117,7 @@ Historical/deep-reference documents may describe older designs. If they conflict
 
 ## Current Product Line
 
-The released product is on the **1.1 line**. Active 1.2 design work is tracked
-in the [1.2 Development Charter](1.2.0-DEVELOPMENT-CHARTER.md). The current
-released baseline has:
+The released product is on the **1.3 line**. The current baseline has:
 
 - `memorix setup --agent <agent> --global` is the default agent integration command
 - `memorix serve` is the manual stdio MCP server for external agents

--- a/docs/dev-log/progress.txt
+++ b/docs/dev-log/progress.txt
@@ -364,3 +364,25 @@
   CLI `context --json` path returned a structured Workset. `npm pack --dry-run`
   and `npm publish --dry-run --ignore-scripts` both accepted the final tarball
   without manifest normalization warnings.
+
+## 1.3 Curated Long-Term Memory
+- Added an additive SQLite long-term-memory layer with explicit episodic,
+  semantic, and procedural kinds; independent scope and portability; source
+  evidence; and an auditable `candidate -> qualified -> approved ->
+  archived/superseded` lifecycle. Existing Observation, Claim, Wiki, Workflow,
+  Session, and Code State stores remain their own canonical sources.
+- Added the complete CLI lifecycle surface and extended the existing MCP store/
+  detail routes without increasing the default seven-tool micro profile. Task
+  Worksets expose at most three relevant approved or qualified records as short
+  `durable:<id>` references for progressive expansion.
+- Explicit `user + portable` manual/user-confirmed records can be reused across
+  local projects for the same owner. Code, Git, tests, sessions, workflows,
+  observations, claims, and team/project evidence remain project-bound.
+- Semantic durable retrieval is an optional cross-language/paraphrase fallback
+  after lexical selection. Provider initialization and the one batch request use
+  a 1.8-second no-retry budget; API request cancellation is propagated to the
+  remote fetch so an unavailable embedding service cannot retain a CLI process.
+- Verification in progress: focused lifecycle/CLI/MCP/embedding tests, a real
+  packed-package cross-project Chinese-to-English retrieval smoke, and an
+  isolated Claude Code plugin user test that returned the reviewed release
+  procedure without inspecting project files.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -6,7 +6,7 @@ Memorix is a TypeScript/Node.js project that gives AI coding agents persistent, 
 
 If you are an AI coding agent helping a user install, operate, or troubleshoot Memorix, read `docs/AGENT_OPERATOR_PLAYBOOK.md` before taking action. It is the main reference for install, runtime selection, Git/project binding, MCP integration, hooks, and troubleshooting.
 
-## 1.2 Multi-Dimensional Memory Model
+## 1.3 Multi-Dimensional Memory Model
 
 Memorix is not a transcript dump. The normal agent path is `memorix_project_context` or `memorix context --task "..."`, which assembles a bounded task Workset: current Git/package facts, selected observations and reasoning, Code State freshness, source-backed claims, matching knowledge/workflow starts, cautions, and verification hints.
 
@@ -15,6 +15,7 @@ Memorix is not a transcript dump. The normal agent path is `memorix_project_cont
 - **Claim Ledger** keeps provenance, confidence, conflicts, and lifecycle state separate from prose.
 - **Knowledge Workspace** compiles claims into reviewable Markdown proposals; it does not silently overwrite manually edited pages.
 - **Canonical Workflows** represent project process once and render conservative agent-specific adapters only on explicit request.
+- **Curated Long-Term Memory** keeps source-bound episodic, semantic, and procedural records separate from ordinary observations. A record is a candidate first, then can be explicitly qualified or approved; candidates, archived records, and superseded records never enter a Workset. A portable record is allowed only for explicit local `user + portable` knowledge with manual/user evidence. Project, team, Git, code, session, workflow, test, and observation evidence always remains project-bound. Keyword retrieval is primary; an optional semantic fallback is scope-filtered, limited to 1.8 seconds with no retry, and never blocks a lexical Workset when an embedding provider is slow or unavailable.
 - **Lifecycle maintenance** uses durable, resumable jobs so indexing, claim requalification, knowledge compile/lint, retention, and consolidation do not turn an interactive MCP request into a corpus-sized foreground job.
 
 The built-in CodeGraph Lite provider is a structural local fallback, not a complete semantic graph. If a project already has a healthy local CodeGraph index, `[codegraph].external_context = "auto"` can add a small validated semantic outline. Memorix never runs `codegraph init`, `index`, or `sync`, does not transmit the repository, and does not persist raw external code output.
@@ -111,6 +112,9 @@ Typical commands:
 ```bash
 memorix memory search --query "release blocker"
 memorix memory store --text "Auth tokens expire after 24h" --title "Auth token TTL" --entity auth --type decision
+memorix memory long-term add --kind procedural --scope user --portability portable --text "Always run focused tests before a patch release"
+memorix memory long-term qualify --id <memory-id> --reason "Verified in the release workflow"
+memorix memory long-term approve --id <memory-id> --reason "Approved for local reuse"
 memorix reasoning search --query "why sqlite"
 memorix session start --agent codex-main --agentType codex
 memorix receipt --json

--- a/llms.txt
+++ b/llms.txt
@@ -25,6 +25,7 @@ Memorix combines durable memory with a bounded task Workset:
 - **Code State**: versioned local file/symbol/import facts and freshness links that keep memory tied to the current checkout
 - **Claim Ledger and Knowledge Workspace**: source-backed claims compiled into reviewable Markdown proposals, never silent overwrites
 - **Canonical Workflows**: project workflows with safe per-agent adapters and recorded verification outcomes
+- **Curated Long-Term Memory**: source-bound episodic, semantic, and procedural records that stay candidates until explicitly qualified or approved; only deliberately created `user + portable` records can be reused across projects on the same local installation. Keyword retrieval stays primary; optional cross-language/paraphrase fallback is bounded to 1.8 seconds and never blocks lexical delivery.
 
 For non-trivial coding work, agents normally call `memorix_project_context` (or `memorix context --task "...")`. It selects a small task Workset with current facts, relevant evidence, start files, cautions, and verification hints instead of dumping all old text memory. Search is project-scoped by default. Use global scope only when cross-project recall is intentional.
 
@@ -109,4 +110,5 @@ Endpoint: `http://localhost:3211/mcp`.
 - Git Memory: https://github.com/AVIDS2/memorix/blob/main/docs/GIT_MEMORY.md
 - memcode: https://github.com/AVIDS2/memorix/blob/main/docs/MEMCODE.md
 - Agent Playbook: https://github.com/AVIDS2/memorix/blob/main/docs/AGENT_OPERATOR_PLAYBOOK.md
+- Long-Term Memory Architecture: https://github.com/AVIDS2/memorix/blob/main/docs/1.3-MEMORY-ARCHITECTURE.md
 - Full AI context: https://github.com/AVIDS2/memorix/blob/main/llms-full.txt

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.2.10",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.2.10",
+      "version": "1.3.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memorix",
   "mcpName": "io.github.AVIDS2/memorix",
-  "version": "1.2.10",
+  "version": "1.3.0",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/plugins/antigravity/memorix/rules/memorix.md
+++ b/plugins/antigravity/memorix/rules/memorix.md
@@ -9,6 +9,8 @@ Use Memorix when prior workspace context, decisions, fixes, or handoff state wou
 - Use `memorix_search` for focused lookup.
 - Use `memorix_detail` before relying on a specific memory.
 - Use `memorix_store` for durable workspace knowledge.
+- Use `longTerm` on `memorix_store` only for a stable fact, reusable procedure, or completed episode that merits explicit review. It creates a candidate, not live context; keep the default project scope and do not use it for routine updates.
+- A `user` + `portable` durable memory in a task brief is intentionally reusable across projects. When it matches the task, use it as background even if it originated elsewhere; it is not a current-project fact. Expand it only when needed with `memorix_detail` and `typedRefs: ["durable:<id>"]`, stating the missing fact as `purpose`.
 - Use `memorix_store_reasoning` for the reason behind a technical decision.
 - Use `memorix_resolve` when completed or outdated memories should stop surfacing.
 

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.2.10",
+  "version": "1.3.0",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/claude/memorix/skills/memorix-memory/SKILL.md
+++ b/plugins/claude/memorix/skills/memorix-memory/SKILL.md
@@ -17,6 +17,7 @@ Use Memorix as the shared memory layer for the active workspace when Memorix too
 | Need the full source for a search hit | `memorix_detail` | `memorix memory detail --id <id>` |
 | Need the sequence around one memory | `memorix_timeline` | `memorix memory timeline --id <id>` |
 | Learned reusable project knowledge | `memorix_store` | `memorix memory store --type <type> --entity <name> --title "<title>" "<text>"` |
+| Stable source-backed fact or procedure needing long-term review | `memorix_store` with `longTerm` | `memorix memory long-term qualify|approve --id <id> --reason "..."` |
 | Task or bug is complete/outdated | `memorix_resolve` | `memorix memory resolve --ids <ids>` |
 
 ## Search Rules
@@ -41,4 +42,6 @@ Use Memorix as the shared memory layer for the active workspace when Memorix too
 | Accepted compromise | `trade-off` |
 
 - Use concise titles, stable entity names, relevant `filesModified`, and `topicKey` for evolving topics.
+- Use `longTerm` only for a stable fact, reusable procedure, or completed episode that merits explicit review. It creates a candidate, not live context; keep the default project scope and do not use it for routine updates.
+- A `user` + `portable` durable memory in a task brief is intentionally reusable across projects. When it matches the task, use it as background even if it originated elsewhere; it is not a current-project fact. Expand it only when needed with `memorix_detail` and `typedRefs: ["durable:<id>"]`, stating the missing fact as `purpose`.
 - Do not store secrets, credentials, raw private transcripts, trivial commands, or routine file reads.

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.10",
+  "version": "1.3.0",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/skills/memorix-memory/SKILL.md
+++ b/plugins/codex/memorix/skills/memorix-memory/SKILL.md
@@ -18,6 +18,7 @@ Use Memorix as the shared memory layer for the active workspace when Memorix too
 | Need the full source for a search hit | `memorix_detail` | `memorix memory detail --id <id>` |
 | Need the sequence around one memory | `memorix_timeline` | `memorix memory timeline --id <id>` |
 | Learned reusable project knowledge | `memorix_store` | `memorix memory store --type <type> --entity <name> --title "<title>" "<text>"` |
+| Stable source-backed fact or procedure needing long-term review | `memorix_store` with `longTerm` | `memorix memory long-term qualify|approve --id <id> --reason "..."` |
 | Task or bug is complete/outdated | `memorix_resolve` | `memorix memory resolve --ids <ids>` |
 
 ## Search Rules
@@ -42,4 +43,6 @@ Use Memorix as the shared memory layer for the active workspace when Memorix too
 | Accepted compromise | `trade-off` |
 
 - Use concise titles, stable entity names, relevant `filesModified`, and `topicKey` for evolving topics.
+- Use `longTerm` only for a stable fact, reusable procedure, or completed episode that merits explicit review. It creates a candidate, not live context; keep the default project scope and do not use it for routine updates.
+- A `user` + `portable` durable memory in a task brief is intentionally reusable across projects. When it matches the task, use it as background even if it originated elsewhere; it is not a current-project fact. Expand it only when needed with `memorix_detail` and `typedRefs: ["durable:<id>"]`, stating the missing fact as `purpose`.
 - Do not store secrets, credentials, raw private transcripts, trivial commands, or routine file reads.

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.10",
+  "version": "1.3.0",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/skills/memorix-memory/SKILL.md
+++ b/plugins/copilot/memorix/skills/memorix-memory/SKILL.md
@@ -18,6 +18,7 @@ Use Memorix as the shared memory layer for the active workspace when Memorix too
 | Need the full source for a search hit | `memorix_detail` | `memorix memory detail --id <id>` |
 | Need the sequence around one memory | `memorix_timeline` | `memorix memory timeline --id <id>` |
 | Learned reusable project knowledge | `memorix_store` | `memorix memory store --type <type> --entity <name> --title "<title>" "<text>"` |
+| Stable source-backed fact or procedure needing long-term review | `memorix_store` with `longTerm` | `memorix memory long-term qualify|approve --id <id> --reason "..."` |
 | Task or bug is complete/outdated | `memorix_resolve` | `memorix memory resolve --ids <ids>` |
 
 ## Search Rules
@@ -42,4 +43,6 @@ Use Memorix as the shared memory layer for the active workspace when Memorix too
 | Accepted compromise | `trade-off` |
 
 - Use concise titles, stable entity names, relevant `filesModified`, and `topicKey` for evolving topics.
+- Use `longTerm` only for a stable fact, reusable procedure, or completed episode that merits explicit review. It creates a candidate, not live context; keep the default project scope and do not use it for routine updates.
+- A `user` + `portable` durable memory in a task brief is intentionally reusable across projects. When it matches the task, use it as background even if it originated elsewhere; it is not a current-project fact. Expand it only when needed with `memorix_detail` and `typedRefs: ["durable:<id>"]`, stating the missing fact as `purpose`.
 - Do not store secrets, credentials, raw private transcripts, trivial commands, or routine file reads.

--- a/plugins/cursor/memorix/skills/memorix-memory/SKILL.md
+++ b/plugins/cursor/memorix/skills/memorix-memory/SKILL.md
@@ -18,6 +18,7 @@ Use Memorix as the shared memory layer for the active workspace when Memorix too
 | Need the full source for a search hit | `memorix_detail` | `memorix memory detail --id <id>` |
 | Need the sequence around one memory | `memorix_timeline` | `memorix memory timeline --id <id>` |
 | Learned reusable project knowledge | `memorix_store` | `memorix memory store --type <type> --entity <name> --title "<title>" "<text>"` |
+| Stable source-backed fact or procedure needing long-term review | `memorix_store` with `longTerm` | `memorix memory long-term qualify|approve --id <id> --reason "..."` |
 | Task or bug is complete/outdated | `memorix_resolve` | `memorix memory resolve --ids <ids>` |
 
 ## Search Rules
@@ -42,4 +43,6 @@ Use Memorix as the shared memory layer for the active workspace when Memorix too
 | Accepted compromise | `trade-off` |
 
 - Use concise titles, stable entity names, relevant `filesModified`, and `topicKey` for evolving topics.
+- Use `longTerm` only for a stable fact, reusable procedure, or completed episode that merits explicit review. It creates a candidate, not live context; keep the default project scope and do not use it for routine updates.
+- A `user` + `portable` durable memory in a task brief is intentionally reusable across projects. When it matches the task, use it as background even if it originated elsewhere; it is not a current-project fact. Expand it only when needed with `memorix_detail` and `typedRefs: ["durable:<id>"]`, stating the missing fact as `purpose`.
 - Do not store secrets, credentials, raw private transcripts, trivial commands, or routine file reads.

--- a/plugins/gemini/memorix/GEMINI.md
+++ b/plugins/gemini/memorix/GEMINI.md
@@ -11,6 +11,8 @@ Use Memorix when prior workspace context, decisions, fixes, or handoff state wou
 - Use `memorix_search` for focused lookup.
 - Use `memorix_detail` before relying on a specific memory.
 - Use `memorix_store` for durable workspace knowledge.
+- Use `longTerm` on `memorix_store` only for a stable fact, reusable procedure, or completed episode that merits explicit review. It creates a candidate, not live context; keep the default project scope and do not use it for routine updates.
+- A `user` + `portable` durable memory in a task brief is intentionally reusable across projects. When it matches the task, use it as background even if it originated elsewhere; it is not a current-project fact. Expand it only when needed with `memorix_detail` and `typedRefs: ["durable:<id>"]`, stating the missing fact as `purpose`.
 - Use `memorix_store_reasoning` for the reason behind a technical decision.
 - Use `memorix_resolve` when completed or outdated memories should stop surfacing.
 

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.10",
+  "version": "1.3.0",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.2.10",
+  "version": "1.3.0",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.2.10",
+  "version": "1.3.0",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.2.10",
+  "version": "1.3.0",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/pi/memorix/skills/memorix-memory/SKILL.md
+++ b/plugins/pi/memorix/skills/memorix-memory/SKILL.md
@@ -18,6 +18,7 @@ Use Memorix as the shared memory layer for the active workspace when Memorix too
 | Need the full source for a search hit | `memorix_detail` | `memorix memory detail --id <id>` |
 | Need the sequence around one memory | `memorix_timeline` | `memorix memory timeline --id <id>` |
 | Learned reusable project knowledge | `memorix_store` | `memorix memory store --type <type> --entity <name> --title "<title>" "<text>"` |
+| Stable source-backed fact or procedure needing long-term review | `memorix_store` with `longTerm` | `memorix memory long-term qualify|approve --id <id> --reason "..."` |
 | Task or bug is complete/outdated | `memorix_resolve` | `memorix memory resolve --ids <ids>` |
 
 ## Search Rules
@@ -42,4 +43,6 @@ Use Memorix as the shared memory layer for the active workspace when Memorix too
 | Accepted compromise | `trade-off` |
 
 - Use concise titles, stable entity names, relevant `filesModified`, and `topicKey` for evolving topics.
+- Use `longTerm` only for a stable fact, reusable procedure, or completed episode that merits explicit review. It creates a candidate, not live context; keep the default project scope and do not use it for routine updates.
+- A `user` + `portable` durable memory in a task brief is intentionally reusable across projects. When it matches the task, use it as background even if it originated elsewhere; it is not a current-project fact. Expand it only when needed with `memorix_detail` and `typedRefs: ["durable:<id>"]`, stating the missing fact as `purpose`.
 - Do not store secrets, credentials, raw private transcripts, trivial commands, or routine file reads.

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AVIDS2/memorix",
     "source": "github"
   },
-  "version": "1.2.10",
+  "version": "1.3.0",
   "websiteUrl": "https://github.com/AVIDS2/memorix#readme",
   "icons": [
     {
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "memorix",
-      "version": "1.2.10",
+      "version": "1.3.0",
       "runtimeHint": "npx",
       "packageArguments": [
         {

--- a/src/cli/command-guide.ts
+++ b/src/cli/command-guide.ts
@@ -15,8 +15,16 @@ const GUIDES: Record<string, CliCommandGuide> = {
       'memorix memory resolve --ids 42,43 [--status resolved|archived]',
       'memorix memory consolidate --action preview|execute',
       'memorix memory promote --ids 42,43 [--trigger "..."] [--instruction "..."]',
+      'memorix memory long-term list [--all]',
+      'memorix memory long-term add --kind semantic --scope user --portability portable --title "..." --text "..." [--tags "..."] [--applicability "..."]',
+      'memorix memory long-term promote --from-observation 42 --kind procedural --scope project',
+      'memorix memory long-term qualify|approve|archive --id <id> --reason "..."',
+      'memorix memory long-term supersede --id <old-id> --superseded-by <qualified-id> --reason "..."',
     ],
-    notes: ['Personal and team visibility require `memorix identity join` or `memorix identity use` first.'],
+    notes: [
+      'Personal and team visibility require `memorix identity join` or `memorix identity use` first.',
+      'Candidates never enter a task Workset. Only manual or user-confirmed `user + portable` memory may cross local projects.',
+    ],
   },
   identity: {
     summary: 'Select the active local actor for private memory and coordination commands.',

--- a/src/cli/commands/codegraph.ts
+++ b/src/cli/commands/codegraph.ts
@@ -217,6 +217,7 @@ export default defineCommand({
             ...(external.caution
               ? { runtimeCautions: [{ kind: 'external-codegraph-fallback' as const, message: external.caution }] }
               : {}),
+            reader,
           });
           emitResult({ project, pack, providerQuality: external.quality }, buildContextPackPrompt(pack), asJson);
           return;

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -51,17 +51,30 @@ export default defineCommand({
     instruction: { type: 'string', description: 'Custom instruction for promoted mini-skills' },
     tags: { type: 'string', description: 'Comma-separated extra tags for promoted mini-skills' },
     skillId: { type: 'string', description: 'Mini-skill ID for list/delete actions' },
+    kind: { type: 'string', description: 'Long-term memory kind: episodic, semantic, or procedural' },
+    scope: { type: 'string', description: 'Long-term memory scope: project, user, or team' },
+    portability: { type: 'string', description: 'Long-term memory portability: project-bound or portable' },
+    applicability: { type: 'string', description: 'When a long-term memory applies' },
+    fromObservation: { type: 'string', description: 'Observation ID to promote into long-term memory' },
+    supersededBy: { type: 'string', description: 'Qualified or approved long-term memory that replaces the current record' },
+    'superseded-by': { type: 'string', description: 'Kebab-case alias for --supersededBy' },
+    reason: { type: 'string', description: 'Evidence review reason for qualify, approve, or archive' },
+    all: { type: 'boolean', description: 'Include archived and superseded long-term memories in list output' },
     json: { type: 'boolean', description: 'Emit machine-readable JSON output' },
   },
   run: async ({ args }) => {
     const action = (args._ as string[])?.[0] || '';
     const positional = ((args._ as string[]) ?? []).slice(1);
+    const longTermAction = action === 'long-term'
+      ? (positional[0] || (args.action as string | undefined) || 'list').trim().toLowerCase()
+      : undefined;
     const asJson = !!args.json;
 
     try {
       const readOnlyActions = new Set(['', 'search', 'graph-context', 'recent', 'suggest-topic-key', 'detail', 'timeline']);
       const needsSearchIndex = action === 'search' || action === 'detail' || action === 'timeline';
-      const context = readOnlyActions.has(action)
+      const longTermReadOnly = longTermAction === 'list' || longTermAction === 'show';
+      const context = readOnlyActions.has(action) || longTermReadOnly
         ? await getCliReadContext({ searchIndex: needsSearchIndex })
         : await getCliProjectContext({ searchIndex: true });
       const { project, dataDir, reader, identity } = context;
@@ -425,6 +438,178 @@ export default defineCommand({
           return;
         }
 
+        case 'long-term': {
+          const resolvedLongTermAction = longTermAction ?? 'list';
+          const longTermPositional = positional.slice(1);
+          const {
+            archiveLongTermMemory,
+            approveLongTermMemory,
+            createManualLongTermMemory,
+            getLongTermMemoryDetail,
+            listLongTermMemories,
+            promoteObservationToLongTermMemory,
+            qualifyLongTermMemory,
+            supersedeLongTermMemory,
+          } = await import('../../memory/long-term.js');
+          const { resolveLocalMemoryOwner } = await import('../../memory/owner.js');
+          const owner = await resolveLocalMemoryOwner(dataDir, { create: false });
+          const longTermReader = {
+            projectId: project.id,
+            ...(owner ? { ownerId: owner.id } : {}),
+            ...(reader.agentId ? { agentId: reader.agentId } : {}),
+            ...(reader.isTeamMember ? { isTeamMember: true } : {}),
+          };
+
+          const memoryId = (): string => {
+            const id = (args.id as string | undefined)?.trim()
+              || (args.fromObservation as string | undefined)?.trim()
+              || longTermPositional[0]?.trim();
+            if (!id) throw new Error('long-term memory id is required.');
+            return id;
+          };
+          const scope = () => longTermScope(args.scope as string | undefined);
+          const kind = () => longTermKind(args.kind as string | undefined);
+          const portability = () => longTermPortability(args.portability as string | undefined);
+          const reason = () => requiredLongTermReason(args.reason as string | undefined);
+
+          switch (resolvedLongTermAction) {
+            case 'list': {
+              const memories = await listLongTermMemories({
+                dataDir,
+                reader: longTermReader,
+                includeInactive: !!args.all,
+                limit: parsePositiveInt(args.limit as string | undefined, 50),
+              });
+              emitResult(
+                { project, memories },
+                memories.length === 0
+                  ? 'No long-term memories are visible in the active scope.'
+                  : memories.map(item => `- ${item.memory.id} [${item.memory.state}/${item.memory.kind}/${item.memory.scope}] ${item.memory.title}`).join('\n'),
+                asJson,
+              );
+              return;
+            }
+
+            case 'show': {
+              const detail = await getLongTermMemoryDetail({ dataDir, id: memoryId(), reader: longTermReader });
+              emitResult(
+                { project, ...detail },
+                [
+                  `${detail.memory.id} [${detail.memory.state}/${detail.memory.kind}/${detail.memory.scope}]`,
+                  detail.memory.title,
+                  detail.memory.content,
+                  `Evidence: ${detail.evidence.length}`,
+                  `Audit events: ${detail.events.length}`,
+                ].join('\n'),
+                asJson,
+              );
+              return;
+            }
+
+            case 'add': {
+              const content = getStringArg(args.text as string | undefined, longTermPositional);
+              if (!content) {
+                emitError('text is required for "memorix memory long-term add"', asJson);
+                return;
+              }
+              const result = await createManualLongTermMemory({
+                dataDir,
+                projectId: project.id,
+                scope: scope(),
+                kind: kind(),
+                title: (args.title as string | undefined)?.trim() || content.slice(0, 100),
+                content,
+                facts: parseCsvList(args.facts as string | undefined),
+                tags: parseCsvList(args.tags as string | undefined),
+                applicability: (args.applicability as string | undefined)?.trim(),
+                portability: portability(),
+                reader: longTermReader,
+              });
+              emitResult(
+                { project, ...result },
+                `Created long-term memory candidate ${result.memory.id}. Qualify it after checking its evidence.`,
+                asJson,
+              );
+              return;
+            }
+
+            case 'promote': {
+              const rawId = (args.fromObservation as string | undefined)?.trim()
+                || (args.id as string | undefined)?.trim()
+                || longTermPositional[0]?.trim();
+              const observationId = Number.parseInt(rawId || '', 10);
+              if (!Number.isFinite(observationId)) {
+                emitError('fromObservation or id must be an observation ID for "memorix memory long-term promote"', asJson);
+                return;
+              }
+              const observation = getObservation(observationId, project.id);
+              if (!observation || !canManageObservation(observation, reader)) {
+                emitError('Observation was not found or is outside the active write scope.', asJson);
+                return;
+              }
+              const result = await promoteObservationToLongTermMemory({
+                dataDir,
+                observation,
+                scope: scope(),
+                kind: kind(),
+                tags: parseCsvList(args.tags as string | undefined),
+                applicability: (args.applicability as string | undefined)?.trim(),
+                reader: longTermReader,
+              });
+              emitResult(
+                { project, sourceObservationId: observation.id, ...result },
+                `Promoted observation #${observation.id} to long-term memory candidate ${result.memory.id}.`,
+                asJson,
+              );
+              return;
+            }
+
+            case 'qualify': {
+              await getLongTermMemoryDetail({ dataDir, id: memoryId(), reader: longTermReader });
+              const memory = await qualifyLongTermMemory({ dataDir, id: memoryId(), reason: reason() });
+              emitResult({ project, memory }, `Qualified long-term memory ${memory.id}.`, asJson);
+              return;
+            }
+
+            case 'approve': {
+              await getLongTermMemoryDetail({ dataDir, id: memoryId(), reader: longTermReader });
+              const memory = await approveLongTermMemory({ dataDir, id: memoryId(), reason: reason() });
+              emitResult({ project, memory }, `Approved long-term memory ${memory.id}.`, asJson);
+              return;
+            }
+
+            case 'archive': {
+              await getLongTermMemoryDetail({ dataDir, id: memoryId(), reader: longTermReader });
+              const memory = await archiveLongTermMemory({ dataDir, id: memoryId(), reason: reason() });
+              emitResult({ project, memory }, `Archived long-term memory ${memory.id}.`, asJson);
+              return;
+            }
+
+            case 'supersede': {
+              const supersededBy = (args.supersededBy as string | undefined)?.trim()
+                || (args['superseded-by'] as string | undefined)?.trim();
+              if (!supersededBy) {
+                emitError('supersededBy is required for "memorix memory long-term supersede"', asJson);
+                return;
+              }
+              await getLongTermMemoryDetail({ dataDir, id: memoryId(), reader: longTermReader });
+              await getLongTermMemoryDetail({ dataDir, id: supersededBy, reader: longTermReader });
+              const memory = await supersedeLongTermMemory({
+                dataDir,
+                id: memoryId(),
+                supersededBy,
+                reason: reason(),
+              });
+              emitResult({ project, memory }, `Superseded long-term memory ${memory.id} with ${supersededBy}.`, asJson);
+              return;
+            }
+
+            default:
+              emitError('long-term action must be list, show, add, promote, qualify, approve, archive, or supersede.', asJson);
+          }
+          return;
+        }
+
         default:
           console.log('Memorix Memory Commands');
           console.log('');
@@ -440,6 +625,13 @@ export default defineCommand({
           console.log('  memorix memory deduplicate [--query "..."] [--dryRun]');
           console.log('  memorix memory consolidate [--action preview|execute] [--threshold 0.45]');
           console.log('  memorix memory promote --ids 42,43 [--trigger "..."] [--instruction "..."]');
+          console.log('  memorix memory long-term list [--all]');
+          console.log('  memorix memory long-term add --kind semantic --scope user --portability portable --title "..." --text "..." [--tags "..."] [--applicability "..."]');
+          console.log('  memorix memory long-term promote --fromObservation 42 --kind procedural --scope project');
+          console.log('  memorix memory long-term qualify --id <id> --reason "verified against evidence"');
+          console.log('  memorix memory long-term approve --id <id> --reason "reviewed by operator"');
+          console.log('  memorix memory long-term archive --id <id> --reason "no longer current"');
+          console.log('  memorix memory long-term supersede --id <old-id> --superseded-by <qualified-id> --reason "replaced"');
       }
     } catch (error) {
       emitError(error instanceof Error ? error.message : String(error), asJson);
@@ -458,4 +650,28 @@ function getIdArg(args: Record<string, unknown>, positional: string[]): string {
     (args.id as string | undefined) ||
     positional.join(',')
   );
+}
+
+function longTermKind(value: string | undefined): 'episodic' | 'semantic' | 'procedural' {
+  const normalized = (value ?? 'semantic').trim().toLowerCase();
+  if (normalized === 'episodic' || normalized === 'semantic' || normalized === 'procedural') return normalized;
+  throw new Error('long-term kind must be episodic, semantic, or procedural.');
+}
+
+function longTermScope(value: string | undefined): 'project' | 'user' | 'team' {
+  const normalized = (value ?? 'project').trim().toLowerCase();
+  if (normalized === 'project' || normalized === 'user' || normalized === 'team') return normalized;
+  throw new Error('long-term scope must be project, user, or team.');
+}
+
+function longTermPortability(value: string | undefined): 'project-bound' | 'portable' {
+  const normalized = (value ?? 'project-bound').trim().toLowerCase();
+  if (normalized === 'project-bound' || normalized === 'portable') return normalized;
+  throw new Error('long-term portability must be project-bound or portable.');
+}
+
+function requiredLongTermReason(value: string | undefined): string {
+  const reason = value?.trim();
+  if (!reason) throw new Error('reason is required for this long-term memory transition.');
+  return reason;
 }

--- a/src/codegraph/auto-context.ts
+++ b/src/codegraph/auto-context.ts
@@ -388,6 +388,7 @@ export async function buildAutoProjectContext(input: {
       stale: overview.freshness.stale,
     },
     runtimeCautions,
+    ...(input.reader ? { reader: input.reader } : {}),
     ...(input.deliveryTarget ? { deliveryTarget: input.deliveryTarget } : {}),
   });
 
@@ -600,6 +601,16 @@ export function formatAutoProjectContextSummary(context: AutoProjectContext): st
       ? `- ${reliableSources.length} current code-bound memory link(s)`
       : '- none yet',
   );
+
+  if (context.workset.durableMemory.length > 0) {
+    lines.push('', 'Durable memory');
+    for (const memory of context.workset.durableMemory.slice(0, 3)) {
+      lines.push(
+        '- ' + memory.kind + ' (' + memory.scope + ', ' + memory.state + '): '
+          + compactContinuationText(memory.summary, 28),
+      );
+    }
+  }
 
   const continuation = context.workset.continuation;
   if (continuation?.previousSession || continuation?.memories.length || continuation?.compactCheckpoint) {

--- a/src/codegraph/context-pack.ts
+++ b/src/codegraph/context-pack.ts
@@ -10,6 +10,7 @@ import type {
 } from './types.js';
 import type { CodeGraphStore } from './store.js';
 import { isCodeGraphExcludedPath } from './exclude.js';
+import type { ObservationReader } from '../types.js';
 
 export interface ContextPackMemory {
   id: number;
@@ -276,6 +277,7 @@ export async function attachTaskWorkset(input: {
   semanticCode?: ExternalCodeGraphOutline;
   providerQuality?: CodeGraphProviderQuality;
   runtimeCautions?: WorksetCaution[];
+  reader?: ObservationReader;
 }): Promise<ContextPack> {
   const semanticStartHere = input.semanticCode
     ? [...input.semanticCode.relatedFiles, ...input.semanticCode.entryPoints.map(entry => entry.path)]
@@ -316,6 +318,7 @@ export async function attachTaskWorkset(input: {
       stale: input.pack.warnings.filter(warning => warning.status === 'stale').length,
     },
     runtimeCautions: input.runtimeCautions,
+    ...(input.reader ? { reader: input.reader } : {}),
     deliveryTarget: 'context-pack',
   });
   return { ...input.pack, workset };

--- a/src/embedding/api-provider.ts
+++ b/src/embedding/api-provider.ts
@@ -9,7 +9,7 @@ import { createHash } from 'node:crypto';
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import type { EmbeddingProvider } from './provider.js';
+import type { EmbeddingProvider, EmbeddingRequestOptions } from './provider.js';
 
 const CACHE_DIR = process.env.MEMORIX_DATA_DIR || join(homedir(), '.memorix', 'data');
 const CACHE_FILE = join(CACHE_DIR, '.embedding-api-cache.json');
@@ -306,6 +306,10 @@ export interface APIEmbeddingProviderCreateOptions {
    * the provider. This keeps startup/cache hydration off the remote API path.
    */
   allowNetworkProbe?: boolean;
+  /** Bound the one-off remote dimension probe used on a cold API start. */
+  requestTimeoutMs?: number;
+  /** Disable retries for a bounded, best-effort API initialization. */
+  retry?: boolean;
 }
 
 function resolveEnvEmbeddingApiKey(): string | undefined {
@@ -370,7 +374,10 @@ export class APIEmbeddingProvider implements EmbeddingProvider {
       }
     } else {
       if (!allowNetworkProbe) return null;
-      probeDimensions = await APIEmbeddingProvider.probeAPI(config);
+      probeDimensions = await APIEmbeddingProvider.probeAPI(config, {
+        timeoutMs: options.requestTimeoutMs,
+        retry: options.retry,
+      });
       console.error(`[memorix] API embedding: ${config.model} @ ${config.baseUrl} (${probeDimensions}d)`);
       // Persist for next cold start
       saveCachedDims(config, probeDimensions).catch(() => {});
@@ -430,7 +437,7 @@ export class APIEmbeddingProvider implements EmbeddingProvider {
     return { apiKey, baseUrl, model, requestedDimensions };
   }
 
-  private static async probeAPI(config: APIEmbeddingConfig): Promise<number> {
+  private static async probeAPI(config: APIEmbeddingConfig, options?: EmbeddingRequestOptions): Promise<number> {
     const body: Record<string, unknown> = {
       model: config.model,
       input: 'dimension probe',
@@ -443,6 +450,7 @@ export class APIEmbeddingProvider implements EmbeddingProvider {
       `${config.baseUrl}/embeddings`,
       config.apiKey,
       body,
+      options,
     );
 
     if (response.data.length === 0 || !response.data[0].embedding) {
@@ -452,7 +460,7 @@ export class APIEmbeddingProvider implements EmbeddingProvider {
     return response.data[0].embedding.length;
   }
 
-  async embed(text: string): Promise<number[]> {
+  async embed(text: string, options?: EmbeddingRequestOptions): Promise<number[]> {
     const normalized = normalizeText(text);
     const hash = textHash(normalized, this.cacheKeyNamespace);
 
@@ -477,6 +485,7 @@ export class APIEmbeddingProvider implements EmbeddingProvider {
         `${this.config.baseUrl}/embeddings`,
         this.config.apiKey,
         body,
+        options,
       );
       const embedding = response.data[0].embedding;
       if (embedding.length !== this.dimensions) {
@@ -521,7 +530,7 @@ export class APIEmbeddingProvider implements EmbeddingProvider {
     return embedding;
   }
 
-  async embedBatch(texts: string[]): Promise<number[][]> {
+  async embedBatch(texts: string[], options?: EmbeddingRequestOptions): Promise<number[][]> {
     await ensureDiskCacheLoaded();
     const normalizedTexts = texts.map(normalizeText);
     const results: number[][] = new Array(texts.length);
@@ -562,6 +571,7 @@ export class APIEmbeddingProvider implements EmbeddingProvider {
           `${this.config.baseUrl}/embeddings`,
           this.config.apiKey,
           body,
+          options,
         );
 
         this.trackUsage(response);
@@ -638,10 +648,14 @@ async function fetchWithRetry(
   url: string,
   apiKey: string,
   body: Record<string, unknown>,
+  options: EmbeddingRequestOptions = {},
   attempt = 0,
 ): Promise<EmbeddingAPIResponse> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 10_000);
+  const timeoutMs = typeof options.timeoutMs === 'number' && Number.isFinite(options.timeoutMs)
+    ? Math.max(100, Math.min(Math.floor(options.timeoutMs), 60_000))
+    : 10_000;
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
   let response: Response;
   try {
     response = await fetch(url, {
@@ -656,7 +670,7 @@ async function fetchWithRetry(
   } catch (err: unknown) {
     clearTimeout(timeout);
     if (err instanceof Error && err.name === 'AbortError') {
-      throw new Error(`Embedding API timeout after 10s: ${url}`);
+      throw new Error(`Embedding API timeout after ${timeoutMs}ms: ${url}`);
     }
     throw err;
   }
@@ -666,13 +680,13 @@ async function fetchWithRetry(
     return response.json() as Promise<EmbeddingAPIResponse>;
   }
 
-  if ((response.status === 429 || response.status >= 500) && attempt < MAX_RETRIES) {
+  if (options.retry !== false && (response.status === 429 || response.status >= 500) && attempt < MAX_RETRIES) {
     const delay = BASE_DELAY_MS * Math.pow(2, attempt);
     const retryAfter = response.headers.get('retry-after');
     const waitMs = retryAfter ? parseInt(retryAfter, 10) * 1000 : delay;
     console.error(`[memorix] Embedding API ${response.status}, retry ${attempt + 1}/${MAX_RETRIES} in ${waitMs}ms`);
     await new Promise(resolve => setTimeout(resolve, waitMs));
-    return fetchWithRetry(url, apiKey, body, attempt + 1);
+    return fetchWithRetry(url, apiKey, body, options, attempt + 1);
   }
 
   const errorText = await response.text().catch(() => 'unknown error');

--- a/src/embedding/provider.ts
+++ b/src/embedding/provider.ts
@@ -27,15 +27,22 @@
  * Architecture inspired by Mem0's multi-provider embedding design.
  */
 
+export interface EmbeddingRequestOptions {
+  /** Bound one remote embedding request without changing the provider default. */
+  timeoutMs?: number;
+  /** Disable provider retries for latency-sensitive best-effort work. */
+  retry?: boolean;
+}
+
 export interface EmbeddingProvider {
   /** Provider name for logging/cache keys */
   readonly name: string;
   /** Vector dimensions (e.g., 384 for bge-small) */
   readonly dimensions: number;
   /** Generate embedding for a single text */
-  embed(text: string): Promise<number[]>;
+  embed(text: string, options?: EmbeddingRequestOptions): Promise<number[]>;
   /** Generate embeddings for multiple texts (batch) */
-  embedBatch(texts: string[]): Promise<number[][]>;
+  embedBatch(texts: string[], options?: EmbeddingRequestOptions): Promise<number[][]>;
   /** Return already-persisted embeddings without generating new vectors. */
   getCachedEmbeddings?(texts: string[]): Promise<(number[] | null)[]>;
 }
@@ -43,6 +50,10 @@ export interface EmbeddingProvider {
 export interface GetEmbeddingProviderOptions {
   /** Avoid remote API dimension probes while preparing a startup index. */
   allowNetworkProbe?: boolean;
+  /** Bound a remote API dimension probe for a latency-sensitive caller. */
+  requestTimeoutMs?: number;
+  /** Disable retries while resolving a best-effort provider. */
+  retry?: boolean;
 }
 
 /** Singleton provider instance (null = not available) */
@@ -205,9 +216,9 @@ function wrapProvider(candidate: EmbeddingProvider): EmbeddingProvider {
   return {
     name: candidate.name,
     dimensions: candidate.dimensions,
-    async embed(text: string): Promise<number[]> {
+    async embed(text: string, options?: EmbeddingRequestOptions): Promise<number[]> {
       try {
-        return await candidate.embed(text);
+        return await candidate.embed(text, options);
       } catch (error) {
         if (kind === 'api' && getEmbeddingMode() === 'auto' && isTemporaryEmbeddingFailure(error)) {
           warnOnce('[memorix] API embedding temporarily unavailable — switching to local fallback provider');
@@ -215,7 +226,7 @@ function wrapProvider(candidate: EmbeddingProvider): EmbeddingProvider {
           if (fallback) {
             provider = wrapProvider(fallback);
             warnOnce(`[memorix] Embedding fallback activated: ${provider.name} (${provider.dimensions}d)`);
-            return provider.embed(text);
+            return provider.embed(text, options);
           }
         }
 
@@ -225,9 +236,9 @@ function wrapProvider(candidate: EmbeddingProvider): EmbeddingProvider {
         throw error;
       }
     },
-    async embedBatch(texts: string[]): Promise<number[][]> {
+    async embedBatch(texts: string[], options?: EmbeddingRequestOptions): Promise<number[][]> {
       try {
-        return await candidate.embedBatch(texts);
+        return await candidate.embedBatch(texts, options);
       } catch (error) {
         if (kind === 'api' && getEmbeddingMode() === 'auto' && isTemporaryEmbeddingFailure(error)) {
           warnOnce('[memorix] API embedding temporarily unavailable — switching to local fallback provider');
@@ -235,7 +246,7 @@ function wrapProvider(candidate: EmbeddingProvider): EmbeddingProvider {
           if (fallback) {
             provider = wrapProvider(fallback);
             warnOnce(`[memorix] Embedding fallback activated: ${provider.name} (${provider.dimensions}d)`);
-            return provider.embedBatch(texts);
+            return provider.embedBatch(texts, options);
           }
         }
 
@@ -331,7 +342,7 @@ export async function getEmbeddingProvider(
 
     // API mode: remote embedding via OpenAI-compatible endpoint
     if (mode === 'api') {
-      const initialized = await createAPIProvider();
+      const initialized = await createAPIProvider(options);
       if (!initialized) return null;
       provider = wrapProvider(initialized);
       warnOnce(`[memorix] Embedding provider: ${provider.name} (${provider.dimensions}d)`);
@@ -340,7 +351,7 @@ export async function getEmbeddingProvider(
 
     // Auto mode: try configured API first, then local fallbacks
     if (hasAPIEmbeddingConfig()) {
-      const initialized = await createAPIProvider();
+      const initialized = await createAPIProvider(options);
       if (initialized) {
         provider = wrapProvider(initialized);
         warnOnce(`[memorix] Embedding provider: ${provider.name} (${provider.dimensions}d)`);

--- a/src/hooks/installers/index.ts
+++ b/src/hooks/installers/index.ts
@@ -1247,6 +1247,8 @@ function getAgentRulesContent(agent?: AgentName, scope: 'project' | 'global' = '
     '- Include \x60filesModified\x60 when relevant',
     '- Use \x60topicKey\x60 for topics that evolve over time (prevents duplicates)',
     '- For "why" decisions, use \x60memorix_store_reasoning\x60',
+    '- For a stable fact, reusable procedure, or completed episode that merits deliberate long-term review, include \x60longTerm\x60 in \x60memorix_store\x60 with the appropriate kind and normally \x60scope: "project"\x60. It creates a candidate only: do not use it for routine updates, do not make project-derived evidence portable user memory, and do not assume it enters context until an operator qualifies and approves it through \x60memorix memory long-term\x60.',
+    '- A \x60user\x60 + \x60portable\x60 durable memory delivered in a task brief is intentionally available across projects. When it matches the task, use it as reusable background even if its origin differs; do not treat it as a current-project fact. Expand it only when needed with \x60memorix_detail\x60 using its \x60durable:<id>\x60 reference and a specific purpose.',
     '',
     "**Don't store:** greetings, simple file reads, trivial commands (ls, pwd, git status).",
     '',

--- a/src/knowledge/context-assembly.ts
+++ b/src/knowledge/context-assembly.ts
@@ -18,6 +18,7 @@ export type ContextCandidateKind =
   | 'semantic-code'
   | 'start-here'
   | 'memory'
+  | 'durable-memory'
   | 'claim'
   | 'knowledge-page'
   | 'workflow'
@@ -43,7 +44,7 @@ export interface ContextReceiptOmission {
 }
 
 export interface ContextReceipt {
-  version: '1.2.4';
+  version: '1.3';
   target: ContextDeliveryTarget;
   elapsedMs: number;
   budget: {

--- a/src/knowledge/workset.ts
+++ b/src/knowledge/workset.ts
@@ -6,6 +6,7 @@ import { KnowledgeWorkspaceStore } from './workspace-store.js';
 import { loadKnowledgeWorkspace } from './workspace.js';
 import { WorkflowStore } from './workflow-store.js';
 import { selectWorkflows } from './workflows.js';
+import { renderLongTermMemorySummary, selectLongTermMemoriesForTask } from '../memory/long-term.js';
 import type {
   ContextCandidateFreshness,
   ContextCandidateKind,
@@ -18,6 +19,8 @@ import type { CodeGraphProviderQuality, ExternalCodeGraphOutline } from '../code
 import type { KnowledgeClaim, ClaimEvidenceRef } from './types.js';
 import type { KnowledgePageRecord, KnowledgeWorkspace } from './workspace-types.js';
 import type { WorkflowSelection } from './workflow-types.js';
+import type { ObservationReader } from '../types.js';
+import type { LongTermMemory, LongTermMemoryEvidence } from '../memory/long-term-types.js';
 
 export type WorksetCautionKind =
   | 'dirty-worktree'
@@ -77,6 +80,18 @@ export interface WorksetMemorySource {
   reason?: string;
 }
 
+/** A task-matching curated long-term item. The full record stays behind CLI detail. */
+export interface WorksetLongTermMemory {
+  id: string;
+  kind: LongTermMemory['kind'];
+  scope: LongTermMemory['scope'];
+  state: LongTermMemory['state'];
+  title: string;
+  summary: string;
+  evidenceRefs: string[];
+  reason: string;
+}
+
 /** Prior-work evidence selected only for an explicit or inferred continuation. */
 export interface WorksetContinuation {
   previousSession?: {
@@ -103,7 +118,7 @@ export interface WorksetContinuation {
 }
 
 export interface TaskWorkset {
-  version: '1.2';
+  version: '1.3';
   task: string;
   lens: string;
   currentFacts: string[];
@@ -117,6 +132,7 @@ export interface TaskWorkset {
   hiddenCautionMemoryCount: number;
   claims: WorksetClaim[];
   pages: WorksetPage[];
+  durableMemory: WorksetLongTermMemory[];
   workflows: WorksetWorkflow[];
   cautions: WorksetCaution[];
   verification: string[];
@@ -164,6 +180,8 @@ export interface BuildTaskWorksetInput {
     stale: number;
   };
   runtimeCautions?: WorksetCaution[];
+  /** Reader identity used only for team-scoped durable memory filtering. */
+  reader?: ObservationReader;
   maxTokens?: number;
   /** Delivery surface controls receipt semantics without changing prompt shape. */
   deliveryTarget?: ContextDeliveryTarget;
@@ -297,6 +315,7 @@ function receiptOmissionKind(raw: string): ContextCandidateKind | undefined {
   if (raw.includes('state')) return 'code-state';
   if (raw.includes('semantic')) return 'semantic-code';
   if (raw.includes('start')) return 'start-here';
+  if (raw.includes('durable-memory')) return 'durable-memory';
   if (raw.includes('memory')) return 'memory';
   if (raw.includes('claim')) return 'claim';
   if (raw.includes('knowledge-page')) return 'knowledge-page';
@@ -593,6 +612,27 @@ export function renderTaskWorksetPrompt(input: Omit<TaskWorkset, 'prompt' | 'bud
     }
   }
 
+  if (input.durableMemory.length > 0) {
+    appendLine(lines, '', maxTokens, omitted, 'durable-memory-heading');
+    appendLine(lines, 'Durable memory', maxTokens, omitted, 'durable-memory-heading');
+    for (const memory of input.durableMemory.slice(0, 3)) {
+      appendLine(
+        lines,
+        '- ' + memory.kind + ' (' + memory.scope + ', ' + memory.state + '; ref durable:' + memory.id + '): ' + memory.summary,
+        maxTokens,
+        omitted,
+        'durable-memory',
+        selected,
+        {
+          kind: 'durable-memory',
+          id: 'durable:' + memory.id,
+          reason: memory.reason,
+          trust: 'source-backed',
+        },
+      );
+    }
+  }
+
   if (input.workflows.length > 0) {
     appendLine(lines, '', maxTokens, omitted, 'workflow-heading');
     appendLine(lines, 'Project workflow', maxTokens, omitted, 'workflow-heading');
@@ -674,6 +714,35 @@ export async function buildTaskWorkset(input: BuildTaskWorksetInput): Promise<Ta
     reason: selection.reasons[claim.id] ?? 'source-qualified task match',
   }));
 
+  let durableMemory: WorksetLongTermMemory[] = [];
+  let durableEvidence: LongTermMemoryEvidence[] = [];
+  if (task) {
+    try {
+      const selected = await selectLongTermMemoriesForTask({
+        dataDir: input.dataDir,
+        projectId: input.projectId,
+        task,
+        ...(input.reader?.agentId ? { agentId: input.reader.agentId } : {}),
+        ...(input.reader?.isTeamMember ? { isTeamMember: true } : {}),
+        limit: 3,
+      });
+      durableMemory = selected.map(item => ({
+        id: item.memory.id,
+        kind: item.memory.kind,
+        scope: item.memory.scope,
+        state: item.memory.state,
+        title: item.memory.title,
+        summary: renderLongTermMemorySummary(item.memory, 20),
+        evidenceRefs: item.evidence.map(evidence => evidence.id),
+        reason: item.reason,
+      }));
+      durableEvidence = selected.flatMap(item => item.evidence);
+    } catch {
+      // Long-term memory is optional enrichment; a local identity or schema
+      // problem must never block current source/code context delivery.
+    }
+  }
+
   let workspace: KnowledgeWorkspace | undefined;
   let pages: WorksetPage[] = [];
   let workflows: WorksetWorkflow[] = [];
@@ -719,7 +788,10 @@ export async function buildTaskWorkset(input: BuildTaskWorksetInput): Promise<Ta
   const evidenceIds = unique(selection.claims.flatMap(claim => evidenceIdsForClaim(
     claim,
     evidenceByClaim.get(claim.id) ?? [],
-  )));
+  )).concat(
+    durableMemory.map(memory => 'durable:' + memory.id),
+    durableEvidence.map(evidence => 'durable-evidence:' + evidence.id),
+  ));
   const verification = unique([
     ...workflows.flatMap(workflow => workflow.verificationGates),
     ...input.verificationHints,
@@ -758,7 +830,7 @@ export async function buildTaskWorkset(input: BuildTaskWorksetInput): Promise<Ta
     }
     : undefined;
   const base = {
-    version: '1.2' as const,
+    version: '1.3' as const,
     task,
     lens: input.lens,
     currentFacts: input.currentFacts?.map(fact => fact.startsWith('Historical note:')
@@ -773,6 +845,7 @@ export async function buildTaskWorkset(input: BuildTaskWorksetInput): Promise<Ta
     hiddenCautionMemoryCount: input.hiddenCautionMemoryCount ?? 0,
     claims,
     pages,
+    durableMemory,
     workflows,
     cautions: normalizedCautions,
     verification,
@@ -789,7 +862,7 @@ export async function buildTaskWorkset(input: BuildTaskWorksetInput): Promise<Ta
     budget: { maxTokens },
   });
   const receipt: ContextReceipt = {
-    version: '1.2.4',
+    version: '1.3',
     target: input.deliveryTarget ?? 'project-context',
     elapsedMs: Math.max(0, Date.now() - startedAt),
     budget: {

--- a/src/memory/long-term-store.ts
+++ b/src/memory/long-term-store.ts
@@ -1,0 +1,242 @@
+import { randomUUID } from 'node:crypto';
+import { getDatabase } from '../store/sqlite-db.js';
+import type {
+  LongTermMemory,
+  LongTermMemoryEvidence,
+  LongTermMemoryEvent,
+} from './long-term-types.js';
+
+function optionalText(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function arrayValue(value: unknown): string[] {
+  if (typeof value !== 'string' || !value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === 'string') : [];
+  } catch {
+    return [];
+  }
+}
+
+function rowToMemory(row: any): LongTermMemory {
+  return {
+    id: row.id,
+    originProjectId: row.originProjectId,
+    ownerId: row.ownerId,
+    scope: row.scope,
+    kind: row.kind,
+    state: row.state,
+    portability: row.portability,
+    title: row.title,
+    content: row.content,
+    facts: arrayValue(row.factsJson),
+    tags: arrayValue(row.tagsJson),
+    ...(optionalText(row.applicability) ? { applicability: row.applicability } : {}),
+    origin: row.origin,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    ...(optionalText(row.qualifiedAt) ? { qualifiedAt: row.qualifiedAt } : {}),
+    ...(optionalText(row.approvedAt) ? { approvedAt: row.approvedAt } : {}),
+    ...(optionalText(row.archivedAt) ? { archivedAt: row.archivedAt } : {}),
+    ...(optionalText(row.supersededBy) ? { supersededBy: row.supersededBy } : {}),
+    ...(optionalText(row.lastValidatedAt) ? { lastValidatedAt: row.lastValidatedAt } : {}),
+    accessCount: Number(row.accessCount ?? 0),
+    ...(optionalText(row.lastAccessedAt) ? { lastAccessedAt: row.lastAccessedAt } : {}),
+  } as LongTermMemory;
+}
+
+function rowToEvidence(row: any): LongTermMemoryEvidence {
+  return {
+    id: row.id,
+    memoryId: row.memoryId,
+    kind: row.kind,
+    referenceId: row.referenceId,
+    relation: row.relation,
+    ...(optionalText(row.locator) ? { locator: row.locator } : {}),
+    ...(optionalText(row.capturedHash) ? { capturedHash: row.capturedHash } : {}),
+    createdAt: row.createdAt,
+  } as LongTermMemoryEvidence;
+}
+
+function rowToEvent(row: any): LongTermMemoryEvent {
+  return {
+    id: row.id,
+    memoryId: row.memoryId,
+    kind: row.kind,
+    ...(optionalText(row.fromState) ? { fromState: row.fromState } : {}),
+    ...(optionalText(row.toState) ? { toState: row.toState } : {}),
+    ...(optionalText(row.detail) ? { detail: row.detail } : {}),
+    createdAt: row.createdAt,
+  } as LongTermMemoryEvent;
+}
+
+/** Persistence only. Lifecycle, privacy, and portability policy live in long-term.ts. */
+export class LongTermMemoryStore {
+  private db: any = null;
+
+  async init(dataDir: string): Promise<void> {
+    this.db = getDatabase(dataDir);
+  }
+
+  transaction<T>(fn: () => T): T {
+    return this.db.transaction(fn)();
+  }
+
+  get(id: string): LongTermMemory | undefined {
+    const row = this.db.prepare('SELECT * FROM long_term_memories WHERE id = ?').get(id);
+    return row ? rowToMemory(row) : undefined;
+  }
+
+  list(options: { ownerId?: string; originProjectId?: string; limit?: number } = {}): LongTermMemory[] {
+    const limit = Math.max(1, Math.min(1_000, Math.floor(options.limit ?? 500)));
+    const clauses: string[] = [];
+    const params: unknown[] = [];
+    if (options.ownerId) {
+      clauses.push('ownerId = ?');
+      params.push(options.ownerId);
+    }
+    if (options.originProjectId) {
+      clauses.push('originProjectId = ?');
+      params.push(options.originProjectId);
+    }
+    const where = clauses.length ? ' WHERE ' + clauses.join(' AND ') : '';
+    const rows = this.db.prepare(
+      'SELECT * FROM long_term_memories' + where + ' ORDER BY updatedAt DESC, id LIMIT ?',
+    ).all(...params, limit);
+    return rows.map(rowToMemory);
+  }
+
+  insert(memory: LongTermMemory): void {
+    this.db.prepare(`
+      INSERT INTO long_term_memories (
+        id, originProjectId, ownerId, scope, kind, state, portability,
+        title, content, factsJson, tagsJson, applicability, origin,
+        createdAt, updatedAt, qualifiedAt, approvedAt, archivedAt,
+        supersededBy, lastValidatedAt, accessCount, lastAccessedAt
+      ) VALUES (
+        @id, @originProjectId, @ownerId, @scope, @kind, @state, @portability,
+        @title, @content, @factsJson, @tagsJson, @applicability, @origin,
+        @createdAt, @updatedAt, @qualifiedAt, @approvedAt, @archivedAt,
+        @supersededBy, @lastValidatedAt, @accessCount, @lastAccessedAt
+      )
+    `).run({
+      ...memory,
+      factsJson: JSON.stringify(memory.facts),
+      tagsJson: JSON.stringify(memory.tags),
+      applicability: memory.applicability ?? null,
+      qualifiedAt: memory.qualifiedAt ?? null,
+      approvedAt: memory.approvedAt ?? null,
+      archivedAt: memory.archivedAt ?? null,
+      supersededBy: memory.supersededBy ?? null,
+      lastValidatedAt: memory.lastValidatedAt ?? null,
+      lastAccessedAt: memory.lastAccessedAt ?? null,
+    });
+  }
+
+  update(memory: LongTermMemory): void {
+    this.db.prepare(`
+      UPDATE long_term_memories SET
+        scope = @scope,
+        kind = @kind,
+        state = @state,
+        portability = @portability,
+        title = @title,
+        content = @content,
+        factsJson = @factsJson,
+        tagsJson = @tagsJson,
+        applicability = @applicability,
+        updatedAt = @updatedAt,
+        qualifiedAt = @qualifiedAt,
+        approvedAt = @approvedAt,
+        archivedAt = @archivedAt,
+        supersededBy = @supersededBy,
+        lastValidatedAt = @lastValidatedAt,
+        accessCount = @accessCount,
+        lastAccessedAt = @lastAccessedAt
+      WHERE id = @id
+    `).run({
+      ...memory,
+      factsJson: JSON.stringify(memory.facts),
+      tagsJson: JSON.stringify(memory.tags),
+      applicability: memory.applicability ?? null,
+      qualifiedAt: memory.qualifiedAt ?? null,
+      approvedAt: memory.approvedAt ?? null,
+      archivedAt: memory.archivedAt ?? null,
+      supersededBy: memory.supersededBy ?? null,
+      lastValidatedAt: memory.lastValidatedAt ?? null,
+      lastAccessedAt: memory.lastAccessedAt ?? null,
+    });
+  }
+
+  insertEvidence(input: Omit<LongTermMemoryEvidence, 'id' | 'createdAt'> & { createdAt?: string }): LongTermMemoryEvidence {
+    const evidence: LongTermMemoryEvidence = {
+      id: randomUUID(),
+      ...input,
+      createdAt: input.createdAt ?? new Date().toISOString(),
+    };
+    this.db.prepare(`
+      INSERT INTO long_term_memory_evidence (
+        id, memoryId, kind, referenceId, relation, locator, capturedHash, createdAt
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      evidence.id,
+      evidence.memoryId,
+      evidence.kind,
+      evidence.referenceId,
+      evidence.relation,
+      evidence.locator ?? null,
+      evidence.capturedHash ?? null,
+      evidence.createdAt,
+    );
+    return evidence;
+  }
+
+  listEvidence(memoryId: string): LongTermMemoryEvidence[] {
+    return this.db.prepare(`
+      SELECT * FROM long_term_memory_evidence WHERE memoryId = ? ORDER BY createdAt ASC, id
+    `).all(memoryId).map(rowToEvidence);
+  }
+
+  recordEvent(input: Omit<LongTermMemoryEvent, 'id' | 'createdAt'> & { createdAt?: string }): LongTermMemoryEvent {
+    const event: LongTermMemoryEvent = {
+      id: randomUUID(),
+      ...input,
+      createdAt: input.createdAt ?? new Date().toISOString(),
+    };
+    this.db.prepare(`
+      INSERT INTO long_term_memory_events (id, memoryId, kind, fromState, toState, detail, createdAt)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      event.id,
+      event.memoryId,
+      event.kind,
+      event.fromState ?? null,
+      event.toState ?? null,
+      event.detail ?? null,
+      event.createdAt,
+    );
+    return event;
+  }
+
+  listEvents(memoryId: string): LongTermMemoryEvent[] {
+    return this.db.prepare(`
+      SELECT * FROM long_term_memory_events WHERE memoryId = ? ORDER BY createdAt ASC, rowid ASC
+    `).all(memoryId).map(rowToEvent);
+  }
+
+  markAccess(ids: string[], at = new Date().toISOString()): void {
+    const unique = [...new Set(ids.filter(Boolean))];
+    if (unique.length === 0) return;
+    const statement = this.db.prepare(`
+      UPDATE long_term_memories
+      SET accessCount = accessCount + 1, lastAccessedAt = ?
+      WHERE id = ?
+    `);
+    this.db.transaction(() => {
+      for (const id of unique) statement.run(at, id);
+    })();
+  }
+
+}

--- a/src/memory/long-term-types.ts
+++ b/src/memory/long-term-types.ts
@@ -1,0 +1,136 @@
+/**
+ * Durable cognitive-memory contracts. These types are intentionally separate
+ * from Observation provenance and Knowledge Claim truth contracts.
+ */
+
+export const LONG_TERM_MEMORY_KINDS = ['episodic', 'semantic', 'procedural'] as const;
+export type LongTermMemoryKind = typeof LONG_TERM_MEMORY_KINDS[number];
+
+export const LONG_TERM_MEMORY_SCOPES = ['project', 'user', 'team'] as const;
+export type LongTermMemoryScope = typeof LONG_TERM_MEMORY_SCOPES[number];
+
+export const LONG_TERM_MEMORY_STATES = [
+  'candidate',
+  'qualified',
+  'approved',
+  'archived',
+  'superseded',
+] as const;
+export type LongTermMemoryState = typeof LONG_TERM_MEMORY_STATES[number];
+
+export const LONG_TERM_MEMORY_PORTABILITIES = ['project-bound', 'portable'] as const;
+export type LongTermMemoryPortability = typeof LONG_TERM_MEMORY_PORTABILITIES[number];
+
+export const LONG_TERM_MEMORY_EVIDENCE_KINDS = [
+  'observation',
+  'claim',
+  'workflow',
+  'session',
+  'checkpoint',
+  'git',
+  'code',
+  'test',
+  'run',
+  'document',
+  'manual',
+  'user',
+] as const;
+export type LongTermMemoryEvidenceKind = typeof LONG_TERM_MEMORY_EVIDENCE_KINDS[number];
+
+export const LONG_TERM_MEMORY_EVIDENCE_RELATIONS = [
+  'supports',
+  'verifies',
+  'derives',
+  'user-confirmed',
+] as const;
+export type LongTermMemoryEvidenceRelation = typeof LONG_TERM_MEMORY_EVIDENCE_RELATIONS[number];
+
+export type LongTermMemoryOrigin = 'manual' | 'agent' | 'hook' | 'git' | 'migration';
+
+export interface LongTermMemoryEvidence {
+  id: string;
+  memoryId: string;
+  kind: LongTermMemoryEvidenceKind;
+  referenceId: string;
+  relation: LongTermMemoryEvidenceRelation;
+  locator?: string;
+  capturedHash?: string;
+  createdAt: string;
+}
+
+export interface LongTermMemory {
+  id: string;
+  /** Project from which this item and its evidence originated. */
+  originProjectId: string;
+  /** Local stable owner identity. Team and project records retain attribution. */
+  ownerId: string;
+  scope: LongTermMemoryScope;
+  kind: LongTermMemoryKind;
+  state: LongTermMemoryState;
+  portability: LongTermMemoryPortability;
+  title: string;
+  content: string;
+  facts: string[];
+  tags: string[];
+  /** Short condition explaining when the procedure/fact applies. */
+  applicability?: string;
+  origin: LongTermMemoryOrigin;
+  createdAt: string;
+  updatedAt: string;
+  qualifiedAt?: string;
+  approvedAt?: string;
+  archivedAt?: string;
+  supersededBy?: string;
+  lastValidatedAt?: string;
+  accessCount: number;
+  lastAccessedAt?: string;
+}
+
+export type LongTermMemoryEventKind = 'created' | 'qualified' | 'approved' | 'archived' | 'superseded';
+
+export interface LongTermMemoryEvent {
+  id: string;
+  memoryId: string;
+  kind: LongTermMemoryEventKind;
+  fromState?: LongTermMemoryState;
+  toState?: LongTermMemoryState;
+  detail?: string;
+  createdAt: string;
+}
+
+export interface LongTermMemoryReader {
+  projectId: string;
+  ownerId?: string;
+  agentId?: string;
+  isTeamMember?: boolean;
+}
+
+export interface LongTermMemoryEvidenceInput {
+  kind: LongTermMemoryEvidenceKind;
+  referenceId: string;
+  relation: LongTermMemoryEvidenceRelation;
+  locator?: string;
+  capturedHash?: string;
+}
+
+export interface CreateLongTermMemoryInput {
+  originProjectId: string;
+  ownerId: string;
+  scope: LongTermMemoryScope;
+  kind: LongTermMemoryKind;
+  portability?: LongTermMemoryPortability;
+  title: string;
+  content: string;
+  facts?: string[];
+  tags?: string[];
+  applicability?: string;
+  origin?: LongTermMemoryOrigin;
+  evidence: LongTermMemoryEvidenceInput[];
+}
+
+export interface LongTermMemorySelection {
+  memory: LongTermMemory;
+  evidence: LongTermMemoryEvidence[];
+  score: number;
+  reason: string;
+}

--- a/src/memory/long-term.ts
+++ b/src/memory/long-term.ts
@@ -1,0 +1,626 @@
+import { randomUUID } from 'node:crypto';
+import { countTextTokens, truncateToTokenBudget } from '../compact/token-budget.js';
+import type { EmbeddingProvider } from '../embedding/provider.js';
+import { withTimeout } from '../timeout.js';
+import { sanitizeCredentials } from './secret-filter.js';
+import type { Observation } from '../types.js';
+import { resolveLocalMemoryOwner } from './owner.js';
+import { LongTermMemoryStore } from './long-term-store.js';
+import {
+  LONG_TERM_MEMORY_EVIDENCE_KINDS,
+  LONG_TERM_MEMORY_EVIDENCE_RELATIONS,
+  LONG_TERM_MEMORY_KINDS,
+  LONG_TERM_MEMORY_PORTABILITIES,
+  LONG_TERM_MEMORY_SCOPES,
+  type CreateLongTermMemoryInput,
+  type LongTermMemory,
+  type LongTermMemoryEvidence,
+  type LongTermMemoryEvidenceInput,
+  type LongTermMemoryKind,
+  type LongTermMemoryPortability,
+  type LongTermMemoryReader,
+  type LongTermMemoryScope,
+  type LongTermMemorySelection,
+} from './long-term-types.js';
+
+const MAX_TEXT_LENGTH = 12_000;
+const MAX_LIST_ITEMS = 40;
+const MAX_SEMANTIC_CANDIDATES = 48;
+const SEMANTIC_RETRIEVAL_TIMEOUT_MS = 1_800;
+const MIN_SEMANTIC_SIMILARITY = 0.58;
+const PORTABLE_EVIDENCE_KINDS = new Set(['manual', 'user']);
+const STOP_TERMS = new Set([
+  'the', 'and', 'for', 'with', 'from', 'that', 'this', 'into', 'when', 'what',
+  '如何', '什么', '这个', '那个', '我们', '项目', '进行', '需要', '继续', '处理',
+]);
+
+function isOneOf<T extends readonly string[]>(value: unknown, values: T): value is T[number] {
+  return typeof value === 'string' && (values as readonly string[]).includes(value);
+}
+
+function compactText(value: string, field: string, max = MAX_TEXT_LENGTH): string {
+  if (typeof value !== 'string') throw new Error('Long-term memory ' + field + ' must be text.');
+  const safe = sanitizeCredentials(value).replace(/\s+/g, ' ').trim();
+  if (!safe) throw new Error('Long-term memory ' + field + ' is required.');
+  if (safe.length > max) throw new Error('Long-term memory ' + field + ' is too long.');
+  return safe;
+}
+
+function compactList(values: string[] | undefined, field: string): string[] {
+  if (!values) return [];
+  if (!Array.isArray(values)) throw new Error('Long-term memory ' + field + ' must be an array.');
+  return [...new Set(values
+    .filter((value): value is string => typeof value === 'string')
+    .map(value => compactText(value, field, 500)))]
+    .slice(0, MAX_LIST_ITEMS);
+}
+
+function normalizeEvidence(input: LongTermMemoryEvidenceInput[]): LongTermMemoryEvidenceInput[] {
+  if (!Array.isArray(input) || input.length === 0) {
+    throw new Error('A long-term memory requires at least one source evidence reference.');
+  }
+  return input.map((evidence) => {
+    if (!evidence || !isOneOf(evidence.kind, LONG_TERM_MEMORY_EVIDENCE_KINDS)) {
+      throw new Error('Long-term memory evidence kind is invalid.');
+    }
+    if (!isOneOf(evidence.relation, LONG_TERM_MEMORY_EVIDENCE_RELATIONS)) {
+      throw new Error('Long-term memory evidence relation is invalid.');
+    }
+    return {
+      kind: evidence.kind,
+      referenceId: compactText(evidence.referenceId, 'evidence reference', 1_000),
+      relation: evidence.relation,
+      ...(evidence.locator ? { locator: compactText(evidence.locator, 'evidence locator', 1_000) } : {}),
+      ...(evidence.capturedHash ? { capturedHash: compactText(evidence.capturedHash, 'evidence hash', 1_000) } : {}),
+    };
+  });
+}
+
+function assertScope(scope: unknown): asserts scope is LongTermMemoryScope {
+  if (!isOneOf(scope, LONG_TERM_MEMORY_SCOPES)) throw new Error('Long-term memory scope is invalid.');
+}
+
+function assertKind(kind: unknown): asserts kind is LongTermMemoryKind {
+  if (!isOneOf(kind, LONG_TERM_MEMORY_KINDS)) throw new Error('Long-term memory kind is invalid.');
+}
+
+function assertPortability(value: unknown): asserts value is LongTermMemoryPortability {
+  if (!isOneOf(value, LONG_TERM_MEMORY_PORTABILITIES)) {
+    throw new Error('Long-term memory portability is invalid.');
+  }
+}
+
+function assertPortableEvidence(scope: LongTermMemoryScope, portability: LongTermMemoryPortability, evidence: LongTermMemoryEvidenceInput[]): void {
+  if (portability !== 'portable') return;
+  if (scope !== 'user') {
+    throw new Error('Only user-scoped long-term memories may be portable across projects.');
+  }
+  if (evidence.some(item => !PORTABLE_EVIDENCE_KINDS.has(item.kind))) {
+    throw new Error('Portable user memory may only use manual or user-confirmed evidence; project code, Git, observation, test, session, claim, and workflow evidence must remain project-bound.');
+  }
+}
+
+function requireTeamReader(scope: LongTermMemoryScope, reader?: LongTermMemoryReader): void {
+  if (scope === 'team' && reader?.isTeamMember !== true) {
+    throw new Error('Team long-term memory requires an explicit active team identity for this project.');
+  }
+}
+
+function matchesScope(memory: LongTermMemory, reader: LongTermMemoryReader): boolean {
+  if (memory.scope === 'project') return memory.originProjectId === reader.projectId;
+  if (memory.scope === 'team') {
+    return memory.originProjectId === reader.projectId && reader.isTeamMember === true;
+  }
+  if (!reader.ownerId || memory.ownerId !== reader.ownerId) return false;
+  return memory.portability === 'portable' || memory.originProjectId === reader.projectId;
+}
+
+export function canReadLongTermMemory(memory: LongTermMemory, reader: LongTermMemoryReader): boolean {
+  return matchesScope(memory, reader);
+}
+
+export function isEligibleLongTermMemory(memory: LongTermMemory): boolean {
+  return memory.state === 'qualified' || memory.state === 'approved';
+}
+
+function taskTerms(task: string): string[] {
+  const matches = task.toLocaleLowerCase('en-US').match(/[\p{L}\p{N}_./:-]+/gu) ?? [];
+  return [...new Set(matches.filter(term => term.length > 1 && !STOP_TERMS.has(term)))].slice(0, 16);
+}
+
+function kindFitScore(kind: LongTermMemoryKind, task: string): number {
+  const normalized = task.toLocaleLowerCase('en-US');
+  const hints: Record<LongTermMemoryKind, string[]> = {
+    episodic: ['resume', 'continue', 'handoff', 'previous', 'session', '接手', '继续', '交接', '上次', '会话'],
+    semantic: ['why', 'what', 'architecture', 'design', 'decision', 'reason', '为什么', '是什么', '架构', '设计', '决策', '原因'],
+    procedural: ['how', 'steps', 'procedure', 'run', 'release', 'publish', 'verify', 'implement', '流程', '步骤', '发布', '验证', '修复', '实现'],
+  };
+  return hints[kind].some(hint => normalized.includes(hint)) ? 1 : 0;
+}
+
+function validationFreshnessScore(memory: LongTermMemory): number {
+  const validatedAt = memory.lastValidatedAt ?? memory.approvedAt ?? memory.qualifiedAt;
+  if (!validatedAt) return 0;
+  const time = Date.parse(validatedAt);
+  if (!Number.isFinite(time)) return 0;
+  const ageDays = Math.max(0, Date.now() - time) / (24 * 60 * 60 * 1000);
+  if (ageDays <= 30) return 0.35;
+  if (ageDays <= 90) return 0.15;
+  return 0;
+}
+
+function scoreForTask(memory: LongTermMemory, task: string): { score: number; reason: string } | undefined {
+  const terms = taskTerms(task);
+  if (terms.length === 0) return undefined;
+  const title = memory.title.toLocaleLowerCase('en-US');
+  const content = memory.content.toLocaleLowerCase('en-US');
+  const facts = memory.facts.join(' ').toLocaleLowerCase('en-US');
+  const tags = memory.tags.join(' ').toLocaleLowerCase('en-US');
+  const applicability = (memory.applicability ?? '').toLocaleLowerCase('en-US');
+  let score = memory.state === 'approved' ? 0.5 : 0;
+  const matched: string[] = [];
+  for (const term of terms) {
+    let termScore = 0;
+    if (title.includes(term)) termScore += 5;
+    if (tags.includes(term)) termScore += 4;
+    if (applicability.includes(term)) termScore += 3;
+    if (facts.includes(term)) termScore += 2;
+    if (content.includes(term)) termScore += 1;
+    if (termScore > 0) {
+      score += termScore;
+      matched.push(term);
+    }
+  }
+  if (matched.length === 0) return undefined;
+  score += kindFitScore(memory.kind, task);
+  score += validationFreshnessScore(memory);
+  const kindLabel = memory.kind === 'procedural' ? 'procedure' : memory.kind === 'semantic' ? 'fact' : 'episode';
+  const freshness = validationFreshnessScore(memory) > 0 ? '; recently validated' : '';
+  return { score, reason: kindLabel + ' matches ' + matched.slice(0, 3).join(', ') + freshness };
+}
+
+type LongTermEmbeddingProvider = Pick<EmbeddingProvider, 'embedBatch'>;
+
+function semanticText(memory: LongTermMemory): string {
+  return sanitizeCredentials([
+    memory.title,
+    memory.applicability,
+    memory.tags.join(' '),
+    memory.facts.join(' '),
+    memory.content,
+  ].filter((value): value is string => Boolean(value)).join('\n'))
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, MAX_TEXT_LENGTH);
+}
+
+function cosineSimilarity(left: number[], right: number[]): number {
+  if (left.length === 0 || left.length !== right.length) return 0;
+  let dot = 0;
+  let leftMagnitude = 0;
+  let rightMagnitude = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    const a = left[index];
+    const b = right[index];
+    if (!Number.isFinite(a) || !Number.isFinite(b)) return 0;
+    dot += a * b;
+    leftMagnitude += a * a;
+    rightMagnitude += b * b;
+  }
+  if (leftMagnitude === 0 || rightMagnitude === 0) return 0;
+  return dot / Math.sqrt(leftMagnitude * rightMagnitude);
+}
+
+function semanticSelection(memory: LongTermMemory, similarity: number, task: string): { score: number; reason: string } | undefined {
+  if (similarity < MIN_SEMANTIC_SIMILARITY) return undefined;
+  const kindLabel = memory.kind === 'procedural' ? 'procedure' : memory.kind === 'semantic' ? 'fact' : 'episode';
+  const freshness = validationFreshnessScore(memory) > 0 ? '; recently validated' : '';
+  return {
+    score: similarity * 10 + (memory.state === 'approved' ? 0.5 : 0) + kindFitScore(memory.kind, task) + validationFreshnessScore(memory),
+    reason: kindLabel + ' semantic match ' + similarity.toFixed(2) + freshness,
+  };
+}
+
+async function resolveSemanticProvider(explicit?: LongTermEmbeddingProvider | null): Promise<LongTermEmbeddingProvider | null> {
+  if (explicit !== undefined) return explicit;
+  try {
+    const { getEmbeddingProvider } = await import('../embedding/provider.js');
+    return await withTimeout(
+      getEmbeddingProvider({ requestTimeoutMs: SEMANTIC_RETRIEVAL_TIMEOUT_MS, retry: false }),
+      SEMANTIC_RETRIEVAL_TIMEOUT_MS,
+      'Long-term semantic provider initialization',
+    );
+  } catch {
+    return null;
+  }
+}
+
+function createStore(dataDir: string): Promise<LongTermMemoryStore> {
+  const store = new LongTermMemoryStore();
+  return store.init(dataDir).then(() => store);
+}
+
+export interface CreateManualLongTermMemoryInput {
+  dataDir: string;
+  projectId: string;
+  scope: LongTermMemoryScope;
+  kind: LongTermMemoryKind;
+  title: string;
+  content: string;
+  facts?: string[];
+  tags?: string[];
+  applicability?: string;
+  portability?: LongTermMemoryPortability;
+  reader?: LongTermMemoryReader;
+}
+
+/** Create a local manually declared candidate with explicit user/manual provenance. */
+export async function createManualLongTermMemory(input: CreateManualLongTermMemoryInput): Promise<{
+  memory: LongTermMemory;
+  evidence: LongTermMemoryEvidence[];
+}> {
+  const owner = await resolveLocalMemoryOwner(input.dataDir, { create: true });
+  if (!owner) throw new Error('Memorix could not resolve a local memory owner.');
+  assertScope(input.scope);
+  const evidence: LongTermMemoryEvidenceInput[] = input.scope === 'user'
+    ? [{ kind: 'user', referenceId: owner.id, relation: 'user-confirmed' }]
+    : [{ kind: 'manual', referenceId: 'manual:' + randomUUID(), relation: 'supports' }];
+  return createLongTermMemoryWithDataDir({
+    dataDir: input.dataDir,
+    originProjectId: input.projectId,
+    ownerId: owner.id,
+    scope: input.scope,
+    kind: input.kind,
+    portability: input.portability,
+    title: input.title,
+    content: input.content,
+    facts: input.facts,
+    tags: input.tags,
+    applicability: input.applicability,
+    origin: 'manual',
+    evidence,
+    reader: input.reader,
+  });
+}
+
+export interface PromoteObservationToLongTermInput {
+  dataDir: string;
+  observation: Observation;
+  scope: LongTermMemoryScope;
+  kind: LongTermMemoryKind;
+  tags?: string[];
+  applicability?: string;
+  reader?: LongTermMemoryReader;
+}
+
+/**
+ * Promote an existing observation without duplicating or hiding its source.
+ * Observation-derived items are deliberately project-bound.
+ */
+export async function promoteObservationToLongTermMemory(input: PromoteObservationToLongTermInput): Promise<{
+  memory: LongTermMemory;
+  evidence: LongTermMemoryEvidence[];
+}> {
+  const owner = await resolveLocalMemoryOwner(input.dataDir, { create: true });
+  if (!owner) throw new Error('Memorix could not resolve a local memory owner.');
+  return createLongTermMemoryWithDataDir({
+    dataDir: input.dataDir,
+    originProjectId: input.observation.projectId,
+    ownerId: owner.id,
+    scope: input.scope,
+    kind: input.kind,
+    portability: 'project-bound',
+    title: input.observation.title,
+    content: input.observation.narrative,
+    facts: input.observation.facts,
+    tags: input.tags ?? input.observation.concepts,
+    applicability: input.applicability,
+    origin: input.observation.source === 'git' ? 'git' : 'agent',
+    evidence: [{
+      kind: 'observation',
+      referenceId: 'obs:' + input.observation.projectId + ':' + input.observation.id,
+      relation: 'derives',
+    }],
+    reader: input.reader,
+  });
+}
+
+export interface CreateLongTermMemoryCandidateInput extends CreateLongTermMemoryInput {
+  dataDir: string;
+  reader?: LongTermMemoryReader;
+}
+
+/** Create a candidate only. Qualification and approval are deliberate later transitions. */
+export async function createLongTermMemoryCandidate(input: CreateLongTermMemoryCandidateInput): Promise<{
+  memory: LongTermMemory;
+  evidence: LongTermMemoryEvidence[];
+}> {
+  return createLongTermMemoryWithDataDir(input);
+}
+
+async function createLongTermMemoryWithDataDir(input: CreateLongTermMemoryCandidateInput): Promise<{
+  memory: LongTermMemory;
+  evidence: LongTermMemoryEvidence[];
+}> {
+  assertScope(input.scope);
+  assertKind(input.kind);
+  const portability = input.portability ?? 'project-bound';
+  assertPortability(portability);
+  requireTeamReader(input.scope, input.reader);
+  const evidenceInputs = normalizeEvidence(input.evidence);
+  assertPortableEvidence(input.scope, portability, evidenceInputs);
+  const now = new Date().toISOString();
+  const memory: LongTermMemory = {
+    id: randomUUID(),
+    originProjectId: compactText(input.originProjectId, 'origin project id', 1_000),
+    ownerId: compactText(input.ownerId, 'owner id', 160),
+    scope: input.scope,
+    kind: input.kind,
+    state: 'candidate',
+    portability,
+    title: compactText(input.title, 'title', 500),
+    content: compactText(input.content, 'content'),
+    facts: compactList(input.facts, 'facts'),
+    tags: compactList(input.tags, 'tags'),
+    ...(input.applicability ? { applicability: compactText(input.applicability, 'applicability', 1_000) } : {}),
+    origin: input.origin ?? 'manual',
+    createdAt: now,
+    updatedAt: now,
+    accessCount: 0,
+  };
+  const store = await createStore(input.dataDir);
+  const evidence = store.transaction(() => {
+    store.insert(memory);
+    const written = evidenceInputs.map(item => store.insertEvidence({ memoryId: memory.id, ...item, createdAt: now }));
+    store.recordEvent({
+      memoryId: memory.id,
+      kind: 'created',
+      toState: 'candidate',
+      detail: 'Created as a source-backed long-term memory candidate.',
+      createdAt: now,
+    });
+    return written;
+  });
+  return { memory, evidence };
+}
+
+function transitionDetail(value: string): string {
+  return compactText(value, 'transition reason', 1_000);
+}
+
+async function transitionMemory(input: {
+  dataDir: string;
+  id: string;
+  expected: 'candidate' | 'qualified';
+  next: 'qualified' | 'approved';
+  event: 'qualified' | 'approved';
+  reason: string;
+}): Promise<LongTermMemory> {
+  const store = await createStore(input.dataDir);
+  return store.transaction(() => {
+    const current = store.get(input.id);
+    if (!current) throw new Error('Long-term memory was not found.');
+    if (current.state !== input.expected) {
+      throw new Error('Long-term memory must be ' + input.expected + ' before it can be ' + input.next + '.');
+    }
+    const evidence = store.listEvidence(current.id);
+    if (evidence.length === 0) throw new Error('Long-term memory cannot advance without source evidence.');
+    const now = new Date().toISOString();
+    const next: LongTermMemory = {
+      ...current,
+      state: input.next,
+      updatedAt: now,
+      lastValidatedAt: now,
+      ...(input.next === 'qualified' ? { qualifiedAt: now } : { approvedAt: now }),
+    };
+    store.update(next);
+    store.recordEvent({
+      memoryId: next.id,
+      kind: input.event,
+      fromState: current.state,
+      toState: next.state,
+      detail: transitionDetail(input.reason),
+      createdAt: now,
+    });
+    return next;
+  });
+}
+
+export async function qualifyLongTermMemory(input: { dataDir: string; id: string; reason: string }): Promise<LongTermMemory> {
+  return transitionMemory({ ...input, expected: 'candidate', next: 'qualified', event: 'qualified' });
+}
+
+export async function approveLongTermMemory(input: { dataDir: string; id: string; reason: string }): Promise<LongTermMemory> {
+  return transitionMemory({ ...input, expected: 'qualified', next: 'approved', event: 'approved' });
+}
+
+export async function archiveLongTermMemory(input: { dataDir: string; id: string; reason: string }): Promise<LongTermMemory> {
+  const store = await createStore(input.dataDir);
+  return store.transaction(() => {
+    const current = store.get(input.id);
+    if (!current) throw new Error('Long-term memory was not found.');
+    if (current.state === 'archived' || current.state === 'superseded') {
+      throw new Error('Long-term memory is already inactive.');
+    }
+    const now = new Date().toISOString();
+    const next: LongTermMemory = { ...current, state: 'archived', archivedAt: now, updatedAt: now };
+    store.update(next);
+    store.recordEvent({
+      memoryId: next.id,
+      kind: 'archived',
+      fromState: current.state,
+      toState: 'archived',
+      detail: transitionDetail(input.reason),
+      createdAt: now,
+    });
+    return next;
+  });
+}
+
+/**
+ * Retire an active record in favor of another qualified or approved record.
+ * The replacement remains its own audited artifact; this only records the
+ * relationship and prevents the old record from entering future Worksets.
+ */
+export async function supersedeLongTermMemory(input: {
+  dataDir: string;
+  id: string;
+  supersededBy: string;
+  reason: string;
+}): Promise<LongTermMemory> {
+  const store = await createStore(input.dataDir);
+  return store.transaction(() => {
+    const current = store.get(input.id);
+    if (!current) throw new Error('Long-term memory was not found.');
+    if (current.state === 'archived' || current.state === 'superseded') {
+      throw new Error('Long-term memory is already inactive.');
+    }
+    if (current.id === input.supersededBy) {
+      throw new Error('Long-term memory cannot supersede itself.');
+    }
+    const replacement = store.get(input.supersededBy);
+    if (!replacement || !isEligibleLongTermMemory(replacement)) {
+      throw new Error('Replacement long-term memory must be qualified or approved.');
+    }
+    if (replacement.scope !== current.scope) {
+      throw new Error('Replacement long-term memory must use the same scope.');
+    }
+    if (current.scope === 'user' && replacement.ownerId !== current.ownerId) {
+      throw new Error('User long-term memory may only be superseded by the same local owner.');
+    }
+    if (current.scope !== 'user' && replacement.originProjectId !== current.originProjectId) {
+      throw new Error('Project and team long-term memory may only be superseded within the same project.');
+    }
+    const now = new Date().toISOString();
+    const next: LongTermMemory = {
+      ...current,
+      state: 'superseded',
+      supersededBy: replacement.id,
+      updatedAt: now,
+    };
+    store.update(next);
+    store.recordEvent({
+      memoryId: next.id,
+      kind: 'superseded',
+      fromState: current.state,
+      toState: 'superseded',
+      detail: transitionDetail(input.reason),
+      createdAt: now,
+    });
+    return next;
+  });
+}
+
+export async function listLongTermMemories(input: {
+  dataDir: string;
+  reader: LongTermMemoryReader;
+  includeInactive?: boolean;
+  limit?: number;
+}): Promise<Array<{ memory: LongTermMemory; evidence: LongTermMemoryEvidence[] }>> {
+  const store = await createStore(input.dataDir);
+  return store.list({ limit: input.limit ?? 100 })
+    .filter(memory => canReadLongTermMemory(memory, input.reader))
+    .filter(memory => input.includeInactive || memory.state !== 'archived' && memory.state !== 'superseded')
+    .map(memory => ({ memory, evidence: store.listEvidence(memory.id) }));
+}
+
+export async function getLongTermMemoryDetail(input: {
+  dataDir: string;
+  id: string;
+  reader: LongTermMemoryReader;
+}): Promise<{ memory: LongTermMemory; evidence: LongTermMemoryEvidence[]; events: ReturnType<LongTermMemoryStore['listEvents']> }> {
+  const store = await createStore(input.dataDir);
+  const memory = store.get(input.id);
+  if (!memory || !canReadLongTermMemory(memory, input.reader)) {
+    throw new Error('Long-term memory was not found in the active scope.');
+  }
+  store.markAccess([memory.id]);
+  return { memory, evidence: store.listEvidence(memory.id), events: store.listEvents(memory.id) };
+}
+
+export async function selectLongTermMemoriesForTask(input: {
+  dataDir: string;
+  projectId: string;
+  task?: string;
+  agentId?: string;
+  isTeamMember?: boolean;
+  limit?: number;
+  /** Tests and bounded integrations may provide an already-ready provider. Null disables semantic fallback. */
+  embeddingProvider?: LongTermEmbeddingProvider | null;
+}): Promise<LongTermMemorySelection[]> {
+  const task = input.task?.trim();
+  if (!task) return [];
+  const owner = await resolveLocalMemoryOwner(input.dataDir, { create: false });
+  const reader: LongTermMemoryReader = {
+    projectId: input.projectId,
+    ...(owner ? { ownerId: owner.id } : {}),
+    ...(input.agentId ? { agentId: input.agentId } : {}),
+    ...(input.isTeamMember ? { isTeamMember: true } : {}),
+  };
+  const store = await createStore(input.dataDir);
+  const eligible = store.list({ limit: 1_000 })
+    .filter(memory => isEligibleLongTermMemory(memory) && canReadLongTermMemory(memory, reader));
+  let selected = eligible
+    .map(memory => {
+      const ranked = scoreForTask(memory, task);
+      return ranked ? {
+        memory,
+        evidence: store.listEvidence(memory.id),
+        score: ranked.score,
+        reason: ranked.reason,
+      } : undefined;
+    })
+    .filter((item): item is LongTermMemorySelection => Boolean(item))
+    .sort((left, right) => right.score - left.score || right.memory.updatedAt.localeCompare(left.memory.updatedAt) || left.memory.id.localeCompare(right.memory.id));
+
+  // Keyword matches remain the fast, deterministic primary route. Semantic
+  // fallback only runs when none matched, after scope and lifecycle filtering,
+  // so it cannot turn an unrelated global record into default context.
+  if (selected.length === 0 && eligible.length > 0) {
+    const provider = await resolveSemanticProvider(input.embeddingProvider);
+    const candidates = eligible.slice(0, MAX_SEMANTIC_CANDIDATES);
+    if (provider && candidates.length > 0) {
+      try {
+        const vectors = await withTimeout(
+          provider.embedBatch([task, ...candidates.map(semanticText)], {
+            timeoutMs: SEMANTIC_RETRIEVAL_TIMEOUT_MS,
+            retry: false,
+          }),
+          SEMANTIC_RETRIEVAL_TIMEOUT_MS,
+          'Long-term semantic retrieval',
+        );
+        const query = vectors[0];
+        if (Array.isArray(query)) {
+          selected = candidates
+            .map((memory, index) => {
+              const vector = vectors[index + 1];
+              const ranked = Array.isArray(vector)
+                ? semanticSelection(memory, cosineSimilarity(query, vector), task)
+                : undefined;
+              return ranked ? {
+                memory,
+                evidence: store.listEvidence(memory.id),
+                score: ranked.score,
+                reason: ranked.reason,
+              } : undefined;
+            })
+            .filter((item): item is LongTermMemorySelection => Boolean(item))
+            .sort((left, right) => right.score - left.score || right.memory.updatedAt.localeCompare(left.memory.updatedAt) || left.memory.id.localeCompare(right.memory.id));
+        }
+      } catch {
+        // Semantic enrichment is optional. A slow or unavailable provider must
+        // preserve the normal keyword-only retrieval path.
+      }
+    }
+  }
+
+  selected = selected.slice(0, Math.max(1, Math.min(input.limit ?? 3, 5)));
+  store.markAccess(selected.map(item => item.memory.id));
+  return selected;
+}
+
+export function renderLongTermMemorySummary(memory: LongTermMemory, maxTokens = 22): string {
+  const source = [memory.title, memory.applicability, memory.content].filter(Boolean).join(': ');
+  const safe = sanitizeCredentials(source).replace(/\s+/g, ' ').trim();
+  return countTextTokens(safe) <= maxTokens ? safe : truncateToTokenBudget(safe, maxTokens);
+}

--- a/src/memory/owner.ts
+++ b/src/memory/owner.ts
@@ -1,0 +1,75 @@
+import { randomUUID } from 'node:crypto';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+
+const ID_PATTERN = /^[A-Za-z0-9:_-]{3,160}$/;
+
+export interface LocalMemoryOwner {
+  id: string;
+  source: 'environment' | 'local-file';
+}
+
+interface OwnerFile {
+  version: 1;
+  id: string;
+  createdAt: string;
+}
+
+function ownerPath(dataDir: string): string {
+  const resolved = path.resolve(dataDir);
+  // The normal runtime data directory is ~/.memorix/data, so keep identity
+  // beside it. Custom data directories and isolated tests own their identity
+  // inside the supplied directory instead of accidentally sharing a temp root.
+  const home = path.basename(resolved).toLocaleLowerCase('en-US') === 'data'
+    ? path.dirname(resolved)
+    : resolved;
+  return path.join(home, 'memorix-user.json');
+}
+
+function normalizedOwnerId(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && ID_PATTERN.test(trimmed) ? trimmed : undefined;
+}
+
+async function readOwnerFile(filePath: string): Promise<LocalMemoryOwner | undefined> {
+  try {
+    const value = JSON.parse(await fs.readFile(filePath, 'utf8')) as Partial<OwnerFile>;
+    const id = typeof value.id === 'string' ? normalizedOwnerId(value.id) : undefined;
+    return id ? { id, source: 'local-file' } : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve a local stable user identity without deriving anything from prompts,
+ * host names, or account details. Reads do not create an identity; first write
+ * creates one atomically enough for normal local CLI/MCP use.
+ */
+export async function resolveLocalMemoryOwner(
+  dataDir: string,
+  options: { create?: boolean } = {},
+): Promise<LocalMemoryOwner | undefined> {
+  const configured = normalizedOwnerId(process.env.MEMORIX_USER_ID);
+  if (configured) return { id: configured, source: 'environment' };
+
+  const filePath = ownerPath(dataDir);
+  const existing = await readOwnerFile(filePath);
+  if (existing || !options.create) return existing;
+
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  const created: OwnerFile = {
+    version: 1,
+    id: 'local-' + randomUUID(),
+    createdAt: new Date().toISOString(),
+  };
+  try {
+    await fs.writeFile(filePath, JSON.stringify(created, null, 2) + '\n', { encoding: 'utf8', flag: 'wx' });
+    return { id: created.id, source: 'local-file' };
+  } catch (error: any) {
+    if (error?.code !== 'EEXIST') throw error;
+    const concurrent = await readOwnerFile(filePath);
+    if (concurrent) return concurrent;
+    throw new Error('Memorix could not establish a valid local memory owner identity.');
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -671,9 +671,10 @@ export async function createMemorixServer(
         'Use type to classify: gotcha ([GOTCHA] critical pitfall), decision ([DECISION] architecture choice), ' +
         'problem-solution ([FIX] bug fix), how-it-works ([INFO] explanation), what-changed ([CHANGE] change), ' +
         'discovery ([DISCOVERY] insight), why-it-exists ([WHY] rationale), trade-off ([TRADEOFF] compromise), ' +
-        'session-request ([SESSION] original goal). ' +
-        'Project visibility is the default. Personal or team visibility requires an explicitly joined coordination identity. ' +
-        'For a read-only task, do not store unless the user explicitly asks to save a record.',
+         'session-request ([SESSION] original goal). ' +
+         'Project visibility is the default. Personal or team visibility requires an explicitly joined coordination identity. ' +
+         'Set longTerm only when the caller explicitly wants an additional source-backed long-term candidate; it is never injected until an operator records a review through the CLI. ' +
+         'For a read-only task, do not store unless the user explicitly asks to save a record.',
       inputSchema: {
         entityName: z.string().describe('The entity this observation belongs to (e.g., "auth-module", "port-config")'),
         type: z.enum(OBSERVATION_TYPES).describe('Observation type for classification'),
@@ -697,27 +698,50 @@ export async function createMemorixServer(
         visibility: z.enum(['personal', 'project', 'team']).optional().describe(
           'Retrieval scope. Project is the normal shared default; personal/team require memorix_session_start with joinTeam=true.',
         ),
+        longTerm: z.object({
+          kind: z.enum(['episodic', 'semantic', 'procedural']).describe('Cognitive kind for an additional long-term candidate.'),
+          scope: z.enum(['project', 'user', 'team']).optional().default('project').describe('Long-term scope. User capture is private source evidence and needs a bound agent identity.'),
+          tags: z.array(z.string()).optional().describe('Small set of retrieval tags for the candidate.'),
+          applicability: z.string().optional().describe('When this durable fact or procedure applies.'),
+        }).optional().describe('Optional explicit request to create a source-backed long-term candidate alongside this observation. Candidates are not automatically injected.'),
         overrideReadOnly: z.boolean().optional().describe(
           'Use only when the user explicitly asks to save memory during a read-only or no-modification task.',
         ),
       },
     },
-    async ({ entityName: rawEntityName, type: rawType, title: rawTitle, narrative, facts, filesModified, concepts, topicKey, progress, relatedCommits, relatedEntities, visibility, overrideReadOnly }) => {
+    async ({ entityName: rawEntityName, type: rawType, title: rawTitle, narrative, facts, filesModified, concepts, topicKey, progress, relatedCommits, relatedEntities, visibility, longTerm, overrideReadOnly }) => {
       const unresolved = requireResolvedProject('store memory in the current project');
       if (unresolved) return unresolved;
       const readOnlyBoundary = blockReadOnlyAutopilotWrite(overrideReadOnly);
       if (readOnlyBoundary) return readOnlyBoundary;
-      const requestedVisibility = (visibility ?? 'project') as 'personal' | 'project' | 'team';
+      // Keep visibility undefined for an ordinary upsert. storeObservation then
+      // preserves an existing targeted/personal record instead of silently
+      // widening it to project scope. A long-term scope is explicit and must
+      // still set the source observation's corresponding visibility.
+      const requestedVisibility = (
+        longTerm?.scope === 'user'
+          ? 'personal'
+          : longTerm?.scope === 'team'
+            ? 'team'
+            : visibility
+      ) as 'personal' | 'project' | 'team' | undefined;
+      const effectiveVisibility = requestedVisibility ?? 'project';
       const reader = getObservationReader();
-      if (requestedVisibility !== 'project' && !currentAgentId) {
+      if (effectiveVisibility !== 'project' && !currentAgentId) {
         return {
           content: [{ type: 'text' as const, text: 'Personal or team memory requires memorix_session_start with joinTeam=true so Memorix can bind an owner.' }],
           isError: true as const,
         };
       }
-      if (requestedVisibility === 'team' && !reader.isTeamMember) {
+      if (effectiveVisibility === 'team' && !reader.isTeamMember) {
         return {
           content: [{ type: 'text' as const, text: 'Team memory requires an active coordination membership in the current project.' }],
+          isError: true as const,
+        };
+      }
+      if (longTerm?.scope === 'team' && !reader.isTeamMember) {
+        return {
+          content: [{ type: 'text' as const, text: 'Team long-term memory requires an active coordination membership in the current project.' }],
           isError: true as const,
         };
       }
@@ -752,7 +776,7 @@ export async function createMemorixServer(
       // ── Formation Pipeline (active mode: decides storage) ─────────────
       let formationResult: FormedMemory | null = null;
       let formationNote = '';
-      if (useFormation && !topicKey && !progress) {
+      if (useFormation && !topicKey && !progress && !longTerm) {
         let currentFormationStage: FormationStage | 'setup' = 'setup';
         const completedFormationStages: Partial<Record<FormationStage, number>> = {};
         const formationStartTime = Date.now();
@@ -915,7 +939,7 @@ export async function createMemorixServer(
       // This keeps memory count low and prevents duplication (Mem0-style).
       let compactAction = '';
       let compactMerged = false;
-      if (!useFormation && !topicKey && !progress) {
+      if (!useFormation && !topicKey && !progress && !longTerm) {
         try {
           const searchResult = await compactSearch({
             query: `${title} ${narrative.substring(0, 200)}`,
@@ -1094,9 +1118,32 @@ export async function createMemorixServer(
         sourceDetail: 'explicit',
         valueCategory: formationResult?.evaluation.category,
         createdByAgentId: currentAgentId,
-        visibility,
+        visibility: requestedVisibility,
         visibilityReader: reader,
       });
+
+      let longTermNote = '';
+      if (longTerm) {
+        try {
+          const { promoteObservationToLongTermMemory } = await import('./memory/long-term.js');
+          const promoted = await promoteObservationToLongTermMemory({
+            dataDir: projectDir,
+            observation: obs,
+            scope: longTerm.scope,
+            kind: longTerm.kind,
+            tags: longTerm.tags,
+            applicability: longTerm.applicability,
+            reader: {
+              projectId: project.id,
+              ...(reader.agentId ? { agentId: reader.agentId } : {}),
+              ...(reader.isTeamMember ? { isTeamMember: true } : {}),
+            },
+          });
+          longTermNote = `\nLong-term candidate: ${promoted.memory.id} (${promoted.memory.kind}/${promoted.memory.scope}). Review it with the CLI before it is delivered automatically.`;
+        } catch (longTermError) {
+          longTermNote = `\n[WARN] Observation stored, but long-term candidate was not created: ${longTermError instanceof Error ? longTermError.message : 'unknown error'}`;
+        }
+      }
 
       // Add a reference to the entity's observations
       await graphManager.addObservations([
@@ -1123,7 +1170,7 @@ export async function createMemorixServer(
       // ── Formation Pipeline (shadow/fallback mode: observe only) ─────
       // Fire-and-forget: runs after storage to collect metrics.
       // Never blocks the MCP response — purely for A/B comparison data.
-      if (!useFormation && !topicKey && !progress) {
+      if (!useFormation && !topicKey && !progress && !longTerm) {
         const shadowFormation = async () => {
           let oldCompactDecision: { action: string, targetId?: number, reason?: string, durationMs?: number } | null = null;
           try {
@@ -1215,7 +1262,7 @@ export async function createMemorixServer(
         content: [
           {
             type: 'text' as const,
-            text: `${action} observation #${obs.id} "${title}" (~${obs.tokens} tokens)\nEntity: ${entityName} | Type: ${type} | Project: ${project.id}${obs.topicKey ? ` | Topic: ${obs.topicKey}` : ''}${compactAction}${compressionNote}${enrichment}${formationNote}${attributionWarning}`,
+            text: `${action} observation #${obs.id} "${title}" (~${obs.tokens} tokens)\nEntity: ${entityName} | Type: ${type} | Project: ${project.id}${obs.topicKey ? ` | Topic: ${obs.topicKey}` : ''}${compactAction}${compressionNote}${enrichment}${formationNote}${attributionWarning}${longTermNote}`,
           },
         ],
       };
@@ -1667,6 +1714,7 @@ export async function createMemorixServer(
         ...(external.caution
           ? { runtimeCautions: [{ kind: 'external-codegraph-fallback' as const, message: external.caution }] }
           : {}),
+        reader: getObservationReader(),
       });
       const text = buildContextPackPrompt(pack);
 
@@ -2475,11 +2523,11 @@ export async function createMemorixServer(
     {
       title: 'Memory Details',
       description:
-        'Fetch full observation or mini-skill details — includes source kind (explicit memory / hook trace / git evidence), ' +
+        'Fetch full observation, mini-skill, or curated durable-memory details — includes source kind (explicit memory / hook trace / git evidence), ' +
         'value category, and cross-references (~500-1000 tokens each). ' +
         'Do not re-fetch content already covered by a complete memorix_project_context brief unless a specific fact is still missing or the user asks for deeper history; provide purpose when intentionally expanding. ' +
         'Always use memorix_search first to find relevant IDs, then fetch only what you need. ' +
-        'Accepts typed refs from search results (e.g. "obs:42", "skill:3") via the typedRefs field, ' +
+        'Accepts typed refs from search results (e.g. "obs:42", "skill:3") and durable refs from a project brief (e.g. "durable:<uuid>") via the typedRefs field, ' +
         'or legacy numeric ids / object refs for backward compatibility.',
       inputSchema: {
         ids: z.array(z.number()).optional().describe('Observation IDs to fetch (legacy, from memorix_search results)'),
@@ -2489,7 +2537,7 @@ export async function createMemorixServer(
             projectId: z.string().optional().describe('Project ID for global-search disambiguation'),
           }),
         ).optional().describe('Explicit observation refs. Prefer this for global search results.'),
-        typedRefs: z.array(z.string()).optional().describe('Typed memory refs from search results, e.g. "obs:42", "skill:3", "obs:42@org/proj"'),
+        typedRefs: z.array(z.string()).optional().describe('Typed memory refs from search results or a project brief, e.g. "obs:42", "skill:3", "durable:<uuid>", "obs:42@org/proj"'),
         purpose: z.string().optional().describe(
           'Why this must expand beyond the latest Autopilot brief. Name the missing fact or the user\'s explicit request.',
         ),
@@ -2503,15 +2551,20 @@ export async function createMemorixServer(
       const safeIds = coerceNumberArray(ids);
       const safeRefs = coerceObservationRefs(refs);
       const safeTypedRefs = coerceStringArray(typedRefs);
+      const durableIds = safeTypedRefs.flatMap((ref) => {
+        const match = /^durable:([0-9a-f-]{36})$/i.exec(ref.trim());
+        return match ? [match[1]] : [];
+      });
+      const observationTypedRefs = safeTypedRefs.filter(ref => !/^durable:/i.test(ref.trim()));
       const hasCrossProjectRef = safeRefs.some((ref) => ref.projectId && ref.projectId !== project.id)
-        || safeTypedRefs.some((ref) => ref.includes('@') && !ref.endsWith(`@${project.id}`));
+        || observationTypedRefs.some((ref) => ref.includes('@') && !ref.endsWith(`@${project.id}`));
       if (!hasCrossProjectRef) {
         const boundary = requireExplicitAutopilotExpansion('memorix_detail', purpose);
         if (boundary) return boundary;
         const requestedObservationIds = [
           ...safeIds,
           ...safeRefs.map(ref => ref.id),
-          ...safeTypedRefs.flatMap((ref) => {
+          ...observationTypedRefs.flatMap((ref) => {
             const match = /^obs:(\d+)(?:@.+)?$/i.exec(ref.trim());
             return match ? [Number(match[1])] : [];
           }),
@@ -2520,18 +2573,47 @@ export async function createMemorixServer(
         if (duplicate) return duplicate;
       }
 
-      // Priority: typedRefs > refs > ids (each is a complete, homogeneous input path)
-      let result;
+      const formatted: string[] = [];
       try {
-        const reader = getObservationReader(hasCrossProjectRef ? 'global' : 'project');
-        if (safeTypedRefs.length > 0) {
-          // Pass typed ref strings directly — compactDetail handles parsing
-          result = await compactDetail(safeTypedRefs, { reader });
-        } else if (safeRefs.length > 0) {
-          result = await compactDetail(safeRefs, { reader });
-        } else {
-          // Bare numeric IDs are scoped to the current project
-          result = await compactDetail(safeIds.map(id => ({ id, projectId: project.id })), { reader });
+        if (durableIds.length > 0) {
+          const [{ getLongTermMemoryDetail }, { resolveLocalMemoryOwner }] = await Promise.all([
+            import('./memory/long-term.js'),
+            import('./memory/owner.js'),
+          ]);
+          const owner = await resolveLocalMemoryOwner(projectDir, { create: false });
+          const observationReader = getObservationReader();
+          const durableReader = {
+            projectId: project.id,
+            ...(owner ? { ownerId: owner.id } : {}),
+            ...(observationReader.agentId ? { agentId: observationReader.agentId } : {}),
+            ...(observationReader.isTeamMember ? { isTeamMember: true } : {}),
+          };
+          const details = await Promise.all(durableIds.slice(0, 5).map(async (id) => {
+            try {
+              return await getLongTermMemoryDetail({ dataDir: projectDir, id, reader: durableReader });
+            } catch (error) {
+              return { error: error instanceof Error ? error.message : String(error), id };
+            }
+          }));
+          formatted.push(JSON.stringify({ durableMemory: details }, null, 2));
+        }
+
+        if (observationTypedRefs.length > 0 || safeRefs.length > 0 || safeIds.length > 0) {
+          const reader = getObservationReader(hasCrossProjectRef ? 'global' : 'project');
+          const result = observationTypedRefs.length > 0
+            ? await compactDetail(observationTypedRefs, { reader })
+            : safeRefs.length > 0
+              ? await compactDetail(safeRefs, { reader })
+              : await compactDetail(safeIds.map(id => ({ id, projectId: project.id })), { reader });
+          formatted.push(
+            result.documents.length > 0
+              ? result.formatted
+              : observationTypedRefs.length > 0
+                ? `No memories found for refs: ${observationTypedRefs.join(', ')}`
+                : safeRefs.length > 0
+                  ? `No memories found for refs: ${safeRefs.map((ref) => `${ref.projectId ?? 'current'}#${ref.id}`).join(', ')}`
+                  : `No memories found for IDs: ${safeIds.join(', ')}`,
+          );
         }
       } catch (err) {
         return { content: [{ type: 'text' as const, text: err instanceof Error ? err.message : String(err) }], isError: true };
@@ -2541,8 +2623,8 @@ export async function createMemorixServer(
         content: [
           {
             type: 'text' as const,
-            text: result.documents.length > 0
-              ? result.formatted
+            text: formatted.length > 0
+              ? formatted.join('\n\n')
               : safeTypedRefs.length > 0
                 ? `No memories found for refs: ${safeTypedRefs.join(', ')}`
                 : safeRefs.length > 0

--- a/src/store/sqlite-db.ts
+++ b/src/store/sqlite-db.ts
@@ -497,6 +497,62 @@ const CREATE_KNOWLEDGE_WORKFLOW_RUNS_TABLE = [
   ');',
 ].join('\n');
 
+// ── 1.3 Durable cognitive memory ───────────────────────────────────
+
+const CREATE_LONG_TERM_MEMORIES_TABLE = `
+CREATE TABLE IF NOT EXISTS long_term_memories (
+  id                TEXT PRIMARY KEY,
+  originProjectId   TEXT NOT NULL,
+  ownerId           TEXT NOT NULL,
+  scope             TEXT NOT NULL,
+  kind              TEXT NOT NULL,
+  state             TEXT NOT NULL,
+  portability       TEXT NOT NULL DEFAULT 'project-bound',
+  title             TEXT NOT NULL,
+  content           TEXT NOT NULL,
+  factsJson         TEXT NOT NULL DEFAULT '[]',
+  tagsJson          TEXT NOT NULL DEFAULT '[]',
+  applicability     TEXT,
+  origin            TEXT NOT NULL,
+  createdAt         TEXT NOT NULL,
+  updatedAt         TEXT NOT NULL,
+  qualifiedAt       TEXT,
+  approvedAt        TEXT,
+  archivedAt        TEXT,
+  supersededBy      TEXT,
+  lastValidatedAt   TEXT,
+  accessCount       INTEGER NOT NULL DEFAULT 0,
+  lastAccessedAt    TEXT
+);
+`;
+
+const CREATE_LONG_TERM_MEMORY_EVIDENCE_TABLE = `
+CREATE TABLE IF NOT EXISTS long_term_memory_evidence (
+  id             TEXT PRIMARY KEY,
+  memoryId       TEXT NOT NULL,
+  kind           TEXT NOT NULL,
+  referenceId    TEXT NOT NULL,
+  relation       TEXT NOT NULL,
+  locator        TEXT,
+  capturedHash   TEXT,
+  createdAt      TEXT NOT NULL,
+  FOREIGN KEY (memoryId) REFERENCES long_term_memories(id) ON DELETE CASCADE
+);
+`;
+
+const CREATE_LONG_TERM_MEMORY_EVENTS_TABLE = `
+CREATE TABLE IF NOT EXISTS long_term_memory_events (
+  id          TEXT PRIMARY KEY,
+  memoryId    TEXT NOT NULL,
+  kind        TEXT NOT NULL,
+  fromState   TEXT,
+  toState     TEXT,
+  detail      TEXT,
+  createdAt   TEXT NOT NULL,
+  FOREIGN KEY (memoryId) REFERENCES long_term_memories(id) ON DELETE CASCADE
+);
+`;
+
 // ── Runtime maintenance jobs ───────────────────────────────────────
 
 const CREATE_MAINTENANCE_JOBS_TABLE = `
@@ -599,6 +655,11 @@ CREATE INDEX IF NOT EXISTS idx_knowledge_page_claims_claim ON knowledge_page_cla
 CREATE INDEX IF NOT EXISTS idx_knowledge_proposals_workspace_status ON knowledge_proposals(workspaceId, status, createdAt DESC);
 CREATE INDEX IF NOT EXISTS idx_knowledge_workflows_workspace_status ON knowledge_workflows(workspaceId, status, updatedAt DESC);
 CREATE INDEX IF NOT EXISTS idx_knowledge_workflow_runs_project_workflow ON knowledge_workflow_runs(projectId, workflowId, startedAt DESC);
+CREATE INDEX IF NOT EXISTS idx_long_term_memories_owner_state ON long_term_memories(ownerId, state, updatedAt DESC);
+CREATE INDEX IF NOT EXISTS idx_long_term_memories_project_state ON long_term_memories(originProjectId, state, updatedAt DESC);
+CREATE INDEX IF NOT EXISTS idx_long_term_memories_scope_portability ON long_term_memories(scope, portability, state, updatedAt DESC);
+CREATE INDEX IF NOT EXISTS idx_long_term_memory_evidence_memory ON long_term_memory_evidence(memoryId, createdAt);
+CREATE INDEX IF NOT EXISTS idx_long_term_memory_events_memory ON long_term_memory_events(memoryId, createdAt);
 CREATE INDEX IF NOT EXISTS idx_maintenance_jobs_ready ON maintenance_jobs(status, run_after);
 CREATE INDEX IF NOT EXISTS idx_maintenance_jobs_project ON maintenance_jobs(project_id, status, run_after);
 CREATE INDEX IF NOT EXISTS idx_maintenance_targets_updated ON maintenance_targets(updated_at);
@@ -703,6 +764,19 @@ const SCHEMA_MIGRATIONS: SchemaMigration[] = [
       db.exec('CREATE INDEX IF NOT EXISTS idx_compaction_checkpoints_project_recent ON compaction_checkpoints(project_id, status, completed_at DESC, pre_captured_at DESC)');
       db.exec('CREATE INDEX IF NOT EXISTS idx_compaction_checkpoints_session_pending ON compaction_checkpoints(project_id, session_id, agent, phase, status, pre_captured_at DESC)');
       db.exec('CREATE INDEX IF NOT EXISTS idx_compaction_checkpoints_source ON compaction_checkpoints(project_id, source_key)');
+    },
+  },
+  {
+    id: '1.3-long-term-memory',
+    apply: (db) => {
+      db.exec(CREATE_LONG_TERM_MEMORIES_TABLE);
+      db.exec(CREATE_LONG_TERM_MEMORY_EVIDENCE_TABLE);
+      db.exec(CREATE_LONG_TERM_MEMORY_EVENTS_TABLE);
+      db.exec('CREATE INDEX IF NOT EXISTS idx_long_term_memories_owner_state ON long_term_memories(ownerId, state, updatedAt DESC)');
+      db.exec('CREATE INDEX IF NOT EXISTS idx_long_term_memories_project_state ON long_term_memories(originProjectId, state, updatedAt DESC)');
+      db.exec('CREATE INDEX IF NOT EXISTS idx_long_term_memories_scope_portability ON long_term_memories(scope, portability, state, updatedAt DESC)');
+      db.exec('CREATE INDEX IF NOT EXISTS idx_long_term_memory_evidence_memory ON long_term_memory_evidence(memoryId, createdAt)');
+      db.exec('CREATE INDEX IF NOT EXISTS idx_long_term_memory_events_memory ON long_term_memory_events(memoryId, createdAt)');
     },
   },
 ];

--- a/src/types.ts
+++ b/src/types.ts
@@ -648,3 +648,23 @@ export interface MCPConfigAdapter {
   /** Get the default config file path for this agent */
   getConfigPath(projectRoot?: string): string;
 }
+
+// Durable cognitive memory is intentionally kept in its own module so the
+// legacy Observation contract remains source/provenance focused.
+export type {
+  CreateLongTermMemoryInput,
+  LongTermMemory,
+  LongTermMemoryEvidence,
+  LongTermMemoryEvidenceInput,
+  LongTermMemoryEvidenceKind,
+  LongTermMemoryEvidenceRelation,
+  LongTermMemoryEvent,
+  LongTermMemoryEventKind,
+  LongTermMemoryKind,
+  LongTermMemoryOrigin,
+  LongTermMemoryPortability,
+  LongTermMemoryReader,
+  LongTermMemoryScope,
+  LongTermMemorySelection,
+  LongTermMemoryState,
+} from './memory/long-term-types.js';

--- a/tests/cli/context-command.test.ts
+++ b/tests/cli/context-command.test.ts
@@ -189,7 +189,7 @@ describe('project context CLI commands', () => {
     expect(parsed.currentFacts.packageVersion).toBe('9.9.9');
     expect(parsed.currentFacts.latestChangelog).toEqual({ version: '9.9.9', date: '2026-07-02' });
     expect(parsed.workset).toMatchObject({
-      version: '1.2',
+      version: '1.3',
       lens: 'release',
       startHere: expect.arrayContaining(['CHANGELOG.md', 'package.json']),
     });
@@ -232,7 +232,7 @@ describe('project context CLI commands', () => {
     });
     expect(parsed.explain.overview.code.files).toBe(3);
     expect(parsed.receipt).toMatchObject({
-      version: '1.2.4',
+      version: '1.3',
       target: 'project-context',
       budget: {
         maxTokens: expect.any(Number),

--- a/tests/cli/long-term-command.test.ts
+++ b/tests/cli/long-term-command.test.ts
@@ -1,0 +1,207 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import memoryCommand from '../../src/cli/commands/memory.js';
+import contextCommand from '../../src/cli/commands/context.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+import { resetObservationStore } from '../../src/store/obs-store.js';
+import { resetSessionStore } from '../../src/store/session-store.js';
+import { resetTeamStore } from '../../src/team/team-store.js';
+import { resetDb } from '../../src/store/orama-store.js';
+
+async function runCommand(command: any, args: Record<string, unknown>) {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...parts) => logs.push(parts.map(String).join(' ')));
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation((...parts) => errors.push(parts.map(String).join(' ')));
+  const previousExitCode = process.exitCode;
+  process.exitCode = undefined;
+  try {
+    await command.run?.({ args, rawArgs: [], cmd: command } as any);
+    return { stdout: logs.join('\n'), stderr: errors.join('\n'), exitCode: process.exitCode ?? 0 };
+  } finally {
+    process.exitCode = previousExitCode;
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  }
+}
+
+describe('long-term memory CLI', () => {
+  const originalCwd = process.cwd();
+  const originalDataDir = process.env.MEMORIX_DATA_DIR;
+  const originalEmbedding = process.env.MEMORIX_EMBEDDING;
+  let root = '';
+  let projectA = '';
+  let projectB = '';
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), 'memorix-long-term-cli-'));
+    projectA = path.join(root, 'project-a');
+    projectB = path.join(root, 'project-b');
+    for (const project of [projectA, projectB]) {
+      mkdirSync(project, { recursive: true });
+      writeFileSync(path.join(project, 'README.md'), '# test\n', 'utf8');
+      execSync('git init', { cwd: project, stdio: 'ignore' });
+      execSync('git config user.email test@example.com', { cwd: project, stdio: 'ignore' });
+      execSync('git config user.name "Memorix Test"', { cwd: project, stdio: 'ignore' });
+    }
+    process.chdir(projectA);
+    process.env.MEMORIX_DATA_DIR = path.join(root, 'data');
+    process.env.MEMORIX_EMBEDDING = 'off';
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    if (originalDataDir === undefined) delete process.env.MEMORIX_DATA_DIR;
+    else process.env.MEMORIX_DATA_DIR = originalDataDir;
+    if (originalEmbedding === undefined) delete process.env.MEMORIX_EMBEDDING;
+    else process.env.MEMORIX_EMBEDDING = originalEmbedding;
+    resetObservationStore();
+    resetSessionStore();
+    resetTeamStore();
+    await resetDb();
+    closeAllDatabases();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('manages an explicit portable user memory through the full lifecycle and delivers it in another project', async () => {
+    const created = await runCommand(memoryCommand, {
+      _: ['long-term', 'add'],
+      title: 'Verify package before release',
+      text: 'Run the focused package smoke before publishing an npm release.',
+      kind: 'procedural',
+      scope: 'user',
+      portability: 'portable',
+      tags: 'release,package',
+      applicability: 'When publishing any local npm package.',
+      json: true,
+    });
+    expect(created.exitCode).toBe(0);
+    const candidate = JSON.parse(created.stdout).memory;
+    expect(candidate.state).toBe('candidate');
+
+    const qualified = await runCommand(memoryCommand, {
+      _: ['long-term', 'qualify'],
+      id: candidate.id,
+      reason: 'The user explicitly confirmed this release procedure.',
+      json: true,
+    });
+    expect(JSON.parse(qualified.stdout).memory.state).toBe('qualified');
+
+    const approved = await runCommand(memoryCommand, {
+      _: ['long-term', 'approve'],
+      id: candidate.id,
+      reason: 'Operator reviewed the portable user procedure.',
+      json: true,
+    });
+    expect(JSON.parse(approved.stdout).memory.state).toBe('approved');
+
+    const shown = await runCommand(memoryCommand, { _: ['long-term', 'show'], id: candidate.id, json: true });
+    expect(JSON.parse(shown.stdout).evidence).toHaveLength(1);
+    expect(JSON.parse(shown.stdout).events.map((event: { kind: string }) => event.kind)).toEqual(['created', 'qualified', 'approved']);
+
+    process.chdir(projectB);
+    const context = await runCommand(contextCommand, {
+      input: 'Prepare an npm release and verify the package.',
+      refresh: 'never',
+      json: true,
+    });
+    expect(context.exitCode).toBe(0);
+    expect(JSON.parse(context.stdout).workset.durableMemory).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: candidate.id, scope: 'user', kind: 'procedural' }),
+    ]));
+
+    process.chdir(projectA);
+    const archived = await runCommand(memoryCommand, {
+      _: ['long-term', 'archive'],
+      id: candidate.id,
+      reason: 'The procedure was replaced by a newer one.',
+      json: true,
+    });
+    expect(JSON.parse(archived.stdout).memory.state).toBe('archived');
+    const listed = await runCommand(memoryCommand, { _: ['long-term', 'list'], json: true });
+    expect(JSON.parse(listed.stdout).memories).toHaveLength(0);
+  }, 30000);
+
+  it('promotes an observation without removing its source record', async () => {
+    const stored = await runCommand(memoryCommand, {
+      _: ['store'],
+      title: 'Release smoke source observation',
+      text: 'The package smoke is the final release verification gate.',
+      entity: 'release',
+      type: 'decision',
+      json: true,
+    });
+    const observation = JSON.parse(stored.stdout).observation;
+
+    const promoted = await runCommand(memoryCommand, {
+      _: ['long-term', 'promote'],
+      fromObservation: String(observation.id),
+      kind: 'procedural',
+      scope: 'project',
+      applicability: 'When preparing the package release.',
+      json: true,
+    });
+    expect(promoted.exitCode).toBe(0);
+    const memory = JSON.parse(promoted.stdout).memory;
+    expect(memory.state).toBe('candidate');
+    expect(JSON.parse(promoted.stdout).evidence[0]).toMatchObject({
+      kind: 'observation',
+      referenceId: expect.stringContaining('obs:'),
+    });
+
+    const sourceStillExists = await runCommand(memoryCommand, {
+      _: ['detail'],
+      id: String(observation.id),
+      json: true,
+    });
+    expect(JSON.parse(sourceStillExists.stdout).documents[0].title).toBe('Release smoke source observation');
+  });
+
+  it('supersedes an old long-term procedure through the CLI', async () => {
+    const create = async (title: string) => {
+      const result = await runCommand(memoryCommand, {
+        _: ['long-term', 'add'],
+        title,
+        text: title + ' for the package release.',
+        kind: 'procedural',
+        scope: 'project',
+        tags: 'release,package',
+        json: true,
+      });
+      return JSON.parse(result.stdout).memory;
+    };
+    const oldMemory = await create('Old package smoke');
+    const replacement = await create('Current package smoke');
+    for (const memory of [oldMemory, replacement]) {
+      const qualified = await runCommand(memoryCommand, {
+        _: ['long-term', 'qualify'],
+        id: memory.id,
+        reason: 'Verified against the package release path.',
+        json: true,
+      });
+      expect(qualified.exitCode).toBe(0);
+    }
+
+    const superseded = await runCommand(memoryCommand, {
+      _: ['long-term', 'supersede'],
+      id: oldMemory.id,
+      supersededBy: replacement.id,
+      reason: 'The current package smoke replaces the old procedure.',
+      json: true,
+    });
+    expect(superseded.exitCode).toBe(0);
+    expect(JSON.parse(superseded.stdout).memory).toMatchObject({
+      id: oldMemory.id,
+      state: 'superseded',
+      supersededBy: replacement.id,
+    });
+
+    const listed = await runCommand(memoryCommand, { _: ['long-term', 'list'], json: true });
+    expect(JSON.parse(listed.stdout).memories.map((item: { memory: { id: string } }) => item.memory.id)).toEqual([
+      replacement.id,
+    ]);
+  });
+});

--- a/tests/codegraph/auto-context.test.ts
+++ b/tests/codegraph/auto-context.test.ts
@@ -11,6 +11,7 @@ import {
 import { CodeGraphStore } from '../../src/codegraph/store.js';
 import { getAllObservations, initObservations, storeObservation } from '../../src/memory/observations.js';
 import { endSession, startSession } from '../../src/memory/session.js';
+import { createManualLongTermMemory, qualifyLongTermMemory } from '../../src/memory/long-term.js';
 import { closeAllDatabases } from '../../src/store/sqlite-db.js';
 import { initObservationStore, resetObservationStore } from '../../src/store/obs-store.js';
 import { resetDb } from '../../src/store/orama-store.js';
@@ -124,6 +125,39 @@ describe('auto project context', () => {
     expect(text).toBe(context.workset.prompt);
     expect(context.workset.budget.tokenCount).toBeLessThanOrEqual(context.workset.budget.maxTokens);
     expect(context.workset.receipt.target).toBe('project-context');
+  });
+
+  it('keeps approved long-term memory visible in prompt and summary formats', async () => {
+    const candidate = await createManualLongTermMemory({
+      dataDir,
+      projectId: 'local/repo',
+      scope: 'project',
+      kind: 'procedural',
+      title: 'Release verification procedure',
+      content: 'Run focused tests and package smoke before publishing.',
+      tags: ['release', 'verify'],
+    });
+    await qualifyLongTermMemory({
+      dataDir,
+      id: candidate.memory.id,
+      reason: 'Verified in the release workflow.',
+    });
+
+    const context = await buildAutoProjectContext({
+      project: { id: 'local/repo', name: 'repo', rootPath: repoDir },
+      dataDir,
+      observations: getAllObservations(),
+      refresh: 'never',
+      task: 'Prepare a release with focused verification.',
+    });
+
+    expect(context.workset.durableMemory).toEqual([
+      expect.objectContaining({ title: 'Release verification procedure', state: 'qualified' }),
+    ]);
+    expect(formatAutoProjectContextPrompt(context)).toContain('Release verification procedure');
+    const summary = formatAutoProjectContextSummary(context);
+    expect(summary).toContain('Durable memory');
+    expect(summary).toContain('Release verification procedure');
   });
 
   it('does not source an unqualified automatic capture in an agent brief', async () => {

--- a/tests/codegraph/context-pack.test.ts
+++ b/tests/codegraph/context-pack.test.ts
@@ -362,7 +362,7 @@ describe('buildContextPackPrompt', () => {
       });
 
       expect(pack.workset?.receipt).toMatchObject({
-        version: '1.2.4',
+        version: '1.3',
         target: 'context-pack',
       });
       expect(pack.workset?.receipt.selected).toEqual(expect.arrayContaining([

--- a/tests/embedding/api-provider.test.ts
+++ b/tests/embedding/api-provider.test.ts
@@ -383,6 +383,22 @@ describe('API Embedding Provider', () => {
   });
 
   describe('error handling & retry', () => {
+    it('allows a bounded caller to disable API retries', async () => {
+      const probeVec = makeVector(1536);
+      mockFetch.mockResolvedValueOnce(mockEmbeddingResponse([probeVec]));
+      const provider = await APIEmbeddingProvider.create();
+
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        headers: mockHeaders([['retry-after', '0']]),
+        text: () => Promise.resolve('rate limited'),
+      });
+
+      await expect(provider.embed('no-retry test', { timeoutMs: 100, retry: false })).rejects.toThrow('429');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
     it('should retry on 429 rate limit', async () => {
       const probeVec = makeVector(1536);
       mockFetch.mockResolvedValueOnce(mockEmbeddingResponse([probeVec]));

--- a/tests/embedding/provider.test.ts
+++ b/tests/embedding/provider.test.ts
@@ -223,6 +223,25 @@ describe('Embedding Provider', () => {
   });
 
   describe('strict api mode runtime degradation', () => {
+    it('forwards a bounded provider-init budget to the API provider', async () => {
+      process.env.MEMORIX_EMBEDDING = 'api';
+      process.env.MEMORIX_EMBEDDING_API_KEY = 'api-key';
+      process.env.MEMORIX_EMBEDDING_BASE_URL = 'https://embeddings.example/v1';
+      process.env.MEMORIX_EMBEDDING_MODEL = 'text-embedding-3-small';
+
+      const apiProvider = {
+        name: 'api-text-embedding-3-small',
+        dimensions: 1536,
+        embed: vi.fn(),
+        embedBatch: vi.fn(),
+      };
+      mockApiProviderCreate.mockResolvedValue(apiProvider);
+
+      await getEmbeddingProvider({ requestTimeoutMs: 1_800, retry: false });
+
+      expect(mockApiProviderCreate).toHaveBeenCalledWith({ requestTimeoutMs: 1_800, retry: false });
+    });
+
     it('opens a cooldown circuit after runtime API failures in strict api mode', async () => {
       process.env.MEMORIX_EMBEDDING = 'api';
       process.env.MEMORIX_EMBEDDING_API_KEY = 'api-key';

--- a/tests/hooks/install-uninstall.test.ts
+++ b/tests/hooks/install-uninstall.test.ts
@@ -72,6 +72,8 @@ describe('Hooks install/uninstall lifecycle', () => {
     expect(content).toContain('The absence of `.memorix` or visible memory files never proves project memory is empty.');
     expect(content).toContain('memorix_search');
     expect(content).toContain('When to store memory');
+    expect(content).toContain('longTerm');
+    expect(content).toContain('candidate only');
   });
 
   it('should record audit entry when creating new GEMINI.md (gemini-cli)', async () => {

--- a/tests/integration/long-term-mcp.test.ts
+++ b/tests/integration/long-term-mcp.test.ts
@@ -1,0 +1,135 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/embedding/provider.js', () => ({
+  getEmbeddingProvider: async () => null,
+  isVectorSearchAvailable: async () => false,
+  isEmbeddingExplicitlyDisabled: () => true,
+  resetProvider: () => {},
+}));
+
+vi.mock('../../src/llm/provider.js', () => ({
+  initLLM: () => null,
+  isLLMEnabled: () => false,
+  getLLMConfig: () => null,
+  setLLMConfig: () => {},
+}));
+
+vi.mock('../../src/config.js', () => ({
+  getLLMApiKey: () => null,
+  getLLMProvider: () => 'openai',
+  getLLMModel: (fallback?: string) => fallback ?? 'gpt-4.1-nano',
+  getLLMBaseUrl: (fallback?: string) => fallback ?? 'https://api.openai.com/v1',
+}));
+
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createMemorixServer } from '../../src/server.js';
+import { qualifyLongTermMemory } from '../../src/memory/long-term.js';
+import { resetDb } from '../../src/store/orama-store.js';
+import { resetObservationStore } from '../../src/store/obs-store.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+import { resetResolvedConfigCache } from '../../src/config/resolved-config.js';
+import { resetTomlConfigCache } from '../../src/config/toml-loader.js';
+
+function getHandler(server: any, name: string): (args: Record<string, unknown>) => Promise<any> {
+  const handler = server._registeredTools?.[name]?.handler;
+  expect(handler).toBeTypeOf('function');
+  return handler;
+}
+
+function toolText(result: any): string {
+  return (result?.content ?? [])
+    .filter((item: any) => item?.type === 'text')
+    .map((item: any) => item.text)
+    .join('\n');
+}
+
+describe('long-term memory through the MCP micro profile', () => {
+  const previousDataDir = process.env.MEMORIX_DATA_DIR;
+  let root = '';
+  let projectDir = '';
+  let dataDir = '';
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-long-term-mcp-'));
+    projectDir = path.join(root, 'project');
+    dataDir = path.join(root, 'data');
+    await fs.mkdir(path.join(projectDir, '.git'), { recursive: true });
+    await fs.writeFile(path.join(projectDir, 'package.json'), JSON.stringify({ name: 'long-term-mcp-test', version: '1.0.0' }));
+    process.env.MEMORIX_DATA_DIR = dataDir;
+    resetTomlConfigCache();
+    resetResolvedConfigCache();
+    resetObservationStore();
+    await resetDb();
+  });
+
+  afterEach(async () => {
+    if (previousDataDir === undefined) delete process.env.MEMORIX_DATA_DIR;
+    else process.env.MEMORIX_DATA_DIR = previousDataDir;
+    resetTomlConfigCache();
+    resetResolvedConfigCache();
+    resetObservationStore();
+    await resetDb();
+    closeAllDatabases();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('creates a candidate with the existing store tool and only delivers it after qualification', async () => {
+    const { server, projectId } = await createMemorixServer(
+      projectDir,
+      undefined,
+      undefined,
+      { toolProfile: 'micro' } as any,
+    );
+    expect(Object.keys((server as any)._registeredTools ?? {})).toHaveLength(7);
+    const store = getHandler(server as any, 'memorix_store');
+    const projectContext = getHandler(server as any, 'memorix_project_context');
+    const detail = getHandler(server as any, 'memorix_detail');
+
+    const stored = await store({
+      entityName: 'release',
+      type: 'decision',
+      title: 'Package smoke is required before release',
+      narrative: 'Run the focused package smoke before publishing the package.',
+      longTerm: {
+        kind: 'procedural',
+        scope: 'project',
+        tags: ['release', 'package'],
+        applicability: 'When publishing an npm release.',
+      },
+    });
+    expect(stored.isError).not.toBe(true);
+    const candidateId = toolText(stored).match(/Long-term candidate: ([A-Za-z0-9-]+)/)?.[1];
+    expect(candidateId).toBeTruthy();
+
+    const before = toolText(await projectContext({
+      task: 'Prepare the package release and run smoke.',
+      refresh: 'never',
+      format: 'prompt',
+    }));
+    expect(before).not.toContain('Durable memory');
+
+    await qualifyLongTermMemory({
+      dataDir,
+      id: candidateId!,
+      reason: 'The store observation is the source evidence for this release procedure.',
+    });
+    const after = toolText(await projectContext({
+      task: 'Prepare the package release and run smoke.',
+      refresh: 'never',
+      format: 'prompt',
+    }));
+    expect(after).toContain('Durable memory');
+    expect(after).toContain('Package smoke is required before release');
+    expect(after).toContain('durable:' + candidateId);
+
+    const expanded = toolText(await detail({
+      typedRefs: ['durable:' + candidateId],
+      purpose: 'Need the full approved release procedure before publishing.',
+    }));
+    expect(expanded).toContain('Package smoke is required before release');
+    expect(expanded).toContain('"kind": "observation"');
+    expect(projectId).toBeTruthy();
+  }, 30000);
+});

--- a/tests/knowledge/workset.test.ts
+++ b/tests/knowledge/workset.test.ts
@@ -7,6 +7,7 @@ import { writeClaim } from '../../src/knowledge/claims.js';
 import { applyKnowledgeProposal, compileKnowledgeWorkspace } from '../../src/knowledge/wiki.js';
 import { initializeKnowledgeWorkspace } from '../../src/knowledge/workspace.js';
 import { buildTaskWorkset } from '../../src/knowledge/workset.js';
+import { createManualLongTermMemory, qualifyLongTermMemory } from '../../src/memory/long-term.js';
 import { recordWorkflowRun, writeCanonicalWorkflow } from '../../src/knowledge/workflows.js';
 import { closeAllDatabases } from '../../src/store/sqlite-db.js';
 
@@ -147,7 +148,7 @@ describe('Task Workset', () => {
     expect(workset.prompt).toContain('Project workflow');
     expect(workset.budget.tokenCount).toBeLessThanOrEqual(workset.budget.maxTokens);
     expect(workset.receipt).toMatchObject({
-      version: '1.2.4',
+      version: '1.3',
       target: 'project-context',
       budget: {
         maxTokens: workset.budget.maxTokens,
@@ -188,6 +189,52 @@ describe('Task Workset', () => {
     expect(workset.workflows).toHaveLength(0);
     expect(workset.prompt).not.toContain('Project knowledge');
     expect(workset.prompt).not.toContain('Project workflow');
+  });
+
+  it('adds only qualified task-matching durable memory within the Workset budget', async () => {
+    const root = tempDir();
+    const durable = await createManualLongTermMemory({
+      dataDir: root,
+      projectId: 'org/project-a',
+      scope: 'user',
+      kind: 'procedural',
+      portability: 'portable',
+      title: 'Verify package before release',
+      content: 'Run the focused package smoke before publishing an npm release.',
+      tags: ['release', 'package'],
+      applicability: 'When publishing a package from any local project.',
+    });
+    await qualifyLongTermMemory({
+      dataDir: root,
+      id: durable.memory.id,
+      reason: 'The local user explicitly confirmed this release workflow.',
+    });
+
+    const workset = await buildTaskWorkset({
+      projectId: 'org/project-b',
+      dataDir: root,
+      task: 'Prepare the npm release and verify the package.',
+      lens: 'release',
+      currentFacts: ['Git: clean worktree'],
+      startHere: ['package.json'],
+      reliableMemory: [],
+      cautionMemory: [],
+      verificationHints: ['Run the package smoke.'],
+      worktreeDirty: false,
+      freshness: { suspect: 0, stale: 0 },
+      maxTokens: 180,
+    });
+
+    expect(workset.durableMemory).toEqual([
+      expect.objectContaining({ id: durable.memory.id, scope: 'user', kind: 'procedural' }),
+    ]);
+    expect(workset.prompt).toContain('Durable memory');
+    expect(workset.prompt).toContain('Verify package before release');
+    expect(workset.prompt).toContain('durable:' + durable.memory.id);
+    expect(workset.receipt.selected).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'durable-memory', id: 'durable:' + durable.memory.id }),
+    ]));
+    expect(workset.budget.tokenCount).toBeLessThanOrEqual(workset.budget.maxTokens);
   });
 
   it('puts a bounded continuation projection ahead of optional project detail', async () => {

--- a/tests/memory/long-term.test.ts
+++ b/tests/memory/long-term.test.ts
@@ -1,0 +1,314 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  approveLongTermMemory,
+  archiveLongTermMemory,
+  createLongTermMemoryCandidate,
+  createManualLongTermMemory,
+  getLongTermMemoryDetail,
+  listLongTermMemories,
+  qualifyLongTermMemory,
+  selectLongTermMemoriesForTask,
+  supersedeLongTermMemory,
+} from '../../src/memory/long-term.js';
+import { resolveLocalMemoryOwner } from '../../src/memory/owner.js';
+import { closeAllDatabases, getDatabase } from '../../src/store/sqlite-db.js';
+
+let root: string | undefined;
+
+function dataDir(): string {
+  root = mkdtempSync(path.join(tmpdir(), 'memorix-long-term-'));
+  return path.join(root, 'data');
+}
+
+afterEach(() => {
+  closeAllDatabases();
+  if (root) rmSync(root, { recursive: true, force: true });
+  root = undefined;
+});
+
+describe('long-term memory architecture', () => {
+  it('creates an additive, tracked SQLite migration without changing legacy storage', async () => {
+    const dir = dataDir();
+    const db = getDatabase(dir);
+    const migration = db.prepare("SELECT id FROM schema_migrations WHERE id = '1.3-long-term-memory'").get();
+    const table = db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'long_term_memories'").get();
+
+    expect(migration).toMatchObject({ id: '1.3-long-term-memory' });
+    expect(table).toMatchObject({ name: 'long_term_memories' });
+    expect(db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'observations'").get()).toMatchObject({ name: 'observations' });
+  });
+
+  it('does not inject a candidate until it is explicitly qualified', async () => {
+    const dir = dataDir();
+    const created = await createManualLongTermMemory({
+      dataDir: dir,
+      projectId: 'local/project-a',
+      scope: 'project',
+      kind: 'semantic',
+      title: 'Release requires package smoke',
+      content: 'Run the packed package smoke before publishing a release.',
+      tags: ['release', 'package'],
+      applicability: 'When preparing an npm release.',
+    });
+
+    expect((await selectLongTermMemoriesForTask({
+      dataDir: dir,
+      projectId: 'local/project-a',
+      task: 'Prepare the npm release and run package smoke.',
+    }))).toHaveLength(0);
+
+    const qualified = await qualifyLongTermMemory({
+      dataDir: dir,
+      id: created.memory.id,
+      reason: 'Checked against the focused package smoke gate.',
+    });
+    expect(qualified.state).toBe('qualified');
+
+    const selected = await selectLongTermMemoriesForTask({
+      dataDir: dir,
+      projectId: 'local/project-a',
+      task: 'Prepare the npm release and run package smoke.',
+    });
+    expect(selected).toEqual([
+      expect.objectContaining({
+        memory: expect.objectContaining({ id: created.memory.id, state: 'qualified' }),
+      }),
+    ]);
+  });
+
+  it('allows an explicitly portable user fact across projects but keeps project-bound user memory local', async () => {
+    const dir = dataDir();
+    const portable = await createManualLongTermMemory({
+      dataDir: dir,
+      projectId: 'local/project-a',
+      scope: 'user',
+      kind: 'semantic',
+      portability: 'portable',
+      title: 'Prefer focused verification before release',
+      content: 'The local user prefers a focused test and package smoke before every release.',
+      tags: ['release', 'verification'],
+      applicability: 'When the task publishes a package.',
+    });
+    const localOnly = await createManualLongTermMemory({
+      dataDir: dir,
+      projectId: 'local/project-a',
+      scope: 'user',
+      kind: 'semantic',
+      title: 'Project A adapter is experimental',
+      content: 'Do not enable the Project A adapter by default.',
+      tags: ['adapter'],
+      applicability: 'Only while changing Project A adapter code.',
+    });
+    await qualifyLongTermMemory({ dataDir: dir, id: portable.memory.id, reason: 'User explicitly confirmed this release preference.' });
+    await qualifyLongTermMemory({ dataDir: dir, id: localOnly.memory.id, reason: 'Checked against Project A source context.' });
+    await approveLongTermMemory({ dataDir: dir, id: portable.memory.id, reason: 'Operator reviewed the portable user preference.' });
+
+    const inProjectB = await selectLongTermMemoriesForTask({
+      dataDir: dir,
+      projectId: 'local/project-b',
+      task: 'Prepare a release with focused verification.',
+    });
+    expect(inProjectB.map(item => item.memory.id)).toContain(portable.memory.id);
+    expect(inProjectB.map(item => item.memory.id)).not.toContain(localOnly.memory.id);
+
+    const projectABound = await selectLongTermMemoriesForTask({
+      dataDir: dir,
+      projectId: 'local/project-a',
+      task: 'Change the experimental adapter.',
+    });
+    expect(projectABound.map(item => item.memory.id)).toContain(localOnly.memory.id);
+  });
+
+  it('uses a bounded semantic fallback for a cross-language task only after scope and lifecycle filtering', async () => {
+    const dir = dataDir();
+    const portable = await createManualLongTermMemory({
+      dataDir: dir,
+      projectId: 'local/project-a',
+      scope: 'user',
+      kind: 'procedural',
+      portability: 'portable',
+      title: 'Release verification procedure',
+      content: 'Run lint, build, focused tests, package smoke, and inspect CI before publishing.',
+      tags: ['release', 'verify'],
+      applicability: 'Use before publishing a release.',
+    });
+    const projectOnly = await createManualLongTermMemory({
+      dataDir: dir,
+      projectId: 'local/project-a',
+      scope: 'project',
+      kind: 'procedural',
+      title: 'Project A deployment procedure',
+      content: 'Only use this deployment path in Project A.',
+      tags: ['deployment'],
+    });
+    await qualifyLongTermMemory({ dataDir: dir, id: portable.memory.id, reason: 'User confirmed this reusable procedure.' });
+    await qualifyLongTermMemory({ dataDir: dir, id: projectOnly.memory.id, reason: 'Verified only for Project A.' });
+
+    let requestOptions: { timeoutMs?: number; retry?: boolean } | undefined;
+    const selected = await selectLongTermMemoriesForTask({
+      dataDir: dir,
+      projectId: 'local/project-b',
+      task: '请给出发布前的验证流程。',
+      embeddingProvider: {
+        async embedBatch(texts, options) {
+          requestOptions = options;
+          return texts.map((text) => text.includes('发布') || text.includes('Release verification')
+            ? [1, 0]
+            : [0, 1]);
+        },
+      },
+    });
+
+    expect(selected).toEqual([
+      expect.objectContaining({
+        memory: expect.objectContaining({ id: portable.memory.id }),
+        reason: expect.stringContaining('semantic match'),
+      }),
+    ]);
+    expect(requestOptions).toEqual({ timeoutMs: 1_800, retry: false });
+  });
+
+  it('rejects a portable user candidate derived from project evidence', async () => {
+    const dir = dataDir();
+    const owner = await resolveLocalMemoryOwner(dir, { create: true });
+    await expect(createLongTermMemoryCandidate({
+      dataDir: dir,
+      originProjectId: 'local/project-a',
+      ownerId: owner!.id,
+      scope: 'user',
+      kind: 'procedural',
+      portability: 'portable',
+      title: 'Do not leak project adapter procedure',
+      content: 'This should remain project-bound.',
+      evidence: [{ kind: 'observation', referenceId: 'obs:local/project-a:9', relation: 'derives' }],
+    })).rejects.toThrow('Portable user memory may only use manual or user-confirmed evidence');
+  });
+
+  it('keeps team memory unavailable without explicit active membership', async () => {
+    const dir = dataDir();
+    await expect(createManualLongTermMemory({
+      dataDir: dir,
+      projectId: 'local/project-a',
+      scope: 'team',
+      kind: 'procedural',
+      title: 'Review handoff protocol',
+      content: 'Review the evidence before handoff.',
+    })).rejects.toThrow('active team identity');
+
+    const created = await createManualLongTermMemory({
+      dataDir: dir,
+      projectId: 'local/project-a',
+      scope: 'team',
+      kind: 'procedural',
+      title: 'Review handoff protocol',
+      content: 'Review the evidence before handoff.',
+      tags: ['handoff'],
+      reader: { projectId: 'local/project-a', isTeamMember: true },
+    });
+    await qualifyLongTermMemory({ dataDir: dir, id: created.memory.id, reason: 'Verified in a coordinated handoff.' });
+
+    expect((await selectLongTermMemoriesForTask({
+      dataDir: dir,
+      projectId: 'local/project-a',
+      task: 'Prepare a handoff review.',
+    })).map(item => item.memory.id)).not.toContain(created.memory.id);
+
+    expect((await selectLongTermMemoriesForTask({
+      dataDir: dir,
+      projectId: 'local/project-a',
+      task: 'Prepare a handoff review.',
+      isTeamMember: true,
+    })).map(item => item.memory.id)).toContain(created.memory.id);
+  });
+
+  it('keeps an auditable lifecycle and removes archived records from delivery', async () => {
+    const dir = dataDir();
+    const created = await createManualLongTermMemory({
+      dataDir: dir,
+      projectId: 'local/project-a',
+      scope: 'project',
+      kind: 'episodic',
+      title: 'Release smoke recovery',
+      content: 'The last release smoke was recovered by rebuilding the package.',
+      tags: ['release', 'smoke'],
+    });
+    await qualifyLongTermMemory({ dataDir: dir, id: created.memory.id, reason: 'The recovery result was verified.' });
+    await approveLongTermMemory({ dataDir: dir, id: created.memory.id, reason: 'Operator approved the durable episode.' });
+    const archived = await archiveLongTermMemory({ dataDir: dir, id: created.memory.id, reason: 'The release process changed.' });
+    expect(archived.state).toBe('archived');
+
+    const owner = await resolveLocalMemoryOwner(dir);
+    const detail = await getLongTermMemoryDetail({
+      dataDir: dir,
+      id: created.memory.id,
+      reader: { projectId: 'local/project-a', ownerId: owner!.id },
+    });
+    expect(detail.events.map(event => event.kind)).toEqual(['created', 'qualified', 'approved', 'archived']);
+    expect((await listLongTermMemories({
+      dataDir: dir,
+      reader: { projectId: 'local/project-a', ownerId: owner!.id },
+    })).map(item => item.memory.id)).not.toContain(created.memory.id);
+    expect((await selectLongTermMemoriesForTask({
+      dataDir: dir,
+      projectId: 'local/project-a',
+      task: 'Recover release smoke.',
+    }))).toHaveLength(0);
+  });
+
+  it('supersedes an active record only with an eligible scoped replacement', async () => {
+    const dir = dataDir();
+    const oldMemory = await createManualLongTermMemory({
+      dataDir: dir,
+      projectId: 'local/project-a',
+      scope: 'project',
+      kind: 'procedural',
+      title: 'Old release smoke',
+      content: 'Use the old release smoke procedure.',
+      tags: ['release', 'smoke'],
+    });
+    const replacement = await createManualLongTermMemory({
+      dataDir: dir,
+      projectId: 'local/project-a',
+      scope: 'project',
+      kind: 'procedural',
+      title: 'Current release smoke',
+      content: 'Use the current package smoke procedure.',
+      tags: ['release', 'smoke'],
+    });
+    await qualifyLongTermMemory({ dataDir: dir, id: oldMemory.memory.id, reason: 'Verified when the old release flow was current.' });
+
+    await expect(supersedeLongTermMemory({
+      dataDir: dir,
+      id: oldMemory.memory.id,
+      supersededBy: replacement.memory.id,
+      reason: 'A candidate cannot replace an active procedure.',
+    })).rejects.toThrow('must be qualified or approved');
+
+    await qualifyLongTermMemory({ dataDir: dir, id: replacement.memory.id, reason: 'Verified against the current packed-package smoke.' });
+    const superseded = await supersedeLongTermMemory({
+      dataDir: dir,
+      id: oldMemory.memory.id,
+      supersededBy: replacement.memory.id,
+      reason: 'The package release procedure changed.',
+    });
+    expect(superseded).toMatchObject({ state: 'superseded', supersededBy: replacement.memory.id });
+
+    const selected = await selectLongTermMemoriesForTask({
+      dataDir: dir,
+      projectId: 'local/project-a',
+      task: 'Run the release smoke procedure.',
+    });
+    expect(selected.map(item => item.memory.id)).toEqual([replacement.memory.id]);
+
+    const owner = await resolveLocalMemoryOwner(dir);
+    const detail = await getLongTermMemoryDetail({
+      dataDir: dir,
+      id: oldMemory.memory.id,
+      reader: { projectId: 'local/project-a', ownerId: owner!.id },
+    });
+    expect(detail.events.map(event => event.kind)).toEqual(['created', 'qualified', 'superseded']);
+  });
+});


### PR DESCRIPTION
## Summary
- add a source-backed, audited long-term memory lifecycle for episodic, semantic, and procedural records
- support explicit local user-portable records while keeping code, Git, session, and workflow-derived records project-bound
- surface at most three task-matched durable summaries through existing CLI and seven-tool MCP micro profile
- bound optional remote semantic recall to 1.8 seconds with no retry so it cannot stall normal context delivery

## Verification
- `npm run lint`
- `npm test`
- `npm run check:mcp-registry`
- `npm publish --dry-run --ignore-scripts`
- packed-package CLI, MCP stdio, cross-project retrieval, and Claude Code smoke tests