### PR TITLE
fix(windows): prevent CLI console flicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.1] - 2026-07-31
+
+### Fixed
+- **Windows CLI window flicker** -- Memorix now hides Windows child-process windows across normal CLI work: startup restart, Git/project probes, hook runners, setup checks, background controls, orchestration, and memcode utility commands no longer flash a console for each invocation.
+- **Recoverable vector backfill** -- One-shot vector backfill no longer launches as a detached Windows process. The durable queue still preserves and retries the work, while `unref()` lets the foreground CLI return without a visible extra console.
+
 ## [1.3.0] - 2026-07-30
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memorix",
   "mcpName": "io.github.AVIDS2/memorix",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/packages/agent-core/src/harness/env/nodejs.ts
+++ b/packages/agent-core/src/harness/env/nodejs.ts
@@ -192,11 +192,12 @@ function getShellEnv(baseEnv?: NodeJS.ProcessEnv, extraEnv?: Record<string, stri
 function killProcessTree(pid: number): void {
 	if (process.platform === "win32") {
 		try {
-			spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
+			const child = spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
 				stdio: "ignore",
-				detached: true,
+				detached: false,
 				windowsHide: true,
 			});
+			child.unref();
 		} catch {
 			// Ignore errors.
 		}

--- a/packages/memcode/src/core/exec.ts
+++ b/packages/memcode/src/core/exec.ts
@@ -42,6 +42,7 @@ export async function execCommand(
 			cwd,
 			shell: false,
 			stdio: ["ignore", "pipe", "pipe"],
+			windowsHide: true,
 		});
 
 		let stdout = "";

--- a/packages/memcode/src/core/footer-data-provider.ts
+++ b/packages/memcode/src/core/footer-data-provider.ts
@@ -53,6 +53,7 @@ function resolveBranchWithGitSync(repoDir: string): string | null {
 		cwd: repoDir,
 		encoding: "utf8",
 		stdio: ["ignore", "pipe", "ignore"],
+		windowsHide: true,
 	});
 	const branch = result.status === 0 ? result.stdout.trim() : "";
 	return branch || null;
