### PR TITLE
fix: release 1.3.2 reliability audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.2] - 2026-08-02
+
+### Fixed
+- **Windows background lifecycle** -- Background Control Plane startup now uses a hidden, independent Windows launcher that returns the real Node PID immediately, writes managed state before readiness checks, and avoids both console flashes and host-reclaimed child processes.
+- **Safe stale-process handling** -- Background start, stop, and ensure no longer kill a live PID merely because old local state is unhealthy. A forced stop happens only after the health endpoint proves the PID belongs to the registered Memorix service.
+- **Truthful setup preview** -- `memorix setup --dry-run`, including `--global`, now performs no file, plugin, hook, MCP, or agent-setting changes. This is covered for Codex user-level paths.
+- **CLI failure boundaries** -- `background`, `serve-http`, and `dashboard` now reject malformed or out-of-range ports before starting a service; background log line limits are bounded, and these expected input errors are concise rather than internal stack traces.
+- **Recoverable orchestration work** -- Failed or timed-out orchestration worktrees retain uncommitted work for inspection rather than being force-removed; Git helper calls use argument arrays and bounded inputs.
+- **Dependency hardening** -- Refreshed the MCP SDK and transitive package overrides; production dependency audit is clean.
+
 ## [1.3.1] - 2026-07-31
 
 ### Fixed

--- a/compose.yaml
+++ b/compose.yaml
@@ -3,7 +3,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    image: memorix:1.1.4-local
+    image: memorix:local
     init: true
     restart: unless-stopped
     ports:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",
@@ -16,7 +16,7 @@
       ],
       "dependencies": {
         "@clack/prompts": "^0.9.1",
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "@orama/orama": "^3.1.0",
         "@orama/plugin-data-persistence": "^3.1.0",
         "citty": "^0.1.6",
@@ -651,9 +651,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -661,9 +661,9 @@
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
       "cpu": [
         "ppc64"
       ],
@@ -678,9 +678,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
       "cpu": [
         "arm"
       ],
@@ -695,9 +695,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
       "cpu": [
         "arm64"
       ],
@@ -712,9 +712,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
       "cpu": [
         "x64"
       ],
@@ -729,9 +729,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
       "cpu": [
         "arm64"
       ],
@@ -746,9 +746,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
       "cpu": [
         "x64"
       ],
@@ -763,9 +763,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
       "cpu": [
         "arm64"
       ],
@@ -780,9 +780,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
       "cpu": [
         "x64"
       ],
@@ -797,9 +797,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
       "cpu": [
         "arm"
       ],
@@ -814,9 +814,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
       "cpu": [
         "arm64"
       ],
@@ -831,9 +831,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
       "cpu": [
         "ia32"
       ],
@@ -848,9 +848,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
       "cpu": [
         "loong64"
       ],
@@ -865,9 +865,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
       "cpu": [
         "mips64el"
       ],
@@ -882,9 +882,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
       "cpu": [
         "ppc64"
       ],
@@ -899,9 +899,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
       "cpu": [
         "riscv64"
       ],
@@ -916,9 +916,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
       "cpu": [
         "s390x"
       ],
@@ -933,9 +933,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
       "cpu": [
         "x64"
       ],
@@ -950,9 +950,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
       "cpu": [
         "arm64"
       ],
@@ -967,9 +967,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
       "cpu": [
         "x64"
       ],
@@ -984,9 +984,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
       "cpu": [
         "arm64"
       ],
@@ -1001,9 +1001,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
       "cpu": [
         "x64"
       ],
@@ -1018,9 +1018,9 @@
       }
     },
     "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
       "cpu": [
         "arm64"
       ],
@@ -1035,9 +1035,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
       "cpu": [
         "x64"
       ],
@@ -1052,9 +1052,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
       "cpu": [
         "arm64"
       ],
@@ -1069,9 +1069,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
       "cpu": [
         "ia32"
       ],
@@ -1086,9 +1086,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
       "cpu": [
         "x64"
       ],
@@ -1127,12 +1127,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.12.tgz",
+      "integrity": "sha512-eWpQYr67tqJLeaSUl0Q+TquuYfUdTibpOJlUMV2FfUP7+KqCC5TufnwnlXL6mobZBJbGAYRd7ZvEBDCbLInjhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -1162,9 +1162,9 @@
       }
     },
     "node_modules/@img/colour": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
