### PR TITLE
Add MiniMax image generation provider

### DIFF
--- a/packages/ai/scripts/generate-image-models.ts
+++ b/packages/ai/scripts/generate-image-models.ts
@@ -3,12 +3,17 @@
 import { writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath, pathToFileURL } from "url";
-import type { ImagesModel } from "../src/types.ts";
+import type { ImagesApi, ImagesModel } from "../src/types.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const packageRoot = join(__dirname, "..");
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+const MINIMAX_IMAGE_MODEL_IDS = ["image-01", "image-01-live"] as const;
+const MINIMAX_IMAGE_VARIANTS = [
+	{ provider: "minimax", baseUrl: "https://api.minimax.io/v1/image_generation" },
+	{ provider: "minimax-cn", baseUrl: "https://api.minimaxi.com/v1/image_generation" },
+] as const;
 const MIN_GENERATED_IMAGE_MODEL_COUNT = 1;
 const CATALOG_SHRINK_OVERRIDE_ENV = "MEMORIX_ALLOW_MODEL_CATALOG_SHRINK";
 
@@ -78,6 +83,21 @@ async function fetchOpenRouterImageModels(): Promise<ImagesModel<"openrouter-ima
 	}
 }
 
+function getMiniMaxImageModels(): ImagesModel<"minimax-images">[] {
+	return MINIMAX_IMAGE_VARIANTS.flatMap(({ provider, baseUrl }) =>
+		MINIMAX_IMAGE_MODEL_IDS.map((modelId) => ({
+			id: modelId,
+			name: modelId,
+			api: "minimax-images",
+			provider,
+			baseUrl,
+			input: ["text"],
+			output: ["image"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		})),
+	);
+}
+
 export async function loadExistingGeneratedImageModelCount(): Promise<number> {
 	try {
 		const generatedUrl = new URL("../src/image-models.generated.ts", import.meta.url).href;
@@ -104,14 +124,8 @@ export function assertImageModelCatalogRefreshSafe(nextCount: number, existingCo
 	);
 }
 
-function generateImageModelsFile(models: ImagesModel<"openrouter-images">[]): string {
-	const imageModelsByProvider = {
-		openrouter: Object.fromEntries(
-			models
-				.sort((a, b) => a.id.localeCompare(b.id))
-				.map((model) => [
-					model.id,
-					`{
+function serializeImageModel(model: ImagesModel<ImagesApi>): string {
+	return `{
 			id: ${JSON.stringify(model.id)},
 			name: ${JSON.stringify(model.name)},
 			api: ${JSON.stringify(model.api)},
@@ -120,14 +134,24 @@ function generateImageModelsFile(models: ImagesModel<"openrouter-images">[]): st
 			input: ${JSON.stringify(model.input)},
 			output: ${JSON.stringify(model.output)},
 			cost: ${JSON.stringify(model.cost, null, 2).replace(/^/gm, "\t")}
-		} satisfies ImagesModel<${JSON.stringify(model.api)}>`,
-				]),
-		),
-	};
+		} satisfies ImagesModel<${JSON.stringify(model.api)}>`;
+}
 
-	const providerEntries = Object.entries(imageModelsByProvider)
+function generateImageModelsFile(models: ImagesModel<ImagesApi>[]): string {
+	const imageModelsByProvider = new Map<string, Map<string, string>>();
+	for (const model of models) {
+		let providerModels = imageModelsByProvider.get(model.provider);
+		if (!providerModels) {
+			providerModels = new Map();
+			imageModelsByProvider.set(model.provider, providerModels);
+		}
+		providerModels.set(model.id, serializeImageModel(model));
+	}
+
+	const providerEntries = Array.from(imageModelsByProvider.entries())
 		.map(([provider, providerModels]) => {
-			const modelEntries = Object.entries(providerModels)
+			const modelEntries = Array.from(providerModels.entries())
+				.sort(([left], [right]) => left.localeCompare(right))
 				.map(([id, serialized]) => `\t\t${JSON.stringify(id)}: ${serialized},`)
 				.join("\n");
 			return `\t${JSON.stringify(provider)}: {\n${modelEntries}\n\t},`;
@@ -146,7 +170,7 @@ ${providerEntries}
 }
 
 async function main(): Promise<void> {
-	const models = await fetchOpenRouterImageModels();
+	const models: ImagesModel<ImagesApi>[] = [...(await fetchOpenRouterImageModels()), ...getMiniMaxImageModels()];
 	const existingModelCount = await loadExistingGeneratedImageModelCount();
 	assertImageModelCatalogRefreshSafe(models.length, existingModelCount);
 	const output = generateImageModelsFile(models);

--- a/packages/ai/src/image-models.generated.ts
+++ b/packages/ai/src/image-models.generated.ts
@@ -531,4 +531,68 @@ export const IMAGE_MODELS = {
 	}
 		} satisfies ImagesModel<"openrouter-images">,
 	},
+	"minimax": {
+		"image-01": {
+			id: "image-01",
+			name: "image-01",
+			api: "minimax-images",
+			provider: "minimax",
+			baseUrl: "https://api.minimax.io/v1/image_generation",
+			input: ["text"],
+			output: ["image"],
+			cost: 	{
+	  "input": 0,
+	  "output": 0,
+	  "cacheRead": 0,
+	  "cacheWrite": 0
+	}
+		} satisfies ImagesModel<"minimax-images">,
+		"image-01-live": {
+			id: "image-01-live",
+			name: "image-01-live",
+			api: "minimax-images",
+			provider: "minimax",
+			baseUrl: "https://api.minimax.io/v1/image_generation",
+			input: ["text"],
+			output: ["image"],
+			cost: 	{
+	  "input": 0,
+	  "output": 0,
+	  "cacheRead": 0,
+	  "cacheWrite": 0
+	}
+		} satisfies ImagesModel<"minimax-images">,
+	},
+	"minimax-cn": {
+		"image-01": {
+			id: "image-01",
+			name: "image-01",
+			api: "minimax-images",
+			provider: "minimax-cn",
+			baseUrl: "https://api.minimaxi.com/v1/image_generation",
+			input: ["text"],
+			output: ["image"],
+			cost: 	{
+	  "input": 0,
+	  "output": 0,
+	  "cacheRead": 0,
+	  "cacheWrite": 0
+	}
+		} satisfies ImagesModel<"minimax-images">,
+		"image-01-live": {
+			id: "image-01-live",
+			name: "image-01-live",
+			api: "minimax-images",
+			provider: "minimax-cn",
+			baseUrl: "https://api.minimaxi.com/v1/image_generation",
+			input: ["text"],
+			output: ["image"],
+			cost: 	{
+	  "input": 0,
+	  "output": 0,
+	  "cacheRead": 0,
+	  "cacheWrite": 0
+	}
+		} satisfies ImagesModel<"minimax-images">,
+	},
 } as const satisfies Record<string, Record<string, ImagesModel<ImagesApi>>>;

--- a/packages/ai/src/providers/images/minimax.ts
+++ b/packages/ai/src/providers/images/minimax.ts
@@ -1,0 +1,220 @@
+import type {
+	AssistantImages,
+	ImageContent,
+	ImagesContext,
+	ImagesFunction,
+	ImagesModel,
+	ImagesOptions,
+} from "../../types.ts";
+import { headersToRecord } from "../../utils/headers.ts";
+import { sanitizeSurrogates } from "../../utils/sanitize-unicode.ts";
+
+export interface MiniMaxImagesOptions extends ImagesOptions {
+	aspectRatio?: "1:1" | "16:9" | "4:3" | "3:2" | "2:3" | "3:4" | "9:16" | "21:9";
+	width?: number;
+	height?: number;
+	responseFormat?: "url" | "base64";
+	seed?: number;
+	n?: number;
+	promptOptimizer?: boolean;
+}
+
+interface MiniMaxImageGenerationRequest {
+	model: string;
+	prompt: string;
+	aspect_ratio?: MiniMaxImagesOptions["aspectRatio"];
+	width?: number;
+	height?: number;
+	response_format?: MiniMaxImagesOptions["responseFormat"];
+	seed?: number;
+	n?: number;
+	prompt_optimizer?: boolean;
+}
+
+interface MiniMaxImageGenerationResponse {
+	id?: string;
+	data?: {
+		image_urls?: string[];
+		image_base64?: string[];
+	};
+	metadata?: {
+		success_count?: number | string;
+		failed_count?: number | string;
+	};
+	base_resp?: {
+		status_code?: number;
+		status_msg?: string;
+	};
+}
+
+export const generateImagesMiniMax: ImagesFunction<"minimax-images", MiniMaxImagesOptions> = async (
+	model: ImagesModel<"minimax-images">,
+	context: ImagesContext,
+	options?: MiniMaxImagesOptions,
+) => {
+	const output: AssistantImages = {
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		output: [],
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+
+	try {
+		const apiKey = options?.apiKey;
+		if (!apiKey) {
+			throw new Error(`No API key for provider: ${model.provider}`);
+		}
+		if (options?.signal?.aborted) {
+			throw new Error("Request was aborted");
+		}
+
+		let payload = buildPayload(model, context, options);
+		const nextPayload = await options?.onPayload?.(payload, model);
+		if (nextPayload !== undefined) {
+			payload = nextPayload as MiniMaxImageGenerationRequest;
+		}
+
+		const response = await fetch(model.baseUrl, {
+			method: "POST",
+			headers: buildHeaders(apiKey, model.headers, options?.headers),
+			body: JSON.stringify(payload),
+			signal: createRequestSignal(options),
+		});
+		await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
+
+		const responseText = await response.text();
+		const responseBody = parseResponseBody(responseText);
+		const statusCode = responseBody.base_resp?.status_code;
+		if (!response.ok || (statusCode !== undefined && statusCode !== 0)) {
+			throw new Error(getErrorMessage(response, responseBody));
+		}
+
+		output.responseId = responseBody.id;
+		for (const imageUrl of responseBody.data?.image_urls ?? []) {
+			output.output.push(await imageUrlToContent(imageUrl, options));
+		}
+		for (const imageBase64 of responseBody.data?.image_base64 ?? []) {
+			output.output.push(base64ToContent(imageBase64));
+		}
+
+		if (output.output.length === 0) {
+			throw new Error("MiniMax image generation returned no images");
+		}
+
+		return output;
+	} catch (error) {
+		output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+		output.errorMessage = error instanceof Error ? error.message : String(error);
+		return output;
+	}
+};
+
+function buildPayload(
+	model: ImagesModel<"minimax-images">,
+	context: ImagesContext,
+	options?: MiniMaxImagesOptions,
+): MiniMaxImageGenerationRequest {
+	if (context.input.some((item) => item.type === "image")) {
+		throw new Error(`Model ${model.id} does not support image input`);
+	}
+
+	const prompt = context.input
+		.filter((item) => item.type === "text")
+		.map((item) => sanitizeSurrogates(item.text).trim())
+		.filter(Boolean)
+		.join("\n");
+	if (!prompt) {
+		throw new Error("MiniMax image generation requires a text prompt");
+	}
+
+	return {
+		model: model.id,
+		prompt,
+		...(options?.aspectRatio !== undefined ? { aspect_ratio: options.aspectRatio } : {}),
+		...(options?.width !== undefined ? { width: options.width } : {}),
+		...(options?.height !== undefined ? { height: options.height } : {}),
+		...(options?.responseFormat !== undefined ? { response_format: options.responseFormat } : {}),
+		...(options?.seed !== undefined ? { seed: options.seed } : {}),
+		...(options?.n !== undefined ? { n: options.n } : {}),
+		...(options?.promptOptimizer !== undefined ? { prompt_optimizer: options.promptOptimizer } : {}),
+	};
+}
+
+function buildHeaders(
+	apiKey: string,
+	modelHeaders?: Record<string, string>,
+	optionHeaders?: Record<string, string>,
+): Headers {
+	const headers = new Headers({
+		Authorization: `Bearer ${apiKey}`,
+		"Content-Type": "application/json",
+	});
+	for (const [name, value] of Object.entries(modelHeaders ?? {})) headers.set(name, value);
+	for (const [name, value] of Object.entries(optionHeaders ?? {})) headers.set(name, value);
+	return headers;
+}
+
+function createRequestSignal(options?: MiniMaxImagesOptions): AbortSignal | undefined {
+	if (options?.timeoutMs === undefined) return options?.signal;
+	if (!Number.isFinite(options.timeoutMs) || options.timeoutMs < 0) {
+		throw new Error(`Invalid timeoutMs: ${String(options.timeoutMs)}`);
+	}
+	const timeoutSignal = AbortSignal.timeout(Math.floor(options.timeoutMs));
+	return options.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal;
+}
+
+function parseResponseBody(responseText: string): MiniMaxImageGenerationResponse {
+	if (!responseText) return {};
+	try {
+		return JSON.parse(responseText) as MiniMaxImageGenerationResponse;
+	} catch {
+		throw new Error("MiniMax image generation returned invalid JSON");
+	}
+}
+
+function getErrorMessage(response: Response, responseBody: MiniMaxImageGenerationResponse): string {
+	const statusMessage = responseBody.base_resp?.status_msg?.trim();
+	if (statusMessage) return `MiniMax image generation failed: ${statusMessage}`;
+	const statusCode = responseBody.base_resp?.status_code;
+	if (statusCode !== undefined) return `MiniMax image generation failed with status code ${statusCode}`;
+	return `MiniMax image generation failed with HTTP ${response.status}`;
+}
+
+async function imageUrlToContent(imageUrl: string, options?: MiniMaxImagesOptions): Promise<ImageContent> {
+	if (imageUrl.startsWith("data:")) return base64ToContent(imageUrl);
+	const url = new URL(imageUrl);
+	if (url.protocol !== "http:" && url.protocol !== "https:") {
+		throw new Error("MiniMax image generation returned an unsupported image URL");
+	}
+
+	const response = await fetch(url, { signal: createRequestSignal(options) });
+	if (!response.ok) {
+		throw new Error(`Failed to download generated image: HTTP ${response.status}`);
+	}
+	const data = Buffer.from(await response.arrayBuffer()).toString("base64");
+	const contentType = response.headers.get("content-type")?.split(";", 1)[0]?.trim();
+	return {
+		type: "image",
+		mimeType: contentType || detectImageMimeType(data),
+		data,
+	};
+}
+
+function base64ToContent(value: string): ImageContent {
+	const dataUrlMatch = value.match(/^data:([^;,]+);base64,(.+)$/s);
+	const data = (dataUrlMatch?.[2] ?? value).replace(/\s+/g, "");
+	return {
+		type: "image",
+		mimeType: dataUrlMatch?.[1] ?? detectImageMimeType(data),
+		data,
+	};
+}
+
+function detectImageMimeType(data: string): string {
+	if (data.startsWith("iVBORw0KGgo")) return "image/png";
+	if (data.startsWith("R0lGOD")) return "image/gif";
+	if (data.startsWith("UklGR")) return "image/webp";
+	return "image/jpeg";
+}

--- a/packages/ai/src/providers/images/register-builtins.ts
+++ b/packages/ai/src/providers/images/register-builtins.ts
@@ -1,14 +1,32 @@
 import { registerImagesApiProvider } from "../../images-api-registry.ts";
-import type { AssistantImages, ImagesContext, ImagesFunction, ImagesModel, ImagesOptions } from "../../types.ts";
+import type {
+	AssistantImages,
+	ImagesApi,
+	ImagesContext,
+	ImagesFunction,
+	ImagesModel,
+	ImagesOptions,
+} from "../../types.ts";
+import type {
+	generateImagesMiniMax as generateImagesMiniMaxFunction,
+	MiniMaxImagesOptions,
+} from "./minimax.ts";
 import type { generateImagesOpenRouter as generateImagesOpenRouterFunction } from "./openrouter.ts";
+
+export type { MiniMaxImagesOptions } from "./minimax.ts";
+
+interface MiniMaxImagesProviderModule {
+	generateImagesMiniMax: typeof generateImagesMiniMaxFunction;
+}
 
 interface OpenRouterImagesProviderModule {
 	generateImagesOpenRouter: typeof generateImagesOpenRouterFunction;
 }
 
 let openRouterImagesProviderModulePromise: Promise<OpenRouterImagesProviderModule> | undefined;
+let miniMaxImagesProviderModulePromise: Promise<MiniMaxImagesProviderModule> | undefined;
 
-function createLazyLoadErrorImages(model: ImagesModel<"openrouter-images">, error: unknown): AssistantImages {
+function createLazyLoadErrorImages<TApi extends ImagesApi>(model: ImagesModel<TApi>, error: unknown): AssistantImages {
 	return {
 		api: model.api,
 		provider: model.provider,
@@ -18,6 +36,13 @@ function createLazyLoadErrorImages(model: ImagesModel<"openrouter-images">, erro
 		errorMessage: error instanceof Error ? error.message : String(error),
 		timestamp: Date.now(),
 	};
+}
+
+function loadMiniMaxImagesProviderModule(): Promise<MiniMaxImagesProviderModule> {
+	miniMaxImagesProviderModulePromise ||= import("./minimax.ts").then(
+		(module) => module as MiniMaxImagesProviderModule,
+	);
+	return miniMaxImagesProviderModulePromise;
 }
 
 function loadOpenRouterImagesProviderModule(): Promise<OpenRouterImagesProviderModule> {
@@ -40,10 +65,27 @@ export const generateImagesOpenRouter: ImagesFunction<"openrouter-images", Image
 	}
 };
 
+export const generateImagesMiniMax: ImagesFunction<"minimax-images", MiniMaxImagesOptions> = async (
+	model: ImagesModel<"minimax-images">,
+	context: ImagesContext,
+	options?: MiniMaxImagesOptions,
+) => {
+	try {
+		const module = await loadMiniMaxImagesProviderModule();
+		return await module.generateImagesMiniMax(model, context, options);
+	} catch (error) {
+		return createLazyLoadErrorImages(model, error);
+	}
+};
+
 export function registerBuiltInImagesApiProviders(): void {
 	registerImagesApiProvider({
 		api: "openrouter-images",
 		generateImages: generateImagesOpenRouter,
+	});
+	registerImagesApiProvider({
+		api: "minimax-images",
+		generateImages: generateImagesMiniMax,
 	});
 }
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -16,7 +16,7 @@ export type KnownApi =
 
 export type Api = KnownApi | (string & {});
 
-export type KnownImagesApi = "openrouter-images";
+export type KnownImagesApi = "openrouter-images" | "minimax-images";
 
 export type ImagesApi = KnownImagesApi | (string & {});
 
@@ -58,7 +58,7 @@ export type KnownProvider =
 	| "xiaomi-token-plan-sgp";
 export type Provider = KnownProvider | string;
 
-export type KnownImagesProvider = "openrouter";
+export type KnownImagesProvider = "openrouter" | "minimax" | "minimax-cn";
 
 export type ImagesProvider = KnownImagesProvider | string;
 

--- a/packages/ai/test/minimax-images.test.ts
+++ b/packages/ai/test/minimax-images.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getImageModel, getImageModels } from "../src/image-models.ts";
+import { generateImages } from "../src/images.ts";
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("MiniMax images", () => {
+	it("registers global and China image models", () => {
+		const globalModel = getImageModel("minimax", "image-01");
+		const chinaModel = getImageModel("minimax-cn", "image-01-live");
+
+		expect(globalModel).toMatchObject({
+			api: "minimax-images",
+			provider: "minimax",
+			baseUrl: "https://api.minimax.io/v1/image_generation",
+			input: ["text"],
+			output: ["image"],
+		});
+		expect(chinaModel).toMatchObject({
+			api: "minimax-images",
+			provider: "minimax-cn",
+			baseUrl: "https://api.minimaxi.com/v1/image_generation",
+		});
+		expect(getImageModels("minimax").map((model) => model.id)).toEqual(["image-01", "image-01-live"]);
+	});
+
+	it("sends supported text-to-image fields and parses base64 output", async () => {
+		const fetchMock = vi.fn(async () =>
+			new Response(
+				JSON.stringify({
+					id: "image-request-1",
+					data: { image_base64: ["iVBORw0KGgo="] },
+					metadata: { success_count: 1, failed_count: 0 },
+					base_resp: { status_code: 0, status_msg: "success" },
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json", "X-Request-Id": "image-request-1" } },
+			),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const onResponse = vi.fn();
+
+		const output = await generateImages(
+			getImageModel("minimax", "image-01"),
+			{ input: [{ type: "text", text: "Generate a blue square" }] },
+			{
+				apiKey: "test-key",
+				aspectRatio: "1:1",
+				width: 1024,
+				height: 1024,
+				responseFormat: "base64",
+				seed: 42,
+				n: 1,
+				promptOptimizer: true,
+				onResponse,
+			},
+		);
+
+		expect(output).toMatchObject({
+			responseId: "image-request-1",
+			stopReason: "stop",
+			output: [{ type: "image", mimeType: "image/png", data: "iVBORw0KGgo=" }],
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [url, request] = fetchMock.mock.calls[0];
+		expect(url).toBe("https://api.minimax.io/v1/image_generation");
+		expect(request?.method).toBe("POST");
+		expect(new Headers(request?.headers).get("authorization")).toBe("Bearer test-key");
+		expect(JSON.parse(String(request?.body))).toEqual({
+			model: "image-01",
+			prompt: "Generate a blue square",
+			aspect_ratio: "1:1",
+			width: 1024,
+			height: 1024,
+			response_format: "base64",
+			seed: 42,
+			n: 1,
+			prompt_optimizer: true,
+		});
+		expect(onResponse).toHaveBeenCalledWith(
+			{ status: 200, headers: expect.objectContaining({ "x-request-id": "image-request-1" }) },
+			expect.objectContaining({ id: "image-01" }),
+		);
+	});
+
+	it("downloads URL output from the China endpoint", async () => {
+		const imageBytes = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+		const fetchMock = vi.fn(async (input: string | URL | Request) => {
+			const url = input.toString();
+			if (url === "https://api.minimaxi.com/v1/image_generation") {
+				return new Response(
+					JSON.stringify({
+						data: { image_urls: ["https://images.example.test/generated.png"] },
+						base_resp: { status_code: 0 },
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			return new Response(imageBytes, { status: 200, headers: { "Content-Type": "image/png" } });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const output = await generateImages(getImageModel("minimax-cn", "image-01-live"), {
+			input: [{ type: "text", text: "Generate a city skyline" }],
+		}, { apiKey: "test-key" });
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(output.stopReason).toBe("stop");
+		expect(output.output[0]).toEqual({
+			type: "image",
+			mimeType: "image/png",
+			data: Buffer.from(imageBytes).toString("base64"),
+		});
+	});
+
+	it("returns API errors without throwing", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () =>
+				new Response(JSON.stringify({ base_resp: { status_code: 2013, status_msg: "Invalid input" } }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+			),
+		);
+
+		const output = await generateImages(
+			getImageModel("minimax", "image-01"),
+			{ input: [{ type: "text", text: "Generate an image" }] },
+			{ apiKey: "test-key" },
+		);
+
+		expect(output.stopReason).toBe("error");
+		expect(output.errorMessage).toBe("MiniMax image generation failed: Invalid input");
+	});
+
+	it("returns an aborted result for an aborted signal", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+		const controller = new AbortController();
+		controller.abort();
+
+		const output = await generateImages(
+			getImageModel("minimax", "image-01"),
+			{ input: [{ type: "text", text: "Generate an image" }] },
+			{ apiKey: "test-key", signal: controller.signal },
+		);
+
+		expect(output.stopReason).toBe("aborted");
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
Reason: Add direct MiniMax text-to-image generation for global and China endpoints.

Changes:
- Register a dedicated image generation API with global and China model catalogs.
- Send supported generation options with bearer authentication and payload/response hooks.
- Parse base64 and URL image responses with API, HTTP, timeout, and abort handling.
- Add mocked coverage for regional lookup, request payloads, response formats, and failures.

Checks:
- `npm --workspace @memorix/ai run build`
- `npm --workspace @memorix/ai test -- minimax-images.test.ts openrouter-images.test.ts`
- `npm run lint`
- `npm --workspace @memorix/ai test` (one unchanged generated-catalog assertion fails)