@@ -67,6 +68,7 @@ function resolveBranchWithGitAsync(repoDir: string): Promise<string | null> {
 			{
 				cwd: repoDir,
 				encoding: "utf8",
+				windowsHide: true,
 			},
 			(error: ExecFileException | null, stdout: string) => {
 				if (error) {

--- a/packages/memcode/src/core/resolve-config-value.ts
+++ b/packages/memcode/src/core/resolve-config-value.ts
@@ -191,6 +191,7 @@ function executeWithDefaultShell(command: string): string | undefined {
 			encoding: "utf-8",
 			timeout: 10000,
 			stdio: ["ignore", "pipe", "ignore"],
+			windowsHide: true,
 		});
 		return output.trim() || undefined;
 	} catch {

--- a/packages/memcode/src/core/tools/find.ts
+++ b/packages/memcode/src/core/tools/find.ts
@@ -259,7 +259,10 @@ export function createFindToolDefinition(
 						}
 						args.push("--", effectivePattern, searchPath);
 
-						const child = spawn(fdPath, args, { stdio: ["ignore", "pipe", "pipe"] });
+						const child = spawn(fdPath, args, {
+							stdio: ["ignore", "pipe", "pipe"],
+							windowsHide: true,
+						});
 						const rl = createInterface({ input: child.stdout });
 						let stderr = "";
 						const lines: string[] = [];

--- a/packages/memcode/src/core/tools/grep.ts
+++ b/packages/memcode/src/core/tools/grep.ts
@@ -218,7 +218,10 @@ export function createGrepToolDefinition(
 						if (glob) args.push("--glob", glob);
 						args.push("--", pattern, searchPath);
 
-						const child = spawn(rgPath, args, { stdio: ["ignore", "pipe", "pipe"] });
+						const child = spawn(rgPath, args, {
+							stdio: ["ignore", "pipe", "pipe"],
+							windowsHide: true,
+						});
 						const rl = createInterface({ input: child.stdout });
 						let stderr = "";
 						let matchCount = 0;

--- a/packages/memcode/src/modes/interactive/components/extension-editor.ts
+++ b/packages/memcode/src/modes/interactive/components/extension-editor.ts
@@ -133,6 +133,7 @@ export class ExtensionEditorComponent extends Container implements Focusable {
 				const child = spawn(editor, [...editorArgs, tmpFile], {
 					stdio: "inherit",
 					shell: process.platform === "win32",
+					windowsHide: true,
 				});
 				child.on("error", () => resolve(null));
 				child.on("close", (code) => resolve(code));

--- a/packages/memcode/src/modes/interactive/components/session-selector.ts
+++ b/packages/memcode/src/modes/interactive/components/session-selector.ts
@@ -648,7 +648,7 @@ async function deleteSessionFile(
 ): Promise<{ ok: boolean; method: "trash" | "unlink"; error?: string }> {
 	// Try `trash` first (if installed)
 	const trashArgs = sessionPath.startsWith("-") ? ["--", sessionPath] : [sessionPath];
-	const trashResult = spawnSync("trash", trashArgs, { encoding: "utf-8" });
+	const trashResult = spawnSync("trash", trashArgs, { encoding: "utf-8", windowsHide: true });
 
 	const getTrashErrorHint = (): string | null => {
 		const parts: string[] = [];

--- a/packages/memcode/src/modes/interactive/interactive-mode.ts
+++ b/packages/memcode/src/modes/interactive/interactive-mode.ts
@@ -974,6 +974,7 @@ export class InteractiveMode {
 			return new Promise((resolve) => {
 				const proc = spawn("tmux", ["show", "-gv", option], {
 					stdio: ["ignore", "pipe", "ignore"],
+					windowsHide: true,
 				});
 				let stdout = "";
 				const timer = setTimeout(() => {
@@ -4055,6 +4056,7 @@ export class InteractiveMode {
 				const child = spawn(editor, [...editorArgs, tmpFile], {
 					stdio: "inherit",
 					shell: process.platform === "win32",
+					windowsHide: true,
 				});
 				child.on("error", () => resolve(null));
 				child.on("close", (code) => resolve(code));
@@ -5663,7 +5665,10 @@ export class InteractiveMode {
 	private async handleShareCommand(): Promise<void> {
 		// Check if gh is available and logged in
 		try {
-			const authResult = spawnSync("gh", ["auth", "status"], { encoding: "utf-8" });
+			const authResult = spawnSync("gh", ["auth", "status"], {
+				encoding: "utf-8",
+				windowsHide: true,
+			});
 			if (authResult.status !== 0) {
 				this.showError("GitHub CLI is not logged in. Run 'gh auth login' first.");
 				return;
@@ -5712,7 +5717,7 @@ export class InteractiveMode {
 
 		try {
 			const result = await new Promise<{ stdout: string; stderr: string; code: number | null }>((resolve) => {
-				proc = spawn("gh", ["gist", "create", "--public=false", tmpFile]);
+				proc = spawn("gh", ["gist", "create", "--public=false", tmpFile], { windowsHide: true });
 				let stdout = "";
 				let stderr = "";
 				proc.stdout?.on("data", (data) => {

--- a/packages/memcode/src/modes/rpc/rpc-client.ts
+++ b/packages/memcode/src/modes/rpc/rpc-client.ts
@@ -93,6 +93,7 @@ export class RpcClient {
 			cwd: this.options.cwd,
 			env: { ...process.env, ...this.options.env },
 			stdio: ["pipe", "pipe", "pipe"],
+			windowsHide: true,
 		});
 		this.process = childProcess;
 

--- a/packages/memcode/src/utils/child-process.ts
+++ b/packages/memcode/src/utils/child-process.ts
@@ -22,7 +22,8 @@ export function spawnProcess(
 ): ChildProcessByStdio<null, Readable, Readable>;
 export function spawnProcess(command: string, args: string[], options: SpawnOptions): ChildProcess;
 export function spawnProcess(command: string, args: string[], options: SpawnOptions): ChildProcess {
-	return process.platform === "win32" ? crossSpawn(command, args, options) : nodeSpawn(command, args, options);
+	const hiddenOptions = { ...options, windowsHide: true };
+	return process.platform === "win32" ? crossSpawn(command, args, hiddenOptions) : nodeSpawn(command, args, hiddenOptions);
 }
 
 export function spawnProcessSync(
@@ -30,9 +31,10 @@ export function spawnProcessSync(
 	args: string[],
 	options: SpawnSyncOptionsWithStringEncoding,
 ): SpawnSyncReturns<string> {
+	const hiddenOptions = { ...options, windowsHide: true };
 	return process.platform === "win32"
-		? crossSpawn.sync(command, args, options)
-		: nodeSpawnSync(command, args, options);
+		? crossSpawn.sync(command, args, hiddenOptions)
+		: nodeSpawnSync(command, args, hiddenOptions);
 }
 
 /**

--- a/packages/memcode/src/utils/clipboard-image.ts
+++ b/packages/memcode/src/utils/clipboard-image.ts
@@ -98,6 +98,7 @@ function runCommand(
 		timeout: timeoutMs,
 		maxBuffer: maxBufferBytes,
 		env: options?.env,
+		windowsHide: true,
 	});
 
 	if (result.error) {

--- a/packages/memcode/src/utils/clipboard.ts
+++ b/packages/memcode/src/utils/clipboard.ts
@@ -7,6 +7,7 @@ type NativeClipboardExecOptions = {
 	input: string;
 	timeout: number;
 	stdio: ["pipe", "ignore", "ignore"];
+	windowsHide: true;
 };
 
 function copyToX11Clipboard(options: NativeClipboardExecOptions): void {
@@ -61,7 +62,12 @@ export async function copyToClipboard(text: string): Promise<void> {
 		return;
 	}
 
-	const options: NativeClipboardExecOptions = { input: text, timeout: 5000, stdio: ["pipe", "ignore", "ignore"] };
+	const options: NativeClipboardExecOptions = {
+		input: text,
+		timeout: 5000,
+		stdio: ["pipe", "ignore", "ignore"],
+		windowsHide: true,
+	};
 
 	if (!copied) {
 		try {
@@ -89,9 +95,12 @@ export async function copyToClipboard(text: string): Promise<void> {
 					if (isWayland && hasWaylandDisplay) {
 						try {
 							// Verify wl-copy exists (spawn errors are async and won't be caught)
-							execSync("which wl-copy", { stdio: "ignore" });
+							execSync("which wl-copy", { stdio: "ignore", windowsHide: true });
 							// wl-copy with execSync hangs due to fork behavior; use spawn instead
-							const proc = spawn("wl-copy", [], { stdio: ["pipe", "ignore", "ignore"] });
+							const proc = spawn("wl-copy", [], {
+								stdio: ["pipe", "ignore", "ignore"],
+								windowsHide: true,
+							});
 							proc.stdin.on("error", () => {
 								// Ignore EPIPE errors if wl-copy exits early
 							});

--- a/packages/memcode/src/utils/open-browser.ts
+++ b/packages/memcode/src/utils/open-browser.ts
@@ -18,7 +18,11 @@ export function openBrowser(target: string): void {
 	// spawn reports launcher failures (for example, missing xdg-open) via an
 	// error event. Browser launch is best-effort: callers still present the target
 	// to the user, so keep the launcher failure from becoming a process crash.
-	spawn(cmd, args, { stdio: "ignore", detached: true })
+	spawn(cmd, args, {
+		stdio: "ignore",
+		detached: process.platform !== "win32",
+		windowsHide: true,
+	})
 		.on("error", () => {})
 		.unref();
 }

--- a/packages/memcode/src/utils/shell.ts
+++ b/packages/memcode/src/utils/shell.ts
@@ -34,7 +34,11 @@ function findBashOnPath(): string | null {
 
 	// Unix: Use 'which' and trust its output (handles Termux and special filesystems)
 	try {
-		const result = spawnSync("which", ["bash"], { encoding: "utf-8", timeout: 5000 });
+		const result = spawnSync("which", ["bash"], {
+			encoding: "utf-8",
+			timeout: 5000,
+			windowsHide: true,
+		});
 		if (result.status === 0 && result.stdout) {
 			const firstMatch = result.stdout.trim().split(/\r?\n/)[0];
 			if (firstMatch) {
@@ -191,11 +195,12 @@ export function killProcessTree(pid: number): void {
 	if (process.platform === "win32") {
 		// Use taskkill on Windows to kill process tree
 		try {
-			spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
+			const child = spawn("taskkill", ["/F", "/T", "/PID", String(pid)], {
 				stdio: "ignore",
-				detached: true,
+				detached: false,
 				windowsHide: true,
 			});
+			child.unref();
 		} catch {
 			// Ignore errors if taskkill fails
 		}

--- a/packages/memcode/src/utils/tools-manager.ts
+++ b/packages/memcode/src/utils/tools-manager.ts
@@ -73,7 +73,7 @@ const TOOLS: Record<string, ToolConfig> = {
 // Check if a command exists in PATH by trying to run it
 function commandExists(cmd: string): boolean {
 	try {
-		const result = spawnSync(cmd, ["--version"], { stdio: "pipe" });
+		const result = spawnSync(cmd, ["--version"], { stdio: "pipe", windowsHide: true });
 		// Check for ENOENT error (command not found)
 		return result.error === undefined || result.error === null;
 	} catch {
@@ -174,7 +174,7 @@ function formatSpawnFailure(result: SpawnSyncReturns<Buffer>): string {
 }
 
 function runExtractionCommand(command: string, args: string[]): string | null {
-	const result = spawnSync(command, args, { stdio: "pipe" });
+	const result = spawnSync(command, args, { stdio: "pipe", windowsHide: true });
 	if (!result.error && result.status === 0) {
 		return null;
 	}

--- a/packages/memcode/test/clipboard.test.ts
+++ b/packages/memcode/test/clipboard.test.ts
@@ -121,6 +121,7 @@ describe("copyToClipboard", () => {
 			input: "hello",
 			stdio: ["pipe", "ignore", "ignore"],
 			timeout: 5000,
+			windowsHide: true,
 		});
 		expect(osc52Writes()).toHaveLength(0);
 	});

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AVIDS2/memorix",
     "source": "github"
   },
-  "version": "1.3.0",
+  "version": "1.3.1",
   "websiteUrl": "https://github.com/AVIDS2/memorix#readme",
   "icons": [
     {
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "memorix",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "runtimeHint": "npx",
       "packageArguments": [
         {

--- a/src/cli/commands/agent-integrations.ts
+++ b/src/cli/commands/agent-integrations.ts
@@ -430,6 +430,7 @@ function inspectCodexPluginRuntime(): AgentPluginCheck {
     encoding: 'utf-8',
     stdio: 'pipe',
     shell: process.platform === 'win32',
+    windowsHide: true,
   });
   if (result.error || result.status !== 0) {
     return {

--- a/src/cli/commands/background.ts
+++ b/src/cli/commands/background.ts
@@ -217,12 +217,11 @@ export async function doStart(port: number): Promise<void> {
   // The entry point is the same binary that's running now
   const cliEntry = process.argv[1]; // e.g., dist/cli/index.js or node_modules/.bin/memorix
 
-  // 6. Spawn detached process
-  // On Windows, detached:true + stdio:['ignore', fd, fd] + unref() is the correct
-  // pattern. The child gets its own console and survives the parent terminal closing.
-  // Note: Node.js spawn does NOT support a 'flags' option — that was a dead code path.
+  // 6. Spawn the background service. The service can safely outlive this CLI through
+  // unref() and file-backed stdio. Avoid detached on Windows because it can create a
+  // visible console even when windowsHide is set.
   const child = spawn(process.execPath, [cliEntry, 'serve-http', '--port', String(port)], {
-    detached: true,
+    detached: process.platform !== 'win32',
     stdio: ['ignore', logFd, logFd],
     env: { ...process.env },
     cwd: process.cwd(),
@@ -331,7 +330,7 @@ export async function doStop(): Promise<void> {
     console.log('  This may be a PID-reused unrelated process. Force-killing and cleaning up stale state.');
     try {
       if (process.platform === 'win32') {
-        execSync(`taskkill /F /PID ${state.pid}`, { stdio: 'ignore' });
+        execSync(`taskkill /F /PID ${state.pid}`, { stdio: 'ignore', windowsHide: true });
       } else {
         process.kill(state.pid, 'SIGKILL');
       }
@@ -373,7 +372,7 @@ export async function doStop(): Promise<void> {
     // Force kill on Windows
     try {
       if (process.platform === 'win32') {
-        execSync(`taskkill /F /PID ${state.pid}`, { stdio: 'ignore' });
+        execSync(`taskkill /F /PID ${state.pid}`, { stdio: 'ignore', windowsHide: true });
       } else {
         process.kill(state.pid, 'SIGKILL');
       }

--- a/src/cli/commands/hooks-install.ts
+++ b/src/cli/commands/hooks-install.ts
@@ -122,7 +122,12 @@ async function installSingleAgent(agent: string, cwd: string, global: boolean): 
     if (agent === 'copilot' && process.platform === 'win32') {
       try {
         const { execSync } = await import('node:child_process');
-        execSync('pwsh --version', { encoding: 'utf-8', timeout: 3000, stdio: ['pipe', 'pipe', 'ignore'] });
+        execSync('pwsh --version', {
+          encoding: 'utf-8',
+          timeout: 3000,
+          stdio: ['pipe', 'pipe', 'ignore'],
+          windowsHide: true,
+        });
       } catch {
         console.warn(`[WARN]  ${agent}: pwsh (PowerShell v7+) not found. Copilot hooks will use the bash field via Git Bash.`);
         console.warn(`   For best Windows support, install PowerShell v7+: winget install Microsoft.PowerShell`);

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -998,6 +998,7 @@ function tryInstallClaudePlugin(marketplaceRoot: string): { ok: boolean; message
     encoding: 'utf-8',
     stdio: 'pipe',
     shell: process.platform === 'win32',
+    windowsHide: true,
   });
 
   const alreadyAdded = `${add.stderr || ''}\n${add.stdout || ''}`.toLowerCase().includes('already');
@@ -1015,6 +1016,7 @@ function tryInstallClaudePlugin(marketplaceRoot: string): { ok: boolean; message
     encoding: 'utf-8',
     stdio: 'pipe',
     shell: process.platform === 'win32',
+    windowsHide: true,
   });
 
   const installOutput = `${install.stderr || ''}\n${install.stdout || ''}`.toLowerCase();
@@ -1062,6 +1064,7 @@ function getCodexPluginState(): CodexPluginState {
     encoding: 'utf-8',
     stdio: 'pipe',
     shell: process.platform === 'win32',
+    windowsHide: true,
   });
   if (result.status !== 0) return 'unknown';
   return parseCodexPluginState(result.stdout || '');
@@ -1072,6 +1075,7 @@ export function tryInstallCodexPlugin(): { ok: boolean; message: string } {
     encoding: 'utf-8',
     stdio: 'pipe',
     shell: process.platform === 'win32',
+    windowsHide: true,
   });
 
   const output = `${result.stderr || ''}\n${result.stdout || ''}`.toLowerCase();
@@ -1112,6 +1116,7 @@ function tryInstallCopilotPlugin(pluginPath: string): { ok: boolean; message: st
     encoding: 'utf-8',
     stdio: 'pipe',
     shell: process.platform === 'win32',
+    windowsHide: true,
   });
 
   if (result.status === 0) {
@@ -1140,6 +1145,7 @@ function tryInstallPiPackage(packagePath: string, global = false): { ok: boolean
     encoding: 'utf-8',
     stdio: 'pipe',
     shell: process.platform === 'win32',
+    windowsHide: true,
   });
 
   if (result.status === 0) {
@@ -1178,6 +1184,7 @@ function tryInstallOpenClawBundle(bundlePath: string): { ok: boolean; message: s
     encoding: 'utf-8',
     stdio: 'pipe',
     shell: process.platform === 'win32',
+    windowsHide: true,
   });
 
   const installOutput = `${install.stderr || ''}\n${install.stdout || ''}`.toLowerCase();
@@ -1195,6 +1202,7 @@ function tryInstallOpenClawBundle(bundlePath: string): { ok: boolean; message: s
     encoding: 'utf-8',
     stdio: 'pipe',
     shell: process.platform === 'win32',
+    windowsHide: true,
   });
   const hookOutput = `${hook.stderr || ''}\n${hook.stdout || ''}`.toLowerCase();
   if (hook.status === 0 || hookOutput.includes('already') || hookOutput.includes('enabled')) {
@@ -1225,6 +1233,7 @@ function tryEnableHermesPlugin(pluginName = 'memorix', hermesHome = resolveHerme
     env: { ...process.env, HERMES_HOME: hermesHome },
     stdio: 'pipe',
     shell: process.platform === 'win32' && command === 'hermes',
+    windowsHide: true,
   });
 
   if (result.status === 0) {
@@ -1250,6 +1259,7 @@ function tryInstallOmpPackage(packagePath: string): { ok: boolean; message: stri
     encoding: 'utf-8',
     stdio: 'pipe',
     shell: process.platform === 'win32',
+    windowsHide: true,
   });
 
   if (result.status === 0) {

--- a/src/cli/tui/App.tsx
+++ b/src/cli/tui/App.tsx
@@ -825,20 +825,20 @@ export function WorkbenchApp({ version, onExitForInteractive }: AppProps): React
       if (background.running) {
         switch (action) {
           case 'w': if (background.dashboard) {
-            try { execSync(`start "" "${background.dashboard}"`, { stdio: 'pipe' }); } catch {
-              try { execSync(`open "${background.dashboard}"`, { stdio: 'pipe' }); } catch {
-                try { execSync(`xdg-open "${background.dashboard}"`, { stdio: 'pipe' }); } catch { /* */ }
+            try { execSync(`start "" "${background.dashboard}"`, { stdio: 'pipe', windowsHide: true }); } catch {
+              try { execSync(`open "${background.dashboard}"`, { stdio: 'pipe', windowsHide: true }); } catch {
+                try { execSync(`xdg-open "${background.dashboard}"`, { stdio: 'pipe', windowsHide: true }); } catch { /* */ }
               }
             }
             setStatusMsg({ text: `Opening ${background.dashboard}`, type: 'success' });
           } break;
-          case '1': try { execSync('memorix background restart', { stdio: 'pipe', timeout: 15000 }); setStatusMsg({ text: 'Restarted.', type: 'success' }); } catch (e) { setStatusMsg({ text: `Restart failed: ${e}`, type: 'error' }); } break;
-          case '2': try { execSync('memorix background stop', { stdio: 'pipe', timeout: 10000 }); setStatusMsg({ text: 'Stopped.', type: 'success' }); } catch (e) { setStatusMsg({ text: `Stop failed: ${e}`, type: 'error' }); } break;
+          case '1': try { execSync('memorix background restart', { stdio: 'pipe', timeout: 15000, windowsHide: true }); setStatusMsg({ text: 'Restarted.', type: 'success' }); } catch (e) { setStatusMsg({ text: `Restart failed: ${e}`, type: 'error' }); } break;
+          case '2': try { execSync('memorix background stop', { stdio: 'pipe', timeout: 10000, windowsHide: true }); setStatusMsg({ text: 'Stopped.', type: 'success' }); } catch (e) { setStatusMsg({ text: `Stop failed: ${e}`, type: 'error' }); } break;
           case '3': setStatusMsg({ text: 'Run: memorix background logs (separate terminal)', type: 'info' }); break;
         }
       } else {
         switch (action) {
-          case '1': try { execSync('memorix background start', { stdio: 'pipe', timeout: 15000 }); setStatusMsg({ text: 'Started.', type: 'success' }); } catch (e) { setStatusMsg({ text: `Start failed: ${e}`, type: 'error' }); } break;
+          case '1': try { execSync('memorix background start', { stdio: 'pipe', timeout: 15000, windowsHide: true }); setStatusMsg({ text: 'Started.', type: 'success' }); } catch (e) { setStatusMsg({ text: `Start failed: ${e}`, type: 'error' }); } break;
           case '2': setStatusMsg({ text: 'Run: memorix dashboard (separate terminal)', type: 'info' }); break;
         }
       }
@@ -852,15 +852,15 @@ export function WorkbenchApp({ version, onExitForInteractive }: AppProps): React
       const { execSync } = await import('node:child_process');
       if (background.healthy && background.dashboard) {
         if (action === '1') {
-          try { execSync(`start "" "${background.dashboard}"`, { stdio: 'pipe' }); } catch {
-            try { execSync(`open "${background.dashboard}"`, { stdio: 'pipe' }); } catch {
-              try { execSync(`xdg-open "${background.dashboard}"`, { stdio: 'pipe' }); } catch { /* */ }
+          try { execSync(`start "" "${background.dashboard}"`, { stdio: 'pipe', windowsHide: true }); } catch {
+            try { execSync(`open "${background.dashboard}"`, { stdio: 'pipe', windowsHide: true }); } catch {
+              try { execSync(`xdg-open "${background.dashboard}"`, { stdio: 'pipe', windowsHide: true }); } catch { /* */ }
             }
           }
           setStatusMsg({ text: `Opening ${background.dashboard}`, type: 'success' });
         } else if (action === '2') { setStatusMsg({ text: 'Run: memorix dashboard (separate terminal)', type: 'info' }); }
       } else {
-        if (action === '1') { try { execSync('memorix background start', { stdio: 'pipe', timeout: 15000 }); setStatusMsg({ text: 'Started.', type: 'success' }); setBackground(await getBackgroundStatus()); } catch (e) { setStatusMsg({ text: `Start failed: ${e}`, type: 'error' }); } }
+        if (action === '1') { try { execSync('memorix background start', { stdio: 'pipe', timeout: 15000, windowsHide: true }); setStatusMsg({ text: 'Started.', type: 'success' }); setBackground(await getBackgroundStatus()); } catch (e) { setStatusMsg({ text: `Start failed: ${e}`, type: 'error' }); } }
         else if (action === '2') { setStatusMsg({ text: 'Run: memorix dashboard (separate terminal)', type: 'info' }); }
       }
     } catch (err) { setStatusMsg({ text: `Error: ${err instanceof Error ? err.message : String(err)}`, type: 'error' }); }

--- a/src/cli/update-checker.ts
+++ b/src/cli/update-checker.ts
@@ -167,7 +167,7 @@ function installUpdateInBackground(targetVersion: string, currentVersion: string
     const child = execFile(
       npmCmd,
       ['install', '-g', `${PACKAGE_NAME}@${targetVersion}`],
-      { timeout: timeoutMs },
+      { timeout: timeoutMs, windowsHide: true },
       async (error) => {
         const failure = error ? describeAutoUpdateFailure(error, timeoutMs) : null;
         const updatedCache: UpdateCache = {

--- a/src/codegraph/current-facts.ts
+++ b/src/codegraph/current-facts.ts
@@ -66,6 +66,7 @@ function runGit(rootPath: string, args: string[]): string | undefined {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
       timeout: 3000,
+      windowsHide: true,
     }).trim() || undefined;
   } catch {
     return undefined;

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -833,7 +833,7 @@ function openBrowser(url: string) {
         process.platform === 'win32' ? `start "" "${url}"` :
             process.platform === 'darwin' ? `open "${url}"` :
                 `xdg-open "${url}"`;
-    exec(cmd, () => { /* ignore errors */ });
+    exec(cmd, { windowsHide: true }, () => { /* ignore errors */ });
 }
 
 /** Mutable dashboard state — updated at runtime when project changes */

--- a/src/git/extractor.ts
+++ b/src/git/extractor.ts
@@ -41,7 +41,7 @@ export function getCommitInfo(cwd: string, ref = 'HEAD'): CommitInfo {
   const FORMAT = '%H%n%h%n%aN%n%aI%n%s%n%b';
   const raw = execSync(
     `git log -1 --format="${FORMAT}" ${ref}`,
-    { cwd, encoding: 'utf-8', timeout: 10000 },
+    { cwd, encoding: 'utf-8', timeout: 10000, windowsHide: true },
   ).trim();
 
   const lines = raw.split('\n');
@@ -55,7 +55,7 @@ export function getCommitInfo(cwd: string, ref = 'HEAD'): CommitInfo {
   // Get diff stat
   const stat = execSync(
     `git diff-tree --no-commit-id --numstat ${hash}`,
-    { cwd, encoding: 'utf-8', timeout: 10000 },
+    { cwd, encoding: 'utf-8', timeout: 10000, windowsHide: true },
   ).trim();
 
   let insertions = 0;
@@ -78,7 +78,7 @@ export function getCommitInfo(cwd: string, ref = 'HEAD'): CommitInfo {
   try {
     const diff = execSync(
       `git diff-tree -p --no-commit-id ${hash}`,
-      { cwd, encoding: 'utf-8', timeout: 10000, maxBuffer: 1024 * 100 },
+      { cwd, encoding: 'utf-8', timeout: 10000, maxBuffer: 1024 * 100, windowsHide: true },
     );
     diffSummary = diff.substring(0, 500);
   } catch { /* diff may be too large */ }
@@ -95,7 +95,7 @@ export function getCommitInfo(cwd: string, ref = 'HEAD'): CommitInfo {
 export function getRecentCommits(cwd: string, count = 10): CommitInfo[] {
   const hashes = execSync(
     `git log --format="%H" -${count}`,
-    { cwd, encoding: 'utf-8', timeout: 10000 },
+    { cwd, encoding: 'utf-8', timeout: 10000, windowsHide: true },
   ).trim().split('\n').filter(Boolean);
 
   return hashes.map(hash => getCommitInfo(cwd, hash));

--- a/src/hooks/installers/index.ts
+++ b/src/hooks/installers/index.ts
@@ -136,7 +136,12 @@ function generateCopilotConfig(): Record<string, unknown> {
  */
 function detectPwsh(): boolean {
   try {
-    execSync('pwsh --version', { encoding: 'utf-8', timeout: 3000, stdio: ['pipe', 'pipe', 'ignore'] });
+    execSync('pwsh --version', {
+      encoding: 'utf-8',
+      timeout: 3000,
+      stdio: ['pipe', 'pipe', 'ignore'],
+      windowsHide: true,
+    });
     return true;
   } catch {
     return false;
@@ -447,6 +452,7 @@ export const MemorixPlugin = async ({ project, client, $, directory, worktree })
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
         shell: process.platform === 'win32',
+        windowsHide: true,
       });
       if (result.status !== 0) {
         reportHookFailure(eventName, {
@@ -818,7 +824,7 @@ export async function detectInstalledAgents(): Promise<AgentName[]> {
   try {
     const { execSync } = await import('node:child_process');
     const whereCmd = process.platform === 'win32' ? 'where gemini' : 'which gemini';
-    execSync(whereCmd, { stdio: 'ignore' });
+    execSync(whereCmd, { stdio: 'ignore', windowsHide: true });
     agents.push('gemini-cli');
   } catch { /* not installed */ }
 

--- a/src/orchestrate/adapters/spawn-helper.ts
+++ b/src/orchestrate/adapters/spawn-helper.ts
@@ -21,7 +21,7 @@ const DEFAULT_TIMEOUT_MS = 600_000;  // 10 minutes
 export function isCommandAvailable(command: string): boolean {
   const probe = process.platform === 'win32' ? `where ${command}` : `which ${command}`;
   try {
-    execSync(probe, { stdio: 'ignore', timeout: 5_000 });
+    execSync(probe, { stdio: 'ignore', timeout: 5_000, windowsHide: true });
     return true;
   } catch {
     return false;

--- a/src/orchestrate/context-collector.ts
+++ b/src/orchestrate/context-collector.ts
@@ -101,6 +101,7 @@ function collectFileTree(projectDir: string, maxEntries: number): string {
       encoding: 'utf-8',
       timeout: 5_000,
       maxBuffer: 512 * 1024,
+      windowsHide: true,
     }).trim();
 
     if (!raw) return '';
@@ -139,6 +140,7 @@ function collectGitLog(projectDir: string, maxEntries: number): string {
       cwd: projectDir,
       encoding: 'utf-8',
       timeout: 5_000,
+      windowsHide: true,
     }).trim();
   } catch {
     return '';

--- a/src/orchestrate/coordinator.ts
+++ b/src/orchestrate/coordinator.ts
@@ -1169,6 +1169,7 @@ function isGitRepository(projectDir: string): boolean {
       encoding: 'utf-8',
       timeout: 5_000,
       stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
     });
     return true;
   } catch {
@@ -1183,6 +1184,7 @@ function getGitStatus(projectDir: string): string {
       encoding: 'utf-8',
       timeout: 5_000,
       stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
     }).trim();
   } catch {
     return '';

--- a/src/orchestrate/verify-gate.ts
+++ b/src/orchestrate/verify-gate.ts
@@ -79,6 +79,7 @@ export function runGate(
       detached: process.platform !== 'win32',
       stdio: ['ignore', 'pipe', 'pipe'],
       env: { ...process.env, FORCE_COLOR: '0', NO_COLOR: '1' },
+      windowsHide: true,
     });
 
     const collectOutput = (data: Buffer) => {

--- a/src/orchestrate/worktree.ts
+++ b/src/orchestrate/worktree.ts
@@ -43,6 +43,7 @@ export function createWorktree(
     cwd: projectDir,
     encoding: 'utf-8',
     timeout: 30_000,
+    windowsHide: true,
   });
 
   return { worktreePath, branch };
@@ -78,18 +79,21 @@ export function mergeWorktree(
         cwd: worktreePath,
         encoding: 'utf-8',
         timeout: 15_000,
+        windowsHide: true,
       });
       // Check if there's anything to commit
       const status = execSync('git status --porcelain', {
         cwd: worktreePath,
         encoding: 'utf-8',
         timeout: 5_000,
+        windowsHide: true,
       }).trim();
       if (status) {
         execSync('git commit -m "task: agent work" --no-verify', {
           cwd: worktreePath,
           encoding: 'utf-8',
           timeout: 15_000,
+          windowsHide: true,
         });
       }
       // else: nothing to commit — merge will be a no-op
@@ -106,12 +110,18 @@ export function mergeWorktree(
       cwd: projectDir,
       encoding: 'utf-8',
       timeout: 30_000,
+      windowsHide: true,
     });
     return { success: true };
   } catch (err) {
     // Abort the failed merge to leave working tree clean
     try {
-      execSync('git merge --abort', { cwd: projectDir, encoding: 'utf-8', timeout: 5_000 });
+      execSync('git merge --abort', {
+        cwd: projectDir,
+        encoding: 'utf-8',
+        timeout: 5_000,
+        windowsHide: true,
+      });
     } catch { /* best-effort */ }
 
     const msg = err instanceof Error ? err.message : String(err);
@@ -134,6 +144,7 @@ export function removeWorktree(
       cwd: projectDir,
       encoding: 'utf-8',
       timeout: 10_000,
+      windowsHide: true,
     });
   } catch {
     // If git worktree remove fails, try manual cleanup
@@ -141,7 +152,12 @@ export function removeWorktree(
       try { rmSync(worktreePath, { recursive: true, force: true }); } catch { /* best-effort */ }
     }
     try {
-      execSync('git worktree prune', { cwd: projectDir, encoding: 'utf-8', timeout: 5_000 });
+      execSync('git worktree prune', {
+        cwd: projectDir,
+        encoding: 'utf-8',
+        timeout: 5_000,
+        windowsHide: true,
+      });
     } catch { /* best-effort */ }
   }
 
@@ -152,6 +168,7 @@ export function removeWorktree(
         cwd: projectDir,
         encoding: 'utf-8',
         timeout: 5_000,
+        windowsHide: true,
       });
     } catch { /* may already be deleted or is current branch */ }
   }
@@ -169,6 +186,7 @@ export function listWorktrees(projectDir: string): Array<{ path: string; branch:
       cwd: projectDir,
       encoding: 'utf-8',
       timeout: 5_000,
+      windowsHide: true,
     });
 
     const worktrees: Array<{ path: string; branch: string | null }> = [];

--- a/src/project/detector.ts
+++ b/src/project/detector.ts
@@ -127,6 +127,7 @@ function getGitRootWithDiagnostics(cwd: string): { root: string | null; failure:
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,
+      windowsHide: true,
     }).trim();
     return root ? { root, failure: null } : { root: null, failure: null };
   } catch (err) {
@@ -166,6 +167,7 @@ function getGitRemote(cwd: string): string | null {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,
+      windowsHide: true,
     }).trim();
     return remote || null;
   } catch {

--- a/src/runtime/vector-backfill-runner.ts
+++ b/src/runtime/vector-backfill-runner.ts
@@ -84,7 +84,9 @@ export function launchDetachedVectorBackfill(
   try {
     const child = (options.spawn ?? spawn)(process.execPath, [runnerPath], {
       cwd: request.projectRoot,
-      detached: true,
+      // Windows creates a console for detached children. This worker is backed
+      // by the durable queue, so unref alone is sufficient there.
+      detached: process.platform !== 'win32',
       stdio: 'ignore',
       // The request contains only local project metadata, never credentials.
       // Environment transport avoids a live stdin pipe keeping the CLI alive.

--- a/src/server.ts
+++ b/src/server.ts
@@ -4251,7 +4251,7 @@ export async function createMemorixServer(
           process.platform === 'win32' ? `start "" "${projectUrl}"` :
             process.platform === 'darwin' ? `open "${projectUrl}"` :
               `xdg-open "${projectUrl}"`;
-        exec(cmd, () => { });
+        exec(cmd, { windowsHide: true }, () => { });
 
         return {
           content: [{
@@ -4300,7 +4300,7 @@ export async function createMemorixServer(
             process.platform === 'win32' ? `start "" "${projectUrl}"` :
               process.platform === 'darwin' ? `open "${projectUrl}"` :
                 `xdg-open "${projectUrl}"`;
-          exec(cmd, () => { });
+          exec(cmd, { windowsHide: true }, () => { });
           return {
             content: [{ type: 'text' as const, text: `Dashboard is already running at ${url}. Switched to project: ${project.name} (${project.id}).` }],
           };

--- a/tests/cli/windows-child-process.test.ts
+++ b/tests/cli/windows-child-process.test.ts
@@ -1,0 +1,51 @@
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const childProcess = vi.hoisted(() => ({
+  execSync: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => childProcess);
+
+import { detectProjectWithDiagnostics } from '../../src/project/detector.js';
+
+describe('Windows CLI child process behavior', () => {
+  afterEach(() => {
+    childProcess.execSync.mockReset();
+  });
+
+  it('hides the heap-size restart subprocess in the published CLI banner', () => {
+    const config = readFileSync(join(process.cwd(), 'tsup.config.ts'), 'utf8');
+    expect(config).toContain('windowsHide:true');
+  });
+
+  it('does not create a detached Windows console for the background service', () => {
+    const command = readFileSync(join(process.cwd(), 'src/cli/commands/background.ts'), 'utf8');
+    expect(command).toContain("detached: process.platform !== 'win32'");
+    expect(command).toContain('windowsHide: true');
+  });
+
+  it('hides the slow-path Git probes used by normal CLI commands', () => {
+    const workspace = mkdtempSync(join(tmpdir(), 'memorix-window-hide-'));
+    try {
+      childProcess.execSync
+        .mockReturnValueOnce(workspace)
+        .mockReturnValueOnce('https://github.com/AVIDS2/memorix.git');
+
+      const result = detectProjectWithDiagnostics(workspace);
+
+      expect(result.project?.id).toBe('AVIDS2/memorix');
+      expect(childProcess.execSync).toHaveBeenCalledTimes(2);
+      const [rootCommand, rootOptions] = childProcess.execSync.mock.calls[0]!;
+      const [remoteCommand, remoteOptions] = childProcess.execSync.mock.calls[1]!;
+      expect(rootCommand).toBe('git -c safe.directory=* rev-parse --show-toplevel');
+      expect(rootOptions.windowsHide).toBe(true);
+      expect(remoteCommand).toBe('git -c safe.directory=* remote get-url origin');
+      expect(remoteOptions.windowsHide).toBe(true);
+    } finally {
+      rmSync(workspace, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/orchestrate/coordinator.test.ts
+++ b/tests/orchestrate/coordinator.test.ts
@@ -522,7 +522,7 @@ describe('Coordinator', () => {
     // (stale events are only for external agents)
     const staleEvents = events.filter(e => e.type === 'agent:stale');
     expect(staleEvents.length).toBe(0);
-  });
+  }, 15_000);
 
   // ═══════════════════════════════════════════════════════════════
   // Blocker 2: Orchestrator owns task lifecycle (方案 A)

--- a/tests/runtime/vector-backfill-runner.test.ts
+++ b/tests/runtime/vector-backfill-runner.test.ts
@@ -8,6 +8,14 @@ import {
   resolveVectorBackfillRunnerPath,
 } from '../../src/runtime/vector-backfill-runner.js';
 
+type SpawnOptions = {
+  cwd?: string;
+  detached?: boolean;
+  stdio?: unknown;
+  windowsHide?: boolean;
+  env?: NodeJS.ProcessEnv;
+};
+
 describe('detached vector backfill runner', () => {
   const request = {
     projectId: 'AVIDS2/memorix',
@@ -40,19 +48,44 @@ describe('detached vector backfill runner', () => {
     });
 
     expect(started).toBe(true);
-    expect(spawn).toHaveBeenCalledWith(
-      process.execPath,
-      ['E:/pkg/dist/vector-backfill-runner.js'],
-      expect.objectContaining({
-        cwd: request.projectRoot,
-        detached: true,
-        stdio: 'ignore',
-        windowsHide: true,
-        env: expect.objectContaining({
-          MEMORIX_VECTOR_BACKFILL_REQUEST: JSON.stringify(request),
-        }),
-      }),
-    );
+    expect(spawn).toHaveBeenCalledOnce();
+    const [command, args, rawOptions] = spawn.mock.calls[0]!;
+    const options = rawOptions as SpawnOptions;
+    expect(command).toBe(process.execPath);
+    expect(args).toEqual(['E:/pkg/dist/vector-backfill-runner.js']);
+    expect(options.cwd).toBe(request.projectRoot);
+    expect(options.detached).toBe(process.platform !== 'win32');
+    expect(options.stdio).toBe('ignore');
+    expect(options.windowsHide).toBe(true);
+    expect(options.env?.MEMORIX_VECTOR_BACKFILL_REQUEST).toBe(JSON.stringify(request));
     expect(unref).toHaveBeenCalledOnce();
+  });
+
+  it('does not create a detached Windows console for a recoverable backfill job', () => {
+    const platform = Object.getOwnPropertyDescriptor(process, 'platform');
+    const unref = vi.fn();
+    const spawn = vi.fn(() => ({ unref }));
+
+    Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+    try {
+      const started = launchDetachedVectorBackfill(request, {
+        runnerPath: 'E:/pkg/dist/vector-backfill-runner.js',
+        exists: () => true,
+        spawn: spawn as never,
+      });
+
+      expect(started).toBe(true);
+      expect(spawn).toHaveBeenCalledOnce();
+      const [command, args, rawOptions] = spawn.mock.calls[0]!;
+      const options = rawOptions as SpawnOptions;
+      expect(command).toBe(process.execPath);
+      expect(args).toEqual(['E:/pkg/dist/vector-backfill-runner.js']);
+      expect(options.detached).toBe(false);
+      expect(options.stdio).toBe('ignore');
+      expect(options.windowsHide).toBe(true);
+      expect(unref).toHaveBeenCalledOnce();
+    } finally {
+      Object.defineProperty(process, 'platform', platform!);
+    }
   });
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -50,7 +50,7 @@ export default defineConfig([
         'import {spawnSync as __ms} from "node:child_process";',
         'import {fileURLToPath as __fu} from "node:url";',
         'if(!process.env.__MEMORIX_HEAP){process.env.__MEMORIX_HEAP="1";',
-        'let r=__ms(process.execPath,["--max-old-space-size=4096",__fu(import.meta.url),...process.argv.slice(2)],{stdio:"inherit",env:process.env});',
+        'let r=__ms(process.execPath,["--max-old-space-size=4096",__fu(import.meta.url),...process.argv.slice(2)],{stdio:"inherit",env:process.env,windowsHide:true});',
         'process.exit(r.status??1);}',
         'import {createRequire as __memorix_cjsRequire} from "module";',
         'const require = __memorix_cjsRequire(import.meta.url);',


### PR DESCRIPTION
Fixes #163. Audits Memorix and bundled memcode child-process launches, hides Windows child windows, and avoids detached Windows consoles for recoverable background work. Verified with lint, build, focused regression tests (161 assertions), registry check, npm pack dry run, and a real CLI memory store/recent smoke.