-      "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -1172,9 +1172,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -1184,19 +1184,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -1206,19 +1206,38 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -1232,9 +1251,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -1248,9 +1267,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
@@ -1264,9 +1283,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
@@ -1280,9 +1299,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
@@ -1296,9 +1315,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
@@ -1312,9 +1331,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
@@ -1328,9 +1347,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
@@ -1344,9 +1363,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
@@ -1360,9 +1379,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
@@ -1376,9 +1395,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
@@ -1388,19 +1407,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
@@ -1410,19 +1429,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
@@ -1432,19 +1451,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1454,19 +1473,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
@@ -1476,19 +1495,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
@@ -1498,19 +1517,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
@@ -1520,19 +1539,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
@@ -1542,38 +1561,54 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -1583,16 +1618,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -1602,16 +1637,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -1621,7 +1656,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -1972,12 +2007,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -3387,15 +3422,15 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4186,9 +4221,9 @@
       "optional": true
     },
     "node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -4199,32 +4234,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escape-html": {
@@ -4514,9 +4549,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -5080,9 +5115,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.26",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
-      "integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
+      "version": "4.12.33",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.33.tgz",
+      "integrity": "sha512-+SwvkaiJtxsiPjhy9LivY/1m7UsNqCJetM1BrZl9A5DkQhlbHQDU730mMiDPWjnoCYOM8Chf3WrCJw27kNTPFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -6644,9 +6679,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -7087,9 +7122,9 @@
       "optional": true
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -7107,7 +7142,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -7218,9 +7253,9 @@
       }
     },
     "node_modules/protobufjs": {
-      "version": "7.6.4",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
-      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -7724,9 +7759,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.8.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
-      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "devOptional": true,
       "license": "ISC",
       "bin": {
@@ -7820,48 +7855,53 @@
       "license": "ISC"
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/shebang-command": {
@@ -7886,9 +7926,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -8414,9 +8454,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "optional": true,
       "dependencies": {
@@ -8502,9 +8542,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memorix",
   "mcpName": "io.github.AVIDS2/memorix",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,
@@ -121,7 +121,7 @@
   },
   "dependencies": {
     "@clack/prompts": "^0.9.1",
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "@orama/orama": "^3.1.0",
     "@orama/plugin-data-persistence": "^3.1.0",
     "citty": "^0.1.6",
@@ -148,18 +148,22 @@
     "better-sqlite3": "^12.11.1"
   },
   "overrides": {
-    "tar": "^7.5.16",
+    "tar": "^7.5.22",
     "react": "19.2.7",
     "@types/react": "19.2.7",
-    "protobufjs": "^7.6.4",
+    "protobufjs": "^7.6.5",
     "lodash": "^4.18.1",
-    "hono": "^4.12.26",
-    "@hono/node-server": "^1.19.14",
+    "hono": "^4.12.33",
+    "@hono/node-server": "^2.0.5",
     "express-rate-limit": "^8.5.2",
     "path-to-regexp": "^8.4.2",
     "js-yaml": "^3.15.0",
     "ajv": "^8.20.0",
-    "fast-uri": "^3.1.2"
+    "fast-uri": "^3.1.5",
+    "shell-quote": "^1.10.0",
+    "postcss": "^8.5.25",
+    "esbuild": "^0.28.1",
+    "sharp": "^0.35.3"
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.0",

--- a/packages/tui/src/autocomplete.ts
+++ b/packages/tui/src/autocomplete.ts
@@ -163,6 +163,7 @@ async function walkDirectoryWithFd(
 
 		const child = spawn(fdPath, args, {
 			stdio: ["ignore", "pipe", "pipe"],
+			windowsHide: true,
 		});
 		let stdout = "";
 		let resolved = false;

--- a/packages/tui/src/terminal-image.ts
+++ b/packages/tui/src/terminal-image.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 
 export type ImageProtocol = "kitty" | "iterm2" | null;
 
@@ -48,10 +48,11 @@ export function setCellDimensions(dims: CellDimensions): void {
  */
 function probeTmuxHyperlinks(): boolean {
 	try {
-		const termfeatures = execSync("tmux display-message -p '#{client_termfeatures}'", {
+		const termfeatures = execFileSync("tmux", ["display-message", "-p", "#{client_termfeatures}"], {
 			encoding: "utf8",
 			timeout: 250,
 			stdio: ["ignore", "pipe", "ignore"],
+			windowsHide: true,
 		});
 		return termfeatures
 			.split(",")

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AVIDS2/memorix",
     "source": "github"
   },
-  "version": "1.3.1",
+  "version": "1.3.2",
   "websiteUrl": "https://github.com/AVIDS2/memorix#readme",
   "icons": [
     {
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "memorix",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "runtimeHint": "npx",
       "packageArguments": [
         {

--- a/src/cli/commands/background.ts
+++ b/src/cli/commands/background.ts
@@ -19,8 +19,9 @@
 
 import { defineCommand } from 'citty';
 import * as fs from 'node:fs';
-import { spawn, execSync } from 'node:child_process';
+import { spawn, execFileSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
+import { parseTcpPort } from '../port.js';
 
 // ============================================================
 // Paths & Types
@@ -54,6 +55,33 @@ function getStateFilePath(): string {
 
 function getLogFilePath(): string {
   return getMemorixDir() + '/background.log';
+}
+
+function parseBoundedPositiveInteger(value: string | undefined, fallback: number, label: string, maximum: number): number {
+  const raw = value ?? String(fallback);
+  if (!/^[0-9]+$/u.test(raw)) {
+    throw new Error(`${label} must be a whole number between 1 and ${maximum}.`);
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed < 1 || parsed > maximum) {
+    throw new Error(`${label} must be a whole number between 1 and ${maximum}.`);
+  }
+  return parsed;
+}
+
+function parseBackgroundPort(value: string | undefined): number {
+  return parseTcpPort(value, 3211);
+}
+
+function parseLogLines(value: string | undefined): number {
+  return parseBoundedPositiveInteger(value, 50, 'Log line count', 10_000);
+}
+
+function formatBackgroundCommandError(error: unknown, includeStack = process.env.MEMORIX_DEBUG === '1'): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const base = `[memorix background] Error: ${message}\n`;
+  if (!includeStack || !(error instanceof Error) || !error.stack) return base;
+  return `${base}${error.stack}\n`;
 }
 
 // ============================================================
@@ -104,6 +132,108 @@ function killProcess(pid: number): boolean {
   }
 }
 
+function forceTerminateProcess(pid: number): void {
+  if (process.platform === 'win32') {
+    execFileSync('taskkill', ['/F', '/PID', String(pid)], { stdio: 'ignore', windowsHide: true });
+    return;
+  }
+  process.kill(pid, 'SIGKILL');
+}
+
+function quotePowerShellLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function quoteWindowsCommandArgument(value: string): string {
+  if (value.length > 0 && !/[\s"]/u.test(value)) return value;
+  return `"${value.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\*)$/g, '$1$1')}"`;
+}
+
+interface WindowsBackgroundLaunchOptions {
+  nodePath: string;
+  cliEntry: string;
+  port: number;
+  cwd: string;
+  stdoutLogFile: string;
+  stderrLogFile: string;
+}
+
+function buildWindowsBackgroundStartScript(options: WindowsBackgroundLaunchOptions): string {
+  const commandLine = [options.cliEntry, 'serve-http', '--port', String(options.port)]
+    .map(quoteWindowsCommandArgument)
+    .join(' ');
+  return [
+    '$ErrorActionPreference = "Stop";',
+    `$process = Start-Process -FilePath ${quotePowerShellLiteral(options.nodePath)}`,
+    `-ArgumentList ${quotePowerShellLiteral(commandLine)}`,
+    `-WorkingDirectory ${quotePowerShellLiteral(options.cwd)}`,
+    '-WindowStyle Hidden',
+    `-RedirectStandardOutput ${quotePowerShellLiteral(options.stdoutLogFile)}`,
+    `-RedirectStandardError ${quotePowerShellLiteral(options.stderrLogFile)}`,
+    '-PassThru;',
+    '[Console]::Out.Write($process.Id);',
+  ].join(' ');
+}
+
+async function startWindowsBackgroundService(options: WindowsBackgroundLaunchOptions): Promise<number> {
+  const script = buildWindowsBackgroundStartScript(options);
+  return new Promise((resolve, reject) => {
+    const launcher = spawn('powershell.exe', [
+      '-NoLogo',
+      '-NoProfile',
+      '-NonInteractive',
+      '-WindowStyle', 'Hidden',
+      '-Command', script,
+    ], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    const finish = (result: { pid?: number; error?: Error }): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+
+      // Start-Process may keep the launcher's inherited pipe open after it has
+      // already returned the child PID. We only need that first PID, so release
+      // the pipe instead of keeping the CLI alive waiting for PowerShell to exit.
+      launcher.stdout?.destroy();
+      launcher.stderr?.destroy();
+      launcher.unref();
+
+      if (result.pid !== undefined) resolve(result.pid);
+      else reject(result.error ?? new Error('Windows background launcher failed'));
+    };
+    const tryResolvePid = (): void => {
+      const match = stdout.match(/^\s*(\d+)\b/u);
+      if (!match) return;
+      const pid = Number.parseInt(match[1], 10);
+      if (Number.isSafeInteger(pid) && pid > 0) finish({ pid });
+    };
+    const timeout = setTimeout(() => {
+      finish({ error: new Error('Windows background launcher timed out before returning a process ID') });
+    }, 10_000);
+
+    launcher.stdout?.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+      tryResolvePid();
+    });
+    launcher.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+    launcher.on('error', (error) => finish({ error }));
+    launcher.on('close', (code) => {
+      if (settled) return;
+      const pid = Number.parseInt(stdout.trim(), 10);
+      if (code === 0 && Number.isSafeInteger(pid) && pid > 0) {
+        finish({ pid });
+        return;
+      }
+      finish({ error: new Error(`Windows background launcher failed${stderr ? `: ${stderr.trim()}` : ''}`) });
+    });
+  });
+}
+
 async function healthCheck(port: number, timeoutMs = 3000): Promise<{ ok: boolean; data?: any; error?: string }> {
   try {
     const controller = new AbortController();
@@ -152,9 +282,10 @@ export async function doStart(port: number): Promise<void> {
         console.log(`  MCP:        http://127.0.0.1:${state.port}/mcp`);
         return;
       }
-      // Stale or PID-reused — kill and auto-restart
-      console.log(`[WARN] Stale process ${state.pid} detected (PID alive but port ${state.port} not responding), cleaning up...`);
-      killProcess(state.pid);
+      // A live PID without a matching health response may have been reused by an
+      // unrelated process. Never kill it based on stale local state alone.
+      console.log(`[WARN] Registered process ${state.pid} is alive but port ${state.port} is not responding.`);
+      console.log('  Cleared stale Memorix state without stopping that process.');
       clearState();
       // Fall through to auto-restart below
     } else {
@@ -210,30 +341,41 @@ export async function doStart(port: number): Promise<void> {
     try { fs.renameSync(logFile, logFile + '.prev'); } catch { /* ok */ }
   }
 
-  const logFd = fs.openSync(logFile, 'a');
-
   // 5. Find the memorix CLI entry point
   // We need to spawn `node <cli-entry> serve-http --port <port>`
   // The entry point is the same binary that's running now
   const cliEntry = process.argv[1]; // e.g., dist/cli/index.js or node_modules/.bin/memorix
 
-  // 6. Spawn the background service. The service can safely outlive this CLI through
-  // unref() and file-backed stdio. Avoid detached on Windows because it can create a
-  // visible console even when windowsHide is set.
-  const child = spawn(process.execPath, [cliEntry, 'serve-http', '--port', String(port)], {
-    detached: process.platform !== 'win32',
-    stdio: ['ignore', logFd, logFd],
-    env: { ...process.env },
-    cwd: process.cwd(),
-    windowsHide: true,
-  });
-
-  child.unref();
-  fs.closeSync(logFd);
-
-  const pid = child.pid;
-  if (!pid) {
-    console.error('[ERROR] Failed to spawn background process');
+  // 6. Start the service without a visible console. A regular non-detached child
+  // can be reclaimed with its parent by terminal hosts on Windows; a detached Node
+  // child can flash a console. Start-Process gives us a hidden, independent child
+  // and its real Node PID. POSIX retains the direct detached child path.
+  let pid: number;
+  try {
+    if (process.platform === 'win32') {
+      pid = await startWindowsBackgroundService({
+        nodePath: process.execPath,
+        cliEntry,
+        port,
+        cwd: process.cwd(),
+        stdoutLogFile: `${logFile}.stdout`,
+        stderrLogFile: logFile,
+      });
+    } else {
+      const logFd = fs.openSync(logFile, 'a');
+      const child = spawn(process.execPath, [cliEntry, 'serve-http', '--port', String(port)], {
+        detached: true,
+        stdio: ['ignore', logFd, logFd],
+        env: { ...process.env },
+        cwd: process.cwd(),
+      });
+      child.unref();
+      fs.closeSync(logFd);
+      if (!child.pid) throw new Error('Failed to obtain background process ID');
+      pid = child.pid;
+    }
+  } catch (err) {
+    console.error(`[ERROR] Failed to start background process: ${err instanceof Error ? err.message : err}`);
     process.exitCode = 1;
     return;
   }
@@ -327,14 +469,7 @@ export async function doStop(): Promise<void> {
   if (!health.ok) {
     // PID alive but port not responding — likely PID-reused or process stuck
     console.log(`[WARN] PID ${state.pid} is alive but port ${state.port} is not responding.`);
-    console.log('  This may be a PID-reused unrelated process. Force-killing and cleaning up stale state.');
-    try {
-      if (process.platform === 'win32') {
-        execSync(`taskkill /F /PID ${state.pid}`, { stdio: 'ignore', windowsHide: true });
-      } else {
-        process.kill(state.pid, 'SIGKILL');
-      }
-    } catch { /* best effort */ }
+    console.log('  It may be a PID-reused unrelated process, so Memorix will not kill it.');
     clearState();
     try { fs.unlinkSync(getMemorixDir() + '/background.ready'); } catch { /* ignore */ }
     return;
@@ -369,13 +504,9 @@ export async function doStop(): Promise<void> {
   } catch { /* process may already be gone */ }
 
   if (!graceful && isProcessRunning(state.pid)) {
-    // Force kill on Windows
+    // Health previously proved this PID belongs to the registered Memorix service.
     try {
-      if (process.platform === 'win32') {
-        execSync(`taskkill /F /PID ${state.pid}`, { stdio: 'ignore', windowsHide: true });
-      } else {
-        process.kill(state.pid, 'SIGKILL');
-      }
+      forceTerminateProcess(state.pid);
     } catch { /* best effort */ }
   }
 
@@ -514,8 +645,8 @@ async function doEnsure(port: number): Promise<void> {
       // Already running and healthy — silent success
       return;
     }
-    // PID alive but unhealthy — kill and restart
-    killProcess(state.pid);
+    // A live PID without a matching health response may have been reused by an
+    // unrelated process. Clear stale state but never kill based on it alone.
     clearState();
   } else if (state) {
     // PID dead — clean up
@@ -600,7 +731,7 @@ export default defineCommand({
   run: async ({ args }) => {
     try {
       const subcommand = (args._ as string[])?.[0] || '';
-      const port = parseInt(args.port || '3211', 10);
+      const port = parseBackgroundPort(args.port);
 
       switch (subcommand) {
         case 'start':
@@ -622,7 +753,7 @@ export default defineCommand({
           await doEnsure(port);
           break;
         case 'logs':
-          doLogs(!!args.follow, parseInt(args.lines || '50', 10));
+          doLogs(!!args.follow, parseLogLines(args.lines));
           break;
         default:
           console.log('Memorix Background Control Plane');
@@ -648,11 +779,17 @@ export default defineCommand({
       }
     } catch (err) {
       // Ensure errors are never silently swallowed by citty
-      process.stderr.write(`[memorix background] Error: ${err instanceof Error ? err.message : err}\n`);
-      if (err instanceof Error && err.stack) {
-        process.stderr.write(err.stack + '\n');
-      }
+      process.stderr.write(formatBackgroundCommandError(err));
       process.exitCode = 1;
     }
   },
 });
+
+/** @internal Test-only helpers for Windows launcher construction. */
+export const _testing = {
+  buildWindowsBackgroundStartScript,
+  quoteWindowsCommandArgument,
+  parseBackgroundPort,
+  parseLogLines,
+  formatBackgroundCommandError,
+};

--- a/src/cli/commands/dashboard.ts
+++ b/src/cli/commands/dashboard.ts
@@ -12,6 +12,7 @@
 import { defineCommand } from 'citty';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+import { parseTcpPortOrReport } from '../port.js';
 
 export default defineCommand({
     meta: {
@@ -36,7 +37,11 @@ export default defineCommand({
             process.exit(1);
         }
         const dataDir = await getProjectDataDir(project.id);
-        const port = parseInt(args.port as string, 10) || 3210;
+        const port = parseTcpPortOrReport(args.port as string | undefined, 3210);
+        if (port === undefined) {
+            process.exitCode = 1;
+            return;
+        }
 
         // Resolve static directory relative to the compiled CLI entry point
         // CLI is at dist/cli/index.js; static files are at dist/dashboard/static.

--- a/src/cli/commands/ingest-commit.ts
+++ b/src/cli/commands/ingest-commit.ts
@@ -147,6 +147,7 @@ export default defineCommand({
       } else {
         console.error(`Failed to ingest commit: ${err}`);
         p.outro('Ingest failed. Make sure you are in a git repository.');
+        process.exitCode = 1;
       }
     }
   },

--- a/src/cli/commands/ingest-log.ts
+++ b/src/cli/commands/ingest-log.ts
@@ -20,6 +20,18 @@ type IngestLogResult = {
   errSkipped: number;
 };
 
+export function parseCommitCount(value?: string): number {
+  const raw = value?.trim() || '10';
+  if (!/^\d+$/.test(raw)) {
+    throw new Error('Commit count must be an integer between 1 and 100.');
+  }
+  const count = Number(raw);
+  if (!Number.isSafeInteger(count) || count < 1 || count > 100) {
+    throw new Error('Commit count must be an integer between 1 and 100.');
+  }
+  return count;
+}
+
 /**
  * Shared dedup logic for batch git ingest.
  * Exported so tests can exercise the production path rather than reimplementing it.
@@ -72,7 +84,14 @@ export default defineCommand({
     let cwd: string;
     try { cwd = process.cwd(); } catch { cwd = os.homedir(); }
 
-    const count = parseInt(args.count || '10', 10);
+    let count: number;
+    try {
+      count = parseCommitCount(args.count);
+    } catch (err) {
+      p.log.error(err instanceof Error ? err.message : String(err));
+      process.exitCode = 1;
+      return;
+    }
 
     p.intro(`Ingest recent ${count} commits`);
 
@@ -178,6 +197,7 @@ export default defineCommand({
     } catch (err) {
       console.error(`Failed to ingest log: ${err}`);
       p.outro('Ingest failed. Make sure you are in a git repository.');
+      process.exitCode = 1;
     }
   },
 });

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -88,7 +88,7 @@ export default defineCommand({
           }
           const limit = parsePositiveInt(args.limit as string | undefined, 10);
           const quality = coerceRetrievalQuality(args.quality as string | undefined);
-          const result = await compactSearch({ query, limit, quality, projectId: project.id, reader });
+          const result = await compactSearch({ query, limit, quality, projectId: project.id, reader }, 'cli');
           emitResult({ project, entries: result.entries }, result.formatted, asJson);
           return;
         }
@@ -206,13 +206,20 @@ export default defineCommand({
               : ref;
           });
           const result = await compactDetail(scopedRefs, { reader });
+          if (scopedRefs.length === 1 && result.documents.length === 0) {
+            emitError(`No readable memory found for ${scopedRefs[0]}.`, asJson);
+            return;
+          }
           emitResult({ project, documents: result.documents }, result.formatted, asJson);
           return;
         }
 
         case 'timeline': {
-          const id = Number.parseInt((args.id as string | undefined) || positional[0] || '', 10);
-          if (!Number.isFinite(id)) {
+          const rawId = (args.id as string | undefined) || positional[0] || '';
+          let id: number;
+          try {
+            id = parseObservationId(rawId);
+          } catch {
             emitError('Provide --id <n> for "memorix memory timeline"', asJson);
             return;
           }
@@ -222,15 +229,18 @@ export default defineCommand({
             parsePositiveInt(args.before as string | undefined, 3),
             parsePositiveInt(args.after as string | undefined, 3),
             reader,
+            'cli',
           );
+          if (!result.timeline.anchorEntry) {
+            emitError(`Observation #${id} was not found.`, asJson);
+            return;
+          }
           emitResult({ project, timeline: result.timeline }, result.formatted, asJson);
           return;
         }
 
         case 'resolve': {
-          const ids = parseCsvList(getIdArg(args, positional))
-            .map((value) => Number.parseInt(value, 10))
-            .filter((value) => Number.isFinite(value));
+          const ids = parseObservationIds(getIdArg(args, positional));
           if (ids.length === 0) {
             emitError('Provide --id <n> or --ids 1,2,3 for "memorix memory resolve"', asJson);
             return;
@@ -242,6 +252,16 @@ export default defineCommand({
           });
           if (authorizedIds.length === 0) {
             emitError('No requested observations are manageable with the active CLI scope.', asJson);
+            return;
+          }
+          const dryRun = !!args.dryRun || !!args['dry-run'];
+          if (dryRun) {
+            const unavailableIds = ids.filter((id) => !authorizedIds.includes(id));
+            emitResult(
+              { project, dryRun: true, status, wouldResolve: authorizedIds, unavailableIds },
+              `Would resolve ${authorizedIds.length} observation(s) to ${status}${unavailableIds.length > 0 ? `; unavailable: ${unavailableIds.join(', ')}` : ''}`,
+              asJson,
+            );
             return;
           }
           const result = await resolveObservations(authorizedIds, status);
@@ -409,9 +429,7 @@ export default defineCommand({
             return;
           }
 
-          const ids = parseCsvList(getIdArg(args, positional))
-            .map((value) => Number.parseInt(value, 10))
-            .filter((value) => Number.isFinite(value));
+          const ids = parseObservationIds(getIdArg(args, positional));
           if (ids.length === 0) {
             emitError('Provide --id <n> or --ids 1,2,3 for "memorix memory promote"', asJson);
             return;
@@ -611,27 +629,12 @@ export default defineCommand({
         }
 
         default:
-          console.log('Memorix Memory Commands');
-          console.log('');
-          console.log('Usage:');
-          console.log('  memorix memory search --query "timeout bug" [--limit 10] [--quality fast|balanced|thorough]');
-          console.log('  memorix memory recent [--limit 10]');
-          console.log('  memorix memory store --text "..." [--title "..."] [--type discovery] [--visibility project|personal|team]');
-          console.log('  memorix memory suggest-topic-key --type decision --title "..."');
-          console.log('  memorix memory detail --id 42');
-          console.log('  memorix memory detail obs:42@org/project');
-          console.log('  memorix memory timeline --id 42 [--before 3 --after 3]');
-          console.log('  memorix memory resolve --ids 42,43 [--status resolved|archived]');
-          console.log('  memorix memory deduplicate [--query "..."] [--dryRun]');
-          console.log('  memorix memory consolidate [--action preview|execute] [--threshold 0.45]');
-          console.log('  memorix memory promote --ids 42,43 [--trigger "..."] [--instruction "..."]');
-          console.log('  memorix memory long-term list [--all]');
-          console.log('  memorix memory long-term add --kind semantic --scope user --portability portable --title "..." --text "..." [--tags "..."] [--applicability "..."]');
-          console.log('  memorix memory long-term promote --fromObservation 42 --kind procedural --scope project');
-          console.log('  memorix memory long-term qualify --id <id> --reason "verified against evidence"');
-          console.log('  memorix memory long-term approve --id <id> --reason "reviewed by operator"');
-          console.log('  memorix memory long-term archive --id <id> --reason "no longer current"');
-          console.log('  memorix memory long-term supersede --id <old-id> --superseded-by <qualified-id> --reason "replaced"');
+          if (!action) {
+            printMemoryUsage();
+            return;
+          }
+          if (!asJson) printMemoryUsage();
+          emitError(`Unknown memory action "${action}".`, asJson);
       }
     } catch (error) {
       emitError(error instanceof Error ? error.message : String(error), asJson);
@@ -650,6 +653,46 @@ function getIdArg(args: Record<string, unknown>, positional: string[]): string {
     (args.id as string | undefined) ||
     positional.join(',')
   );
+}
+
+function parseObservationId(value: string): number {
+  const normalized = value.trim();
+  if (!/^[1-9]\d*$/.test(normalized)) {
+    throw new Error(`Invalid observation ID: ${value}`);
+  }
+  const id = Number(normalized);
+  if (!Number.isSafeInteger(id)) throw new Error(`Invalid observation ID: ${value}`);
+  return id;
+}
+
+function parseObservationIds(value: string): number[] {
+  const values = parseCsvList(value);
+  if (values.length === 0) return [];
+  return values.map(parseObservationId);
+}
+
+function printMemoryUsage(): void {
+  console.log('Memorix Memory Commands');
+  console.log('');
+  console.log('Usage:');
+  console.log('  memorix memory search --query "timeout bug" [--limit 10] [--quality fast|balanced|thorough]');
+  console.log('  memorix memory recent [--limit 10]');
+  console.log('  memorix memory store --text "..." [--title "..."] [--type discovery] [--visibility project|personal|team]');
+  console.log('  memorix memory suggest-topic-key --type decision --title "..."');
+  console.log('  memorix memory detail --id 42');
+  console.log('  memorix memory detail obs:42@org/project');
+  console.log('  memorix memory timeline --id 42 [--before 3 --after 3]');
+  console.log('  memorix memory resolve --ids 42,43 [--status resolved|archived] [--dry-run]');
+  console.log('  memorix memory deduplicate [--query "..."] [--dryRun]');
+  console.log('  memorix memory consolidate [--action preview|execute] [--threshold 0.45]');
+  console.log('  memorix memory promote --ids 42,43 [--trigger "..."] [--instruction "..."]');
+  console.log('  memorix memory long-term list [--all]');
+  console.log('  memorix memory long-term add --kind semantic --scope user --portability portable --title "..." --text "..." [--tags "..."] [--applicability "..."]');
+  console.log('  memorix memory long-term promote --fromObservation 42 --kind procedural --scope project');
+  console.log('  memorix memory long-term qualify --id <id> --reason "verified against evidence"');
+  console.log('  memorix memory long-term approve --id <id> --reason "reviewed by operator"');
+  console.log('  memorix memory long-term archive --id <id> --reason "no longer current"');
+  console.log('  memorix memory long-term supersede --id <old-id> --superseded-by <qualified-id> --reason "replaced"');
 }
 
 function longTermKind(value: string | undefined): 'episodic' | 'semantic' | 'procedural' {

--- a/src/cli/commands/operator-shared.ts
+++ b/src/cli/commands/operator-shared.ts
@@ -175,9 +175,15 @@ export function shortId(id?: string | null): string {
 }
 
 export function parsePositiveInt(input: string | undefined, fallback: number): number {
-  if (!input) return fallback;
-  const parsed = Number.parseInt(input, 10);
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+  if (input == null || input.trim() === '') return fallback;
+  if (!/^\d+$/.test(input.trim())) {
+    throw new Error(`Expected a positive integer, received "${input}".`);
+  }
+  const parsed = Number(input);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`Expected a positive integer, received "${input}".`);
+  }
+  return parsed;
 }
 
 const OBSERVATION_TYPES: ObservationType[] = [

--- a/src/cli/commands/serve-http.ts
+++ b/src/cli/commands/serve-http.ts
@@ -26,6 +26,7 @@ import { resolveToolProfile } from '../../server/tool-profile.js';
 import { scopeKnowledgeGraphToProject } from '../../memory/graph-scope.js';
 import { projectObservationRetention, summarizeRetentionProjections } from '../../memory/retention.js';
 import { canManageObservation, filterReadableObservations } from '../../memory/visibility.js';
+import { parseTcpPortOrReport } from '../port.js';
 
 export const DEFAULT_SESSION_TIMEOUT_MS = 30 * 60 * 1000;
 
@@ -79,7 +80,11 @@ export default defineCommand({
     const { homedir } = await import('node:os');
     const earlyPath = await import('node:path');
 
-    const port = parseInt(args.port || '3211', 10);
+    const port = parseTcpPortOrReport(args.port, 3211);
+    if (port === undefined) {
+      process.exitCode = 1;
+      return;
+    }
     const host = args.host || '127.0.0.1';
     const toolProfile = resolveToolProfile({ explicit: args.mode, envValue: process.env.MEMORIX_MODE, fallback: 'team' });
 
@@ -1599,4 +1604,5 @@ export default defineCommand({
 export const _testing = {
   DEFAULT_SESSION_TIMEOUT_MS,
   parseSessionTimeoutMs,
+  parseTcpPortOrReport,
 };

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -1513,6 +1513,16 @@ export default defineCommand({
       description: 'Skip plugin package installation',
       required: false,
     },
+    dryRun: {
+      type: 'boolean',
+      description: 'Preview setup actions without changing files or agent settings',
+      required: false,
+    },
+    'dry-run': {
+      type: 'boolean',
+      description: 'Alias for --dryRun',
+      required: false,
+    },
     list: {
       type: 'boolean',
       description: 'List supported agent entrypoints',
@@ -1530,6 +1540,7 @@ export default defineCommand({
       mcp = parseMcp(args.mcp);
     } catch (error) {
       p.log.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
       return;
     }
 
@@ -1561,6 +1572,7 @@ export default defineCommand({
 
     if (selectedAgent !== 'all' && !SUPPORTED_SETUP_AGENTS.includes(selectedAgent as AgentName)) {
       p.log.error(`Unsupported agent: ${selectedAgent}`);
+      process.exitCode = 1;
       return;
     }
 
@@ -1568,16 +1580,37 @@ export default defineCommand({
       ? SUPPORTED_SETUP_AGENTS
       : [selectedAgent as AgentName];
 
-    p.intro('Memorix Setup');
-    for (const agent of targets) {
-      const plan = buildSetupPlan({
+    const plans = targets.map((agent) => buildSetupPlan({
         agent,
         mcp,
         hooks: !args.noHooks,
         rules: !args.noRules,
         plugin: !args.noPlugin,
         global: Boolean(args.global),
-      });
+      }));
+    const dryRun = Boolean(args.dryRun || args['dry-run']);
+
+    if (dryRun) {
+      p.intro('Memorix Setup (dry run)');
+      for (const plan of plans) {
+        p.note(
+          [
+            `Scope: ${args.global ? 'global user configuration' : 'current project only'}`,
+            `MCP transport: ${plan.mcp}`,
+            `Actions: ${plan.actions.join(', ') || 'none'}`,
+            `Hooks: ${plan.includeHooks ? 'included' : 'skipped'}`,
+            `Rules: ${plan.includeRules ? 'included' : 'skipped'}`,
+          ].join('\n'),
+          plan.agent,
+        );
+      }
+      p.outro('Dry run complete. No files, plugins, hooks, or agent settings were changed.');
+      return;
+    }
+
+    p.intro('Memorix Setup');
+    for (const plan of plans) {
+      const agent = plan.agent as AgentName;
       await installAgentSetup(agent, plan, Boolean(args.global));
     }
 

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -10,7 +10,11 @@ export default defineCommand({
     name: 'status',
     description: 'Show project info and rules sync status',
   },
-  run: async () => {
+  args: {
+    json: { type: 'boolean', description: 'Emit machine-readable JSON output' },
+  },
+  run: async ({ args }) => {
+    const asJson = !!args.json;
     const { detectProject } = await import('../../project/detector.js');
     const { RulesSyncer } = await import('../../rules/syncer.js');
     const { getProjectDataDir } = await import('../../store/persistence.js');
@@ -18,11 +22,18 @@ export default defineCommand({
     const { getResolvedConfig, getResolvedAgentLane } = await import('../../config/resolved-config.js');
     const { existsSync, readFileSync } = await import('node:fs');
 
-    p.intro('memorix status');
-
     const project = detectProject();
     if (!project) {
-      p.log.error('Memorix requires a git repo to establish project identity. Run `git init` in this workspace first.');
+      const message = 'Memorix requires a git repo to establish project identity. Run `git init` in this workspace first.';
+      if (asJson) {
+        console.log(JSON.stringify({
+          ok: false,
+          error: { code: 'NO_GIT_REPOSITORY', message },
+        }, null, 2));
+      } else {
+        p.intro('memorix status');
+        p.log.error(message);
+      }
       return;
     }
 
@@ -45,25 +56,15 @@ export default defineCommand({
       activeCount = projectObs.filter(o => (o.status ?? 'active') === 'active').length;
     } catch { /* ignore */ }
 
-    p.note(
-      [
-        `Name:         ${project.name}`,
-        `ID:           ${project.id}`,
-        `Root:         ${project.rootPath}`,
-        `Git remote:   ${project.gitRemote || 'none'}`,
-        `Data dir:     ${dataDir}`,
-        `Observations: ${obsCount} (${activeCount} active)`,
-      ].join('\n'),
-      'Project',
-    );
-
     // Embedding / vector search status
     let embeddingStatus = 'None (fulltext/BM25 only)';
     let embeddingHint = '';
+    let embeddingProvider: { name: string; dimensions: number } | null = null;
     const embeddingMode = process.env.MEMORIX_EMBEDDING?.toLowerCase()?.trim() || 'off';
     try {
       const provider = await getEmbeddingProvider();
       if (provider) {
+        embeddingProvider = provider;
         embeddingStatus = `${provider.name} (${provider.dimensions}d)`;
         if (embeddingMode === 'api') {
           const model = process.env.MEMORIX_EMBEDDING_MODEL || 'text-embedding-3-small';
@@ -80,13 +81,9 @@ export default defineCommand({
       embeddingHint = '\n  Hint: Set MEMORIX_EMBEDDING=api for best quality, or install @huggingface/transformers or fastembed for local';
     }
 
-    p.note(
-      `Search:    BM25 fulltext (Orama)\n` +
-      `Embedding: ${embeddingStatus}${embeddingHint}`,
-      'Search Engine',
-    );
-
     // ── TOML-first Config Snapshot ──
+    let configuration: Record<string, unknown> | null = null;
+    let configNote: string | null = null;
     try {
       const { getLoadedEnvFiles } = await import('../../config/dotenv-loader.js');
       const resolved = getResolvedConfig({ projectRoot: project.rootPath });
@@ -132,12 +129,113 @@ export default defineCommand({
         diagLines.push('[TIP] Run "memorix init" to create TOML config');
       }
 
-      p.note(diagLines.join('\n'), 'Configuration');
+      configNote = diagLines.join('\n');
+      configuration = {
+        sources: {
+          toml: resolved.sources.toml,
+          compatibility: resolved.sources.legacy,
+          dotenv: loadedEnv,
+          environment: resolved.sources.env,
+        },
+        lanes: {
+          agent: summarizeLane(agent.provider, agent.model, agent.baseUrl, agent.apiKey),
+          memoryLlm: summarizeLane(resolved.memory.llm.provider, resolved.memory.llm.model, resolved.memory.llm.baseUrl, resolved.memory.llm.apiKey),
+          embedding: summarizeLane(resolved.embedding.provider, resolved.embedding.model, resolved.embedding.baseUrl, resolved.embedding.apiKey),
+        },
+        memory: {
+          inject: resolved.memory.inject ?? 'default',
+          formation: resolved.memory.formation ?? 'default',
+          autoCleanup: resolved.memory.autoCleanup ?? 'default',
+        },
+        git: {
+          autoHook: resolved.git.autoHook ?? 'default',
+          ingestOnCommit: resolved.git.ingestOnCommit ?? 'default',
+          maxDiffSize: resolved.git.maxDiffSize ?? 'default',
+          skipMergeCommits: resolved.git.skipMergeCommits ?? 'default',
+        },
+        server: {
+          transport: resolved.server.transport ?? 'default',
+          dashboard: resolved.server.dashboard ?? 'default',
+          dashboardPort: resolved.server.dashboardPort ?? 'default',
+        },
+      };
     } catch { /* best effort */ }
 
     const syncer = new RulesSyncer(project.rootPath);
     const status = await syncer.syncStatus();
 
+    // Count by source
+    const memorySources: string[] = [];
+    try {
+      const { initObservationStore, getObservationStore } = await import('../../store/obs-store.js');
+      await initObservationStore(dataDir);
+      const store = getObservationStore();
+      const { filterReadableObservations } = await import('../../memory/visibility.js');
+      const allObs = filterReadableObservations(await store.loadAll(), { projectId: project.id });
+      const gitCount = allObs.filter(o => o.source === 'git').length;
+      const reasoningCount = allObs.filter(o => o.type === 'reasoning').length;
+      if (gitCount > 0 || reasoningCount > 0) {
+        if (gitCount > 0) memorySources.push(`Git memories: ${gitCount}`);
+        if (reasoningCount > 0) memorySources.push(`Reasoning traces: ${reasoningCount}`);
+      }
+    } catch { /* best effort */ }
+
+    if (asJson) {
+      console.log(JSON.stringify({
+        ok: true,
+        project: {
+          name: project.name,
+          id: project.id,
+          rootPath: project.rootPath,
+          gitRemote: project.gitRemote ?? null,
+          dataDir,
+        },
+        observations: { total: obsCount, active: activeCount },
+        search: {
+          fulltext: 'orama-bm25',
+          embedding: {
+            mode: embeddingMode,
+            available: embeddingProvider !== null,
+            provider: embeddingProvider?.name ?? null,
+            dimensions: embeddingProvider?.dimensions ?? null,
+            status: embeddingStatus,
+            hint: embeddingHint.trim() || null,
+          },
+        },
+        configuration,
+        rules: {
+          sources: status.sources,
+          total: status.totalRules,
+          unique: status.uniqueRules,
+          conflicts: status.conflicts.map((conflict) => ({
+            left: { source: conflict.ruleA.source, id: conflict.ruleA.id },
+            right: { source: conflict.ruleB.source, id: conflict.ruleB.id },
+            reason: conflict.reason,
+          })),
+        },
+        memorySources,
+      }, null, 2));
+      return;
+    }
+
+    p.intro('memorix status');
+    p.note(
+      [
+        `Name:         ${project.name}`,
+        `ID:           ${project.id}`,
+        `Root:         ${project.rootPath}`,
+        `Git remote:   ${project.gitRemote || 'none'}`,
+        `Data dir:     ${dataDir}`,
+        `Observations: ${obsCount} (${activeCount} active)`,
+      ].join('\n'),
+      'Project',
+    );
+    p.note(
+      `Search:    BM25 fulltext (Orama)\n` +
+      `Embedding: ${embeddingStatus}${embeddingHint}`,
+      'Search Engine',
+    );
+    if (configNote) p.note(configNote, 'Configuration');
     p.note(
       [
         `Sources:      ${status.sources.join(', ') || 'none detected'}`,
@@ -152,7 +250,7 @@ export default defineCommand({
       p.log.warn('Conflicts detected:');
       for (const c of status.conflicts) {
         p.log.warn(`  ${c.ruleA.source}:${c.ruleA.id} vs ${c.ruleB.source}:${c.ruleB.id}`);
-        p.log.warn(`  → ${c.reason}`);
+        p.log.warn(`  -> ${c.reason}`);
       }
     }
 
@@ -160,22 +258,7 @@ export default defineCommand({
       p.log.info('No rule files found. Create .cursorrules, CLAUDE.md, or .windsurfrules to get started.');
     }
 
-    // Count by source
-    try {
-      const { initObservationStore, getObservationStore } = await import('../../store/obs-store.js');
-      await initObservationStore(dataDir);
-      const store = getObservationStore();
-      const { filterReadableObservations } = await import('../../memory/visibility.js');
-      const allObs = filterReadableObservations(await store.loadAll(), { projectId: project.id });
-      const gitCount = allObs.filter(o => o.source === 'git').length;
-      const reasoningCount = allObs.filter(o => o.type === 'reasoning').length;
-      if (gitCount > 0 || reasoningCount > 0) {
-        const parts: string[] = [];
-        if (gitCount > 0) parts.push(`Git memories: ${gitCount}`);
-        if (reasoningCount > 0) parts.push(`Reasoning traces: ${reasoningCount}`);
-        p.note(parts.join('\n'), 'Memory Sources');
-      }
-    } catch { /* best effort */ }
+    if (memorySources.length > 0) p.note(memorySources.join('\n'), 'Memory Sources');
 
     p.outro('Done');
   },
@@ -193,4 +276,13 @@ function formatLane(provider?: string, model?: string, baseUrl?: string, apiKey?
   if (baseUrl) parts.push(`baseUrl=${baseUrl}`);
   parts.push(`apiKey=${apiKey ? '<redacted>' : 'not set'}`);
   return parts.join(' / ');
+}
+
+function summarizeLane(provider?: string, model?: string, baseUrl?: string, apiKey?: string): Record<string, string | boolean | null> {
+  return {
+    provider: provider ?? null,
+    model: model ?? null,
+    baseUrl: baseUrl ?? null,
+    apiKeyConfigured: Boolean(apiKey),
+  };
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -15,7 +15,6 @@
 
 import { defineCommand, runMain } from 'citty';
 import * as p from '@clack/prompts';
-import { execSync, spawn } from 'node:child_process';
 import { getCliVersion } from './version.js';
 import { importBundledMemcode } from './memcode-bootstrap.js';
 import { installCliPipeErrorGuard } from './pipe-errors.js';

--- a/src/cli/port.ts
+++ b/src/cli/port.ts
@@ -1,0 +1,28 @@
+export function parseTcpPort(value: string | undefined, defaultPort: number): number {
+  const raw = value?.trim() || String(defaultPort);
+  if (!/^[0-9]+$/u.test(raw)) {
+    throw new Error('Port must be a whole number between 1 and 65535.');
+  }
+  const port = Number(raw);
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) {
+    throw new Error('Port must be a whole number between 1 and 65535.');
+  }
+  return port;
+}
+
+/**
+ * Command handlers should report malformed user input without delegating an
+ * expected validation error to the CLI framework, which would print a stack.
+ */
+export function parseTcpPortOrReport(
+  value: string | undefined,
+  defaultPort: number,
+  report: (message: string) => void = (message) => console.error(message),
+): number | undefined {
+  try {
+    return parseTcpPort(value, defaultPort);
+  } catch (error) {
+    report(error instanceof Error ? error.message : String(error));
+    return undefined;
+  }
+}

--- a/src/compact/engine.ts
+++ b/src/compact/engine.ts
@@ -13,7 +13,7 @@ import type { SearchOptions, IndexEntry, TimelineContext, MemorixDocument, Obser
 import { searchObservations, getTimeline, getObservationsByIds, makeOramaObservationId } from '../store/orama-store.js';
 import { getObservation, getAllObservations } from '../memory/observations.js';
 import { ensureFreshIndex } from '../memory/freshness.js';
-import { formatIndexTable, formatTimeline, formatObservationDetail } from './index-format.js';
+import { formatIndexTable, formatTimeline, formatObservationDetail, type RetrievalSurface } from './index-format.js';
 import { countTextTokens } from './token-budget.js';
 import { resolveAliases } from '../project/aliases.js';
 import { parseMemoryRef } from '../memory/refs.js';
@@ -64,7 +64,7 @@ export function normalizeMemoryBrowseQuery(query: string): string {
  * Layer 1: Search and return a compact index.
  * Agent scans this to decide which observations to fetch in detail.
  */
-export async function compactSearch(options: SearchOptions): Promise<{
+export async function compactSearch(options: SearchOptions, surface: RetrievalSurface = 'mcp'): Promise<{
   entries: IndexEntry[];
   formatted: string;
   totalTokens: number;
@@ -74,7 +74,7 @@ export async function compactSearch(options: SearchOptions): Promise<{
   const entries = (await searchObservations(searchOptions)).map((entry) =>
     entry.projectId || !options.projectId ? entry : { ...entry, projectId: options.projectId },
   );
-  let formatted = formatIndexTable(entries, searchOptions.query, !options.projectId);
+  let formatted = formatIndexTable(entries, searchOptions.query, !options.projectId, surface);
 
   if (entries.length === 0 && options.projectId) {
     const allObservations = filterReadableObservations(getAllObservations(), options.reader);
@@ -111,6 +111,7 @@ export async function compactTimeline(
   depthBefore = 3,
   depthAfter = 3,
   reader?: ObservationReader,
+  surface: RetrievalSurface = 'mcp',
 ): Promise<{
   timeline: TimelineContext;
   formatted: string;
@@ -125,7 +126,7 @@ export async function compactTimeline(
     after: result.after,
   };
 
-  const formatted = formatTimeline(timeline);
+  const formatted = formatTimeline(timeline, surface);
   const totalTokens = countTextTokens(formatted);
 
   return { timeline, formatted, totalTokens };

--- a/src/compact/index-format.ts
+++ b/src/compact/index-format.ts
@@ -11,7 +11,14 @@ import { redactCredentials } from '../memory/secret-filter.js';
 /**
  * Format a list of IndexEntries as a compact markdown table.
  */
-export function formatIndexTable(entries: IndexEntry[], query?: string, forceProjectColumn = false): string {
+export type RetrievalSurface = 'cli' | 'mcp';
+
+export function formatIndexTable(
+  entries: IndexEntry[],
+  query?: string,
+  forceProjectColumn = false,
+  surface: RetrievalSurface = 'mcp',
+): string {
   if (entries.length === 0) {
     return query
       ? `No memories found matching "${query}".`
@@ -84,7 +91,7 @@ export function formatIndexTable(entries: IndexEntry[], query?: string, forcePro
   }
 
   lines.push('');
-  lines.push(getProgressiveDisclosureHint(hasProject));
+  lines.push(getProgressiveDisclosureHint(hasProject, surface));
 
   return lines.join('\n');
 }
@@ -95,7 +102,7 @@ export function formatIndexTable(entries: IndexEntry[], query?: string, forcePro
  * annotates the anchor with its evidence kind. Falls back to the original
  * table format when no provenance is present (backward-compat).
  */
-export function formatTimeline(timeline: TimelineContext): string {
+export function formatTimeline(timeline: TimelineContext, surface: RetrievalSurface = 'mcp'): string {
   if (!timeline.anchorEntry) {
     return `Observation #${timeline.anchorId} not found.`;
   }
@@ -156,7 +163,7 @@ export function formatTimeline(timeline: TimelineContext): string {
     lines.push('');
   }
 
-  lines.push(getProgressiveDisclosureHint(false));
+  lines.push(getProgressiveDisclosureHint(false, surface));
   return lines.join('\n');
 }
 
@@ -313,11 +320,13 @@ function getTypeIcon(type: string): string {
   return icons[type] ?? '[UNKNOWN]';
 }
 
-function getProgressiveDisclosureHint(hasProject: boolean): string {
+function getProgressiveDisclosureHint(hasProject: boolean, surface: RetrievalSurface): string {
+  const detailCommand = surface === 'cli' ? 'memorix memory detail' : 'memorix_detail';
+  const timelineCommand = surface === 'cli' ? 'memorix memory timeline' : 'memorix_timeline';
   const lines = [
     '[TIP] **Progressive Disclosure:** This index shows WHAT exists and retrieval COST.',
-    '- Use `memorix_detail` with typed refs (obs:42@org/project, skill:3) to fetch full details',
-    '- Use `memorix_timeline` to see chronological context around an observation',
+    `- Use \`${detailCommand}\` with typed refs (obs:42@org/project, skill:3) to fetch full details`,
+    `- Use \`${timelineCommand}\` to see chronological context around an observation`,
     '- Critical types ([GOTCHA] gotcha, [DECISION] decision, [TRADEOFF] trade-off) are often worth fetching immediately',
   ];
 

--- a/src/git/extractor.ts
+++ b/src/git/extractor.ts
@@ -8,7 +8,7 @@
  * This module bridges the gap.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 
 export interface CommitInfo {
   hash: string;
@@ -34,15 +34,38 @@ export interface IngestResult {
   filesModified: string[];
 }
 
+function runGit(cwd: string, args: string[], maxBuffer?: number): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    timeout: 10_000,
+    ...(maxBuffer ? { maxBuffer } : {}),
+    windowsHide: true,
+  });
+}
+
+function normalizeCommitRef(ref: string): string {
+  const normalized = ref.trim();
+  if (!normalized || normalized.startsWith('-') || normalized.includes('\0')) {
+    throw new Error('Invalid git commit ref. Use a revision such as HEAD, main, or a commit hash.');
+  }
+  return normalized;
+}
+
+function normalizeCommitCount(count: number): number {
+  if (!Number.isSafeInteger(count) || count < 1 || count > 100) {
+    throw new Error('Commit count must be an integer between 1 and 100.');
+  }
+  return count;
+}
+
 /**
  * Get commit info by hash (or HEAD).
  */
 export function getCommitInfo(cwd: string, ref = 'HEAD'): CommitInfo {
   const FORMAT = '%H%n%h%n%aN%n%aI%n%s%n%b';
-  const raw = execSync(
-    `git log -1 --format="${FORMAT}" ${ref}`,
-    { cwd, encoding: 'utf-8', timeout: 10000, windowsHide: true },
-  ).trim();
+  const revision = normalizeCommitRef(ref);
+  const raw = runGit(cwd, ['log', '-1', `--format=${FORMAT}`, '--end-of-options', revision]).trim();
 
   const lines = raw.split('\n');
   const hash = lines[0];
@@ -53,10 +76,7 @@ export function getCommitInfo(cwd: string, ref = 'HEAD'): CommitInfo {
   const body = lines.slice(5).join('\n').trim();
 
   // Get diff stat
-  const stat = execSync(
-    `git diff-tree --no-commit-id --numstat ${hash}`,
-    { cwd, encoding: 'utf-8', timeout: 10000, windowsHide: true },
-  ).trim();
+  const stat = runGit(cwd, ['diff-tree', '--no-commit-id', '--numstat', hash]).trim();
 
   let insertions = 0;
   let deletions = 0;
@@ -76,10 +96,7 @@ export function getCommitInfo(cwd: string, ref = 'HEAD'): CommitInfo {
   // Get short diff summary (first 500 chars of diff)
   let diffSummary = '';
   try {
-    const diff = execSync(
-      `git diff-tree -p --no-commit-id ${hash}`,
-      { cwd, encoding: 'utf-8', timeout: 10000, maxBuffer: 1024 * 100, windowsHide: true },
-    );
+    const diff = runGit(cwd, ['diff-tree', '-p', '--no-commit-id', hash], 1024 * 100);
     diffSummary = diff.substring(0, 500);
   } catch { /* diff may be too large */ }
 
@@ -93,10 +110,11 @@ export function getCommitInfo(cwd: string, ref = 'HEAD'): CommitInfo {
  * Get recent N commits.
  */
 export function getRecentCommits(cwd: string, count = 10): CommitInfo[] {
-  const hashes = execSync(
-    `git log --format="%H" -${count}`,
-    { cwd, encoding: 'utf-8', timeout: 10000, windowsHide: true },
-  ).trim().split('\n').filter(Boolean);
+  const normalizedCount = normalizeCommitCount(count);
+  const hashes = runGit(cwd, ['log', '--format=%H', '-n', String(normalizedCount)])
+    .trim()
+    .split('\n')
+    .filter(Boolean);
 
   return hashes.map(hash => getCommitInfo(cwd, hash));
 }

--- a/src/orchestrate/context-collector.ts
+++ b/src/orchestrate/context-collector.ts
@@ -6,7 +6,7 @@
  * Pure side-effect-free reads — no LLM calls.
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { readFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { CodeGraphStore } from '../codegraph/store.js';
@@ -41,6 +41,11 @@ export interface ContextCollectorOpts {
   maxGitLogEntries?: number;
 }
 
+function normalizeEntryLimit(value: number, fallback: number): number {
+  if (!Number.isSafeInteger(value) || value < 1) return fallback;
+  return Math.min(value, 500);
+}
+
 // ── Implementation ─────────────────────────────────────────────────
 
 /**
@@ -51,9 +56,11 @@ export function collectPlanningContext(opts: ContextCollectorOpts): PlanningCont
   const {
     projectDir,
     agents,
-    maxFileTreeEntries = 80,
-    maxGitLogEntries = 10,
+    maxFileTreeEntries: rawMaxFileTreeEntries = 80,
+    maxGitLogEntries: rawMaxGitLogEntries = 10,
   } = opts;
+  const maxFileTreeEntries = normalizeEntryLimit(rawMaxFileTreeEntries, 80);
+  const maxGitLogEntries = normalizeEntryLimit(rawMaxGitLogEntries, 10);
 
   return {
     fileTree: collectFileTree(projectDir, maxFileTreeEntries),
@@ -96,7 +103,7 @@ export function contextToPromptSection(ctx: PlanningContext): string {
 function collectFileTree(projectDir: string, maxEntries: number): string {
   try {
     // Use git ls-files to respect .gitignore
-    const raw = execSync('git ls-files --cached --others --exclude-standard', {
+    const raw = execFileSync('git', ['ls-files', '--cached', '--others', '--exclude-standard'], {
       cwd: projectDir,
       encoding: 'utf-8',
       timeout: 5_000,
@@ -136,7 +143,7 @@ function collectDependencies(projectDir: string): string {
 
 function collectGitLog(projectDir: string, maxEntries: number): string {
   try {
-    return execSync(`git log --oneline -${maxEntries}`, {
+    return execFileSync('git', ['log', '--oneline', '-n', String(normalizeEntryLimit(maxEntries, 10))], {
       cwd: projectDir,
       encoding: 'utf-8',
       timeout: 5_000,

--- a/src/orchestrate/coordinator.ts
+++ b/src/orchestrate/coordinator.ts
@@ -839,9 +839,14 @@ export async function runCoordinationLoop(config: CoordinatorConfig): Promise<Co
                   } catch { /* evidence is best-effort */ }
                 }
 
-                // Worktree cleanup on fix exhaustion
+                // Preserve failed work so a user can inspect or recover an
+                // agent's partial result. Retries receive a fresh suffixed
+                // worktree instead of overwriting this one.
                 if (dispatch.worktreePath) {
-                  try { removeWorktree(projectDir, dispatch.worktreePath, dispatch.worktreeBranch); } catch { /* best-effort */ }
+                  emit('worktree:preserve', `Fix loop exhausted; preserved worktree ${dispatch.worktreePath} for recovery`, {
+                    taskId: dispatch.taskId,
+                    agentName: dispatch.adapterName,
+                  });
                 }
 
                 // Check if we can retry from scratch
@@ -946,10 +951,10 @@ export async function runCoordinationLoop(config: CoordinatorConfig): Promise<Co
                     try {
                       teamStore.getDb().prepare(
                         'UPDATE team_tasks SET status = ?, result = ?, updated_at = ? WHERE task_id = ?',
-                      ).run('failed', `Merge conflict — manual recovery required. Worktree preserved at ${dispatch.worktreePath}. Conflicts: ${mergeResult.conflicts?.slice(0, 200)}`, Date.now(), dispatch.taskId);
+                      ).run('failed', `Worktree integration failed — manual recovery required. Worktree preserved at ${dispatch.worktreePath}. Details: ${mergeResult.conflicts?.slice(0, 200)}`, Date.now(), dispatch.taskId);
                     } catch { /* best-effort */ }
                     // Conflict → PRESERVE worktree+branch for manual recovery
-                    emit('task:failed', `Worktree merge conflict for "${taskDesc}" — preserving ${dispatch.worktreePath} for manual recovery`, {
+                    emit('task:failed', `Worktree integration failed for "${taskDesc}" — preserving ${dispatch.worktreePath} for manual recovery`, {
                       taskId: dispatch.taskId,
                       agentName: dispatch.adapterName,
                     });
@@ -968,7 +973,7 @@ export async function runCoordinationLoop(config: CoordinatorConfig): Promise<Co
                   agent: dispatch.adapterName,
                   status: mergeConflict ? 'failed' : 'completed',
                   summary: mergeConflict
-                    ? `Merge conflict — manual recovery required at ${dispatch.worktreePath}`
+                    ? `Worktree integration failed — manual recovery required at ${dispatch.worktreePath}`
                     : (result.tailOutput.slice(-200) || 'Completed'),
                   outputFiles: [],
                   durationMs: Date.now() - dispatch.dispatchedAt,
@@ -1060,9 +1065,13 @@ export async function runCoordinationLoop(config: CoordinatorConfig): Promise<Co
               } catch { /* ledger is best-effort */ }
             }
 
-            // Phase 6i: Remove worktree without merge on failure
+            // A non-zero exit or timeout can still leave useful partial work.
+            // Preserve it rather than deleting a user's only recovery path.
             if (dispatch.worktreePath) {
-              try { removeWorktree(projectDir, dispatch.worktreePath, dispatch.worktreeBranch); } catch { /* best-effort */ }
+              emit('worktree:preserve', `Task did not finish; preserved worktree ${dispatch.worktreePath} for recovery`, {
+                taskId: dispatch.taskId,
+                agentName: dispatch.adapterName,
+              });
             }
 
             // Phase 7: Error recovery classification
@@ -1142,12 +1151,16 @@ export async function runCoordinationLoop(config: CoordinatorConfig): Promise<Co
     process.off('SIGINT', cleanup);
     process.off('SIGTERM', cleanup);
     try { teamStore.leaveAgent(orchAgentId); } catch { /* best-effort */ }
-    // Phase 6i: Freeze remaining worktrees on exit
+    // Do not delete active worktrees during shutdown. They can contain
+    // uncommitted agent changes and are safe to recover on the next run.
     if (useWorktrees) {
       try {
         const remaining = activeDispatches.filter(d => d.worktreePath);
         for (const d of remaining) {
-          try { removeWorktree(projectDir, d.worktreePath!, d.worktreeBranch); } catch { /* best-effort */ }
+          emit('worktree:preserve', `Coordinator stopped; preserved worktree ${d.worktreePath} for recovery`, {
+            taskId: d.taskId,
+            agentName: d.adapterName,
+          });
         }
       } catch { /* best-effort */ }
     }

--- a/src/orchestrate/worktree.ts
+++ b/src/orchestrate/worktree.ts
@@ -6,7 +6,7 @@
  * Startup cleanup handles orphaned worktrees (pays D6 debt).
  */
 
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { existsSync, rmSync } from 'node:fs';
 import { join, basename } from 'node:path';
 
@@ -20,6 +20,46 @@ export interface WorktreeInfo {
 // ── Constants ──────────────────────────────────────────────────────
 
 const WORKTREE_DIR = '.worktrees';
+
+function runGit(cwd: string, args: string[], timeout = 5_000): string {
+  return String(execFileSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    timeout,
+    windowsHide: true,
+  }));
+}
+
+function formatGitError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function hasUncommittedChanges(worktreePath: string): boolean | null {
+  try {
+    return runGit(worktreePath, ['status', '--porcelain']).trim().length > 0;
+  } catch {
+    return null;
+  }
+}
+
+function isBranchMergedIntoHead(projectDir: string, branch: string): boolean {
+  try {
+    runGit(projectDir, ['merge-base', '--is-ancestor', branch, 'HEAD']);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isManagedWorktreePath(worktreePath: string, worktreeBase: string): boolean {
+  const normalize = (value: string) => {
+    const normalized = value.replace(/\\/g, '/').replace(/\/+$/, '');
+    return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+  };
+  const path = normalize(worktreePath);
+  const base = normalize(worktreeBase);
+  return path === base || path.startsWith(`${base}/`);
+}
 
 // ── Create ─────────────────────────────────────────────────────────
 
@@ -35,18 +75,34 @@ export function createWorktree(
 ): WorktreeInfo {
   const shortId = taskId.slice(0, 8);
   const shortPipeline = pipelineId.slice(0, 8);
-  const worktreePath = join(projectDir, WORKTREE_DIR, `task-${shortId}`);
-  const branch = `pipeline/${shortPipeline}/task-${shortId}`;
+  const worktreeBase = join(projectDir, WORKTREE_DIR, `task-${shortId}`);
+  const branchBase = `pipeline/${shortPipeline}/task-${shortId}`;
 
-  // Ensure .worktrees directory exists (git worktree add handles the rest)
-  execSync(`git worktree add "${worktreePath}" -b "${branch}"`, {
-    cwd: projectDir,
-    encoding: 'utf-8',
-    timeout: 30_000,
-    windowsHide: true,
-  });
+  // A failed attempt is preserved for recovery. Pick a new suffix for retries
+  // instead of reusing and overwriting that evidence.
+  for (let attempt = 1; attempt <= 100; attempt++) {
+    const suffix = attempt === 1 ? '' : `-${attempt}`;
+    const worktreePath = `${worktreeBase}${suffix}`;
+    const branch = `${branchBase}${suffix}`;
+    if (existsSync(worktreePath)) continue;
+    // Check refs before merge-base so a fresh branch does not emit Git's
+    // noisy "Not a valid object name" diagnostic on every allocation.
+    if (!isBranchAvailable(projectDir, branch)) continue;
 
-  return { worktreePath, branch };
+    runGit(projectDir, ['worktree', 'add', '-b', branch, worktreePath], 30_000);
+    return { worktreePath, branch };
+  }
+
+  throw new Error(`Unable to allocate an isolated worktree for task ${shortId}`);
+}
+
+function isBranchAvailable(projectDir: string, branch: string): boolean {
+  try {
+    runGit(projectDir, ['show-ref', '--verify', '--quiet', `refs/heads/${branch}`]);
+    return false;
+  } catch {
+    return true;
+  }
 }
 
 // ── Merge ──────────────────────────────────────────────────────────
@@ -74,58 +130,37 @@ export function mergeWorktree(
   // Without this, files written by the agent are untracked and the merge
   // will be a no-op (no commits on the branch beyond the checkout base).
   if (worktreePath) {
-    try {
-      execSync('git add -A', {
-        cwd: worktreePath,
-        encoding: 'utf-8',
-        timeout: 15_000,
-        windowsHide: true,
-      });
-      // Check if there's anything to commit
-      const status = execSync('git status --porcelain', {
-        cwd: worktreePath,
-        encoding: 'utf-8',
-        timeout: 5_000,
-        windowsHide: true,
-      }).trim();
-      if (status) {
-        execSync('git commit -m "task: agent work" --no-verify', {
-          cwd: worktreePath,
-          encoding: 'utf-8',
-          timeout: 15_000,
-          windowsHide: true,
-        });
+    const changes = hasUncommittedChanges(worktreePath);
+    if (changes === null) {
+      return {
+        success: false,
+        conflicts: `Could not inspect worktree changes; preserved at ${worktreePath}.`,
+      };
+    }
+    if (changes) {
+      try {
+        runGit(worktreePath, ['add', '-A'], 15_000);
+        runGit(worktreePath, ['commit', '-m', 'task: agent work', '--no-verify'], 15_000);
+      } catch (error) {
+        return {
+          success: false,
+          conflicts: `Could not commit agent changes; preserved at ${worktreePath}. ${formatGitError(error)}`,
+        };
       }
-      // else: nothing to commit — merge will be a no-op
-    } catch {
-      // "nothing to commit" is fine — the merge will just be a no-op.
-      // Any other git error here (e.g., invalid index) is also non-fatal;
-      // we still attempt the merge which will correctly report as no-op.
     }
   }
 
   // Step 2: Merge the branch into the main repo.
   try {
-    execSync(`git merge --no-ff "${branch}" -m "merge: ${branch}"`, {
-      cwd: projectDir,
-      encoding: 'utf-8',
-      timeout: 30_000,
-      windowsHide: true,
-    });
+    runGit(projectDir, ['merge', '--no-ff', branch, '-m', `merge: ${branch}`], 30_000);
     return { success: true };
   } catch (err) {
     // Abort the failed merge to leave working tree clean
     try {
-      execSync('git merge --abort', {
-        cwd: projectDir,
-        encoding: 'utf-8',
-        timeout: 5_000,
-        windowsHide: true,
-      });
+      runGit(projectDir, ['merge', '--abort']);
     } catch { /* best-effort */ }
 
-    const msg = err instanceof Error ? err.message : String(err);
-    return { success: false, conflicts: msg };
+    return { success: false, conflicts: formatGitError(err) };
   }
 }
 
@@ -140,36 +175,21 @@ export function removeWorktree(
   branch?: string,
 ): void {
   try {
-    execSync(`git worktree remove "${worktreePath}" --force`, {
-      cwd: projectDir,
-      encoding: 'utf-8',
-      timeout: 10_000,
-      windowsHide: true,
-    });
+    runGit(projectDir, ['worktree', 'remove', worktreePath, '--force'], 10_000);
   } catch {
     // If git worktree remove fails, try manual cleanup
     if (existsSync(worktreePath)) {
       try { rmSync(worktreePath, { recursive: true, force: true }); } catch { /* best-effort */ }
     }
     try {
-      execSync('git worktree prune', {
-        cwd: projectDir,
-        encoding: 'utf-8',
-        timeout: 5_000,
-        windowsHide: true,
-      });
+      runGit(projectDir, ['worktree', 'prune']);
     } catch { /* best-effort */ }
   }
 
   // Delete the branch (best-effort)
   if (branch) {
     try {
-      execSync(`git branch -D "${branch}"`, {
-        cwd: projectDir,
-        encoding: 'utf-8',
-        timeout: 5_000,
-        windowsHide: true,
-      });
+      runGit(projectDir, ['branch', '-D', branch]);
     } catch { /* may already be deleted or is current branch */ }
   }
 }
@@ -182,12 +202,7 @@ export function removeWorktree(
  */
 export function listWorktrees(projectDir: string): Array<{ path: string; branch: string | null }> {
   try {
-    const raw = execSync('git worktree list --porcelain', {
-      cwd: projectDir,
-      encoding: 'utf-8',
-      timeout: 5_000,
-      windowsHide: true,
-    });
+    const raw = runGit(projectDir, ['worktree', 'list', '--porcelain']);
 
     const worktrees: Array<{ path: string; branch: string | null }> = [];
     let current: { path: string; branch: string | null } | null = null;
@@ -204,9 +219,10 @@ export function listWorktrees(projectDir: string): Array<{ path: string; branch:
     }
     if (current) worktrees.push(current);
 
-    // Filter to only our managed worktrees (normalize slashes for Windows compat)
-    const worktreeBase = join(projectDir, WORKTREE_DIR).replace(/\\/g, '/');
-    return worktrees.filter(w => w.path.replace(/\\/g, '/').startsWith(worktreeBase));
+    // Filter to only our managed worktrees; require a path boundary so a
+    // sibling such as `.worktrees-old` is never treated as ours.
+    const worktreeBase = join(projectDir, WORKTREE_DIR);
+    return worktrees.filter(w => isManagedWorktreePath(w.path, worktreeBase));
   } catch {
     return [];
   }
@@ -218,7 +234,7 @@ export function listWorktrees(projectDir: string): Array<{ path: string; branch:
  */
 export function extractTaskIdFromPath(worktreePath: string): string | null {
   const name = basename(worktreePath);
-  const match = name.match(/^task-([a-f0-9]+)$/);
+  const match = name.match(/^task-([a-f0-9]+)(?:-\d+)?$/);
   return match ? match[1] : null;
 }
 
@@ -241,8 +257,11 @@ export function cleanupOrphanWorktrees(
     if (!shortId) continue;
 
     if (isTaskTerminal(shortId)) {
-      removeWorktree(projectDir, wt.path, wt.branch ?? undefined);
-      removed++;
+      const changes = hasUncommittedChanges(wt.path);
+      if (changes === false && wt.branch && isBranchMergedIntoHead(projectDir, wt.branch)) {
+        removeWorktree(projectDir, wt.path, wt.branch);
+        removed++;
+      }
     }
   }
 

--- a/tests/cli/background-launcher.test.ts
+++ b/tests/cli/background-launcher.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { _testing } from '../../src/cli/commands/background.js';
+
+describe('Windows background launcher', () => {
+  it('builds a hidden, independent PowerShell launch command with quoted paths', () => {
+    const script = _testing.buildWindowsBackgroundStartScript({
+      nodePath: 'C:\\Program Files\\nodejs\\node.exe',
+      cliEntry: 'C:\\Users\\Test User\\AppData\\Roaming\\npm\\node_modules\\memorix\\dist\\cli\\index.js',
+      port: 43219,
+      cwd: 'C:\\Users\\Test User\\project folder',
+      stdoutLogFile: 'C:\\Users\\Test User\\.memorix\\background.log.stdout',
+      stderrLogFile: 'C:\\Users\\Test User\\.memorix\\background.log',
+    });
+
+    expect(script).toContain('Start-Process');
+    expect(script).toContain('-WindowStyle Hidden');
+    expect(script).toContain('-RedirectStandardOutput');
+    expect(script).toContain('-RedirectStandardError');
+    expect(script).toContain('"C:\\Users\\Test User\\AppData\\Roaming\\npm\\node_modules\\memorix\\dist\\cli\\index.js"');
+    expect(script).toContain('serve-http --port 43219');
+  });
+
+  it('escapes quote characters for Windows command-line arguments', () => {
+    expect(_testing.quoteWindowsCommandArgument('plain')).toBe('plain');
+    expect(_testing.quoteWindowsCommandArgument('folder with spaces')).toBe('"folder with spaces"');
+    expect(_testing.quoteWindowsCommandArgument('a"quoted"value')).toBe('"a\\"quoted\\"value"');
+  });
+
+  it('rejects malformed ports and log line limits before service startup', () => {
+    expect(_testing.parseBackgroundPort(undefined)).toBe(3211);
+    expect(_testing.parseBackgroundPort('43222')).toBe(43222);
+    expect(() => _testing.parseBackgroundPort('43222junk')).toThrow(/Port must be/);
+    expect(() => _testing.parseBackgroundPort('0')).toThrow(/Port must be/);
+    expect(() => _testing.parseBackgroundPort('65536')).toThrow(/Port must be/);
+
+    expect(_testing.parseLogLines(undefined)).toBe(50);
+    expect(() => _testing.parseLogLines('0')).toThrow(/Log line count must be/);
+    expect(() => _testing.parseLogLines('10001')).toThrow(/Log line count must be/);
+  });
+
+  it('keeps normal CLI errors concise but preserves opt-in diagnostics', () => {
+    const error = new Error('Port must be a whole number');
+    error.stack = 'Error: Port must be a whole number\n    at internal-frame';
+
+    expect(_testing.formatBackgroundCommandError(error, false)).toBe(
+      '[memorix background] Error: Port must be a whole number\n',
+    );
+    expect(_testing.formatBackgroundCommandError(error, true)).toContain('at internal-frame');
+  });
+});

--- a/tests/cli/config-command.test.ts
+++ b/tests/cli/config-command.test.ts
@@ -160,6 +160,33 @@ describe('memorix config commands', () => {
     expect(notes).not.toContain('status-secret-key');
   });
 
+  it('emits parseable redacted JSON for status', async () => {
+    detectProjectMock.mockReturnValue({
+      id: 'demo-id',
+      name: 'demo',
+      rootPath: 'E:\\repo\\demo',
+      gitRemote: null,
+    });
+    process.env.MEMORIX_AGENT_API_KEY = 'status-secret-key';
+    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const command = (await import('../../src/cli/commands/status.js')).default;
+
+    await command.run?.({ args: { json: true }, rawArgs: ['--json'], cmd: command } as any);
+
+    const output = String(consoleLog.mock.calls[0]?.[0] ?? '');
+    const result = JSON.parse(output);
+    expect(result).toMatchObject({
+      ok: true,
+      project: { id: 'demo-id', name: 'demo' },
+      observations: { total: 0, active: 0 },
+      configuration: { lanes: { agent: { apiKeyConfigured: true } } },
+    });
+    expect(output).not.toContain('status-secret-key');
+    expect(introMock).not.toHaveBeenCalled();
+    expect(noteMock).not.toHaveBeenCalled();
+    consoleLog.mockRestore();
+  });
+
   it('migrates legacy YAML into project memorix.toml without deleting legacy files or env secrets', async () => {
     tempDir = mkdtempSync(join(process.env.TEMP ?? process.cwd(), 'memorix-config-migrate-'));
     const homeDir = join(tempDir, 'home');

--- a/tests/cli/operator-surface.test.ts
+++ b/tests/cli/operator-surface.test.ts
@@ -324,6 +324,70 @@ describe('CLI operator surface', () => {
     expect(resolvedJson.result.resolved).toContain(obsId);
   });
 
+  it('makes memory resolve dry-run non-mutating and reports the planned change', async () => {
+    const stored = await runCommand(memoryCommand, {
+      _: ['store'],
+      text: 'Dry runs must not resolve a real observation.',
+      title: 'Resolve dry-run contract',
+      entity: 'cli-memory',
+      type: 'decision',
+      json: true,
+    });
+    const obsId = JSON.parse(stored.stdout).observation.id;
+
+    const dryRun = await runCommand(memoryCommand, {
+      _: ['resolve'],
+      id: String(obsId),
+      status: 'resolved',
+      'dry-run': true,
+      json: true,
+    });
+
+    expect(dryRun.exitCode).toBe(0);
+    expect(JSON.parse(dryRun.stdout)).toMatchObject({ dryRun: true, wouldResolve: [obsId] });
+
+    const detail = await runCommand(memoryCommand, { _: ['detail'], id: String(obsId), json: true });
+    expect(detail.exitCode).toBe(0);
+    expect(JSON.parse(detail.stdout).documents).toHaveLength(1);
+  });
+
+  it('fails closed for unknown memory actions, invalid limits, and missing details', async () => {
+    const unknown = await runCommand(memoryCommand, { _: ['nope'], json: true });
+    expect(unknown.exitCode).toBe(1);
+    expect(JSON.parse(unknown.stderr).error).toContain('Unknown memory action');
+
+    const invalidLimit = await runCommand(memoryCommand, {
+      _: ['recent'],
+      limit: 'nope',
+      json: true,
+    });
+    expect(invalidLimit.exitCode).toBe(1);
+    expect(JSON.parse(invalidLimit.stderr).error).toContain('Expected a positive integer');
+
+    const missing = await runCommand(memoryCommand, { _: ['detail'], id: '999', json: true });
+    expect(missing.exitCode).toBe(1);
+    expect(JSON.parse(missing.stderr).error).toContain('No readable memory found');
+  });
+
+  it('uses CLI commands, not MCP tool names, in CLI search guidance', async () => {
+    await runCommand(memoryCommand, {
+      _: ['store'],
+      text: 'The CLI must advertise commands users can actually run.',
+      title: 'CLI progressive disclosure',
+      entity: 'cli-memory',
+      type: 'decision',
+      json: true,
+    });
+
+    const search = await runCommand(memoryCommand, {
+      _: ['search'],
+      query: 'progressive disclosure',
+    });
+    expect(search.exitCode).toBe(0);
+    expect(search.stdout).toContain('memorix memory detail');
+    expect(search.stdout).not.toContain('memorix_detail');
+  });
+
   it('accepts positional arguments for common memory commands', async () => {
     const stored = await runCommand(memoryCommand, {
       _: ['store', 'Positional memory text should be accepted.'],

--- a/tests/cli/port.test.ts
+++ b/tests/cli/port.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { parseTcpPort, parseTcpPortOrReport } from '../../src/cli/port.js';
+
+describe('CLI TCP port parsing', () => {
+  it('uses the supplied port or an explicit default', () => {
+    expect(parseTcpPort(undefined, 3211)).toBe(3211);
+    expect(parseTcpPort('43222', 3211)).toBe(43222);
+    expect(parseTcpPort(' 43222 ', 3211)).toBe(43222);
+  });
+
+  it('rejects partial, non-positive, and out-of-range ports', () => {
+    for (const value of ['43222junk', '0', '-1', '65536', 'not-a-port']) {
+      expect(() => parseTcpPort(value, 3211)).toThrow(/Port must be a whole number/);
+    }
+  });
+
+  it('reports expected command input errors without throwing a framework stack', () => {
+    const messages: string[] = [];
+
+    expect(parseTcpPortOrReport('43222junk', 3211, (message) => messages.push(message))).toBeUndefined();
+    expect(messages).toEqual(['Port must be a whole number between 1 and 65535.']);
+  });
+});

--- a/tests/cli/setup-command.test.ts
+++ b/tests/cli/setup-command.test.ts
@@ -5,7 +5,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { getCliVersion } from '../../src/cli/version.js';
 
-import {
+import setupCommand, {
   buildSetupPlan,
   getSetupIntegrationRows,
   installAntigravityPluginPackage,
@@ -51,6 +51,51 @@ async function expectOfficialSkills(skillsRoot: string): Promise<void> {
 }
 
 describe('setup command planning', () => {
+  it('does not modify the project during setup dry-run', async () => {
+    const tmpDir = makeTmpDir();
+    const originalCwd = process.cwd();
+    try {
+      process.chdir(tmpDir);
+      await setupCommand.run?.({
+        args: { agent: 'claude', mcp: 'stdio', dryRun: true },
+        rawArgs: ['--agent', 'claude', '--dry-run'],
+        cmd: setupCommand,
+      } as any);
+
+      expect(fsSync.existsSync(path.join(tmpDir, 'CLAUDE.md'))).toBe(false);
+      expect(fsSync.existsSync(path.join(tmpDir, '.claude'))).toBe(false);
+    } finally {
+      process.chdir(originalCwd);
+      await cleanup(tmpDir);
+    }
+  });
+
+  it('does not modify user-level Codex files during global setup dry-run', async () => {
+    const tmpDir = makeTmpDir();
+    const homeDir = path.join(tmpDir, 'home');
+    const originalHome = process.env.HOME;
+    const originalUserProfile = process.env.USERPROFILE;
+    try {
+      process.env.HOME = homeDir;
+      process.env.USERPROFILE = homeDir;
+      await setupCommand.run?.({
+        args: { agent: 'codex', mcp: 'stdio', global: true, dryRun: true },
+        rawArgs: ['--agent', 'codex', '--global', '--dry-run'],
+        cmd: setupCommand,
+      } as any);
+
+      expect(fsSync.existsSync(path.join(homeDir, 'plugins', 'memorix'))).toBe(false);
+      expect(fsSync.existsSync(path.join(homeDir, '.agents', 'plugins', 'marketplace.json'))).toBe(false);
+      expect(fsSync.existsSync(path.join(homeDir, '.codex', 'config.toml'))).toBe(false);
+    } finally {
+      if (originalHome === undefined) delete process.env.HOME;
+      else process.env.HOME = originalHome;
+      if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = originalUserProfile;
+      await cleanup(tmpDir);
+    }
+  });
+
   it('keeps Codex project setup plugin-only and leaves .codex untouched', () => {
     const plan = buildSetupPlan({ agent: 'codex', mcp: 'stdio' });
     expect(plan.mcp).toBe('stdio');

--- a/tests/cli/windows-child-process.test.ts
+++ b/tests/cli/windows-child-process.test.ts
@@ -21,10 +21,18 @@ describe('Windows CLI child process behavior', () => {
     expect(config).toContain('windowsHide:true');
   });
 
-  it('does not create a detached Windows console for the background service', () => {
+  it('uses the hidden Windows launcher for the background service', () => {
     const command = readFileSync(join(process.cwd(), 'src/cli/commands/background.ts'), 'utf8');
-    expect(command).toContain("detached: process.platform !== 'win32'");
+    expect(command).toContain("spawn('powershell.exe'");
+    expect(command).toContain('Start-Process');
+    expect(command).toContain('-WindowStyle Hidden');
     expect(command).toContain('windowsHide: true');
+  });
+
+  it('hides verification commands launched by orchestration', () => {
+    const verifyGate = readFileSync(join(process.cwd(), 'src/orchestrate/verify-gate.ts'), 'utf8');
+    expect(verifyGate).toContain('shell: true');
+    expect(verifyGate).toContain('windowsHide: true');
   });
 
   it('hides the slow-path Git probes used by normal CLI commands', () => {

--- a/tests/git/extractor.test.ts
+++ b/tests/git/extractor.test.ts
@@ -69,6 +69,12 @@ describe('Git Commit Parsing', () => {
       expect(c.subject).toBeTruthy();
     }
   }, 30_000);
+
+  it('rejects option-like commit refs and invalid counts', () => {
+    expect(() => getCommitInfo(process.cwd(), '--all')).toThrow('Invalid git commit ref');
+    expect(() => getRecentCommits(process.cwd(), 0)).toThrow('Commit count must be an integer');
+    expect(() => getRecentCommits(process.cwd(), 101)).toThrow('Commit count must be an integer');
+  });
 });
 
 describe('Git Ingest (commit → memory)', () => {

--- a/tests/git/ingest-log-dedup.test.ts
+++ b/tests/git/ingest-log-dedup.test.ts
@@ -25,7 +25,7 @@ vi.mock('../../src/embedding/provider.js', () => ({
 import { storeObservation, initObservations } from '../../src/memory/observations.js';
 import { resetDb } from '../../src/store/orama-store.js';
 import { getObservationStore } from '../../src/store/obs-store.js';
-import { ingestCommitsWithDedup } from '../../src/cli/commands/ingest-log.js';
+import { ingestCommitsWithDedup, parseCommitCount } from '../../src/cli/commands/ingest-log.js';
 
 const PROJECT_ID = 'test/ingest-log-dedup';
 
@@ -78,6 +78,15 @@ describe('Issue #48: ingest-log commitHash dedup', () => {
     { hash: 'bbb2222bbb2222bbb2222bbb2222bbb2222bbb222', subject: 'fix: token expiry bug' },
     { hash: 'ccc3333ccc3333ccc3333ccc3333ccc3333ccc333', subject: 'refactor: clean up utils' },
   ];
+
+  it('accepts only bounded positive commit counts', () => {
+    expect(parseCommitCount()).toBe(10);
+    expect(parseCommitCount('25')).toBe(25);
+    expect(() => parseCommitCount('0')).toThrow('Commit count must be an integer');
+    expect(() => parseCommitCount('-1')).toThrow('Commit count must be an integer');
+    expect(() => parseCommitCount('abc')).toThrow('Commit count must be an integer');
+    expect(() => parseCommitCount('101')).toThrow('Commit count must be an integer');
+  });
 
   it('first ingest stores all commits', async () => {
     const result = await ingestWithDedup(COMMITS);

--- a/tests/orchestrate/context-collector.test.ts
+++ b/tests/orchestrate/context-collector.test.ts
@@ -9,7 +9,7 @@ import { CodeGraphStore } from '../../src/codegraph/store.js';
 import { closeAllDatabases } from '../../src/store/sqlite-db.js';
 
 vi.mock('node:child_process', () => ({
-  execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }));
 
 vi.mock('node:fs', async (importOriginal) => ({
@@ -29,9 +29,9 @@ describe('context-collector', () => {
 
   describe('collectPlanningContext', () => {
     it('should collect file tree via git ls-files', () => {
-      vi.mocked(cp.execSync).mockImplementation((cmd: string) => {
-        if (cmd.includes('ls-files')) return 'src/index.ts\nsrc/main.ts\npackage.json';
-        if (cmd.includes('git log')) return 'abc1234 initial commit';
+      vi.mocked(cp.execFileSync).mockImplementation((file: string, args: readonly string[] | undefined) => {
+        if (file === 'git' && args?.includes('ls-files')) return 'src/index.ts\nsrc/main.ts\npackage.json';
+        if (file === 'git' && args?.includes('log')) return 'abc1234 initial commit';
         return '';
       });
       vi.mocked(fs.existsSync).mockReturnValue(false);
@@ -43,8 +43,8 @@ describe('context-collector', () => {
 
     it('should truncate file tree to maxFileTreeEntries', () => {
       const files = Array.from({ length: 200 }, (_, i) => `file${i}.ts`).join('\n');
-      vi.mocked(cp.execSync).mockImplementation((cmd: string) => {
-        if (cmd.includes('ls-files')) return files;
+      vi.mocked(cp.execFileSync).mockImplementation((file: string, args: readonly string[] | undefined) => {
+        if (file === 'git' && args?.includes('ls-files')) return files;
         return '';
       });
       vi.mocked(fs.existsSync).mockReturnValue(false);
@@ -56,7 +56,7 @@ describe('context-collector', () => {
     });
 
     it('should collect dependencies from package.json', () => {
-      vi.mocked(cp.execSync).mockReturnValue('');
+      vi.mocked(cp.execFileSync).mockReturnValue('');
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify({
         dependencies: { react: '^18', zod: '^3' },
@@ -69,7 +69,7 @@ describe('context-collector', () => {
     });
 
     it('should return empty strings when commands fail', () => {
-      vi.mocked(cp.execSync).mockImplementation(() => { throw new Error('not a git repo'); });
+      vi.mocked(cp.execFileSync).mockImplementation(() => { throw new Error('not a git repo'); });
       vi.mocked(fs.existsSync).mockReturnValue(false);
 
       const ctx = collectPlanningContext({ projectDir: '/fake', agents: ['codex'] });

--- a/tests/orchestrate/coordinator.test.ts
+++ b/tests/orchestrate/coordinator.test.ts
@@ -379,6 +379,54 @@ describe('Coordinator', () => {
     }
   }, 30_000);
 
+  it('should preserve partial agent work after a failed task', async () => {
+    const projectDir = makeTmpDir();
+    const dataDir = makeTmpDir();
+    const failedStore = new TeamStore();
+    await failedStore.init(dataDir);
+    try {
+      initGitRepo(projectDir);
+      failedStore.createTask({ projectId: 'proj1', description: 'Task A' });
+      let workerCwd = '';
+      const adapter: AgentAdapter = {
+        name: 'partial-failure',
+        async available() { return true; },
+        spawn(_prompt: string, opts: SpawnOptions): AgentProcess {
+          workerCwd = opts.cwd;
+          fs.writeFileSync(path.join(workerCwd, 'partial.txt'), 'recover me');
+          return {
+            pid: 99999,
+            completion: Promise.resolve({ exitCode: 1, signal: null, tailOutput: 'failed after writing', killed: false }),
+            abort() {},
+          };
+        },
+      };
+      const events: CoordinatorEvent[] = [];
+
+      const result = await runCoordinationLoop({
+        projectDir,
+        projectId: 'proj1',
+        adapters: [adapter],
+        teamStore: failedStore,
+        maxRetries: 0,
+        pollIntervalMs: 50,
+        taskTimeoutMs: 5_000,
+        pipelineId: 'test-pipe-123',
+        worktreeMode: 'always',
+        onProgress: (event) => events.push(event),
+      });
+
+      expect(result.failed).toBe(1);
+      expect(fs.existsSync(workerCwd)).toBe(true);
+      expect(fs.readFileSync(path.join(workerCwd, 'partial.txt'), 'utf8')).toBe('recover me');
+      expect(events.some((event) => event.type === 'worktree:preserve')).toBe(true);
+    } finally {
+      closeDatabase(dataDir);
+      cleanup(dataDir);
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
   it('should show plan in dry-run mode without spawning', async () => {
     store.createTask({ projectId: 'proj1', description: 'Task DryRun' });
 
@@ -896,7 +944,7 @@ describe('Coordinator', () => {
     const worktreeCreated = events.some(e => e.type === 'worktree:create');
     if (worktreeCreated && conflictWritten) {
       const conflictEvent = events.find(e =>
-        e.type === 'task:failed' && e.message.includes('merge conflict'),
+        e.type === 'task:failed' && e.message.includes('integration failed'),
       );
       const mergeSuccessEvent = events.find(e => e.type === 'worktree:merge');
 

--- a/tests/orchestrate/worktree.test.ts
+++ b/tests/orchestrate/worktree.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
+  mergeWorktree,
   extractTaskIdFromPath,
   cleanupOrphanWorktrees,
   listWorktrees,
@@ -7,7 +8,7 @@ import {
 import * as cp from 'node:child_process';
 
 vi.mock('node:child_process', () => ({
-  execSync: vi.fn(),
+  execFileSync: vi.fn(),
 }));
 
 vi.mock('node:fs', () => ({
@@ -23,6 +24,10 @@ describe('worktree', () => {
   describe('extractTaskIdFromPath', () => {
     it('should extract short ID from valid path', () => {
       expect(extractTaskIdFromPath('/project/.worktrees/task-abc12345')).toBe('abc12345');
+    });
+
+    it('should extract the original ID from a retry worktree path', () => {
+      expect(extractTaskIdFromPath('/project/.worktrees/task-abc12345-2')).toBe('abc12345');
     });
 
     it('should return null for non-matching path', () => {
@@ -47,7 +52,7 @@ describe('worktree', () => {
         '',
       ].join('\n');
 
-      vi.mocked(cp.execSync).mockReturnValue(porcelainOutput);
+      vi.mocked(cp.execFileSync).mockReturnValue(porcelainOutput as never);
 
       const result = listWorktrees('/project');
       // Only the .worktrees one should be returned
@@ -57,7 +62,7 @@ describe('worktree', () => {
     });
 
     it('should return empty array on error', () => {
-      vi.mocked(cp.execSync).mockImplementation(() => { throw new Error('not a repo'); });
+      vi.mocked(cp.execFileSync).mockImplementation(() => { throw new Error('not a repo'); });
       expect(listWorktrees('/fake')).toEqual([]);
     });
   });
@@ -79,12 +84,9 @@ describe('worktree', () => {
         '',
       ].join('\n');
 
-      // First call: list, subsequent calls: remove operations
-      let callCount = 0;
-      vi.mocked(cp.execSync).mockImplementation((cmd: string) => {
-        if (cmd.includes('worktree list')) return porcelainOutput;
-        callCount++;
-        return '';
+      vi.mocked(cp.execFileSync).mockImplementation((_file, args) => {
+        if (args[0] === 'worktree' && args[1] === 'list') return porcelainOutput as never;
+        return '' as never;
       });
 
       const removed = cleanupOrphanWorktrees('/project', (shortId) => {
@@ -96,13 +98,33 @@ describe('worktree', () => {
     });
 
     it('should return 0 when no orphans exist', () => {
-      vi.mocked(cp.execSync).mockImplementation((cmd: string) => {
-        if (cmd.includes('worktree list')) return 'worktree /project\nHEAD abc\nbranch refs/heads/main\n';
-        return '';
+      vi.mocked(cp.execFileSync).mockImplementation((_file, args) => {
+        if (args[0] === 'worktree' && args[1] === 'list') return 'worktree /project\nHEAD abc\nbranch refs/heads/main\n' as never;
+        return '' as never;
       });
 
       const removed = cleanupOrphanWorktrees('/project', () => false);
       expect(removed).toBe(0);
+    });
+  });
+
+  describe('mergeWorktree', () => {
+    it('preserves uncommitted agent changes when the commit cannot be created', () => {
+      vi.mocked(cp.execFileSync).mockImplementation((_file, args) => {
+        if (args[0] === 'status') return '?? partial.txt\n' as never;
+        if (args[0] === 'commit') throw new Error('Author identity unknown');
+        return '' as never;
+      });
+
+      const result = mergeWorktree('/project', 'pipeline/test/task-deadbeef', '/project/.worktrees/task-deadbeef');
+
+      expect(result.success).toBe(false);
+      expect(result.conflicts).toContain('Could not commit agent changes');
+      expect(cp.execFileSync).not.toHaveBeenCalledWith(
+        'git',
+        expect.arrayContaining(['merge']),
+        expect.any(Object),
+      );
     });
   });
 });


### PR DESCRIPTION
## Summary
- make Windows Control Plane startup hidden and independent while retaining the real service PID
- make stale state fail safe: never kill an unverified live PID
- make setup dry-runs non-mutating, make CLI validation fail closed, and preserve recoverable orchestration worktrees
- refresh MCP/dependency release metadata for 1.3.2

## Verification
- npm test (666 passed)
- npm --workspace @memorix/tui test
- npm run lint
- npm run build
- npm audit and npm audit --omit=dev (0 vulnerabilities)
- npm run check:mcp-registry
- npm pack --dry-run
- isolated Windows CLI/background/HTTP MCP smoke, including an actual memorix_project_context call