### PR TITLE
feat(media): complete controlled multimodal foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,17 @@
 # OPENAI_API_KEY=sk-...
 # ANTHROPIC_API_KEY=sk-ant-...
 # OPENROUTER_API_KEY=sk-or-...
+
+# ── Optional MiniMax Media Generation ──
+# Explicit CLI generation only. Never commit these keys.
+# MINIMAX_API_KEY=...
+# MINIMAX_CN_API_KEY=...
+# MINIMAX_REGION=global
+# MINIMAX_IMAGE_MODEL=image-01
+# MINIMAX_IMAGE_BASE_URL=https://api.minimax.io
+# MINIMAX_VIDEO_MODEL=MiniMax-H3
+# MINIMAX_VIDEO_BASE_URL=https://api.minimax.io
+#
+# MCP generation is disabled by default because it can incur provider charges.
+# Set only after deliberately authorizing agent-initiated generation:
+# MEMORIX_MCP_MEDIA_GENERATION=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      # Root source imports the private @memorix/* workspaces through their
+      # published dist/type entrypoints, so typecheck needs those artifacts.
+      - run: npm run build:workspaces
       - run: npm run lint
 
   native-sqlite-node26:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.3] - 2026-08-02
+
+### Added
+- **Controlled media assets** -- Added a local content-addressed asset library for explicit images, audio, video, and PDFs. Assets live outside the Git worktree, keep validated MIME/hash/size provenance, support explicit attachment to normal memory, and have link-aware quota cleanup.
+- **MiniMax media generation** -- Added explicit MiniMax image generation and durable MiniMax-H3 video jobs. Video tasks survive process restarts, expose status/cancellation, and import completed output only after bounded safe download validation.
+- **Honest multimodal embedding foundation** -- Added typed media embedding inputs, profile/modality compatibility checks, and separate media-vector storage. Text-only embedding providers now return a capability fallback instead of inventing a visual vector.
+- **One MCP media operation** -- Added `memorix_media` for agent-facing import, attachment, inspection, and job status while retaining CLI as the complete management surface.
+
+### Changed
+- **Legacy image ingestion joins the asset lifecycle** -- `memorix ingest image` and the full-profile compatibility tool now keep a verified controlled image asset alongside the text retrieval projection instead of discarding the binary.
+- **MCP binding boundary** -- Project binding is now a transport-neutral request context. Legacy HTTP session IDs only route transport requests; explicit project roots cannot be overwritten by Roots discovery, including a workspace that contains a nested Git project.
+
+### Fixed
+- **Atomic media removal** -- Asset removal stages a file in a controlled recovery directory, then atomically detaches links, removes derivations/vectors, and marks the asset deleted. A database failure restores the file instead of silently losing it.
+- **No ambient paid generation** -- MCP image/video generation is disabled until `MEMORIX_MCP_MEDIA_GENERATION=1` is explicitly set. CLI generation remains deliberate and auditable.
+- **Bounded image analysis** -- Legacy base64 image ingestion validates canonical input before decoding, caps visual analysis at 20 MiB, and sanitizes provider-derived descriptions and diagnostics before persistence.
+- **Test data isolation** -- Tool-profile integration tests now always use temporary Memorix data directories instead of a developer's real local memory database.
+- **Smaller install artifact** -- Excluded runtime-unneeded distribution sourcemaps from the npm package while retaining compiled code, source, documentation, and memcode runtime assets.
+
 ## [1.3.2] - 2026-08-02
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -349,6 +349,48 @@ memorix workbench
 
 The CLI is direct and does not depend on an MCP session. It binds to the current Git project, or to the project supplied with `--cwd`. Without an active identity it reads, writes, and exports project-visible memory only. Use `memorix identity join` or `memorix identity use --agent-id <id>` only when you intentionally need personal/team memory or coordinated task actions; `memorix identity clear` returns the terminal to project scope. `--as <active-agent-id>` is the one-command alternative for scripts. Both camelCase and kebab-case flags are accepted.
 
+### Manage controlled media
+
+Media is opt-in. An explicit local import is copied into Memorix's local data
+directory, hashed, and kept outside the Git worktree. It becomes normal memory
+only when you attach it. Memorix never captures every screenshot or tool output.
+An asset may be up to the configured media limit (100 MiB by default). Automatic
+vision analysis is deliberately capped at 20 MiB; a larger image is still kept
+and can be attached, but Memorix records a clear text fallback instead of
+sending an oversized payload to a model provider.
+
+```bash
+memorix media import --path ./architecture.png --json
+memorix media attach --asset <asset-id> --title "Architecture diagram" --json
+memorix media list --kind image --json
+memorix media show --asset <asset-id> --json
+memorix media remove --asset <asset-id> --force --json
+
+# Legacy image analysis now uses the same controlled asset lifecycle.
+memorix ingest image --path ./architecture.png --json
+```
+
+MiniMax image generation is a deliberate CLI operation. Video generation returns
+a durable job immediately; inspect or cancel that job rather than waiting in an
+agent request.
+
+```bash
+# Configure MINIMAX_API_KEY in your user environment or .env, never in Git.
+memorix media generate image --prompt "A clean system architecture diagram" --json
+memorix media generate video --prompt "A short product walkthrough" --json
+memorix media status --job <media-job-id> --json
+memorix media cancel --job <media-job-id> --json
+```
+
+`memorix_media` is the compact MCP companion in the `lite`, `team`, and `full`
+profiles. It supports import, attach, list, show, and job status. MCP image and
+video generation are disabled by default because they may incur provider costs.
+Set `MEMORIX_MCP_MEDIA_GENERATION=1` only after you deliberately want an agent
+to request billed MiniMax output. The normal OpenRouter text embedding lane is
+still text-only; media vectors are created only by a provider that explicitly
+declares support for that modality. Text descriptions and attachments remain a
+useful ordinary retrieval fallback.
+
 ### Use the bundled terminal agent
 
 ```bash
@@ -385,7 +427,7 @@ Long-term memory is deliberately not an automatic dump of every note. A source o
 | Manually expose stdio MCP | `memorix serve` |
 | Run shared HTTP MCP plus dashboard | `memorix background start` |
 | Debug HTTP MCP in the foreground | `memorix serve-http --port 3211` |
-| Inspect or manage memory directly | `memorix memory`, `memorix reasoning`, `memorix session`, `memorix ingest` |
+| Inspect or manage memory directly | `memorix memory`, `memorix reasoning`, `memorix session`, `memorix ingest`, `memorix media` |
 | Manage reviewed long-term memory | `memorix memory long-term list|show|add|promote|qualify|approve|archive|supersede` |
 | Inspect native compaction continuity | `memorix checkpoint list|show|context|archive` |
 | Use the interactive terminal memory control plane | `memorix workbench` |
@@ -434,6 +476,12 @@ formation = "active"
 Use `[memory.llm]` and `[embedding]` for Memorix memory quality and retrieval. Use `[agent]` for the model memcode talks to while coding. Keep credentials in global config or environment variables, and do not commit secrets.
 
 For OpenRouter embeddings, use `provider = "api"`, `base_url = "https://openrouter.ai/api/v1"`, and `model = "qwen/qwen3-embedding-8b"`. Memorix accepts `OPENROUTER_API_KEY` for that embedding endpoint; `MEMORIX_EMBEDDING_API_KEY` remains the explicit override.
+
+For controlled MiniMax media generation, set `MINIMAX_API_KEY` (global) or
+`MINIMAX_CN_API_KEY` (China region) in your environment or `.env`. The media
+library never stores that key, a signed output URL, or base64 payloads. CLI
+generation is explicit; MCP generation additionally requires
+`MEMORIX_MCP_MEDIA_GENERATION=1`.
 
 <h2 id="docker"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-docker.svg"><img src="assets/tags/section-docker.svg" alt="Docker" height="32" /></picture></h2>
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -349,6 +349,33 @@ memorix workbench
 
 CLI 是直接入口，不依赖 MCP 会话。它默认绑定当前 Git 项目，也可以用 `--cwd` 指定项目。没有激活身份时，只会读写和导出项目公开记忆；只有明确需要个人/团队记忆或协同任务时，才运行 `memorix identity join` 或 `memorix identity use --agent-id <id>`。`memorix identity clear` 会回到项目公开范围；脚本可用一次性的 `--as <active-agent-id>`。已有 camelCase 参数仍兼容，kebab-case 也可直接使用。
 
+### 管理受控媒体
+
+媒体是显式、可控的。导入本地文件后，Memorix 会将其复制到本地数据目录、计算哈希，并放在 Git 工作区之外；只有执行附着操作后，资产才会进入普通项目记忆。它不会自动抓取每一张截图或工具输出。默认媒体资产上限为 100 MiB；自动视觉分析单独限制为 20 MiB。更大的图片仍可保存和附着，但不会被强行发送给模型，而是会留下明确的文本回退说明。
+
+```bash
+memorix media import --path ./architecture.png --json
+memorix media attach --asset <asset-id> --title "架构图" --json
+memorix media list --kind image --json
+memorix media show --asset <asset-id> --json
+memorix media remove --asset <asset-id> --force --json
+
+# 旧的图像分析命令现在也会走同一套受控资产生命周期。
+memorix ingest image --path ./architecture.png --json
+```
+
+MiniMax 图像生成是需要明确执行的 CLI 操作。视频生成会立即返回一个可持久查询的任务，不会把 Agent 请求卡在等待生成结果上。
+
+```bash
+# 在用户环境变量或 .env 中配置 MINIMAX_API_KEY，绝不要提交进 Git。
+memorix media generate image --prompt "清晰的系统架构图" --json
+memorix media generate video --prompt "简短的产品演示" --json
+memorix media status --job <media-job-id> --json
+memorix media cancel --job <media-job-id> --json
+```
+
+`memorix_media` 是 `lite`、`team`、`full` profile 中紧凑的 MCP 对应入口，可导入、附着、列出、查看和查询任务状态。因为图像/视频生成可能产生 provider 费用，MCP 默认禁止生成；只有你明确允许 Agent 付费调用时，才设置 `MEMORIX_MCP_MEDIA_GENERATION=1`。默认的 OpenRouter 文本 embedding 仍然只是文本向量；只有明确声明支持该模态的 provider 才会生成媒体向量。文本描述和附着信息仍可通过普通检索使用。
+
 ### 使用内置终端 Agent
 
 ```bash
@@ -385,7 +412,7 @@ memcode
 | 手动暴露 stdio MCP | `memorix serve` |
 | 启动共享 HTTP MCP 和 Dashboard | `memorix background start` |
 | 前台调试 HTTP MCP | `memorix serve-http --port 3211` |
-| 直接检查或管理记忆 | `memorix memory`、`memorix reasoning`、`memorix session`、`memorix ingest` |
+| 直接检查或管理记忆 | `memorix memory`、`memorix reasoning`、`memorix session`、`memorix ingest`、`memorix media` |
 | 管理已审核的长期记忆 | `memorix memory long-term list|show|add|promote|qualify|approve|archive|supersede` |
 | 检查原生上下文压缩连续性 | `memorix checkpoint list|show|context|archive` |
 | 使用交互式终端记忆控制台 | `memorix workbench` |
@@ -432,6 +459,8 @@ formation = "active"
 `[memory.llm]` 和 `[embedding]` 负责记忆质量和检索；`[agent]` 是 memcode 编码时使用的模型。凭据放全局配置或环境变量，不要提交 secrets。
 
 如果使用 OpenRouter embedding，可以设置 `provider = "api"`、`base_url = "https://openrouter.ai/api/v1"`、`model = "qwen/qwen3-embedding-8b"`。这个 endpoint 下 Memorix 会读取官方 `OPENROUTER_API_KEY`；需要单独覆盖 embedding key 时仍可用 `MEMORIX_EMBEDDING_API_KEY`。
+
+受控 MiniMax 媒体生成可在环境变量或 `.env` 中设置全局 `MINIMAX_API_KEY`，或中国区 `MINIMAX_CN_API_KEY`。媒体库不会保存该 key、临时签名 URL 或 base64 负载。CLI 生成本身就是显式操作；若要让 MCP 中的 Agent 发起生成，还必须明确设置 `MEMORIX_MCP_MEDIA_GENERATION=1`。
 
 <h2 id="docker"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-docker.svg"><img src="assets/tags/section-docker.svg" alt="Docker" height="32" /></picture></h2>
 

--- a/docs/1.3.3-MULTIMODAL-MEDIA-AND-MCP-COMPAT.md
+++ b/docs/1.3.3-MULTIMODAL-MEDIA-AND-MCP-COMPAT.md
@@ -1,0 +1,359 @@
+# Memorix 1.3.3: Multimodal Media and Stateless-Ready MCP
+
+## Why this release exists
+
+Memorix can already turn an image into a text observation, but the image itself
+is discarded. That is useful as a one-off note, not as a trustworthy multimedia
+memory system. It also cannot safely distinguish a generated image URL from a
+durable local asset, and it has no durable model for asynchronous video work.
+
+1.3.3 adds the foundation that makes media a real part of project memory without
+turning every screenshot, URL, or model output into an opaque blob collection.
+The release contains five connected capabilities:
+
+1. a controlled local media asset lifecycle;
+2. MiniMax image generation as an explicit asset-producing operation;
+3. MiniMax asynchronous video generation as a durable job, not a blocking tool
+   call;
+4. typed embedding inputs with honest capability and fallback behavior; and
+5. an MCP request boundary that keeps product state independent from the legacy
+   transport session while preserving current clients.
+
+These are one system. A provider response that cannot be stored, traced,
+retrieved, removed, and recovered is not a Memorix media feature.
+
+## Product model
+
+```text
+explicit file import / generated MiniMax output
+                     |
+                     v
+        validated local MediaAsset (content-addressed)
+                     |
+                     +--> derived text description / OCR / tags
+                     |              |
+                     |              v
+                     |      ordinary observation + BM25 retrieval
+                     |
+                     +--> optional typed media embedding
+                     |              |
+                     |              v
+                     |     modality-compatible media-vector retrieval
+                     |
+                     v
+             explicit attachment to memory
+```
+
+The image or video is never an instruction. Descriptions, OCR, file metadata,
+and provider output are treated as untrusted data. They may be searched and
+shown to an agent, but never become executable rules, hooks, commands, or
+workflow gates.
+
+## Goals
+
+### 1. Controlled media assets
+
+Add first-class `MediaAsset` records, separate from `Observation` text:
+
+- Bytes live only under the local Memorix data directory, outside the Git worktree.
+- A SHA-256 content hash is the canonical identity and provides deduplication.
+- The database stores relative storage path, byte size, MIME type, media kind,
+  source type, creation time, optional safe source label, and provider/model
+  provenance. It never persists signed download URLs, inline base64, or API
+  credentials.
+- `media_asset_links` explicitly connects an asset to an observation or another
+  durable consumer. Reference counts are derived from those links rather than
+  trusted from an unprotected mutable counter.
+- Import accepts only a local, regular file under an explicit path. Generation
+  downloads only provider output after response validation. Arbitrary external
+  URLs are not a public ingestion route.
+- Quota cleanup is fail-closed: it removes only unlinked assets, oldest first,
+  and leaves assets alone when link accounting cannot be read.
+- Removing an asset detaches its links and textual/vector derivations together;
+  a linked asset requires an explicit `--force` operator action.
+
+### 2. MiniMax image generation
+
+`memorix media generate image` is a user-controlled creation command. It sends
+a prompt and declared options to MiniMax, validates the provider response,
+downloads each returned image into the controlled asset store, and reports
+asset IDs. It does not silently add model output to project memory.
+
+An image enters memory only through `memorix media attach --asset <id>` or an
+explicit `--attach` flag. The attachment creates a normal source-backed
+observation with a small textual description and asset reference, allowing the
+ordinary memory pipeline to remain the retrieval source of truth.
+
+The provider configuration is environment/config driven. `MINIMAX_API_KEY`,
+base URL, and model are never stored in an asset, observation, or diagnostic.
+Provider output URLs are treated as temporary transport inputs and discarded
+after successful controlled storage.
+
+### 3. MiniMax video generation
+
+Video generation is asynchronous by contract. `memorix media generate video`
+creates a durable `media-video-generation` maintenance job with a Memorix
+`mediaJobId`, then returns immediately. The worker owns:
+
+```text
+queued -> submitting -> provider-pending -> downloading -> completed
+                                      \-> retry / failed / cancelled
+```
+
+- The job payload contains only safe request parameters and the project ID.
+  API keys come from current configuration at execution time.
+- The provider task ID and sanitized provider status are stored separately from
+  the temporary output URL.
+- Polling has bounded backoff, leases, cancellation, and recovery after a host
+  exit. Re-running the same requested job is deduplicated.
+- A finished video is stored like any other controlled asset. It is not attached
+  to memory unless the caller requested attachment.
+- The initial release supports MiniMax's officially documented task creation
+  and query flow. It does not claim video semantic embeddings before a provider
+  capability is configured and tested.
+
+### 4. Typed embeddings and retrieval
+
+Text vectors and media vectors are not interchangeable. An embedding profile
+therefore records provider, model, dimensions, modality, task intent, and
+version. A query only compares vectors from the same compatible profile.
+
+The public input shape is deliberately typed:
+
+```ts
+type EmbeddingInput =
+  | { modality: 'text'; text: string }
+  | { modality: 'image'; assetId: string }
+  | { modality: 'audio'; assetId: string }
+  | { modality: 'video'; assetId: string }
+  | { modality: 'document'; assetId: string };
+
+type EmbeddingIntent = 'query' | 'document';
+```
+
+The provider receives resolved local bytes only after the asset-store boundary
+has checked size and MIME type. It never receives an arbitrary user URL. Text
+providers expose text-only capability. A native multimodal provider may opt in
+for a declared media modality; an unsupported request returns a typed capability
+result rather than faking a vector.
+
+Every media asset has a text fallback path. Image description/tags/OCR are
+stored as an observation and indexed in BM25. If visual embedding is disabled,
+slow, unavailable, or incompatible, normal text retrieval remains useful. This
+is the default behavior for the OpenRouter text embedding configuration used by
+most Memorix installations.
+
+### 5. Stateless-ready MCP boundary
+
+Current released MCP SDK clients use legacy HTTP session headers and some
+clients still use Roots for project discovery. That is a transport compatibility
+layer, not Memorix product identity.
+
+1.3.3 introduces a small `RequestContext`/binding resolver boundary:
+
+- Product operations receive a resolved project/workspace binding and explicit
+  actor metadata; they do not read an HTTP session map directly.
+- The old `Mcp-Session-Id` map remains isolated in `serve-http` as a legacy
+  adapter until the current SDK has a stable released implementation of the
+  2026-07-28 protocol.
+- Asset IDs, media job IDs, project IDs, and attachment targets are explicit
+  durable identifiers. They are never inferred from a live MCP connection.
+- New media tools work through stdio, legacy streamable HTTP, and direct CLI
+  invocation with identical project binding behavior.
+- No release depends on an unreleased MCP SDK 2.x alpha. The current server
+  remains compatible with existing Codex, Claude Code, OpenCode, and other
+  configured clients.
+
+## Non-goals
+
+- No automatic capture of every screenshot, tool output, or browser image.
+- No remote URL ingestion, cloud object store, cross-machine media sync, or
+  third-party account identity.
+- No claim that MiniMax generation itself provides multimodal embeddings.
+- No automatic audio/video transcription, frame extraction, or arbitrary media
+  understanding in 1.3.3. The asset model makes those future derivations safe.
+- No forced migration to a protocol version that the published MCP TypeScript
+  SDK does not yet support.
+- No additional swarm of low-level MCP tools; CLI is the complete management
+  surface and MCP exposes only small agent-facing operations.
+
+## Storage contract
+
+### SQLite tables
+
+`media_assets`
+
+| Field | Meaning |
+| --- | --- |
+| `id` | Stable UUID asset identifier. |
+| `project_id` | Project ownership boundary. |
+| `sha256` | Content identity, unique per project. |
+| `kind`, `mime_type`, `byte_size` | Validated media metadata. |
+| `storage_rel_path` | Path relative to Memorix media root only. |
+| `source_kind` | `import`, `minimax-image`, or `minimax-video`. |
+| `source_label` | Sanitized filename/provider label, never credentials/URL query. |
+| `provider`, `model` | Optional generation/derivation provenance. |
+| `created_at`, `updated_at`, `deleted_at` | Lifecycle audit. |
+
+`media_asset_links`
+
+| Field | Meaning |
+| --- | --- |
+| `asset_id` | Asset being referenced. |
+| `observation_id` | Optional observation owner. |
+| `role` | `source`, `generated`, or `attachment`. |
+| `created_at` | Link provenance. |
+
+`media_derivations`
+
+| Field | Meaning |
+| --- | --- |
+| `asset_id` | Source asset. |
+| `kind` | `description`, `ocr`, `embedding`. |
+| `profile_key` | Embedding profile for vector derivations, otherwise null. |
+| `content` | Sanitized text or serialised vector payload. |
+| `status`, `error` | Bounded processing state and diagnostic. |
+| `created_at`, `updated_at` | Rebuild bookkeeping. |
+
+`media_jobs`
+
+| Field | Meaning |
+| --- | --- |
+| `id` | User-facing durable Memorix job ID. |
+| `project_id`, `kind`, `status` | Ownership and state machine. |
+| `request_json` | Sanitized model/prompt/options, never API key. |
+| `provider_task_id` | MiniMax task handle after submit. |
+| `asset_id` | Completed output when available. |
+| `last_error`, timestamps | Bounded recovery diagnostics. |
+
+All migrations are additive and idempotent. Existing observations and current
+text vector indexes are untouched.
+
+## CLI and MCP surface
+
+The CLI is canonical and supports JSON output for agents:
+
+```text
+memorix media import --path ./architecture.png --json
+memorix media list --kind image --json
+memorix media show --asset <asset-id> --json
+memorix media attach --asset <asset-id> --title "Architecture diagram" --json
+memorix media remove --asset <asset-id> [--force] --json
+memorix media cleanup --max-bytes 1073741824 --json
+
+memorix media generate image --prompt "..." [--model image-01] [--attach] --json
+memorix media generate video --prompt "..." [--model MiniMax-H3] [--attach] --json
+memorix media status --job <media-job-id> --json
+memorix media cancel --job <media-job-id> --json
+```
+
+The MCP profile adds only one high-level `memorix_media` operation with a
+discriminated `action` (`import`, `attach`, `list`, `show`, `generate-image`,
+`generate-video`, `status`). It uses the same services as the CLI. Destructive
+actions remain CLI-first and require an explicit operation.
+
+## Security and resource rules
+
+1. Accept only regular local files. Reject directories, special files, symlinks
+   escaping the supplied path, unknown MIME types, empty input, and assets over
+   a configured maximum.
+2. Verify hash, byte length, and file magic/MIME consistency before commit.
+3. Generated output is downloaded with protocol, redirect, byte-limit, and
+   content-type checks, then copied into local content-addressed storage.
+4. No API key, signed URL, full remote URL, or inline base64 enters SQLite,
+   Orama, memory text, task payload, logs, or CLI JSON.
+5. Descriptions are clearly marked as derived data and subject to the same
+   credential sanitization as observations.
+6. Cleanup never deletes linked assets. A corrupted link table stops cleanup
+   rather than guessing.
+7. Media background work never blocks MCP tool response paths.
+
+## Delivery phases
+
+### Phase A: contract and persistence
+
+Create this specification, the asset domain types, additive SQLite schema,
+content-addressed storage service, and unit tests for import/dedup/remove/quota.
+
+### Phase B: text-backed asset retrieval
+
+Convert the existing `ingest image` path to import a real asset, retain the
+current text analysis as a derivation, and create an attached observation.
+Verify that BM25 can find it without any media vector provider.
+
+### Phase C: typed embedding boundary
+
+Adopt a reviewed, contributor-authored typed input foundation where correct.
+Add profiles and a media-vector store that cannot contaminate the current text
+vector space. Implement a truthful text fallback and capability tests.
+
+### Phase D: MiniMax image and video providers
+
+Review contributor work before accepting it. Use its image provider only if its
+official request/response handling, response byte limits, and tests meet this
+contract. Implement video as durable job lifecycle, not synchronous generation.
+
+### Phase E: stateless-ready transport adapter
+
+Extract binding resolution from HTTP session state, add tests proving a media
+operation works with explicit project binding, stdio, and legacy HTTP adapters,
+then document the 2026-07-28 migration boundary.
+
+### Phase F: 1.3.3 release gates
+
+- focused domain tests plus full typecheck/build/test;
+- mocked MiniMax success, failure, timeout, and recovery tests;
+- real local import/attach/search/remove CLI smoke on Windows;
+- packed-package install smoke;
+- no personal Codex/Claude/OpenCode configuration mutation;
+- documentation and changelog reviewed.
+
+### Phase G: 1.3.4 hardening
+
+1.3.4 is not a feature release. It exercises fresh install, Windows CLI
+windows-hide behavior, CLI/stdio/HTTP MCP routes, cancellation/restart of media
+jobs, quota cleanup, failure messages, and agent-facing UX. Only defects found
+through that work are fixed.
+
+### Phase H: 1.4 stable release
+
+1.4 is cut only when 1.3.3 and 1.3.4 gates are green, all supported paths have
+packaged CLI evidence, the compatibility matrix is updated, and there is no
+known high-severity data-loss, credential-retention, Windows-popup, or MCP
+binding regression. “No bug” means no known release blocker after these tests,
+not an impossible claim of mathematical perfection.
+
+## Acceptance criteria
+
+1. Importing the same local image twice produces one stored asset hash and two
+   explicit links only when two attachments are requested.
+2. An image ingested through the existing command remains usable after restart;
+   deleting the source file does not delete the controlled copy.
+3. Image-derived text is searchable through normal lexical memory retrieval
+   with embeddings disabled.
+4. A text-only embedder never produces a pretend image vector; the returned
+   capability/fallback state is explicit.
+5. Incompatible vector profile dimensions or modalities cannot be compared.
+6. MiniMax image output is retained only after download and hash validation;
+   its temporary source URL never appears in a database dump or CLI JSON.
+7. A video job survives process restart, can be inspected/cancelled, retries
+   boundedly, and produces an asset only after provider completion.
+8. No generated asset enters project memory without an explicit attach action.
+9. The same media action works through CLI and MCP using an explicit resolved
+   project binding, independent of a legacy HTTP session identifier.
+10. 1.3.4 regression tests cover Windows, fresh package install, CLI, stdio,
+    HTTP MCP, quota cleanup, and error UX before 1.4 is published.
+
+## Research and implementation basis
+
+The design borrows the safe pieces of AgentMemory's managed image references,
+reference-count-aware cleanup, and modality provenance. It adopts the
+`AI-Agents-in-Depth` guidance that native multimodal encoding, text extraction,
+and tool-driven inspection are complementary rather than interchangeable.
+It uses the MCP 2026-07-28 direction by isolating legacy connection state now,
+without upgrading production code to an unpublished SDK API.
+
+Contributor work remains contributor work: PR #134 is a potential typed
+embedding foundation, #165 a potential MiniMax image provider, and #153 a
+potential model-capability improvement. They are reviewed and merged with their
+authorship preserved only when their actual contract fits this design.

--- a/docs/1.3.3-MULTIMODAL-MEDIA-AND-MCP-COMPAT.md
+++ b/docs/1.3.3-MULTIMODAL-MEDIA-AND-MCP-COMPAT.md
@@ -84,6 +84,10 @@ explicit `--attach` flag. The attachment creates a normal source-backed
 observation with a small textual description and asset reference, allowing the
 ordinary memory pipeline to remain the retrieval source of truth.
 
+The controlled asset limit is 100 MiB by default. Visual analysis is a separate
+20 MiB bounded operation: a larger image can still be imported and attached,
+but it receives an explicit text fallback instead of an oversized chat request.
+
 The provider configuration is environment/config driven. `MINIMAX_API_KEY`,
 base URL, and model are never stored in an asset, observation, or diagnostic.
 Provider output URLs are treated as temporary transport inputs and discarded
@@ -250,7 +254,10 @@ memorix media cancel --job <media-job-id> --json
 The MCP profile adds only one high-level `memorix_media` operation with a
 discriminated `action` (`import`, `attach`, `list`, `show`, `generate-image`,
 `generate-video`, `status`). It uses the same services as the CLI. Destructive
-actions remain CLI-first and require an explicit operation.
+actions remain CLI-first and require an explicit operation. Generation is
+disabled in MCP by default and requires `MEMORIX_MCP_MEDIA_GENERATION=1`; this
+prevents an agent from creating billable provider output without an operator's
+explicit policy choice.
 
 ## Security and resource rules
 
@@ -267,6 +274,9 @@ actions remain CLI-first and require an explicit operation.
 6. Cleanup never deletes linked assets. A corrupted link table stops cleanup
    rather than guessing.
 7. Media background work never blocks MCP tool response paths.
+8. Legacy base64 image input is canonical, bounded before decoding, and limited
+   to 20 MiB for visual analysis. Provider descriptions and diagnostics are
+   credential-sanitized before they enter durable media records.
 
 ## Delivery phases
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -54,6 +54,7 @@ The current CLI namespaces are:
 - `memorix receipt`
 - `memorix sync`
 - `memorix ingest`
+- `memorix media`
 - `memorix workbench`
 
 Typical examples:
@@ -78,6 +79,8 @@ memorix transfer export --format markdown --out ./memorix-export.md
 memorix skills show --name auth-pattern
 memorix sync workspace --action scan
 memorix ingest image --path ./diagram.png
+memorix media import --path ./architecture.png
+memorix media attach --asset <asset-id> --title "Architecture diagram"
 memorix poll --agentId <agent-id>
 memorix receipt --json --probe "release blocker"
 ```
@@ -721,18 +724,58 @@ it on behalf of the sender.
 
 ---
 
-## 10. Ingestion Tools
+## 10. Controlled Media and Legacy Ingestion
+
+### `memorix media`
+
+`memorix media` is the complete operator surface for local media assets. It
+accepts an explicit local regular file, validates its type and size, stores a
+content-addressed copy outside the Git worktree, and only enters normal memory
+when attached. It does not ingest arbitrary URLs or capture screenshots
+automatically.
+
+The default controlled-asset limit is 100 MiB. `memorix ingest image` and the
+legacy MCP image path limit automatic vision analysis to 20 MiB. Larger images
+can still be imported and attached; they receive a text fallback instead of an
+oversized provider request.
+
+```bash
+memorix media import --path ./architecture.png --json
+memorix media list --kind image --json
+memorix media show --asset <asset-id> --json
+memorix media attach --asset <asset-id> --title "Architecture diagram" --json
+memorix media remove --asset <asset-id> --force --json
+memorix media cleanup --max-bytes 1073741824 --json
+```
+
+MiniMax image creation is an explicit CLI action. Video creation is queued as a
+durable job, so it survives process restarts and can be inspected or cancelled.
+
+```bash
+memorix media generate image --prompt "..." --json
+memorix media generate video --prompt "..." --json
+memorix media status --job <media-job-id> --json
+memorix media cancel --job <media-job-id> --json
+```
+
+Set `MINIMAX_API_KEY` (or `MINIMAX_CN_API_KEY`) outside Git before using
+generation. `memorix_media` is the matching single MCP tool in `lite`, `team`,
+and `full` profiles. Its import/attach/list/show/status actions are available
+normally; generation requires `MEMORIX_MCP_MEDIA_GENERATION=1` because it can
+incur provider charges. Text-only embedding providers never produce a pretend
+image, audio, video, or document vector.
 
 ### `memorix_ingest_image`
 
-Ingest an image as memory context when visual artifacts are relevant to the project.
+This is the legacy full-profile MCP compatibility tool. It accepts image bytes,
+imports the verified image into the same controlled media library, then creates
+a text retrieval projection. Prefer `memorix_media` for new agent integrations.
 
 Important inputs:
 
-- `path`
-- optional `title`
-- optional `entityName`
-- optional `type`
+- `base64`
+- optional `filename`
+- optional `prompt`
 
 CLI equivalent:
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -180,6 +180,27 @@ Then set `OPENROUTER_API_KEY` in your shell, user environment, or `.env`. You
 can still set `MEMORIX_EMBEDDING_API_KEY` when you want an explicit embedding
 key override; it takes priority over `OPENROUTER_API_KEY`.
 
+### Controlled MiniMax media
+
+MiniMax generation is separate from the text embedding lane. Set one of these
+outside Git only when you deliberately use image or video generation:
+
+- `MINIMAX_API_KEY` for the global endpoint
+- `MINIMAX_CN_API_KEY` for the China endpoint
+- optional `MINIMAX_REGION=global|cn`
+- optional image/video model and endpoint overrides for self-managed routing
+
+The CLI is the normal generation path. `memorix_media` can import, attach, and
+inspect assets through MCP, but MCP generation is off by default. Set
+`MEMORIX_MCP_MEDIA_GENERATION=1` only after you intentionally allow an agent to
+create provider-billed output. The default OpenRouter text embedder remains
+text-only; Memorix produces a media vector only when a provider explicitly
+declares compatibility with that media modality.
+
+Controlled assets default to a 100 MiB import limit. Vision analysis has a
+separate 20 MiB cap so a large local file can remain a usable asset without
+creating an oversized chat-completions request.
+
 ### `[memory]`
 
 Runtime memory behavior.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memorix",
   "mcpName": "io.github.AVIDS2/memorix",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,
@@ -33,6 +33,7 @@
   },
   "files": [
     "dist",
+    "!dist/**/*.map",
     "src",
     "server.json",
     "!src/**/*.js",

--- a/packages/ai/scripts/generate-image-models.ts
+++ b/packages/ai/scripts/generate-image-models.ts
@@ -3,12 +3,17 @@
 import { writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath, pathToFileURL } from "url";
-import type { ImagesModel } from "../src/types.ts";
+import type { ImagesApi, ImagesModel } from "../src/types.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const packageRoot = join(__dirname, "..");
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+const MINIMAX_IMAGE_MODEL_IDS = ["image-01", "image-01-live"] as const;
+const MINIMAX_IMAGE_VARIANTS = [
+	{ provider: "minimax", baseUrl: "https://api.minimax.io/v1/image_generation" },
+	{ provider: "minimax-cn", baseUrl: "https://api.minimaxi.com/v1/image_generation" },
+] as const;
 const MIN_GENERATED_IMAGE_MODEL_COUNT = 1;
 const CATALOG_SHRINK_OVERRIDE_ENV = "MEMORIX_ALLOW_MODEL_CATALOG_SHRINK";
 
@@ -78,6 +83,21 @@ async function fetchOpenRouterImageModels(): Promise<ImagesModel<"openrouter-ima
 	}
 }
 
+function getMiniMaxImageModels(): ImagesModel<"minimax-images">[] {
+	return MINIMAX_IMAGE_VARIANTS.flatMap(({ provider, baseUrl }) =>
+		MINIMAX_IMAGE_MODEL_IDS.map((modelId) => ({
+			id: modelId,
+			name: modelId,
+			api: "minimax-images",
+			provider,
+			baseUrl,
+			input: ["text"],
+			output: ["image"],
+			cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+		})),
+	);
+}
+
 export async function loadExistingGeneratedImageModelCount(): Promise<number> {
 	try {
 		const generatedUrl = new URL("../src/image-models.generated.ts", import.meta.url).href;
@@ -104,14 +124,8 @@ export function assertImageModelCatalogRefreshSafe(nextCount: number, existingCo
 	);
 }
 
-function generateImageModelsFile(models: ImagesModel<"openrouter-images">[]): string {
-	const imageModelsByProvider = {
-		openrouter: Object.fromEntries(
-			models
-				.sort((a, b) => a.id.localeCompare(b.id))
-				.map((model) => [
-					model.id,
-					`{
+function serializeImageModel(model: ImagesModel<ImagesApi>): string {
+	return `{
 			id: ${JSON.stringify(model.id)},
 			name: ${JSON.stringify(model.name)},
 			api: ${JSON.stringify(model.api)},
@@ -120,14 +134,24 @@ function generateImageModelsFile(models: ImagesModel<"openrouter-images">[]): st
 			input: ${JSON.stringify(model.input)},
 			output: ${JSON.stringify(model.output)},
 			cost: ${JSON.stringify(model.cost, null, 2).replace(/^/gm, "\t")}
-		} satisfies ImagesModel<${JSON.stringify(model.api)}>`,
-				]),
-		),
-	};
+		} satisfies ImagesModel<${JSON.stringify(model.api)}>`;
+}
 
-	const providerEntries = Object.entries(imageModelsByProvider)
+function generateImageModelsFile(models: ImagesModel<ImagesApi>[]): string {
+	const imageModelsByProvider = new Map<string, Map<string, string>>();
+	for (const model of models) {
+		let providerModels = imageModelsByProvider.get(model.provider);
+		if (!providerModels) {
+			providerModels = new Map();
+			imageModelsByProvider.set(model.provider, providerModels);
+		}
+		providerModels.set(model.id, serializeImageModel(model));
+	}
+
+	const providerEntries = Array.from(imageModelsByProvider.entries())
 		.map(([provider, providerModels]) => {
-			const modelEntries = Object.entries(providerModels)
+			const modelEntries = Array.from(providerModels.entries())
+				.sort(([left], [right]) => left.localeCompare(right))
 				.map(([id, serialized]) => `\t\t${JSON.stringify(id)}: ${serialized},`)
 				.join("\n");
 			return `\t${JSON.stringify(provider)}: {\n${modelEntries}\n\t},`;
@@ -146,7 +170,7 @@ ${providerEntries}
 }
 
 async function main(): Promise<void> {
-	const models = await fetchOpenRouterImageModels();
+	const models: ImagesModel<ImagesApi>[] = [...(await fetchOpenRouterImageModels()), ...getMiniMaxImageModels()];
 	const existingModelCount = await loadExistingGeneratedImageModelCount();
 	assertImageModelCatalogRefreshSafe(models.length, existingModelCount);
 	const output = generateImageModelsFile(models);

--- a/packages/ai/src/image-models.generated.ts
+++ b/packages/ai/src/image-models.generated.ts
@@ -531,4 +531,68 @@ export const IMAGE_MODELS = {
 	}
 		} satisfies ImagesModel<"openrouter-images">,
 	},
+	"minimax": {
+		"image-01": {
+			id: "image-01",
+			name: "image-01",
+			api: "minimax-images",
+			provider: "minimax",
+			baseUrl: "https://api.minimax.io/v1/image_generation",
+			input: ["text"],
+			output: ["image"],
+			cost: 	{
+	  "input": 0,
+	  "output": 0,
+	  "cacheRead": 0,
+	  "cacheWrite": 0
+	}
+		} satisfies ImagesModel<"minimax-images">,
+		"image-01-live": {
+			id: "image-01-live",
+			name: "image-01-live",
+			api: "minimax-images",
+			provider: "minimax",
+			baseUrl: "https://api.minimax.io/v1/image_generation",
+			input: ["text"],
+			output: ["image"],
+			cost: 	{
+	  "input": 0,
+	  "output": 0,
+	  "cacheRead": 0,
+	  "cacheWrite": 0
+	}
+		} satisfies ImagesModel<"minimax-images">,
+	},
+	"minimax-cn": {
+		"image-01": {
+			id: "image-01",
+			name: "image-01",
+			api: "minimax-images",
+			provider: "minimax-cn",
+			baseUrl: "https://api.minimaxi.com/v1/image_generation",
+			input: ["text"],
+			output: ["image"],
+			cost: 	{
+	  "input": 0,
+	  "output": 0,
+	  "cacheRead": 0,
+	  "cacheWrite": 0
+	}
+		} satisfies ImagesModel<"minimax-images">,
+		"image-01-live": {
+			id: "image-01-live",
+			name: "image-01-live",
+			api: "minimax-images",
+			provider: "minimax-cn",
+			baseUrl: "https://api.minimaxi.com/v1/image_generation",
+			input: ["text"],
+			output: ["image"],
+			cost: 	{
+	  "input": 0,
+	  "output": 0,
+	  "cacheRead": 0,
+	  "cacheWrite": 0
+	}
+		} satisfies ImagesModel<"minimax-images">,
+	},
 } as const satisfies Record<string, Record<string, ImagesModel<ImagesApi>>>;

--- a/packages/ai/src/providers/images/minimax.ts
+++ b/packages/ai/src/providers/images/minimax.ts
@@ -1,0 +1,220 @@
+import type {
+	AssistantImages,
+	ImageContent,
+	ImagesContext,
+	ImagesFunction,
+	ImagesModel,
+	ImagesOptions,
+} from "../../types.ts";
+import { headersToRecord } from "../../utils/headers.ts";
+import { sanitizeSurrogates } from "../../utils/sanitize-unicode.ts";
+
+export interface MiniMaxImagesOptions extends ImagesOptions {
+	aspectRatio?: "1:1" | "16:9" | "4:3" | "3:2" | "2:3" | "3:4" | "9:16" | "21:9";
+	width?: number;
+	height?: number;
+	responseFormat?: "url" | "base64";
+	seed?: number;
+	n?: number;
+	promptOptimizer?: boolean;
+}
+
+interface MiniMaxImageGenerationRequest {
+	model: string;
+	prompt: string;
+	aspect_ratio?: MiniMaxImagesOptions["aspectRatio"];
+	width?: number;
+	height?: number;
+	response_format?: MiniMaxImagesOptions["responseFormat"];
+	seed?: number;
+	n?: number;
+	prompt_optimizer?: boolean;
+}
+
+interface MiniMaxImageGenerationResponse {
+	id?: string;
+	data?: {
+		image_urls?: string[];
+		image_base64?: string[];
+	};
+	metadata?: {
+		success_count?: number | string;
+		failed_count?: number | string;
+	};
+	base_resp?: {
+		status_code?: number;
+		status_msg?: string;
+	};
+}
+
+export const generateImagesMiniMax: ImagesFunction<"minimax-images", MiniMaxImagesOptions> = async (
+	model: ImagesModel<"minimax-images">,
+	context: ImagesContext,
+	options?: MiniMaxImagesOptions,
+) => {
+	const output: AssistantImages = {
+		api: model.api,
+		provider: model.provider,
+		model: model.id,
+		output: [],
+		stopReason: "stop",
+		timestamp: Date.now(),
+	};
+
+	try {
+		const apiKey = options?.apiKey;
+		if (!apiKey) {
+			throw new Error(`No API key for provider: ${model.provider}`);
+		}
+		if (options?.signal?.aborted) {
+			throw new Error("Request was aborted");
+		}
+
+		let payload = buildPayload(model, context, options);
+		const nextPayload = await options?.onPayload?.(payload, model);
+		if (nextPayload !== undefined) {
+			payload = nextPayload as MiniMaxImageGenerationRequest;
+		}
+
+		const response = await fetch(model.baseUrl, {
+			method: "POST",
+			headers: buildHeaders(apiKey, model.headers, options?.headers),
+			body: JSON.stringify(payload),
+			signal: createRequestSignal(options),
+		});
+		await options?.onResponse?.({ status: response.status, headers: headersToRecord(response.headers) }, model);
+
+		const responseText = await response.text();
+		const responseBody = parseResponseBody(responseText);
+		const statusCode = responseBody.base_resp?.status_code;
+		if (!response.ok || (statusCode !== undefined && statusCode !== 0)) {
+			throw new Error(getErrorMessage(response, responseBody));
+		}
+
+		output.responseId = responseBody.id;
+		for (const imageUrl of responseBody.data?.image_urls ?? []) {
+			output.output.push(await imageUrlToContent(imageUrl, options));
+		}
+		for (const imageBase64 of responseBody.data?.image_base64 ?? []) {
+			output.output.push(base64ToContent(imageBase64));
+		}
+
+		if (output.output.length === 0) {
+			throw new Error("MiniMax image generation returned no images");
+		}
+
+		return output;
+	} catch (error) {
+		output.stopReason = options?.signal?.aborted ? "aborted" : "error";
+		output.errorMessage = error instanceof Error ? error.message : String(error);
+		return output;
+	}
+};
+
+function buildPayload(
+	model: ImagesModel<"minimax-images">,
+	context: ImagesContext,
+	options?: MiniMaxImagesOptions,
+): MiniMaxImageGenerationRequest {
+	if (context.input.some((item) => item.type === "image")) {
+		throw new Error(`Model ${model.id} does not support image input`);
+	}
+
+	const prompt = context.input
+		.filter((item) => item.type === "text")
+		.map((item) => sanitizeSurrogates(item.text).trim())
+		.filter(Boolean)
+		.join("\n");
+	if (!prompt) {
+		throw new Error("MiniMax image generation requires a text prompt");
+	}
+
+	return {
+		model: model.id,
+		prompt,
+		...(options?.aspectRatio !== undefined ? { aspect_ratio: options.aspectRatio } : {}),
+		...(options?.width !== undefined ? { width: options.width } : {}),
+		...(options?.height !== undefined ? { height: options.height } : {}),
+		...(options?.responseFormat !== undefined ? { response_format: options.responseFormat } : {}),
+		...(options?.seed !== undefined ? { seed: options.seed } : {}),
+		...(options?.n !== undefined ? { n: options.n } : {}),
+		...(options?.promptOptimizer !== undefined ? { prompt_optimizer: options.promptOptimizer } : {}),
+	};
+}
+
+function buildHeaders(
+	apiKey: string,
+	modelHeaders?: Record<string, string>,
+	optionHeaders?: Record<string, string>,
+): Headers {
+	const headers = new Headers({
+		Authorization: `Bearer ${apiKey}`,
+		"Content-Type": "application/json",
+	});
+	for (const [name, value] of Object.entries(modelHeaders ?? {})) headers.set(name, value);
+	for (const [name, value] of Object.entries(optionHeaders ?? {})) headers.set(name, value);
+	return headers;
+}
+
+function createRequestSignal(options?: MiniMaxImagesOptions): AbortSignal | undefined {
+	if (options?.timeoutMs === undefined) return options?.signal;
+	if (!Number.isFinite(options.timeoutMs) || options.timeoutMs < 0) {
+		throw new Error(`Invalid timeoutMs: ${String(options.timeoutMs)}`);
+	}
+	const timeoutSignal = AbortSignal.timeout(Math.floor(options.timeoutMs));
+	return options.signal ? AbortSignal.any([options.signal, timeoutSignal]) : timeoutSignal;
+}
+
+function parseResponseBody(responseText: string): MiniMaxImageGenerationResponse {
+	if (!responseText) return {};
+	try {
+		return JSON.parse(responseText) as MiniMaxImageGenerationResponse;
+	} catch {
+		throw new Error("MiniMax image generation returned invalid JSON");
+	}
+}
+
+function getErrorMessage(response: Response, responseBody: MiniMaxImageGenerationResponse): string {
+	const statusMessage = responseBody.base_resp?.status_msg?.trim();
+	if (statusMessage) return `MiniMax image generation failed: ${statusMessage}`;
+	const statusCode = responseBody.base_resp?.status_code;
+	if (statusCode !== undefined) return `MiniMax image generation failed with status code ${statusCode}`;
+	return `MiniMax image generation failed with HTTP ${response.status}`;
+}
+
+async function imageUrlToContent(imageUrl: string, options?: MiniMaxImagesOptions): Promise<ImageContent> {
+	if (imageUrl.startsWith("data:")) return base64ToContent(imageUrl);
+	const url = new URL(imageUrl);
+	if (url.protocol !== "http:" && url.protocol !== "https:") {
+		throw new Error("MiniMax image generation returned an unsupported image URL");
+	}
+
+	const response = await fetch(url, { signal: createRequestSignal(options) });
+	if (!response.ok) {
+		throw new Error(`Failed to download generated image: HTTP ${response.status}`);
+	}
+	const data = Buffer.from(await response.arrayBuffer()).toString("base64");
+	const contentType = response.headers.get("content-type")?.split(";", 1)[0]?.trim();
+	return {
+		type: "image",
+		mimeType: contentType || detectImageMimeType(data),
+		data,
+	};
+}
+
+function base64ToContent(value: string): ImageContent {
+	const dataUrlMatch = value.match(/^data:([^;,]+);base64,(.+)$/s);
+	const data = (dataUrlMatch?.[2] ?? value).replace(/\s+/g, "");
+	return {
+		type: "image",
+		mimeType: dataUrlMatch?.[1] ?? detectImageMimeType(data),
+		data,
+	};
+}
+
+function detectImageMimeType(data: string): string {
+	if (data.startsWith("iVBORw0KGgo")) return "image/png";
+	if (data.startsWith("R0lGOD")) return "image/gif";
+	if (data.startsWith("UklGR")) return "image/webp";
+	return "image/jpeg";
+}

--- a/packages/ai/src/providers/images/minimax.ts
+++ b/packages/ai/src/providers/images/minimax.ts
@@ -6,8 +6,12 @@ import type {
 	ImagesModel,
 	ImagesOptions,
 } from "../../types.ts";
+import { isIP } from "node:net";
 import { headersToRecord } from "../../utils/headers.ts";
 import { sanitizeSurrogates } from "../../utils/sanitize-unicode.ts";
+
+const MAX_GENERATED_IMAGE_BYTES = 100 * 1024 * 1024;
+const MAX_IMAGE_COUNT = 4;
 
 export interface MiniMaxImagesOptions extends ImagesOptions {
 	aspectRatio?: "1:1" | "16:9" | "4:3" | "3:2" | "2:3" | "3:4" | "9:16" | "21:9";
@@ -128,6 +132,9 @@ function buildPayload(
 	if (!prompt) {
 		throw new Error("MiniMax image generation requires a text prompt");
 	}
+	if (options?.n !== undefined && (!Number.isSafeInteger(options.n) || options.n < 1 || options.n > MAX_IMAGE_COUNT)) {
+		throw new Error(`MiniMax image generation n must be an integer between 1 and ${MAX_IMAGE_COUNT}`);
+	}
 
 	return {
 		model: model.id,
@@ -184,37 +191,104 @@ function getErrorMessage(response: Response, responseBody: MiniMaxImageGeneratio
 
 async function imageUrlToContent(imageUrl: string, options?: MiniMaxImagesOptions): Promise<ImageContent> {
 	if (imageUrl.startsWith("data:")) return base64ToContent(imageUrl);
-	const url = new URL(imageUrl);
-	if (url.protocol !== "http:" && url.protocol !== "https:") {
-		throw new Error("MiniMax image generation returned an unsupported image URL");
-	}
+	const url = assertSafeImageUrl(imageUrl);
 
-	const response = await fetch(url, { signal: createRequestSignal(options) });
+	const response = await fetch(url, { redirect: "error", signal: createRequestSignal(options) });
 	if (!response.ok) {
 		throw new Error(`Failed to download generated image: HTTP ${response.status}`);
 	}
-	const data = Buffer.from(await response.arrayBuffer()).toString("base64");
-	const contentType = response.headers.get("content-type")?.split(";", 1)[0]?.trim();
+	const bytes = await readBoundedImageResponse(response);
+	const mimeType = detectImageMimeType(bytes);
+	if (!mimeType) throw new Error("MiniMax image generation returned an unrecognized image payload");
 	return {
 		type: "image",
-		mimeType: contentType || detectImageMimeType(data),
-		data,
+		mimeType,
+		data: Buffer.from(bytes).toString("base64"),
 	};
 }
 
 function base64ToContent(value: string): ImageContent {
 	const dataUrlMatch = value.match(/^data:([^;,]+);base64,(.+)$/s);
 	const data = (dataUrlMatch?.[2] ?? value).replace(/\s+/g, "");
+	if (!/^[A-Za-z0-9+/]*={0,2}$/.test(data)) {
+		throw new Error("MiniMax image generation returned invalid base64 image data");
+	}
+	const bytes = Buffer.from(data, "base64");
+	if (bytes.length === 0 || bytes.length > MAX_GENERATED_IMAGE_BYTES) {
+		throw new Error(`MiniMax image generation returned an image outside the ${MAX_GENERATED_IMAGE_BYTES}-byte limit`);
+	}
+	const mimeType = detectImageMimeType(bytes);
+	if (!mimeType) throw new Error("MiniMax image generation returned an unrecognized image payload");
 	return {
 		type: "image",
-		mimeType: dataUrlMatch?.[1] ?? detectImageMimeType(data),
+		mimeType,
 		data,
 	};
 }
 
-function detectImageMimeType(data: string): string {
-	if (data.startsWith("iVBORw0KGgo")) return "image/png";
-	if (data.startsWith("R0lGOD")) return "image/gif";
-	if (data.startsWith("UklGR")) return "image/webp";
-	return "image/jpeg";
+function assertSafeImageUrl(value: string): URL {
+	let url: URL;
+	try {
+		url = new URL(value);
+	} catch {
+		throw new Error("MiniMax image generation returned an invalid image URL");
+	}
+	if (url.protocol !== "https:" || url.username || url.password) {
+		throw new Error("MiniMax image generation returned an unsafe image URL");
+	}
+	if (isBlockedLiteralAddress(url.hostname)) {
+		throw new Error("MiniMax image generation returned a private image URL");
+	}
+	return url;
+}
+
+function isBlockedLiteralAddress(hostname: string): boolean {
+	if (!isIP(hostname)) return false;
+	const normalized = hostname.toLowerCase();
+	if (normalized === "::1" || normalized === "::" || normalized.startsWith("fe80:") || /^f[cd][0-9a-f:]*$/i.test(normalized)) {
+		return true;
+	}
+	if (!/^\d+\.\d+\.\d+\.\d+$/.test(hostname)) return false;
+	const [first, second] = hostname.split(".").map(Number);
+	return first === 0
+		|| first === 10
+		|| first === 127
+		|| (first === 169 && second === 254)
+		|| (first === 172 && second >= 16 && second <= 31)
+		|| (first === 192 && second === 168)
+		|| first >= 224;
+}
+
+async function readBoundedImageResponse(response: Response): Promise<Buffer> {
+	const header = response.headers.get("content-length");
+	if (header && (!/^\d+$/.test(header) || Number(header) > MAX_GENERATED_IMAGE_BYTES)) {
+		throw new Error(`MiniMax image generation returned an image above the ${MAX_GENERATED_IMAGE_BYTES}-byte limit`);
+	}
+	if (!response.body) throw new Error("MiniMax image generation returned an empty image response");
+	const reader = response.body.getReader();
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			if (!value) continue;
+			total += value.byteLength;
+			if (total > MAX_GENERATED_IMAGE_BYTES) {
+				throw new Error(`MiniMax image generation returned an image above the ${MAX_GENERATED_IMAGE_BYTES}-byte limit`);
+			}
+			chunks.push(value);
+		}
+	} finally {
+		reader.releaseLock();
+	}
+	return Buffer.concat(chunks);
+}
+
+function detectImageMimeType(bytes: Uint8Array): string | undefined {
+	if (bytes.length >= 8 && bytes.subarray(0, 8).every((value, index) => value === [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a][index])) return "image/png";
+	if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return "image/jpeg";
+	if (bytes.length >= 6 && (Buffer.from(bytes.subarray(0, 6)).toString("ascii") === "GIF87a" || Buffer.from(bytes.subarray(0, 6)).toString("ascii") === "GIF89a")) return "image/gif";
+	if (bytes.length >= 12 && Buffer.from(bytes.subarray(0, 4)).toString("ascii") === "RIFF" && Buffer.from(bytes.subarray(8, 12)).toString("ascii") === "WEBP") return "image/webp";
+	return undefined;
 }

--- a/packages/ai/src/providers/images/register-builtins.ts
+++ b/packages/ai/src/providers/images/register-builtins.ts
@@ -1,14 +1,32 @@
 import { registerImagesApiProvider } from "../../images-api-registry.ts";
-import type { AssistantImages, ImagesContext, ImagesFunction, ImagesModel, ImagesOptions } from "../../types.ts";
+import type {
+	AssistantImages,
+	ImagesApi,
+	ImagesContext,
+	ImagesFunction,
+	ImagesModel,
+	ImagesOptions,
+} from "../../types.ts";
+import type {
+	generateImagesMiniMax as generateImagesMiniMaxFunction,
+	MiniMaxImagesOptions,
+} from "./minimax.ts";
 import type { generateImagesOpenRouter as generateImagesOpenRouterFunction } from "./openrouter.ts";
+
+export type { MiniMaxImagesOptions } from "./minimax.ts";
+
+interface MiniMaxImagesProviderModule {
+	generateImagesMiniMax: typeof generateImagesMiniMaxFunction;
+}
 
 interface OpenRouterImagesProviderModule {
 	generateImagesOpenRouter: typeof generateImagesOpenRouterFunction;
 }
 
 let openRouterImagesProviderModulePromise: Promise<OpenRouterImagesProviderModule> | undefined;
+let miniMaxImagesProviderModulePromise: Promise<MiniMaxImagesProviderModule> | undefined;
 
-function createLazyLoadErrorImages(model: ImagesModel<"openrouter-images">, error: unknown): AssistantImages {
+function createLazyLoadErrorImages<TApi extends ImagesApi>(model: ImagesModel<TApi>, error: unknown): AssistantImages {
 	return {
 		api: model.api,
 		provider: model.provider,
@@ -18,6 +36,13 @@ function createLazyLoadErrorImages(model: ImagesModel<"openrouter-images">, erro
 		errorMessage: error instanceof Error ? error.message : String(error),
 		timestamp: Date.now(),
 	};
+}
+
+function loadMiniMaxImagesProviderModule(): Promise<MiniMaxImagesProviderModule> {
+	miniMaxImagesProviderModulePromise ||= import("./minimax.ts").then(
+		(module) => module as MiniMaxImagesProviderModule,
+	);
+	return miniMaxImagesProviderModulePromise;
 }
 
 function loadOpenRouterImagesProviderModule(): Promise<OpenRouterImagesProviderModule> {
@@ -40,10 +65,27 @@ export const generateImagesOpenRouter: ImagesFunction<"openrouter-images", Image
 	}
 };
 
+export const generateImagesMiniMax: ImagesFunction<"minimax-images", MiniMaxImagesOptions> = async (
+	model: ImagesModel<"minimax-images">,
+	context: ImagesContext,
+	options?: MiniMaxImagesOptions,
+) => {
+	try {
+		const module = await loadMiniMaxImagesProviderModule();
+		return await module.generateImagesMiniMax(model, context, options);
+	} catch (error) {
+		return createLazyLoadErrorImages(model, error);
+	}
+};
+
 export function registerBuiltInImagesApiProviders(): void {
 	registerImagesApiProvider({
 		api: "openrouter-images",
 		generateImages: generateImagesOpenRouter,
+	});
+	registerImagesApiProvider({
+		api: "minimax-images",
+		generateImages: generateImagesMiniMax,
 	});
 }
 

--- a/packages/ai/src/types.ts
+++ b/packages/ai/src/types.ts
@@ -16,7 +16,7 @@ export type KnownApi =
 
 export type Api = KnownApi | (string & {});
 
-export type KnownImagesApi = "openrouter-images";
+export type KnownImagesApi = "openrouter-images" | "minimax-images";
 
 export type ImagesApi = KnownImagesApi | (string & {});
 
@@ -58,7 +58,7 @@ export type KnownProvider =
 	| "xiaomi-token-plan-sgp";
 export type Provider = KnownProvider | string;
 
-export type KnownImagesProvider = "openrouter";
+export type KnownImagesProvider = "openrouter" | "minimax" | "minimax-cn";
 
 export type ImagesProvider = KnownImagesProvider | string;
 

--- a/packages/ai/test/minimax-images.test.ts
+++ b/packages/ai/test/minimax-images.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getImageModel, getImageModels } from "../src/image-models.ts";
+import { generateImages } from "../src/images.ts";
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("MiniMax images", () => {
+	it("registers global and China image models", () => {
+		const globalModel = getImageModel("minimax", "image-01");
+		const chinaModel = getImageModel("minimax-cn", "image-01-live");
+
+		expect(globalModel).toMatchObject({
+			api: "minimax-images",
+			provider: "minimax",
+			baseUrl: "https://api.minimax.io/v1/image_generation",
+			input: ["text"],
+			output: ["image"],
+		});
+		expect(chinaModel).toMatchObject({
+			api: "minimax-images",
+			provider: "minimax-cn",
+			baseUrl: "https://api.minimaxi.com/v1/image_generation",
+		});
+		expect(getImageModels("minimax").map((model) => model.id)).toEqual(["image-01", "image-01-live"]);
+	});
+
+	it("sends supported text-to-image fields and parses base64 output", async () => {
+		const fetchMock = vi.fn(async () =>
+			new Response(
+				JSON.stringify({
+					id: "image-request-1",
+					data: { image_base64: ["iVBORw0KGgo="] },
+					metadata: { success_count: 1, failed_count: 0 },
+					base_resp: { status_code: 0, status_msg: "success" },
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json", "X-Request-Id": "image-request-1" } },
+			),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+		const onResponse = vi.fn();
+
+		const output = await generateImages(
+			getImageModel("minimax", "image-01"),
+			{ input: [{ type: "text", text: "Generate a blue square" }] },
+			{
+				apiKey: "test-key",
+				aspectRatio: "1:1",
+				width: 1024,
+				height: 1024,
+				responseFormat: "base64",
+				seed: 42,
+				n: 1,
+				promptOptimizer: true,
+				onResponse,
+			},
+		);
+
+		expect(output).toMatchObject({
+			responseId: "image-request-1",
+			stopReason: "stop",
+			output: [{ type: "image", mimeType: "image/png", data: "iVBORw0KGgo=" }],
+		});
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const [url, request] = fetchMock.mock.calls[0];
+		expect(url).toBe("https://api.minimax.io/v1/image_generation");
+		expect(request?.method).toBe("POST");
+		expect(new Headers(request?.headers).get("authorization")).toBe("Bearer test-key");
+		expect(JSON.parse(String(request?.body))).toEqual({
+			model: "image-01",
+			prompt: "Generate a blue square",
+			aspect_ratio: "1:1",
+			width: 1024,
+			height: 1024,
+			response_format: "base64",
+			seed: 42,
+			n: 1,
+			prompt_optimizer: true,
+		});
+		expect(onResponse).toHaveBeenCalledWith(
+			{ status: 200, headers: expect.objectContaining({ "x-request-id": "image-request-1" }) },
+			expect.objectContaining({ id: "image-01" }),
+		);
+	});
+
+	it("downloads URL output from the China endpoint", async () => {
+		const imageBytes = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+		const fetchMock = vi.fn(async (input: string | URL | Request) => {
+			const url = input.toString();
+			if (url === "https://api.minimaxi.com/v1/image_generation") {
+				return new Response(
+					JSON.stringify({
+						data: { image_urls: ["https://images.example.test/generated.png"] },
+						base_resp: { status_code: 0 },
+					}),
+					{ status: 200, headers: { "Content-Type": "application/json" } },
+				);
+			}
+			return new Response(imageBytes, { status: 200, headers: { "Content-Type": "image/png" } });
+		});
+		vi.stubGlobal("fetch", fetchMock);
+
+		const output = await generateImages(getImageModel("minimax-cn", "image-01-live"), {
+			input: [{ type: "text", text: "Generate a city skyline" }],
+		}, { apiKey: "test-key" });
+
+		expect(fetchMock).toHaveBeenCalledTimes(2);
+		expect(output.stopReason).toBe("stop");
+		expect(output.output[0]).toEqual({
+			type: "image",
+			mimeType: "image/png",
+			data: Buffer.from(imageBytes).toString("base64"),
+		});
+	});
+
+	it("returns API errors without throwing", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn(async () =>
+				new Response(JSON.stringify({ base_resp: { status_code: 2013, status_msg: "Invalid input" } }), {
+					status: 200,
+					headers: { "Content-Type": "application/json" },
+				}),
+			),
+		);
+
+		const output = await generateImages(
+			getImageModel("minimax", "image-01"),
+			{ input: [{ type: "text", text: "Generate an image" }] },
+			{ apiKey: "test-key" },
+		);
+
+		expect(output.stopReason).toBe("error");
+		expect(output.errorMessage).toBe("MiniMax image generation failed: Invalid input");
+	});
+
+	it("returns an aborted result for an aborted signal", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+		const controller = new AbortController();
+		controller.abort();
+
+		const output = await generateImages(
+			getImageModel("minimax", "image-01"),
+			{ input: [{ type: "text", text: "Generate an image" }] },
+			{ apiKey: "test-key", signal: controller.signal },
+		);
+
+		expect(output.stopReason).toBe("aborted");
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+});

--- a/packages/ai/test/minimax-images.test.ts
+++ b/packages/ai/test/minimax-images.test.ts
@@ -135,6 +135,40 @@ describe("MiniMax images", () => {
 		expect(output.errorMessage).toBe("MiniMax image generation failed: Invalid input");
 	});
 
+	it("refuses unsafe generated URLs before downloading them", async () => {
+		const fetchMock = vi.fn(async () =>
+			new Response(
+				JSON.stringify({
+					data: { image_urls: ["http://127.0.0.1/internal.png"] },
+					base_resp: { status_code: 0 },
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			),
+		);
+		vi.stubGlobal("fetch", fetchMock);
+
+		const output = await generateImages(getImageModel("minimax", "image-01"), {
+			input: [{ type: "text", text: "Generate an image" }],
+		}, { apiKey: "test-key" });
+
+		expect(output.stopReason).toBe("error");
+		expect(output.errorMessage).toContain("unsafe image URL");
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+	});
+
+	it("bounds the requested image count before calling MiniMax", async () => {
+		const fetchMock = vi.fn();
+		vi.stubGlobal("fetch", fetchMock);
+
+		const output = await generateImages(getImageModel("minimax", "image-01"), {
+			input: [{ type: "text", text: "Generate an image" }],
+		}, { apiKey: "test-key", n: 5 });
+
+		expect(output.stopReason).toBe("error");
+		expect(output.errorMessage).toContain("between 1 and 4");
+		expect(fetchMock).not.toHaveBeenCalled();
+	});
+
 	it("returns an aborted result for an aborted signal", async () => {
 		const fetchMock = vi.fn();
 		vi.stubGlobal("fetch", fetchMock);

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AVIDS2/memorix",
     "source": "github"
   },
-  "version": "1.3.2",
+  "version": "1.3.3",
   "websiteUrl": "https://github.com/AVIDS2/memorix#readme",
   "icons": [
     {
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "memorix",
-      "version": "1.3.2",
+      "version": "1.3.3",
       "runtimeHint": "npx",
       "packageArguments": [
         {

--- a/src/cli/capability-map.ts
+++ b/src/cli/capability-map.ts
@@ -18,6 +18,7 @@ export const CLI_NATIVE_PARITY: Record<string, string> = Object.freeze({
   memorix_search_reasoning: 'memorix reasoning search',
   memorix_transfer: 'memorix transfer export|import',
   memorix_retention: 'memorix retention status|archive|stale',
+  memorix_media: 'memorix media import|attach|list|show|generate|status',
   memorix_dashboard: 'memorix dashboard',
   memorix_handoff: 'memorix handoff send',
   memorix_poll: 'memorix poll',

--- a/src/cli/commands/ingest-image.ts
+++ b/src/cli/commands/ingest-image.ts
@@ -1,24 +1,10 @@
 import { defineCommand } from 'citty';
-import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import { analyzeImage } from '../../multimodal/image-loader.js';
-import { storeObservation } from '../../memory/observations.js';
+import { attachMediaAssetToObservation } from '../../media/attachment.js';
+import { importMediaFile, readMediaAsset } from '../../media/asset-store.js';
+import { MediaStore } from '../../media/media-store.js';
 import { emitError, emitResult, getCliProjectContext, resolveCliWriteScope } from './operator-shared.js';
-
-function inferMimeType(filePath: string): string {
-  const ext = path.extname(filePath).toLowerCase();
-  switch (ext) {
-    case '.jpg':
-    case '.jpeg':
-      return 'image/jpeg';
-    case '.gif':
-      return 'image/gif';
-    case '.webp':
-      return 'image/webp';
-    default:
-      return 'image/png';
-  }
-}
 
 export default defineCommand({
   meta: {
@@ -40,32 +26,61 @@ export default defineCommand({
         emitError('path is required for "memorix ingest image"', asJson);
         return;
       }
-      const { project, reader, identity } = await getCliProjectContext();
+      const { project, dataDir, reader, identity } = await getCliProjectContext();
       const resolvedPath = path.resolve(project.rootPath, imagePath);
-      const base64 = readFileSync(resolvedPath).toString('base64');
       const filename = path.basename(resolvedPath);
-      const analysis = await analyzeImage({
-        base64,
-        filename,
-        mimeType: (args.mimeType as string | undefined) || inferMimeType(resolvedPath),
-        prompt: args.prompt as string | undefined,
+      const imported = await importMediaFile({
+        dataDir,
+        projectId: project.id,
+        filePath: resolvedPath,
+        sourceKind: 'import',
+        sourceLabel: filename,
       });
+      if (imported.asset.kind !== 'image') {
+        throw new Error(`Expected an image file, detected ${imported.asset.mimeType}`);
+      }
 
-      const result = await storeObservation({
+      let analysis: { description: string; tags: string[]; entities: string[] };
+      let analysisWarning: string | undefined;
+      try {
+        const bytes = await readMediaAsset(dataDir, imported.asset);
+        analysis = await analyzeImage({
+          base64: bytes.toString('base64'),
+          filename,
+          mimeType: (args.mimeType as string | undefined) || imported.asset.mimeType,
+          prompt: args.prompt as string | undefined,
+        });
+      } catch (error) {
+        analysis = {
+          description: `Imported image asset ${filename}. Visual analysis is unavailable; use the asset reference for high-fidelity inspection.`,
+          tags: ['image', imported.asset.mimeType],
+          entities: [],
+        };
+        analysisWarning = error instanceof Error ? error.message : String(error);
+      }
+
+      new MediaStore(dataDir).addDerivation({
+        projectId: project.id,
+        assetId: imported.asset.id,
+        kind: 'description',
+        content: analysis.description,
+        status: 'ready',
+      });
+      const observation = await attachMediaAssetToObservation({
+        dataDir,
+        projectId: project.id,
+        asset: imported.asset,
         entityName: filename.replace(/\.[^.]+$/, '') || `image-${Date.now()}`,
-        type: 'discovery',
         title: `Image analysis: ${filename}`,
         narrative: analysis.description,
         concepts: analysis.tags,
         facts: analysis.entities,
-        projectId: project.id,
-        source: 'manual',
         ...resolveCliWriteScope({ reader, identity }, args.visibility as string | undefined),
       });
 
       emitResult(
-        { project, analysis, observation: result.observation },
-        `Stored image analysis #${result.observation.id}: ${filename}`,
+        { project, asset: imported.asset, deduplicated: imported.deduplicated, analysis, analysisWarning, observation },
+        `Stored image analysis #${observation.id}: ${filename}`,
         asJson,
       );
     } catch (error) {

--- a/src/cli/commands/ingest-image.ts
+++ b/src/cli/commands/ingest-image.ts
@@ -1,6 +1,8 @@
 import { defineCommand } from 'citty';
 import path from 'node:path';
 import { analyzeImage } from '../../multimodal/image-loader.js';
+import { MAX_VISION_IMAGE_BYTES } from '../../multimodal/image-payload.js';
+import { sanitizeCredentials } from '../../memory/secret-filter.js';
 import { attachMediaAssetToObservation } from '../../media/attachment.js';
 import { importMediaFile, readMediaAsset } from '../../media/asset-store.js';
 import { MediaStore } from '../../media/media-store.js';
@@ -43,7 +45,7 @@ export default defineCommand({
       let analysis: { description: string; tags: string[]; entities: string[] };
       let analysisWarning: string | undefined;
       try {
-        const bytes = await readMediaAsset(dataDir, imported.asset);
+        const bytes = await readMediaAsset(dataDir, imported.asset, MAX_VISION_IMAGE_BYTES);
         analysis = await analyzeImage({
           base64: bytes.toString('base64'),
           filename,
@@ -56,7 +58,9 @@ export default defineCommand({
           tags: ['image', imported.asset.mimeType],
           entities: [],
         };
-        analysisWarning = error instanceof Error ? error.message : String(error);
+        analysisWarning = sanitizeCredentials(
+          error instanceof Error ? error.message : String(error),
+        ).slice(0, 500);
       }
 
       new MediaStore(dataDir).addDerivation({

--- a/src/cli/commands/media.ts
+++ b/src/cli/commands/media.ts
@@ -1,5 +1,6 @@
 import { defineCommand } from 'citty';
 
+import { loadDotenv } from '../../config/dotenv-loader.js';
 import { attachMediaAssetToObservation } from '../../media/attachment.js';
 import { embedMediaAsset, findSimilarMediaAssets } from '../../media/embedding.js';
 import {
@@ -8,7 +9,12 @@ import {
   removeMediaAsset,
 } from '../../media/asset-store.js';
 import { MediaStore } from '../../media/media-store.js';
-import { generateMiniMaxImages, type MiniMaxImageGenerationInput } from '../../media/minimax.js';
+import {
+  generateMiniMaxImages,
+  type MiniMaxImageGenerationInput,
+  type MiniMaxVideoGenerationRequest,
+} from '../../media/minimax.js';
+import { launchMediaVideoRunner, queueMiniMaxVideoGeneration } from '../../media/video-jobs.js';
 import type { MediaKind } from '../../media/types.js';
 import {
   emitError,
@@ -71,6 +77,33 @@ function parseMiniMaxRegion(value: unknown): MiniMaxImageGenerationInput['region
   throw new Error('MiniMax region must be global or cn');
 }
 
+function parseMiniMaxVideoModel(value: unknown): MiniMaxVideoGenerationRequest['model'] | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const model = String(value).trim();
+  if (model === 'MiniMax-H3') return model;
+  throw new Error('MiniMax video model must be MiniMax-H3');
+}
+
+function parseMiniMaxVideoRatio(value: unknown): MiniMaxVideoGenerationRequest['ratio'] | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const ratio = String(value).trim();
+  if (ratio === 'adaptive' || ratio === '16:9' || ratio === '9:16' || ratio === '1:1') return ratio;
+  throw new Error('MiniMax video ratio must be adaptive, 16:9, 9:16, or 1:1');
+}
+
+function parseMiniMaxVideoDuration(value: unknown): MiniMaxVideoGenerationRequest['duration'] | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const duration = Number(value);
+  if (duration === 5 || duration === 10) return duration;
+  throw new Error('MiniMax video duration must be 5 or 10 seconds');
+}
+
+function parseMiniMaxVideoResolution(value: unknown): MiniMaxVideoGenerationRequest['resolution'] | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (String(value).trim() === '2K') return '2K';
+  throw new Error('MiniMax video resolution must be 2K');
+}
+
 function help(): string {
   return [
     'Memorix Media Commands',
@@ -82,6 +115,9 @@ function help(): string {
     '  memorix media embed --asset <asset-id>',
     '  memorix media similar --asset <asset-id> [--limit 10]',
     '  memorix media generate image --prompt "..." [--model image-01] [--attach]',
+    '  memorix media generate video --prompt "..." [--model MiniMax-H3] [--duration 5] [--ratio 16:9] [--attach]',
+    '  memorix media status --job <media-job-id>',
+    '  memorix media cancel --job <media-job-id>',
     '  memorix media remove --asset <asset-id> [--force]',
     '  memorix media cleanup [--maxBytes 1073741824]',
     '',
@@ -108,10 +144,13 @@ export default defineCommand({
     model: { type: 'string', description: 'Provider model' },
     region: { type: 'string', description: 'MiniMax region: global or cn' },
     n: { type: 'string', description: 'Generated image count (1-4)' },
-    ratio: { type: 'string', description: 'Image aspect ratio' },
+    ratio: { type: 'string', description: 'Image or video aspect ratio' },
     width: { type: 'string', description: 'Requested image width' },
     height: { type: 'string', description: 'Requested image height' },
     seed: { type: 'string', description: 'Optional image seed' },
+    duration: { type: 'string', description: 'MiniMax video duration: 5 or 10 seconds' },
+    resolution: { type: 'string', description: 'MiniMax video resolution: 2K' },
+    job: { type: 'string', description: 'Media job ID for status or cancellation' },
     attach: { type: 'boolean', description: 'Explicitly attach generated output to memory' },
     promptOptimizer: { type: 'boolean', description: 'Enable MiniMax prompt optimization' },
     'prompt-optimizer': { type: 'boolean', description: 'Kebab-case alias for --promptOptimizer' },
@@ -129,14 +168,49 @@ export default defineCommand({
     try {
       switch (action) {
         case 'generate':
-        case 'generate-image': {
-          const target = action === 'generate' ? (positional.shift() ?? '').trim().toLowerCase() : 'image';
-          if (target !== 'image') {
-            throw new Error(`Unsupported media generation target: ${target || '(missing)'}. Only "image" is available in this command.`);
+        case 'generate-image':
+        case 'generate-video': {
+          const target = action === 'generate'
+            ? (positional.shift() ?? '').trim().toLowerCase()
+            : action === 'generate-video' ? 'video' : 'image';
+          if (target !== 'image' && target !== 'video') {
+            throw new Error(`Unsupported media generation target: ${target || '(missing)'}. Use "image" or "video".`);
           }
           const prompt = getValue(args.prompt, positional);
-          if (!prompt) throw new Error('prompt is required for "memorix media generate image"');
+          if (!prompt) throw new Error(`prompt is required for "memorix media generate ${target}"`);
           const { project, dataDir, reader, identity } = await getCliProjectContext();
+          // Image/video credentials can live in a project .env. This must be
+          // loaded before the explicit request is validated or submitted.
+          loadDotenv(project.rootPath);
+          if (target === 'video') {
+            const queued = queueMiniMaxVideoGeneration({
+              dataDir,
+              projectId: project.id,
+              prompt,
+              model: parseMiniMaxVideoModel(args.model),
+              region: parseMiniMaxRegion(args.region),
+              duration: parseMiniMaxVideoDuration(args.duration),
+              ratio: parseMiniMaxVideoRatio(args.ratio),
+              resolution: parseMiniMaxVideoResolution(args.resolution),
+              maxBytes: parseByteLimit(args.maxBytes ?? args['max-bytes'], 100 * 1024 * 1024),
+              attachOnComplete: args.attach === true,
+              observationTitle: (args.title as string | undefined)?.trim(),
+            });
+            const runner = launchMediaVideoRunner({
+              projectId: project.id,
+              projectRoot: project.rootPath,
+              dataDir,
+              mediaJobId: queued.mediaJob.id,
+            });
+            emitResult(
+              { project, ...queued, runner },
+              runner.launched
+                ? `Queued MiniMax video job ${queued.mediaJob.id}; generation continues in the background.`
+                : `Queued MiniMax video job ${queued.mediaJob.id}. ${runner.reason ?? 'Run a Memorix server or invoke media status after building to resume it.'}`,
+              asJson,
+            );
+            return;
+          }
           const generated = await generateMiniMaxImages({
             dataDir,
             projectId: project.id,
@@ -167,6 +241,35 @@ export default defineCommand({
             `Generated ${generated.assets.length} controlled image asset(s)${observations.length > 0 ? ` and attached ${observations.length} to memory` : ''}.`,
             asJson,
           );
+          return;
+        }
+        case 'status': {
+          const jobId = getValue(args.job, positional);
+          if (!jobId) throw new Error('job is required for "memorix media status"');
+          const { project, dataDir } = await getCliProjectContext();
+          const job = new MediaStore(dataDir).getJob(project.id, jobId);
+          if (!job) throw new Error(`Media job not found: ${jobId}`);
+          const runner = job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled'
+            ? undefined
+            : launchMediaVideoRunner({
+              projectId: project.id,
+              projectRoot: project.rootPath,
+              dataDir,
+              mediaJobId: job.id,
+            });
+          emitResult(
+            { project, job, ...(runner ? { runner } : {}) },
+            `${job.kind} ${job.id}: ${job.status}${job.assetId ? ` (${job.assetId})` : ''}`,
+            asJson,
+          );
+          return;
+        }
+        case 'cancel': {
+          const jobId = getValue(args.job, positional);
+          if (!jobId) throw new Error('job is required for "memorix media cancel"');
+          const { project, dataDir } = await getCliProjectContext();
+          const job = new MediaStore(dataDir).cancelJob(project.id, jobId);
+          emitResult({ project, job }, `Cancelled media job ${job.id}`, asJson);
           return;
         }
         case 'import': {

--- a/src/cli/commands/media.ts
+++ b/src/cli/commands/media.ts
@@ -1,0 +1,231 @@
+import { defineCommand } from 'citty';
+
+import { attachMediaAssetToObservation } from '../../media/attachment.js';
+import { embedMediaAsset, findSimilarMediaAssets } from '../../media/embedding.js';
+import {
+  cleanupMediaQuota,
+  importMediaFile,
+  removeMediaAsset,
+} from '../../media/asset-store.js';
+import { MediaStore } from '../../media/media-store.js';
+import type { MediaKind } from '../../media/types.js';
+import {
+  emitError,
+  emitResult,
+  getCliProjectContext,
+  getCliReadContext,
+  parsePositiveInt,
+  resolveCliWriteScope,
+} from './operator-shared.js';
+
+function getValue(value: unknown, positional: string[] = []): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : positional[0]?.trim() || undefined;
+}
+
+function parseMediaKind(value: unknown): MediaKind | undefined {
+  if (typeof value !== 'string' || !value.trim()) return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'image' || normalized === 'audio' || normalized === 'video' || normalized === 'document') {
+    return normalized;
+  }
+  throw new Error('kind must be image, audio, video, or document');
+}
+
+function parseByteLimit(value: unknown, fallback: number): number {
+  if (value === undefined || value === null || value === '') return fallback;
+  if (typeof value !== 'string' && typeof value !== 'number') throw new Error('maxBytes must be a positive integer');
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) throw new Error('maxBytes must be a non-negative integer');
+  return parsed;
+}
+
+function help(): string {
+  return [
+    'Memorix Media Commands',
+    '',
+    '  memorix media import --path ./diagram.png',
+    '  memorix media list [--kind image]',
+    '  memorix media show --asset <asset-id>',
+    '  memorix media attach --asset <asset-id> [--title "Architecture"] [--text "..."]',
+    '  memorix media embed --asset <asset-id>',
+    '  memorix media similar --asset <asset-id> [--limit 10]',
+    '  memorix media remove --asset <asset-id> [--force]',
+    '  memorix media cleanup [--maxBytes 1073741824]',
+    '',
+    'Generated images and videos use the same asset lifecycle and are added in the 1.3.3 provider phase.',
+  ].join('\n');
+}
+
+export default defineCommand({
+  meta: {
+    name: 'media',
+    description: 'Import, attach, inspect, and clean controlled local media assets',
+  },
+  args: {
+    action: { type: 'string', description: 'Media action' },
+    path: { type: 'string', description: 'Local file to import' },
+    asset: { type: 'string', description: 'Media asset ID' },
+    kind: { type: 'string', description: 'Filter: image, audio, video, or document' },
+    title: { type: 'string', description: 'Observation title when attaching' },
+    text: { type: 'string', description: 'Observation narrative when attaching' },
+    entity: { type: 'string', description: 'Observation entity when attaching' },
+    concepts: { type: 'string', description: 'Comma-separated concepts when attaching' },
+    visibility: { type: 'string', description: 'Observation visibility when attaching' },
+    limit: { type: 'string', description: 'List limit' },
+    maxBytes: { type: 'string', description: 'Import or cleanup byte limit' },
+    'max-bytes': { type: 'string', description: 'Kebab-case alias for --maxBytes' },
+    force: { type: 'boolean', description: 'Detach linked observations before removal' },
+    json: { type: 'boolean', description: 'Emit machine-readable JSON output' },
+  },
+  run: async ({ args }) => {
+    const action = ((args._ as string[])?.[0] || (args.action as string | undefined) || '').trim().toLowerCase();
+    const positional = ((args._ as string[]) ?? []).slice(1);
+    const asJson = !!args.json;
+
+    try {
+      switch (action) {
+        case 'import': {
+          const filePath = getValue(args.path, positional);
+          if (!filePath) throw new Error('path is required for "memorix media import"');
+          const { project, dataDir } = await getCliProjectContext();
+          const result = await importMediaFile({
+            dataDir,
+            projectId: project.id,
+            filePath,
+            maxBytes: parseByteLimit(args.maxBytes ?? args['max-bytes'], 100 * 1024 * 1024),
+          });
+          emitResult(
+            { project, ...result },
+            `${result.deduplicated ? 'Reused' : 'Imported'} ${result.asset.kind} asset ${result.asset.id}`,
+            asJson,
+          );
+          return;
+        }
+        case 'list': {
+          const { project, dataDir } = await getCliReadContext();
+          const assets = new MediaStore(dataDir).listAssets(project.id, {
+            kind: parseMediaKind(args.kind),
+            limit: parsePositiveInt(args.limit as string | undefined, 50),
+          });
+          emitResult(
+            { project, assets },
+            assets.length === 0
+              ? 'No media assets.'
+              : assets.map((asset) => `- ${asset.id} ${asset.kind} ${asset.sourceLabel ?? asset.sha256.slice(0, 12)}`).join('\n'),
+            asJson,
+          );
+          return;
+        }
+        case 'show': {
+          const assetId = getValue(args.asset, positional);
+          if (!assetId) throw new Error('asset is required for "memorix media show"');
+          const { project, dataDir } = await getCliReadContext();
+          const store = new MediaStore(dataDir);
+          const asset = store.getAsset(project.id, assetId);
+          if (!asset) throw new Error(`Media asset not found: ${assetId}`);
+          const links = store.listLinks(project.id, asset.id);
+          const derivations = store.listDerivations(project.id, asset.id);
+          emitResult(
+            { project, asset, links, derivations },
+            `${asset.kind} ${asset.id}\n${asset.mimeType}, ${asset.byteSize} bytes, ${links.length} link(s)`,
+            asJson,
+          );
+          return;
+        }
+        case 'attach': {
+          const assetId = getValue(args.asset, positional);
+          if (!assetId) throw new Error('asset is required for "memorix media attach"');
+          const { project, dataDir, reader, identity } = await getCliProjectContext();
+          const store = new MediaStore(dataDir);
+          const asset = store.getAsset(project.id, assetId);
+          if (!asset) throw new Error(`Media asset not found: ${assetId}`);
+          const description = store.listDerivations(project.id, asset.id)
+            .find((item) => item.kind === 'description' && item.status === 'ready')?.content;
+          const concepts = typeof args.concepts === 'string'
+            ? args.concepts.split(',').map((value) => value.trim()).filter(Boolean)
+            : [];
+          const observation = await attachMediaAssetToObservation({
+            dataDir,
+            projectId: project.id,
+            asset,
+            title: (args.title as string | undefined)?.trim() || `Media asset: ${asset.sourceLabel ?? asset.id}`,
+            narrative: (args.text as string | undefined)?.trim() || description,
+            entityName: (args.entity as string | undefined)?.trim(),
+            concepts,
+            ...resolveCliWriteScope({ reader, identity }, args.visibility as string | undefined),
+          });
+          emitResult(
+            { project, asset, observation },
+            `Attached ${asset.id} to memory #${observation.id}`,
+            asJson,
+          );
+          return;
+        }
+        case 'remove': {
+          const assetId = getValue(args.asset, positional);
+          if (!assetId) throw new Error('asset is required for "memorix media remove"');
+          const { project, dataDir } = await getCliProjectContext();
+          const result = await removeMediaAsset({
+            dataDir,
+            projectId: project.id,
+            assetId,
+            force: args.force === true,
+          });
+          emitResult({ project, ...result }, `Removed media asset ${assetId}`, asJson);
+          return;
+        }
+        case 'embed': {
+          const assetId = getValue(args.asset, positional);
+          if (!assetId) throw new Error('asset is required for "memorix media embed"');
+          const { project, dataDir } = await getCliProjectContext();
+          const result = await embedMediaAsset({ dataDir, projectId: project.id, assetId, timeoutMs: 8_000 });
+          emitResult(
+            { project, ...result },
+            result.status === 'embedded'
+              ? `Embedded ${assetId} with profile ${result.profileKey}`
+              : result.reason,
+            asJson,
+          );
+          return;
+        }
+        case 'similar': {
+          const assetId = getValue(args.asset, positional);
+          if (!assetId) throw new Error('asset is required for "memorix media similar"');
+          const { project, dataDir } = await getCliReadContext();
+          const matches = findSimilarMediaAssets({
+            dataDir,
+            projectId: project.id,
+            assetId,
+            limit: parsePositiveInt(args.limit as string | undefined, 10),
+          });
+          emitResult(
+            { project, assetId, matches },
+            matches.length === 0
+              ? 'No compatible media embeddings found. Run "memorix media embed --asset <id>" with a multimodal embedding provider first.'
+              : matches.map((match) => `- ${match.asset.id} ${match.score.toFixed(3)} ${match.asset.sourceLabel ?? ''}`).join('\n'),
+            asJson,
+          );
+          return;
+        }
+        case 'cleanup': {
+          const { project, dataDir } = await getCliProjectContext();
+          const result = await cleanupMediaQuota({
+            dataDir,
+            projectId: project.id,
+            maxBytes: parseByteLimit(args.maxBytes ?? args['max-bytes'], 1024 * 1024 * 1024),
+          });
+          emitResult(
+            { project, ...result },
+            `Media cleanup: ${result.removed.length} asset(s), ${result.beforeBytes} -> ${result.afterBytes} bytes`,
+            asJson,
+          );
+          return;
+        }
+        default:
+          emitResult({ usage: help() }, help(), asJson);
+      }
+    } catch (error) {
+      emitError(error instanceof Error ? error.message : String(error), asJson);
+    }
+  },
+});

--- a/src/cli/commands/media.ts
+++ b/src/cli/commands/media.ts
@@ -8,6 +8,7 @@ import {
   removeMediaAsset,
 } from '../../media/asset-store.js';
 import { MediaStore } from '../../media/media-store.js';
+import { generateMiniMaxImages, type MiniMaxImageGenerationInput } from '../../media/minimax.js';
 import type { MediaKind } from '../../media/types.js';
 import {
   emitError,
@@ -39,6 +40,37 @@ function parseByteLimit(value: unknown, fallback: number): number {
   return parsed;
 }
 
+function parseOptionalInteger(value: unknown, label: string, minimum: number, maximum: number): number | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed < minimum || parsed > maximum) {
+    throw new Error(`${label} must be a whole number between ${minimum} and ${maximum}`);
+  }
+  return parsed;
+}
+
+function parseAspectRatio(value: unknown): MiniMaxImageGenerationInput['aspectRatio'] | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const ratio = String(value).trim();
+  const allowed = new Set(['1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9']);
+  if (!allowed.has(ratio)) throw new Error('ratio must be one of 1:1, 16:9, 4:3, 3:2, 2:3, 3:4, 9:16, or 21:9');
+  return ratio as MiniMaxImageGenerationInput['aspectRatio'];
+}
+
+function parseMiniMaxModel(value: unknown): MiniMaxImageGenerationInput['model'] | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const model = String(value).trim();
+  if (model === 'image-01' || model === 'image-01-live') return model;
+  throw new Error('MiniMax image model must be image-01 or image-01-live');
+}
+
+function parseMiniMaxRegion(value: unknown): MiniMaxImageGenerationInput['region'] | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const region = String(value).trim().toLowerCase();
+  if (region === 'global' || region === 'cn') return region;
+  throw new Error('MiniMax region must be global or cn');
+}
+
 function help(): string {
   return [
     'Memorix Media Commands',
@@ -49,10 +81,11 @@ function help(): string {
     '  memorix media attach --asset <asset-id> [--title "Architecture"] [--text "..."]',
     '  memorix media embed --asset <asset-id>',
     '  memorix media similar --asset <asset-id> [--limit 10]',
+    '  memorix media generate image --prompt "..." [--model image-01] [--attach]',
     '  memorix media remove --asset <asset-id> [--force]',
     '  memorix media cleanup [--maxBytes 1073741824]',
     '',
-    'Generated images and videos use the same asset lifecycle and are added in the 1.3.3 provider phase.',
+    'Generated output is stored as a controlled asset. Use --attach to add it to memory explicitly.',
   ].join('\n');
 }
 
@@ -71,6 +104,17 @@ export default defineCommand({
     entity: { type: 'string', description: 'Observation entity when attaching' },
     concepts: { type: 'string', description: 'Comma-separated concepts when attaching' },
     visibility: { type: 'string', description: 'Observation visibility when attaching' },
+    prompt: { type: 'string', description: 'Generation prompt' },
+    model: { type: 'string', description: 'Provider model' },
+    region: { type: 'string', description: 'MiniMax region: global or cn' },
+    n: { type: 'string', description: 'Generated image count (1-4)' },
+    ratio: { type: 'string', description: 'Image aspect ratio' },
+    width: { type: 'string', description: 'Requested image width' },
+    height: { type: 'string', description: 'Requested image height' },
+    seed: { type: 'string', description: 'Optional image seed' },
+    attach: { type: 'boolean', description: 'Explicitly attach generated output to memory' },
+    promptOptimizer: { type: 'boolean', description: 'Enable MiniMax prompt optimization' },
+    'prompt-optimizer': { type: 'boolean', description: 'Kebab-case alias for --promptOptimizer' },
     limit: { type: 'string', description: 'List limit' },
     maxBytes: { type: 'string', description: 'Import or cleanup byte limit' },
     'max-bytes': { type: 'string', description: 'Kebab-case alias for --maxBytes' },
@@ -84,6 +128,47 @@ export default defineCommand({
 
     try {
       switch (action) {
+        case 'generate':
+        case 'generate-image': {
+          const target = action === 'generate' ? (positional.shift() ?? '').trim().toLowerCase() : 'image';
+          if (target !== 'image') {
+            throw new Error(`Unsupported media generation target: ${target || '(missing)'}. Only "image" is available in this command.`);
+          }
+          const prompt = getValue(args.prompt, positional);
+          if (!prompt) throw new Error('prompt is required for "memorix media generate image"');
+          const { project, dataDir, reader, identity } = await getCliProjectContext();
+          const generated = await generateMiniMaxImages({
+            dataDir,
+            projectId: project.id,
+            prompt,
+            model: parseMiniMaxModel(args.model),
+            region: parseMiniMaxRegion(args.region),
+            n: parseOptionalInteger(args.n, 'n', 1, 4),
+            aspectRatio: parseAspectRatio(args.ratio),
+            width: parseOptionalInteger(args.width, 'width', 1, 8_192),
+            height: parseOptionalInteger(args.height, 'height', 1, 8_192),
+            seed: parseOptionalInteger(args.seed, 'seed', 0, 2_147_483_647),
+            promptOptimizer: args.promptOptimizer === true || args['prompt-optimizer'] === true,
+            maxBytes: parseByteLimit(args.maxBytes ?? args['max-bytes'], 100 * 1024 * 1024),
+          });
+          const observations = args.attach === true
+            ? await Promise.all(generated.assets.map(({ asset }) => attachMediaAssetToObservation({
+              dataDir,
+              projectId: project.id,
+              asset,
+              title: `MiniMax image: ${asset.sourceLabel ?? asset.id}`,
+              narrative: `Generated with ${generated.provider}/${generated.model}. Prompt: ${prompt}`,
+              concepts: ['generated-image', 'minimax', generated.model],
+              ...resolveCliWriteScope({ reader, identity }, args.visibility as string | undefined),
+            })))
+            : [];
+          emitResult(
+            { project, ...generated, observations },
+            `Generated ${generated.assets.length} controlled image asset(s)${observations.length > 0 ? ` and attached ${observations.length} to memory` : ''}.`,
+            asJson,
+          );
+          return;
+        }
         case 'import': {
           const filePath = getValue(args.path, positional);
           if (!filePath) throw new Error('path is required for "memorix media import"');

--- a/src/cli/commands/serve-http.ts
+++ b/src/cli/commands/serve-http.ts
@@ -75,6 +75,7 @@ export default defineCommand({
       '@modelcontextprotocol/sdk/types.js'
     );
     const { createMemorixServer } = await import('../../server.js');
+    const { createProjectBindingController } = await import('../../server/request-context.js');
     const { findGitInSubdirs, detectProjectWithDiagnostics } = await import('../../project/detector.js');
     const { existsSync, readFileSync, writeFileSync, mkdirSync } = await import('node:fs');
     const { homedir } = await import('node:os');
@@ -138,7 +139,7 @@ export default defineCommand({
       transport: InstanceType<typeof StreamableHTTPServerTransport>;
       server: Awaited<ReturnType<typeof createMemorixServer>>['server'];
       switchProject: Awaited<ReturnType<typeof createMemorixServer>>['switchProject'];
-      isExplicitlyBound: Awaited<ReturnType<typeof createMemorixServer>>['isExplicitlyBound'];
+      binding: import('../../server/request-context.js').ProjectBindingController;
     };
 
     // Session map: sessionId → transport + per-session server state
@@ -377,8 +378,11 @@ export default defineCommand({
           handleTransportClose();
         };
 
+        // Legacy Mcp-Session-Id only routes requests. Project ownership lives
+        // in this transport-neutral binding object, ready for stateless MCP.
+        const binding = createProjectBindingController(projectRoot);
         // Create a fresh MCP server for this session (with shared team state)
-        const { server, switchProject, isExplicitlyBound, handleTransportClose } = await createMemorixServer(
+        const { server, switchProject, handleTransportClose } = await createMemorixServer(
           projectRoot,
           undefined,
           { teamStore: sharedTeamStore },
@@ -388,9 +392,10 @@ export default defineCommand({
             dashboardMode: 'control-plane',
             dashboardPort: port,
             toolProfile,
+            projectBinding: binding,
           },
         );
-        createdState = { transport, server, switchProject, isExplicitlyBound };
+        createdState = { transport, server, switchProject, binding };
         await server.connect(transport);
 
         const persistRoot = async (rootPath: string) => {
@@ -408,7 +413,7 @@ export default defineCommand({
           try {
             // If session was explicitly bound via projectRoot in memorix_session_start,
             // do NOT allow roots notifications to override the binding.
-            if (isExplicitlyBound()) {
+            if (binding.isExplicit()) {
               console.error(`[memorix] Session ${transport.sessionId?.slice(0, 8) ?? 'pending'} roots switch skipped: session was explicitly bound via projectRoot`);
               return;
             }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1073,6 +1073,7 @@ const main = defineCommand({
     hook: () => import('./commands/hook.js').then(m => m.default),
     hooks: () => import('./commands/hooks.js').then(m => m.default),
     ingest: () => import('./commands/ingest.js').then(m => m.default),
+    media: () => import('./commands/media.js').then(m => m.default),
     'git-hook': () => import('./commands/git-hook-install.js').then(m => m.default),
     'git-hook-uninstall': () => import('./commands/git-hook-uninstall.js').then(m => m.default),
     background: () => import('./commands/background.js').then(m => m.default),
@@ -1122,7 +1123,7 @@ const main = defineCommand({
       'session', 'team', 'task', 'message', 'lock', 'handoff', 'poll',
       'receipt',
       'serve', 'serve-http', 'status', 'sync',
-      'hook', 'hooks', 'ingest', 'git-hook', 'git-hook-uninstall',
+      'hook', 'hooks', 'ingest', 'media', 'git-hook', 'git-hook-uninstall',
       'background', 'bg', 'bs', 'doctor', 'repair', 'dashboard', 'cleanup', 'uninstall', 'orchestrate'];
     if (firstArg && knownSubs.includes(firstArg)) return;
 

--- a/src/compact/engine.ts
+++ b/src/compact/engine.ts
@@ -404,6 +404,12 @@ function observationToDocument(obs: ReturnType<typeof getAllObservations>[number
     facts: obs.facts.join('\n'),
     filesModified: obs.filesModified.join('\n'),
     concepts: obs.concepts.join(', '),
+    attachments: (obs.attachments ?? []).map((attachment) => [
+      attachment.name,
+      attachment.modality,
+      attachment.mimeType,
+      attachment.url,
+    ].filter(Boolean).join(' ')).join('\n'),
     tokens: obs.tokens,
     createdAt: obs.createdAt,
     projectId: obs.projectId,

--- a/src/compact/index-format.ts
+++ b/src/compact/index-format.ts
@@ -181,6 +181,7 @@ export function formatObservationDetail(doc: {
   facts: string;
   filesModified: string;
   concepts: string;
+  attachments?: string;
   createdAt: string;
   projectId: string;
   entityName: string;
@@ -240,6 +241,13 @@ export function formatObservationDetail(doc: {
   if (doc.concepts) {
     lines.push('');
     lines.push(`Concepts: ${doc.concepts}`);
+  }
+
+  const attachments = doc.attachments?.split('\n').filter(Boolean) ?? [];
+  if (attachments.length > 0) {
+    lines.push('');
+    lines.push('Attachments (provenance/BM25 metadata; URL content is not fetched):');
+    for (const attachment of attachments) lines.push(`- ${attachment}`);
   }
 
   return lines.join('\n');

--- a/src/config/dotenv-loader.ts
+++ b/src/config/dotenv-loader.ts
@@ -121,3 +121,11 @@ export function getLoadedEnvFiles(): readonly string[] {
 // OPENAI_API_KEY            — OpenAI compatibility fallback
 // ANTHROPIC_API_KEY         — Anthropic compatibility fallback
 // OPENROUTER_API_KEY        — OpenRouter compatibility fallback
+// MINIMAX_API_KEY           — MiniMax global image/video generation key
+// MINIMAX_CN_API_KEY        — MiniMax China-region image/video generation key
+// MINIMAX_REGION            — MiniMax region: global or cn
+// MINIMAX_IMAGE_MODEL       — MiniMax image model override
+// MINIMAX_IMAGE_BASE_URL    — MiniMax image endpoint override
+// MINIMAX_VIDEO_BASE_URL    — MiniMax video endpoint override
+// MINIMAX_VIDEO_MODEL       — MiniMax video model override
+// MEMORIX_MCP_MEDIA_GENERATION — Set to 1 only to allow billed MiniMax generation through MCP

--- a/src/embedding/api-provider.ts
+++ b/src/embedding/api-provider.ts
@@ -10,6 +10,7 @@ import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import {
+  EmbeddingInputError,
   UnsupportedEmbeddingModalityError,
   validateEmbeddingInput,
   type EmbeddingInput,
@@ -79,6 +80,44 @@ function isJinaEndpoint(baseUrl: string): boolean {
 
 function isGoogleEmbeddingEndpoint(baseUrl: string): boolean {
   return /generativelanguage\.googleapis\.com/i.test(baseUrl);
+}
+
+function isNativeGeminiEndpoint(baseUrl: string): boolean {
+  if (!isGoogleEmbeddingEndpoint(baseUrl)) return false;
+  return !new URL(baseUrl).pathname.split('/').includes('openai');
+}
+
+function geminiModelName(model: string): string {
+  return model.replace(/^models\//, '');
+}
+
+function geminiBody(
+  input: EmbeddingInput,
+  model: string,
+  requestedDimensions: number | null,
+  options: EmbeddingOptions = {},
+): Record<string, unknown> {
+  if (options.instruction) {
+    throw new EmbeddingInputError(`Gemini native ${model} does not support embedding instructions`);
+  }
+  if (input.modality !== 'text' && !('data' in input && input.data !== undefined)) {
+    throw new UnsupportedEmbeddingModalityError(`Gemini native ${model}`, input.modality);
+  }
+  const part = input.modality === 'text'
+    ? { text: input.text }
+    : { inlineData: { mimeType: input.mimeType, data: input.data } };
+  const body: Record<string, unknown> = {
+    content: { parts: [part] },
+  };
+  if (requestedDimensions) body.outputDimensionality = requestedDimensions;
+  if (!/^gemini-embedding-2(?:-|$)/i.test(geminiModelName(model))) {
+    body.taskType = (options.intent ?? 'document') === 'query' ? 'RETRIEVAL_QUERY' : 'RETRIEVAL_DOCUMENT';
+  }
+  return body;
+}
+
+function geminiUrl(baseUrl: string, model: string): string {
+  return `${baseUrl}/models/${geminiModelName(model)}:embedContent`;
 }
 
 function mapIntentTask(baseUrl: string, model: string, options: EmbeddingOptions = {}): Record<string, unknown> {
@@ -345,7 +384,8 @@ function cacheSet(hash: string, value: number[]): void {
 }
 
 interface EmbeddingAPIResponse {
-  object: string;
+  object?: string;
+  embedding?: { values: number[] };
   data: Array<{
     object: string;
     index: number;
@@ -503,6 +543,19 @@ export class APIEmbeddingProvider implements EmbeddingProvider {
   }
 
   private static async probeAPI(config: APIEmbeddingConfig, options?: EmbeddingRequestOptions): Promise<number> {
+    if (isNativeGeminiEndpoint(config.baseUrl)) {
+      const response = await fetchWithRetry(
+        geminiUrl(config.baseUrl, config.model),
+        config.apiKey,
+        geminiBody({ modality: 'text', text: 'dimension probe' }, config.model, config.requestedDimensions),
+        options,
+        0,
+        true,
+      );
+      const embedding = response.embedding?.values;
+      if (!embedding) throw new Error('API probe returned no embeddings; check model name and API key');
+      return embedding.length;
+    }
     const body: Record<string, unknown> = {
       model: config.model,
       input: 'dimension probe',
@@ -518,15 +571,16 @@ export class APIEmbeddingProvider implements EmbeddingProvider {
       options,
     );
 
-    if (response.data.length === 0 || !response.data[0].embedding) {
-      throw new Error('API probe returned no embeddings; check model name and API key');
-    }
-
-    return response.data[0].embedding.length;
+    const embedding = response.data?.[0]?.embedding;
+    if (!embedding) throw new Error('API probe returned no embeddings; check model name and API key');
+    return embedding.length;
   }
 
   async embed(text: string, options?: EmbeddingRequestOptions): Promise<number[]> {
     const normalized = normalizeText(text);
+    if (isNativeGeminiEndpoint(this.config.baseUrl)) {
+      return this.embedInput({ modality: 'text', text: normalized }, { intent: 'document', ...options });
+    }
     const hash = textHash(normalized, this.cacheKeyNamespace);
 
     // Fast path: cache already loaded (warm process) — instant lookup
@@ -596,6 +650,9 @@ export class APIEmbeddingProvider implements EmbeddingProvider {
   }
 
   async embedBatch(texts: string[], options?: EmbeddingRequestOptions): Promise<number[][]> {
+    if (isNativeGeminiEndpoint(this.config.baseUrl)) {
+      return Promise.all(texts.map((text) => this.embedInput({ modality: 'text', text }, { intent: 'document', ...options })));
+    }
     await ensureDiskCacheLoaded();
     const normalizedTexts = texts.map(normalizeText);
     const results: number[][] = new Array(texts.length);
@@ -696,7 +753,7 @@ export class APIEmbeddingProvider implements EmbeddingProvider {
   private supportsModality(modality: EmbeddingInput['modality']): boolean {
     if (modality === 'text') return true;
     if (isJinaEndpoint(this.config.baseUrl)) return true;
-    if (isGoogleEmbeddingEndpoint(this.config.baseUrl) && /embedding-2/i.test(this.config.model)) return true;
+    if (isNativeGeminiEndpoint(this.config.baseUrl) && /embedding-2/i.test(this.config.model)) return true;
     return false;
   }
 
@@ -715,21 +772,27 @@ export class APIEmbeddingProvider implements EmbeddingProvider {
     const cached = cache.get(hash);
     if (cached) return cached;
 
-    const body: Record<string, unknown> = {
-      model: this.config.model,
-      input: input.modality === 'text' && !isJinaEndpoint(this.config.baseUrl)
-        ? input.text
-        : [toProviderInput(input, this.config.baseUrl)],
-      ...mapIntentTask(this.config.baseUrl, this.config.model, options),
-    };
-    if (this.config.requestedDimensions) body.dimensions = this.config.requestedDimensions;
+    const nativeGemini = isNativeGeminiEndpoint(this.config.baseUrl);
+    const body: Record<string, unknown> = nativeGemini
+      ? geminiBody(input, this.config.model, this.config.requestedDimensions, options)
+      : {
+          model: this.config.model,
+          input: input.modality === 'text' && !isJinaEndpoint(this.config.baseUrl)
+            ? input.text
+            : [toProviderInput(input, this.config.baseUrl)],
+          ...mapIntentTask(this.config.baseUrl, this.config.model, options),
+          ...(this.config.requestedDimensions ? { dimensions: this.config.requestedDimensions } : {}),
+        };
 
     const response = await fetchWithRetry(
-      `${this.config.baseUrl}/embeddings`,
+      nativeGemini ? geminiUrl(this.config.baseUrl, this.config.model) : `${this.config.baseUrl}/embeddings`,
       this.config.apiKey,
       body,
+      options,
+      0,
+      nativeGemini,
     );
-    const embedding = response.data[0]?.embedding;
+    const embedding = nativeGemini ? response.embedding?.values : response.data[0]?.embedding;
     if (!embedding) throw new Error('Embedding API returned no vectors');
     if (embedding.length !== this.dimensions) {
       throw new Error(`Expected ${this.dimensions}d, got ${embedding.length}d; dimension mismatch`);
@@ -768,6 +831,7 @@ async function fetchWithRetry(
   body: Record<string, unknown>,
   options: EmbeddingRequestOptions = {},
   attempt = 0,
+  nativeGemini = false,
 ): Promise<EmbeddingAPIResponse> {
   const controller = new AbortController();
   const timeoutMs = typeof options.timeoutMs === 'number' && Number.isFinite(options.timeoutMs)
@@ -778,10 +842,9 @@ async function fetchWithRetry(
   try {
     response = await fetch(url, {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`,
-      },
+      headers: nativeGemini
+        ? { 'Content-Type': 'application/json', 'x-goog-api-key': apiKey }
+        : { 'Content-Type': 'application/json', 'Authorization': `Bearer ${apiKey}` },
       body: JSON.stringify(body),
       signal: controller.signal,
     });
@@ -804,7 +867,7 @@ async function fetchWithRetry(
     const waitMs = retryAfter ? parseInt(retryAfter, 10) * 1000 : delay;
     console.error(`[memorix] Embedding API ${response.status}, retry ${attempt + 1}/${MAX_RETRIES} in ${waitMs}ms`);
     await new Promise(resolve => setTimeout(resolve, waitMs));
-    return fetchWithRetry(url, apiKey, body, options, attempt + 1);
+    return fetchWithRetry(url, apiKey, body, options, attempt + 1, nativeGemini);
   }
 
   const errorText = await response.text().catch(() => 'unknown error');

--- a/src/embedding/api-provider.ts
+++ b/src/embedding/api-provider.ts
@@ -14,6 +14,7 @@ import {
   UnsupportedEmbeddingModalityError,
   validateEmbeddingInput,
   type EmbeddingInput,
+  type EmbeddingModality,
   type EmbeddingOptions,
   type EmbeddingProvider,
   type EmbeddingRequestOptions,
@@ -445,6 +446,7 @@ function parseBatchLimit(error: unknown): number | null {
 export class APIEmbeddingProvider implements EmbeddingProvider {
   readonly name: string;
   readonly dimensions: number;
+  readonly supportedModalities: readonly EmbeddingModality[];
 
   private config: APIEmbeddingConfig;
   private readonly cacheKeyNamespace: string;
@@ -456,6 +458,11 @@ export class APIEmbeddingProvider implements EmbeddingProvider {
     this.cacheKeyNamespace = cacheNamespace(config);
     this.dimensions = detectedDimensions;
     this.name = `api-${config.model.replace(/\//g, '-')}`;
+    this.supportedModalities = isJinaEndpoint(config.baseUrl)
+      ? ['text', 'image', 'audio', 'video', 'document']
+      : isNativeGeminiEndpoint(config.baseUrl) && /embedding-2/i.test(config.model)
+        ? ['text', 'image', 'audio', 'video', 'document']
+        : ['text'];
   }
 
   static async create(): Promise<APIEmbeddingProvider>;
@@ -751,10 +758,7 @@ export class APIEmbeddingProvider implements EmbeddingProvider {
   }
 
   private supportsModality(modality: EmbeddingInput['modality']): boolean {
-    if (modality === 'text') return true;
-    if (isJinaEndpoint(this.config.baseUrl)) return true;
-    if (isNativeGeminiEndpoint(this.config.baseUrl) && /embedding-2/i.test(this.config.model)) return true;
-    return false;
+    return this.supportedModalities.includes(modality);
   }
 
   async embedInput(input: EmbeddingInput, options: EmbeddingOptions = {}): Promise<number[]> {

--- a/src/embedding/api-provider.ts
+++ b/src/embedding/api-provider.ts
@@ -9,12 +9,27 @@ import { createHash } from 'node:crypto';
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import type { EmbeddingProvider, EmbeddingRequestOptions } from './provider.js';
+import {
+  UnsupportedEmbeddingModalityError,
+  validateEmbeddingInput,
+  type EmbeddingInput,
+  type EmbeddingOptions,
+  type EmbeddingProvider,
+  type EmbeddingRequestOptions,
+} from './provider.js';
 
-const CACHE_DIR = process.env.MEMORIX_DATA_DIR || join(homedir(), '.memorix', 'data');
-const CACHE_FILE = join(CACHE_DIR, '.embedding-api-cache.json');
-const DIMS_CACHE_FILE = join(CACHE_DIR, '.embedding-dims-cache.json');
-const CACHE_META_FILE = join(CACHE_DIR, '.embedding-api-cache-meta.json');
+function cacheDir(): string {
+  return process.env.MEMORIX_DATA_DIR || join(homedir(), '.memorix', 'data');
+}
+function cacheFile(): string {
+  return join(cacheDir(), '.embedding-api-cache.json');
+}
+function dimsCacheFile(): string {
+  return join(cacheDir(), '.embedding-dims-cache.json');
+}
+function cacheMetaFile(): string {
+  return join(cacheDir(), '.embedding-api-cache-meta.json');
+}
 
 const cache = new Map<string, number[]>();
 const MAX_CACHE_SIZE = 10000;
@@ -49,10 +64,60 @@ function textHash(text: string, namespace: string): string {
   return createHash('sha256').update(`${namespace}\u0000${text}`).digest('hex').slice(0, 16);
 }
 
+function inputIdentity(input: EmbeddingInput, options: EmbeddingOptions = {}): string {
+  return JSON.stringify({
+    modality: input.modality,
+    input,
+    intent: options.intent ?? 'document',
+    instruction: options.instruction ?? '',
+  });
+}
+
+function isJinaEndpoint(baseUrl: string): boolean {
+  return /jina\.ai/i.test(baseUrl);
+}
+
+function isGoogleEmbeddingEndpoint(baseUrl: string): boolean {
+  return /generativelanguage\.googleapis\.com/i.test(baseUrl);
+}
+
+function mapIntentTask(baseUrl: string, model: string, options: EmbeddingOptions = {}): Record<string, unknown> {
+  const intent = options.intent ?? 'document';
+  if (isJinaEndpoint(baseUrl)) {
+    return { task: intent === 'query' ? 'retrieval.query' : 'retrieval.passage' };
+  }
+  if (isGoogleEmbeddingEndpoint(baseUrl)) {
+    const out: Record<string, unknown> = {
+      task_type: intent === 'query' ? 'RETRIEVAL_QUERY' : 'RETRIEVAL_DOCUMENT',
+    };
+    if (options.instruction) out.instruction = options.instruction;
+    return out;
+  }
+  return options.instruction ? { instruction: options.instruction } : {};
+}
+
+function toProviderInput(input: EmbeddingInput, baseUrl: string): unknown {
+  if (input.modality === 'text') {
+    return isJinaEndpoint(baseUrl) ? { text: input.text } : input.text;
+  }
+  if (isJinaEndpoint(baseUrl)) {
+    const key = input.modality === 'document' ? 'pdf' : input.modality;
+    if ('data' in input && input.data !== undefined) {
+      return { [key]: `data:${input.mimeType};base64,${input.data}` };
+    }
+    return { [key]: input.url };
+  }
+  // Generic OpenAI-compatible multimodal transport for capable Google-style endpoints.
+  if ('data' in input && input.data !== undefined) {
+    return { type: input.modality, data: input.data, media_type: input.mimeType };
+  }
+  return { type: input.modality, url: input.url };
+}
+
 async function loadDiskCache(): Promise<void> {
   if (diskCacheLoaded) return;
   try {
-    const raw = await readFile(CACHE_FILE, 'utf-8');
+    const raw = await readFile(cacheFile(), 'utf-8');
     const entries: [string, number[]][] = JSON.parse(raw);
     for (const [k, v] of entries) cache.set(k, v);
     console.error(`[memorix] Loaded ${entries.length} cached API embeddings from disk`);
@@ -101,7 +166,7 @@ async function loadCachedVectorDimensions(
   config: Pick<APIEmbeddingConfig, 'baseUrl' | 'model' | 'requestedDimensions'>,
 ): Promise<number | null> {
   try {
-    const raw = await readFile(CACHE_META_FILE, 'utf-8');
+    const raw = await readFile(cacheMetaFile(), 'utf-8');
     const data = JSON.parse(raw);
     const namespace = cacheNamespace(config);
     if (!Array.isArray(data?.entries)) return null;
@@ -123,10 +188,10 @@ async function saveCachedVectorDimensions(
 ): Promise<void> {
   if (!isValidDimension(dimensions)) return;
   try {
-    await mkdir(CACHE_DIR, { recursive: true });
+    await mkdir(cacheDir(), { recursive: true });
     let entries: CacheMetadataEntry[] = [];
     try {
-      const raw = await readFile(CACHE_META_FILE, 'utf-8');
+      const raw = await readFile(cacheMetaFile(), 'utf-8');
       const data = JSON.parse(raw);
       if (Array.isArray(data?.entries)) {
         entries = data.entries.filter((candidate: unknown): candidate is CacheMetadataEntry =>
@@ -144,7 +209,7 @@ async function saveCachedVectorDimensions(
     const namespace = cacheNamespace(config);
     entries = entries.filter((entry) => entry.namespace !== namespace);
     entries.push({ namespace, dimensions, ts: Date.now() });
-    await writeFile(CACHE_META_FILE, JSON.stringify({ version: 1, entries }));
+    await writeFile(cacheMetaFile(), JSON.stringify({ version: 1, entries }));
   } catch {
     // A missing or read-only cache must never block embedding requests.
   }
@@ -153,7 +218,7 @@ async function saveCachedVectorDimensions(
 /** Load cached probe dimensions from disk. Returns null if not cached. */
 async function loadCachedDims(config: Pick<APIEmbeddingConfig, 'baseUrl' | 'model' | 'requestedDimensions'>): Promise<number | null> {
   try {
-    const raw = await readFile(DIMS_CACHE_FILE, 'utf-8');
+    const raw = await readFile(dimsCacheFile(), 'utf-8');
     const data = JSON.parse(raw);
 
     const key = dimsCacheKey(config);
@@ -195,12 +260,12 @@ async function loadCachedDims(config: Pick<APIEmbeddingConfig, 'baseUrl' | 'mode
 /** Persist probe dimensions for fast subsequent starts. */
 async function saveCachedDims(config: Pick<APIEmbeddingConfig, 'baseUrl' | 'model' | 'requestedDimensions'>, dimensions: number): Promise<void> {
   try {
-    await mkdir(CACHE_DIR, { recursive: true });
+    await mkdir(cacheDir(), { recursive: true });
     const key = dimsCacheKey(config);
     let entries: Array<{ key: string; baseUrl: string; model: string; requestedDimensions: number | null; dimensions: number; ts: number }> = [];
 
     try {
-      const raw = await readFile(DIMS_CACHE_FILE, 'utf-8');
+      const raw = await readFile(dimsCacheFile(), 'utf-8');
       const data = JSON.parse(raw);
       if (Array.isArray(data.entries)) {
         entries = data.entries.filter((entry: unknown) =>
@@ -245,7 +310,7 @@ async function saveCachedDims(config: Pick<APIEmbeddingConfig, 'baseUrl' | 'mode
     entries = entries.filter((entry) => entry.key !== key);
     entries.push(nextEntry);
 
-    await writeFile(DIMS_CACHE_FILE, JSON.stringify({ entries }));
+    await writeFile(dimsCacheFile(), JSON.stringify({ entries }));
   } catch { /* best-effort */ }
   await saveCachedVectorDimensions(config, dimensions);
 }
@@ -253,9 +318,9 @@ async function saveCachedDims(config: Pick<APIEmbeddingConfig, 'baseUrl' | 'mode
 async function saveDiskCacheNow(): Promise<void> {
   if (!diskCacheDirty) return;
   try {
-    await mkdir(CACHE_DIR, { recursive: true });
+    await mkdir(cacheDir(), { recursive: true });
     const entries = Array.from(cache.entries());
-    await writeFile(CACHE_FILE, JSON.stringify(entries));
+    await writeFile(cacheFile(), JSON.stringify(entries));
     diskCacheDirty = false;
   } catch {
     // Cache persistence is best-effort only.
@@ -626,6 +691,59 @@ export class APIEmbeddingProvider implements EmbeddingProvider {
       const hash = textHash(normalizeText(text), this.cacheKeyNamespace);
       return cache.get(hash) ?? null;
     });
+  }
+
+  private supportsModality(modality: EmbeddingInput['modality']): boolean {
+    if (modality === 'text') return true;
+    if (isJinaEndpoint(this.config.baseUrl)) return true;
+    if (isGoogleEmbeddingEndpoint(this.config.baseUrl) && /embedding-2/i.test(this.config.model)) return true;
+    return false;
+  }
+
+  async embedInput(input: EmbeddingInput, options: EmbeddingOptions = {}): Promise<number[]> {
+    validateEmbeddingInput(input);
+    if (!this.supportsModality(input.modality)) {
+      throw new UnsupportedEmbeddingModalityError(this.name, input.modality);
+    }
+    if (input.modality === 'text' && !options.intent && !options.instruction && !isJinaEndpoint(this.config.baseUrl) && !isGoogleEmbeddingEndpoint(this.config.baseUrl)) {
+      return this.embed(input.text);
+    }
+
+    await ensureDiskCacheLoaded();
+    const identity = inputIdentity(input, options);
+    const hash = textHash(identity, this.cacheKeyNamespace);
+    const cached = cache.get(hash);
+    if (cached) return cached;
+
+    const body: Record<string, unknown> = {
+      model: this.config.model,
+      input: input.modality === 'text' && !isJinaEndpoint(this.config.baseUrl)
+        ? input.text
+        : [toProviderInput(input, this.config.baseUrl)],
+      ...mapIntentTask(this.config.baseUrl, this.config.model, options),
+    };
+    if (this.config.requestedDimensions) body.dimensions = this.config.requestedDimensions;
+
+    const response = await fetchWithRetry(
+      `${this.config.baseUrl}/embeddings`,
+      this.config.apiKey,
+      body,
+    );
+    const embedding = response.data[0]?.embedding;
+    if (!embedding) throw new Error('Embedding API returned no vectors');
+    if (embedding.length !== this.dimensions) {
+      throw new Error(`Expected ${this.dimensions}d, got ${embedding.length}d; dimension mismatch`);
+    }
+    this.trackUsage(response);
+    cacheSet(hash, embedding);
+    scheduleDiskSave();
+    return embedding;
+  }
+
+  async embedInputs(inputs: EmbeddingInput[], options: EmbeddingOptions = {}): Promise<number[][]> {
+    const out: number[][] = [];
+    for (const input of inputs) out.push(await this.embedInput(input, options));
+    return out;
   }
 
   getStats(): { totalTokens: number; totalApiCalls: number; cacheSize: number } {

--- a/src/embedding/fastembed-provider.ts
+++ b/src/embedding/fastembed-provider.ts
@@ -15,7 +15,13 @@ import { createHash } from 'node:crypto';
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
-import type { EmbeddingProvider } from './provider.js';
+import {
+  UnsupportedEmbeddingModalityError,
+  validateEmbeddingInput,
+  type EmbeddingInput,
+  type EmbeddingOptions,
+  type EmbeddingProvider,
+} from './provider.js';
 
 const CACHE_DIR = process.env.MEMORIX_DATA_DIR || join(homedir(), '.memorix', 'data');
 const CACHE_FILE = join(CACHE_DIR, '.embedding-cache.json');
@@ -76,6 +82,18 @@ export class FastEmbedProvider implements EmbeddingProvider {
     // Load disk cache before returning — subsequent embedBatch calls will hit cache
     await loadDiskCache();
     return new FastEmbedProvider(model);
+  }
+
+  async embedInput(input: EmbeddingInput, _options: EmbeddingOptions = {}): Promise<number[]> {
+    validateEmbeddingInput(input);
+    if (input.modality !== 'text') {
+      throw new UnsupportedEmbeddingModalityError(this.name, input.modality);
+    }
+    return this.embed(input.text);
+  }
+
+  async embedInputs(inputs: EmbeddingInput[], options: EmbeddingOptions = {}): Promise<number[][]> {
+    return Promise.all(inputs.map((input) => this.embedInput(input, options)));
   }
 
   async embed(text: string): Promise<number[]> {

--- a/src/embedding/fastembed-provider.ts
+++ b/src/embedding/fastembed-provider.ts
@@ -19,6 +19,7 @@ import {
   UnsupportedEmbeddingModalityError,
   validateEmbeddingInput,
   type EmbeddingInput,
+  type EmbeddingModality,
   type EmbeddingOptions,
   type EmbeddingProvider,
 } from './provider.js';
@@ -61,6 +62,7 @@ async function saveDiskCache(): Promise<void> {
 export class FastEmbedProvider implements EmbeddingProvider {
   readonly name = 'fastembed-bge-small';
   readonly dimensions = 384;
+  readonly supportedModalities: readonly EmbeddingModality[] = ['text'];
 
   private model: { embed: (docs: string[], batchSize?: number) => AsyncGenerator<number[][]>; queryEmbed: (query: string) => Promise<number[]> };
 

--- a/src/embedding/provider.ts
+++ b/src/embedding/provider.ts
@@ -34,15 +34,94 @@ export interface EmbeddingRequestOptions {
   retry?: boolean;
 }
 
+export type EmbeddingModality = 'text' | 'image' | 'audio' | 'video' | 'document';
+export type EmbeddingIntent = 'query' | 'document';
+
+export type EmbeddingInput =
+  | { modality: 'text'; text: string }
+  | { modality: Exclude<EmbeddingModality, 'text'>; url: string; data?: never; mimeType?: string }
+  | { modality: Exclude<EmbeddingModality, 'text'>; data: string; url?: never; mimeType: string };
+
+export interface EmbeddingOptions extends EmbeddingRequestOptions {
+  /** Retrieval role. Providers may use asymmetric query/document models or tasks. */
+  intent?: EmbeddingIntent;
+  /** Optional provider-specific retrieval instruction. Never persisted by the embedding cache. */
+  instruction?: string;
+}
+
+export class EmbeddingInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'EmbeddingInputError';
+  }
+}
+
+export class UnsupportedEmbeddingModalityError extends EmbeddingInputError {
+  readonly modality: EmbeddingModality;
+  readonly provider: string;
+
+  constructor(provider: string, modality: EmbeddingModality) {
+    super(`Embedding provider ${provider} does not support ${modality} input`);
+    this.name = 'UnsupportedEmbeddingModalityError';
+    this.provider = provider;
+    this.modality = modality;
+  }
+}
+
+/** Maximum encoded inline media accepted by the public API (5 MiB). */
+export const MAX_INLINE_EMBEDDING_BYTES = 5 * 1024 * 1024;
+
+function isPrivateHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (host === 'localhost' || host === '::1' || host === '0.0.0.0' || host.endsWith('.localhost')) return true;
+  const parts = host.split('.').map(Number);
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return false;
+  return parts[0] === 10 || parts[0] === 127 || parts[0] === 0 ||
+    (parts[0] === 169 && parts[1] === 254) ||
+    (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
+    (parts[0] === 192 && parts[1] === 168);
+}
+
+/** Validate without reading or fetching the media. Returns the original typed input. */
+export function validateEmbeddingInput(input: EmbeddingInput): EmbeddingInput {
+  if (input.modality === 'text') {
+    if (!input.text.trim()) throw new EmbeddingInputError('Embedding text must not be empty');
+    return input;
+  }
+  if ('data' in input && input.data !== undefined) {
+    if (!input.mimeType?.trim()) throw new EmbeddingInputError('Inline media requires a MIME type');
+    if (Buffer.byteLength(input.data, 'utf8') > MAX_INLINE_EMBEDDING_BYTES) {
+      throw new EmbeddingInputError(`Inline ${input.modality} payload is too large (maximum 5 MiB)`);
+    }
+    return input;
+  }
+  let url: URL;
+  try {
+    url = new URL(input.url);
+  } catch {
+    throw new EmbeddingInputError(`Invalid ${input.modality} URL`);
+  }
+  if (url.protocol !== 'https:') throw new EmbeddingInputError('Unsafe media URL scheme: only https is allowed');
+  if (url.username || url.password) throw new EmbeddingInputError('Media URLs must not contain credentials');
+  if (isPrivateHost(url.hostname)) throw new EmbeddingInputError('Private or local media URLs are not allowed');
+  return input;
+}
+
 export interface EmbeddingProvider {
   /** Provider name for logging/cache keys */
   readonly name: string;
   /** Vector dimensions (e.g., 384 for bge-small) */
   readonly dimensions: number;
-  /** Generate embedding for a single text */
+  /** Generate embedding for a single text. */
   embed(text: string, options?: EmbeddingRequestOptions): Promise<number[]>;
-  /** Generate embeddings for multiple texts (batch) */
+  /** Generate embeddings for multiple texts (batch). */
   embedBatch(texts: string[], options?: EmbeddingRequestOptions): Promise<number[][]>;
+  /** Modalities accepted by the provider. Omitted means text-only. */
+  readonly supportedModalities?: readonly EmbeddingModality[];
+  /** Generate an embedding for typed text or media input. */
+  embedInput?(input: EmbeddingInput, options?: EmbeddingOptions): Promise<number[]>;
+  /** Generate embeddings for typed inputs. */
+  embedInputs?(inputs: EmbeddingInput[], options?: EmbeddingOptions): Promise<number[][]>;
   /** Return already-persisted embeddings without generating new vectors. */
   getCachedEmbeddings?(texts: string[]): Promise<(number[] | null)[]>;
 }

--- a/src/embedding/provider.ts
+++ b/src/embedding/provider.ts
@@ -1,3 +1,5 @@
+import { isIP } from 'node:net';
+
 /**
  * Embedding Provider — Abstraction Layer
  *
@@ -71,15 +73,40 @@ export class UnsupportedEmbeddingModalityError extends EmbeddingInputError {
 /** Maximum encoded inline media accepted by the public API (5 MiB). */
 export const MAX_INLINE_EMBEDDING_BYTES = 5 * 1024 * 1024;
 
-function isPrivateHost(hostname: string): boolean {
-  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
-  if (host === 'localhost' || host === '::1' || host === '0.0.0.0' || host.endsWith('.localhost')) return true;
+function isNonGlobalIPv4(host: string): boolean {
   const parts = host.split('.').map(Number);
-  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return false;
-  return parts[0] === 10 || parts[0] === 127 || parts[0] === 0 ||
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return true;
+  return parts[0] === 0 || parts[0] === 10 || parts[0] === 127 || parts[0] >= 224 ||
+    (parts[0] === 100 && parts[1] >= 64 && parts[1] <= 127) ||
     (parts[0] === 169 && parts[1] === 254) ||
     (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
-    (parts[0] === 192 && parts[1] === 168);
+    (parts[0] === 192 && parts[1] === 0 && parts[2] === 0) ||
+    (parts[0] === 192 && parts[1] === 0 && parts[2] === 2) ||
+    (parts[0] === 192 && parts[1] === 168) ||
+    (parts[0] === 198 && (parts[1] === 18 || parts[1] === 19 || parts[1] === 51 && parts[2] === 100)) ||
+    (parts[0] === 203 && parts[1] === 0 && parts[2] === 113);
+}
+
+function isPrivateHost(hostname: string): boolean {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (host === 'localhost' || host.endsWith('.localhost')) return true;
+  if (isIP(host) === 4) return isNonGlobalIPv4(host);
+  if (isIP(host) !== 6) return false;
+
+  // URL canonicalizes IPv4-mapped addresses to hexadecimal (for example
+  // ::ffff:127.0.0.1 becomes ::ffff:7f00:1), so classify the mapped payload.
+  if (host.startsWith('::ffff:')) {
+    const groups = host.slice(7).split(':');
+    if (groups.length === 2) {
+      const high = parseInt(groups[0], 16);
+      const low = parseInt(groups[1], 16);
+      return isNonGlobalIPv4(`${high >> 8}.${high & 255}.${low >> 8}.${low & 255}`);
+    }
+  }
+  const first = parseInt(host.split(':')[0] || '0', 16);
+  return host === '::' || host === '::1' || (first & 0xfe00) === 0xfc00 ||
+    (first & 0xffc0) === 0xfe80 || (first & 0xff00) === 0xff00 ||
+    host.startsWith('2001:db8:');
 }
 
 /** Validate without reading or fetching the media. Returns the original typed input. */
@@ -102,7 +129,11 @@ export function validateEmbeddingInput(input: EmbeddingInput): EmbeddingInput {
     throw new EmbeddingInputError(`Invalid ${input.modality} URL`);
   }
   if (url.protocol !== 'https:') throw new EmbeddingInputError('Unsafe media URL scheme: only https is allowed');
-  if (url.username || url.password) throw new EmbeddingInputError('Media URLs must not contain credentials');
+  // Hostnames are not resolved here: the remote embedding provider performs the
+  // fetch, so local DNS checks cannot prevent provider-side DNS rebinding.
+  if (url.username || url.password || url.search || url.hash) {
+    throw new EmbeddingInputError('Media URLs must not contain credentials, query parameters, or fragments');
+  }
   if (isPrivateHost(url.hostname)) throw new EmbeddingInputError('Private or local media URLs are not allowed');
   return input;
 }

--- a/src/embedding/transformers-provider.ts
+++ b/src/embedding/transformers-provider.ts
@@ -15,7 +15,13 @@
  * Inspired by Mem0's multi-provider embedding architecture.
  */
 
-import type { EmbeddingProvider } from './provider.js';
+import {
+  UnsupportedEmbeddingModalityError,
+  validateEmbeddingInput,
+  type EmbeddingInput,
+  type EmbeddingOptions,
+  type EmbeddingProvider,
+} from './provider.js';
 
 // In-memory LRU cache
 const cache = new Map<string, number[]>();
@@ -44,6 +50,18 @@ export class TransformersProvider implements EmbeddingProvider {
             { dtype: 'q8' }, // Quantized for small footprint
         );
         return new TransformersProvider(extractor);
+    }
+
+    async embedInput(input: EmbeddingInput, _options: EmbeddingOptions = {}): Promise<number[]> {
+        validateEmbeddingInput(input);
+        if (input.modality !== 'text') {
+            throw new UnsupportedEmbeddingModalityError(this.name, input.modality);
+        }
+        return this.embed(input.text);
+    }
+
+    async embedInputs(inputs: EmbeddingInput[], options: EmbeddingOptions = {}): Promise<number[][]> {
+        return Promise.all(inputs.map((input) => this.embedInput(input, options)));
     }
 
     async embed(text: string): Promise<number[]> {

--- a/src/embedding/transformers-provider.ts
+++ b/src/embedding/transformers-provider.ts
@@ -19,6 +19,7 @@ import {
   UnsupportedEmbeddingModalityError,
   validateEmbeddingInput,
   type EmbeddingInput,
+  type EmbeddingModality,
   type EmbeddingOptions,
   type EmbeddingProvider,
 } from './provider.js';
@@ -30,6 +31,7 @@ const MAX_CACHE_SIZE = 5000;
 export class TransformersProvider implements EmbeddingProvider {
     readonly name = 'transformers-minilm';
     readonly dimensions = 384;
+    readonly supportedModalities: readonly EmbeddingModality[] = ['text'];
 
     private extractor: any; // Pipeline instance
 

--- a/src/media/asset-store.ts
+++ b/src/media/asset-store.ts
@@ -1,0 +1,312 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { copyFile, lstat, mkdir, open, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { MediaStore } from './media-store.js';
+import {
+  DEFAULT_MAX_MEDIA_BYTES,
+  DEFAULT_MEDIA_QUOTA_BYTES,
+  type MediaAsset,
+  type MediaImportResult,
+  type MediaKind,
+  type MediaSourceKind,
+} from './types.js';
+
+interface DetectedMedia {
+  kind: MediaKind;
+  mimeType: string;
+  extension: string;
+}
+
+export interface ImportMediaFileInput {
+  dataDir: string;
+  projectId: string;
+  filePath: string;
+  sourceKind?: MediaSourceKind;
+  sourceLabel?: string;
+  provider?: string;
+  model?: string;
+  maxBytes?: number;
+}
+
+export interface ImportMediaBufferInput {
+  dataDir: string;
+  projectId: string;
+  bytes: Buffer;
+  filename?: string;
+  sourceKind: MediaSourceKind;
+  sourceLabel?: string;
+  provider?: string;
+  model?: string;
+  maxBytes?: number;
+}
+
+function mediaRoot(dataDir: string): string {
+  return path.resolve(dataDir, 'media');
+}
+
+function projectStorageKey(projectId: string): string {
+  return createHash('sha256').update(projectId).digest('hex').slice(0, 16);
+}
+
+function validateUnderRoot(root: string, candidate: string): string {
+  const resolved = path.resolve(candidate);
+  const relative = path.relative(root, resolved);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new Error('Media storage path escaped the Memorix data directory');
+  }
+  return resolved;
+}
+
+function sanitizeLabel(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const basename = path.basename(value).replace(/[\u0000-\u001f<>:"|?*]/g, '_').trim();
+  return basename ? basename.slice(0, 180) : undefined;
+}
+
+function matchesPrefix(bytes: Buffer, prefix: number[]): boolean {
+  return prefix.every((byte, index) => bytes[index] === byte);
+}
+
+function detectMedia(bytes: Buffer): DetectedMedia {
+  if (matchesPrefix(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])) {
+    return { kind: 'image', mimeType: 'image/png', extension: '.png' };
+  }
+  if (matchesPrefix(bytes, [0xff, 0xd8, 0xff])) {
+    return { kind: 'image', mimeType: 'image/jpeg', extension: '.jpg' };
+  }
+  if (bytes.subarray(0, 6).toString('ascii') === 'GIF87a' || bytes.subarray(0, 6).toString('ascii') === 'GIF89a') {
+    return { kind: 'image', mimeType: 'image/gif', extension: '.gif' };
+  }
+  if (bytes.subarray(0, 4).toString('ascii') === 'RIFF' && bytes.subarray(8, 12).toString('ascii') === 'WEBP') {
+    return { kind: 'image', mimeType: 'image/webp', extension: '.webp' };
+  }
+  if (bytes.subarray(0, 4).toString('ascii') === '%PDF') {
+    return { kind: 'document', mimeType: 'application/pdf', extension: '.pdf' };
+  }
+  if (bytes.subarray(4, 8).toString('ascii') === 'ftyp') {
+    return { kind: 'video', mimeType: 'video/mp4', extension: '.mp4' };
+  }
+  if (matchesPrefix(bytes, [0x1a, 0x45, 0xdf, 0xa3])) {
+    return { kind: 'video', mimeType: 'video/webm', extension: '.webm' };
+  }
+  if (bytes.subarray(0, 4).toString('ascii') === 'RIFF' && bytes.subarray(8, 12).toString('ascii') === 'WAVE') {
+    return { kind: 'audio', mimeType: 'audio/wav', extension: '.wav' };
+  }
+  if (matchesPrefix(bytes, [0x49, 0x44, 0x33]) || (bytes[0] === 0xff && (bytes[1] & 0xe0) === 0xe0)) {
+    return { kind: 'audio', mimeType: 'audio/mpeg', extension: '.mp3' };
+  }
+  throw new Error('Unsupported or unrecognized media format');
+}
+
+async function readHeader(filePath: string, bytes = 32): Promise<Buffer> {
+  const handle = await open(filePath, 'r');
+  try {
+    const output = Buffer.alloc(bytes);
+    const { bytesRead } = await handle.read(output, 0, bytes, 0);
+    return output.subarray(0, bytesRead);
+  } finally {
+    await handle.close();
+  }
+}
+
+async function sha256File(filePath: string): Promise<string> {
+  const bytes = await readFile(filePath);
+  return createHash('sha256').update(bytes).digest('hex');
+}
+
+function destinationFor(root: string, projectId: string, sha256: string, extension: string): { absolute: string; relative: string } {
+  const relative = path.join('assets', projectStorageKey(projectId), sha256.slice(0, 2), `${sha256}${extension}`);
+  return { relative, absolute: validateUnderRoot(root, path.join(root, relative)) };
+}
+
+async function destinationExists(destination: string): Promise<boolean> {
+  try {
+    await lstat(destination);
+    return true;
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+async function persistFile(source: string, destination: string): Promise<boolean> {
+  await mkdir(path.dirname(destination), { recursive: true });
+  if (await destinationExists(destination)) return false;
+
+  // The source is copied to a unique temporary neighbor and atomically renamed.
+  const temporary = `${destination}.${randomUUID()}.tmp`;
+  try {
+    await copyFile(source, temporary);
+    await rename(temporary, destination);
+    return true;
+  } catch (error: any) {
+    if (error?.code === 'EEXIST' && await destinationExists(destination)) return false;
+    throw error;
+  } finally {
+    await rm(temporary, { force: true }).catch(() => {});
+  }
+}
+
+async function persistBuffer(bytes: Buffer, destination: string): Promise<boolean> {
+  await mkdir(path.dirname(destination), { recursive: true });
+  if (await destinationExists(destination)) return false;
+
+  // Write through a temporary sibling so an interrupted process cannot create a valid database row for a partial file.
+  const temporary = `${destination}.${randomUUID()}.tmp`;
+  try {
+    await writeFile(temporary, bytes, { flag: 'wx' });
+    await rename(temporary, destination);
+    return true;
+  } catch (error: any) {
+    if (error?.code === 'EEXIST' && await destinationExists(destination)) return false;
+    throw error;
+  } finally {
+    await rm(temporary, { force: true }).catch(() => {});
+  }
+}
+
+export function getMediaAssetPath(dataDir: string, asset: MediaAsset): string {
+  return validateUnderRoot(mediaRoot(dataDir), path.join(mediaRoot(dataDir), asset.storageRelPath));
+}
+
+async function importKnownMedia(input: {
+  dataDir: string;
+  projectId: string;
+  sha256: string;
+  bytes: number;
+  detected: DetectedMedia;
+  persist: (destination: string) => Promise<boolean>;
+  sourceKind: MediaSourceKind;
+  sourceLabel?: string;
+  provider?: string;
+  model?: string;
+}): Promise<MediaImportResult> {
+  const root = mediaRoot(input.dataDir);
+  const destination = destinationFor(root, input.projectId, input.sha256, input.detected.extension);
+  const createdFile = await input.persist(destination.absolute);
+  const store = new MediaStore(input.dataDir);
+  try {
+    return store.createOrReviveAsset({
+      projectId: input.projectId,
+      sha256: input.sha256,
+      kind: input.detected.kind,
+      mimeType: input.detected.mimeType,
+      byteSize: input.bytes,
+      storageRelPath: destination.relative,
+      sourceKind: input.sourceKind,
+      sourceLabel: sanitizeLabel(input.sourceLabel),
+      provider: input.provider,
+      model: input.model,
+    });
+  } catch (error) {
+    // Never remove a pre-existing content-addressed file because a later database
+    // operation failed. It may belong to a valid deduplicated asset record.
+    if (createdFile) await rm(destination.absolute, { force: true }).catch(() => {});
+    throw error;
+  }
+}
+
+export async function importMediaFile(input: ImportMediaFileInput): Promise<MediaImportResult> {
+  const maxBytes = input.maxBytes ?? DEFAULT_MAX_MEDIA_BYTES;
+  const source = path.resolve(input.filePath);
+  const stat = await lstat(source);
+  if (stat.isSymbolicLink()) throw new Error('Media import does not follow symbolic links');
+  if (!stat.isFile()) throw new Error('Media import accepts regular files only');
+  if (stat.size <= 0) throw new Error('Media import rejects empty files');
+  if (stat.size > maxBytes) throw new Error(`Media file is too large (${stat.size} bytes; limit ${maxBytes})`);
+  const header = await readHeader(source);
+  const detected = detectMedia(header);
+  const sha256 = await sha256File(source);
+  return importKnownMedia({
+    dataDir: input.dataDir,
+    projectId: input.projectId,
+    sha256,
+    bytes: stat.size,
+    detected,
+    persist: (destination) => persistFile(source, destination),
+    sourceKind: input.sourceKind ?? 'import',
+    sourceLabel: input.sourceLabel ?? path.basename(source),
+    provider: input.provider,
+    model: input.model,
+  });
+}
+
+export async function importMediaBuffer(input: ImportMediaBufferInput): Promise<MediaImportResult> {
+  const maxBytes = input.maxBytes ?? DEFAULT_MAX_MEDIA_BYTES;
+  if (input.bytes.length === 0) throw new Error('Media import rejects empty payloads');
+  if (input.bytes.length > maxBytes) throw new Error(`Media payload is too large (${input.bytes.length} bytes; limit ${maxBytes})`);
+  const detected = detectMedia(input.bytes.subarray(0, 32));
+  const sha256 = createHash('sha256').update(input.bytes).digest('hex');
+  return importKnownMedia({
+    dataDir: input.dataDir,
+    projectId: input.projectId,
+    sha256,
+    bytes: input.bytes.length,
+    detected,
+    persist: (destination) => persistBuffer(input.bytes, destination),
+    sourceKind: input.sourceKind,
+    sourceLabel: input.sourceLabel ?? input.filename,
+    provider: input.provider,
+    model: input.model,
+  });
+}
+
+export async function readMediaAsset(dataDir: string, asset: MediaAsset, maxBytes = DEFAULT_MAX_MEDIA_BYTES): Promise<Buffer> {
+  if (asset.byteSize > maxBytes) throw new Error(`Media asset exceeds read limit (${asset.byteSize} bytes; limit ${maxBytes})`);
+  const bytes = await readFile(getMediaAssetPath(dataDir, asset));
+  if (bytes.length !== asset.byteSize) throw new Error(`Media asset size no longer matches metadata: ${asset.id}`);
+  const sha256 = createHash('sha256').update(bytes).digest('hex');
+  if (sha256 !== asset.sha256) throw new Error(`Media asset hash no longer matches metadata: ${asset.id}`);
+  return bytes;
+}
+
+export async function removeMediaAsset(input: {
+  dataDir: string;
+  projectId: string;
+  assetId: string;
+  force?: boolean;
+}): Promise<{ asset: MediaAsset; detachedLinks: number }> {
+  const store = new MediaStore(input.dataDir);
+  const asset = store.getAsset(input.projectId, input.assetId);
+  if (!asset) throw new Error(`Media asset not found: ${input.assetId}`);
+  const links = store.listLinks(input.projectId, asset.id);
+  if (links.length > 0 && !input.force) {
+    throw new Error(`Media asset ${asset.id} is attached to ${links.length} memory record(s); rerun with --force to detach it`);
+  }
+  const assetPath = getMediaAssetPath(input.dataDir, asset);
+  await rm(assetPath, { force: true });
+  const detachedLinks = links.length > 0 ? store.unlinkAsset(input.projectId, asset.id) : 0;
+  store.deleteDerivedData(input.projectId, asset.id);
+  store.markAssetDeleted(input.projectId, asset.id);
+  return { asset, detachedLinks };
+}
+
+export async function cleanupMediaQuota(input: {
+  dataDir: string;
+  projectId: string;
+  maxBytes?: number;
+}): Promise<{ beforeBytes: number; afterBytes: number; removed: MediaAsset[] }> {
+  const store = new MediaStore(input.dataDir);
+  const maxBytes = input.maxBytes ?? DEFAULT_MEDIA_QUOTA_BYTES;
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) throw new Error('maxBytes must be a non-negative integer');
+  const beforeBytes = store.activeByteSize(input.projectId);
+  let currentBytes = beforeBytes;
+  const removed: MediaAsset[] = [];
+  if (currentBytes <= maxBytes) return { beforeBytes, afterBytes: currentBytes, removed };
+
+  // Fail closed: all candidates come from the link-aware query. A query error leaves all assets intact.
+  const candidates = store.listUnlinkedAssets(input.projectId);
+  for (const asset of candidates) {
+    if (currentBytes <= maxBytes) break;
+    await removeMediaAsset({
+      dataDir: input.dataDir,
+      projectId: input.projectId,
+      assetId: asset.id,
+      force: false,
+    });
+    currentBytes -= asset.byteSize;
+    removed.push(asset);
+  }
+  return { beforeBytes, afterBytes: Math.max(0, currentBytes), removed };
+}

--- a/src/media/asset-store.ts
+++ b/src/media/asset-store.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from 'node:crypto';
 import { copyFile, lstat, mkdir, open, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
+import { sanitizeCredentials } from '../memory/secret-filter.js';
 import { MediaStore } from './media-store.js';
 import {
   DEFAULT_MAX_MEDIA_BYTES,
@@ -60,7 +61,9 @@ function validateUnderRoot(root: string, candidate: string): string {
 
 function sanitizeLabel(value: string | undefined): string | undefined {
   if (!value) return undefined;
-  const basename = path.basename(value).replace(/[\u0000-\u001f<>:"|?*]/g, '_').trim();
+  const basename = sanitizeCredentials(path.basename(value))
+    .replace(/[\u0000-\u001f<>:"|?*]/g, '_')
+    .trim();
   return basename ? basename.slice(0, 180) : undefined;
 }
 
@@ -118,6 +121,10 @@ async function sha256File(filePath: string): Promise<string> {
 function destinationFor(root: string, projectId: string, sha256: string, extension: string): { absolute: string; relative: string } {
   const relative = path.join('assets', projectStorageKey(projectId), sha256.slice(0, 2), `${sha256}${extension}`);
   return { relative, absolute: validateUnderRoot(root, path.join(root, relative)) };
+}
+
+function deletionStagingPath(root: string, assetId: string): string {
+  return validateUnderRoot(root, path.join(root, '.trash', `${assetId}.${randomUUID()}.pending-delete`));
 }
 
 async function destinationExists(destination: string): Promise<boolean> {
@@ -275,10 +282,29 @@ export async function removeMediaAsset(input: {
     throw new Error(`Media asset ${asset.id} is attached to ${links.length} memory record(s); rerun with --force to detach it`);
   }
   const assetPath = getMediaAssetPath(input.dataDir, asset);
-  await rm(assetPath, { force: true });
-  const detachedLinks = links.length > 0 ? store.unlinkAsset(input.projectId, asset.id) : 0;
-  store.deleteDerivedData(input.projectId, asset.id);
-  store.markAssetDeleted(input.projectId, asset.id);
+  const stagedPath = deletionStagingPath(mediaRoot(input.dataDir), asset.id);
+  await mkdir(path.dirname(stagedPath), { recursive: true });
+
+  // A failed metadata transaction must not turn into data loss. Moving within
+  // the media root is atomic on a single volume and makes the rollback simple.
+  await rename(assetPath, stagedPath);
+  let detachedLinks: number;
+  try {
+    ({ detachedLinks } = store.removeAssetMetadata(input.projectId, asset.id, { force: input.force }));
+  } catch (error) {
+    try {
+      await rename(stagedPath, assetPath);
+    } catch (restoreError: any) {
+      const original = error instanceof Error ? error.message : String(error);
+      const restore = restoreError instanceof Error ? restoreError.message : String(restoreError);
+      throw new Error(`Media removal metadata update failed and the file could not be restored: ${original}; restore error: ${restore}`);
+    }
+    throw error;
+  }
+
+  // A locked file can be retried by a later cleanup; it is already outside the
+  // active asset tree and no database row refers to it anymore.
+  await rm(stagedPath, { force: true }).catch(() => {});
   return { asset, detachedLinks };
 }
 

--- a/src/media/attachment.ts
+++ b/src/media/attachment.ts
@@ -1,0 +1,58 @@
+import type { Observation, ObservationReader, ObservationVisibility } from '../types.js';
+import { storeObservation } from '../memory/observations.js';
+import { MediaStore } from './media-store.js';
+import type { MediaAsset, MediaLinkRole } from './types.js';
+
+export interface AttachMediaAssetInput {
+  dataDir: string;
+  projectId: string;
+  asset: MediaAsset;
+  title: string;
+  narrative?: string;
+  facts?: string[];
+  concepts?: string[];
+  entityName?: string;
+  role?: MediaLinkRole;
+  visibility?: ObservationVisibility;
+  createdByAgentId?: string;
+  visibilityReader?: ObservationReader;
+}
+
+/**
+ * Create normal text retrieval evidence first, then add an explicit asset link.
+ * The media row remains the binary source of truth; the Observation is only a
+ * small, auditable retrieval projection.
+ */
+export async function attachMediaAssetToObservation(input: AttachMediaAssetInput): Promise<Observation> {
+  const asset = input.asset;
+  const sourceLabel = asset.sourceLabel ?? `${asset.kind} asset`;
+  const narrative = input.narrative?.trim()
+    || `Attached ${asset.kind} asset ${sourceLabel} (${asset.mimeType}, ${asset.byteSize} bytes).`;
+  const facts = [
+    `Media asset: ${asset.id}`,
+    `Media kind: ${asset.kind}`,
+    `MIME type: ${asset.mimeType}`,
+    ...(input.facts ?? []),
+  ];
+  const result = await storeObservation({
+    entityName: input.entityName?.trim() || sourceLabel.replace(/\.[^.]+$/, '') || 'media-asset',
+    type: 'discovery',
+    title: input.title.trim() || `Media asset: ${sourceLabel}`,
+    narrative,
+    facts,
+    concepts: ['media', asset.kind, asset.mimeType, ...(input.concepts ?? [])],
+    projectId: input.projectId,
+    source: 'manual',
+    sourceDetail: 'explicit',
+    ...(input.visibility ? { visibility: input.visibility } : {}),
+    ...(input.createdByAgentId ? { createdByAgentId: input.createdByAgentId } : {}),
+    ...(input.visibilityReader ? { visibilityReader: input.visibilityReader } : {}),
+  });
+  new MediaStore(input.dataDir).linkAsset({
+    projectId: input.projectId,
+    assetId: asset.id,
+    observationId: result.observation.id,
+    role: input.role ?? 'attachment',
+  });
+  return result.observation;
+}

--- a/src/media/embedding.ts
+++ b/src/media/embedding.ts
@@ -1,0 +1,150 @@
+import { createHash } from 'node:crypto';
+
+import {
+  getEmbeddingProvider,
+  type EmbeddingProvider,
+} from '../embedding/provider.js';
+import { readMediaAsset } from './asset-store.js';
+import { MediaStore } from './media-store.js';
+import type { MediaAsset } from './types.js';
+
+export type MediaEmbeddingOutcome =
+  | {
+    status: 'embedded';
+    asset: MediaAsset;
+    profileKey: string;
+    dimensions: number;
+  }
+  | {
+    status: 'unsupported' | 'unavailable';
+    asset: MediaAsset;
+    reason: string;
+  };
+
+export interface EmbedMediaAssetInput {
+  dataDir: string;
+  projectId: string;
+  assetId: string;
+  timeoutMs?: number;
+}
+
+export interface SimilarMediaAsset {
+  asset: MediaAsset;
+  score: number;
+  profileKey: string;
+}
+
+function profileKey(provider: EmbeddingProvider, asset: MediaAsset): string {
+  const identity = `${provider.name}\u0000${provider.dimensions}\u0000${asset.kind}`;
+  return `media:${createHash('sha256').update(identity).digest('hex').slice(0, 20)}`;
+}
+
+function supportsAsset(provider: EmbeddingProvider, asset: MediaAsset): boolean {
+  return !!provider.embedInput && (provider.supportedModalities?.includes(asset.kind) ?? false);
+}
+
+function cosineSimilarity(left: number[], right: number[]): number {
+  if (left.length === 0 || left.length !== right.length) return Number.NEGATIVE_INFINITY;
+  let dot = 0;
+  let leftMagnitude = 0;
+  let rightMagnitude = 0;
+  for (let index = 0; index < left.length; index += 1) {
+    dot += left[index] * right[index];
+    leftMagnitude += left[index] * left[index];
+    rightMagnitude += right[index] * right[index];
+  }
+  if (leftMagnitude === 0 || rightMagnitude === 0) return Number.NEGATIVE_INFINITY;
+  return dot / Math.sqrt(leftMagnitude * rightMagnitude);
+}
+
+export async function embedMediaAsset(
+  input: EmbedMediaAssetInput,
+  dependencies: { provider?: EmbeddingProvider | null } = {},
+): Promise<MediaEmbeddingOutcome> {
+  const store = new MediaStore(input.dataDir);
+  const asset = store.getAsset(input.projectId, input.assetId);
+  if (!asset) throw new Error(`Media asset not found: ${input.assetId}`);
+  const provider = dependencies.provider ?? await getEmbeddingProvider({
+    requestTimeoutMs: input.timeoutMs,
+    retry: false,
+  });
+  if (!provider) {
+    return {
+      status: 'unavailable',
+      asset,
+      reason: 'No embedding provider is configured; lexical media descriptions remain available.',
+    };
+  }
+  if (!supportsAsset(provider, asset)) {
+    return {
+      status: 'unsupported',
+      asset,
+      reason: `Embedding provider ${provider.name} does not declare ${asset.kind} support; no media vector was written.`,
+    };
+  }
+
+  const bytes = await readMediaAsset(input.dataDir, asset);
+  const vector = await provider.embedInput!(
+    { modality: asset.kind, data: bytes.toString('base64'), mimeType: asset.mimeType },
+    { intent: 'document', timeoutMs: input.timeoutMs, retry: false },
+  );
+  if (vector.length !== provider.dimensions) {
+    throw new Error(`Media embedding dimension mismatch: provider declared ${provider.dimensions}, returned ${vector.length}`);
+  }
+  const key = profileKey(provider, asset);
+  store.upsertEmbeddingProfile({
+    key,
+    provider: provider.name,
+    model: provider.name,
+    dimensions: provider.dimensions,
+    modality: asset.kind,
+  });
+  store.upsertEmbedding({
+    assetId: asset.id,
+    projectId: input.projectId,
+    profileKey: key,
+    intent: 'document',
+    dimensions: provider.dimensions,
+    vector,
+  });
+  store.addDerivation({
+    assetId: asset.id,
+    projectId: input.projectId,
+    kind: 'embedding',
+    profileKey: key,
+    content: `Embedded ${asset.kind} with ${provider.name} (${provider.dimensions} dimensions).`,
+    status: 'ready',
+  });
+  return { status: 'embedded', asset, profileKey: key, dimensions: provider.dimensions };
+}
+
+export function findSimilarMediaAssets(input: {
+  dataDir: string;
+  projectId: string;
+  assetId: string;
+  limit?: number;
+}): SimilarMediaAsset[] {
+  const store = new MediaStore(input.dataDir);
+  const asset = store.getAsset(input.projectId, input.assetId);
+  if (!asset) throw new Error(`Media asset not found: ${input.assetId}`);
+  const profiles = store.listDerivations(input.projectId, asset.id)
+    .filter((item) => item.kind === 'embedding' && item.status === 'ready' && item.profileKey)
+    .map((item) => item.profileKey!);
+  if (profiles.length === 0) return [];
+  const limit = Math.min(100, Math.max(1, Math.floor(input.limit ?? 10)));
+  const matches: SimilarMediaAsset[] = [];
+  for (const key of new Set(profiles)) {
+    const embeddings = store.listEmbeddings(input.projectId, key);
+    const query = embeddings.find((embedding) => embedding.assetId === asset.id);
+    if (!query) continue;
+    for (const candidate of embeddings) {
+      if (candidate.assetId === asset.id || candidate.dimensions !== query.dimensions) continue;
+      const candidateAsset = store.getAsset(input.projectId, candidate.assetId);
+      if (!candidateAsset || candidateAsset.kind !== asset.kind) continue;
+      const score = cosineSimilarity(query.vector, candidate.vector);
+      if (!Number.isFinite(score)) continue;
+      matches.push({ asset: candidateAsset, score, profileKey: key });
+    }
+  }
+  return matches.sort((left, right) => right.score - left.score).slice(0, limit);
+}

--- a/src/media/media-store.ts
+++ b/src/media/media-store.ts
@@ -32,6 +32,19 @@ function parseRequest(value: unknown): Record<string, unknown> {
   }
 }
 
+function sanitizeRequest(value: Record<string, unknown>): Record<string, unknown> {
+  const visit = (candidate: unknown): unknown => {
+    if (typeof candidate === 'string') return sanitizeCredentials(candidate);
+    if (Array.isArray(candidate)) return candidate.map(visit);
+    if (candidate && typeof candidate === 'object') {
+      return Object.fromEntries(Object.entries(candidate as Record<string, unknown>)
+        .map(([key, nested]) => [key, visit(nested)]));
+    }
+    return candidate;
+  };
+  return visit(value) as Record<string, unknown>;
+}
+
 function parseVector(value: unknown): number[] | undefined {
   if (typeof value !== 'string' || !value) return undefined;
   try {
@@ -208,6 +221,36 @@ export class MediaStore {
     if (Number(result.changes ?? 0) !== 1) throw new Error(`Media asset not found: ${assetId}`);
   }
 
+  /**
+   * Remove all active metadata for an asset as one SQLite transaction. The
+   * caller owns the corresponding file move and can restore it if this fails.
+   */
+  removeAssetMetadata(projectId: string, assetId: string, options: { force?: boolean } = {}): { detachedLinks: number } {
+    return this.db.transaction(() => {
+      const asset = this.getAsset(projectId, assetId);
+      if (!asset) throw new Error(`Media asset not found: ${assetId}`);
+
+      const linkCount = Number(this.db.prepare(`
+        SELECT COUNT(*) AS count FROM media_asset_links WHERE project_id = ? AND asset_id = ?
+      `).get(projectId, assetId)?.count ?? 0);
+      if (linkCount > 0 && !options.force) {
+        throw new Error(`Media asset ${assetId} is attached to ${linkCount} memory record(s); rerun with --force to detach it`);
+      }
+
+      const detachedLinks = Number(this.db.prepare(`
+        DELETE FROM media_asset_links WHERE project_id = ? AND asset_id = ?
+      `).run(projectId, assetId).changes ?? 0);
+      this.db.prepare('DELETE FROM media_derivations WHERE project_id = ? AND asset_id = ?').run(projectId, assetId);
+      this.db.prepare('DELETE FROM media_embeddings WHERE project_id = ? AND asset_id = ?').run(projectId, assetId);
+      const result = this.db.prepare(`
+        UPDATE media_assets SET deleted_at = ?, updated_at = ?
+        WHERE project_id = ? AND id = ? AND deleted_at IS NULL
+      `).run(Date.now(), Date.now(), projectId, assetId);
+      if (Number(result.changes ?? 0) !== 1) throw new Error(`Media asset not found: ${assetId}`);
+      return { detachedLinks };
+    })();
+  }
+
   linkAsset(input: { projectId: string; assetId: string; observationId?: number; role: MediaLinkRole }): MediaAssetLink {
     const existing = this.db.prepare(`
       SELECT * FROM media_asset_links
@@ -243,6 +286,8 @@ export class MediaStore {
 
   addDerivation(input: Omit<MediaDerivation, 'id' | 'createdAt' | 'updatedAt'>): MediaDerivation {
     const now = Date.now();
+    const content = sanitizeCredentials(input.content);
+    const error = input.error ? sanitizeCredentials(input.error).slice(0, 1_000) : undefined;
     const existing = this.db.prepare(`
       SELECT * FROM media_derivations
       WHERE asset_id = ? AND kind = ? AND profile_key IS ? LIMIT 1
@@ -250,10 +295,17 @@ export class MediaStore {
     if (existing) {
       this.db.prepare(`
         UPDATE media_derivations SET content = ?, status = ?, error = ?, updated_at = ? WHERE id = ?
-      `).run(input.content, input.status, input.error ?? null, now, existing.id);
+      `).run(content, input.status, error ?? null, now, existing.id);
       return rowToDerivation(this.db.prepare('SELECT * FROM media_derivations WHERE id = ?').get(existing.id));
     }
-    const derivation: MediaDerivation = { id: randomUUID(), ...input, createdAt: now, updatedAt: now };
+    const derivation: MediaDerivation = {
+      id: randomUUID(),
+      ...input,
+      content,
+      ...(error ? { error } : {}),
+      createdAt: now,
+      updatedAt: now,
+    };
     this.db.prepare(`
       INSERT INTO media_derivations (id, asset_id, project_id, kind, profile_key, content, status, error, created_at, updated_at)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -265,7 +317,7 @@ export class MediaStore {
       derivation.profileKey ?? null,
       derivation.content,
       derivation.status,
-      derivation.error ?? null,
+      error ?? null,
       now,
       now,
     );
@@ -348,10 +400,10 @@ export class MediaStore {
       projectId: input.projectId,
       kind: input.kind,
       status: 'queued',
-      request: input.request,
+      request: sanitizeRequest(input.request),
       attempts: 0,
       attachOnComplete: input.attachOnComplete === true,
-      ...(input.observationTitle ? { observationTitle: input.observationTitle } : {}),
+      ...(input.observationTitle ? { observationTitle: sanitizeCredentials(input.observationTitle) } : {}),
       createdAt: now,
       updatedAt: now,
     };

--- a/src/media/media-store.ts
+++ b/src/media/media-store.ts
@@ -1,0 +1,437 @@
+import { randomUUID } from 'node:crypto';
+
+import { getDatabase } from '../store/sqlite-db.js';
+import { sanitizeCredentials } from '../memory/secret-filter.js';
+import type {
+  MediaAsset,
+  MediaAssetLink,
+  MediaDerivation,
+  MediaEmbedding,
+  MediaEmbeddingProfile,
+  MediaJob,
+  MediaJobKind,
+  MediaJobStatus,
+  MediaKind,
+  MediaLinkRole,
+  MediaSourceKind,
+} from './types.js';
+
+function asOptionalText(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function parseRequest(value: unknown): Record<string, unknown> {
+  if (typeof value !== 'string' || !value) return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as Record<string, unknown>
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function parseVector(value: unknown): number[] | undefined {
+  if (typeof value !== 'string' || !value) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) && parsed.every((item) => typeof item === 'number' && Number.isFinite(item))
+      ? parsed
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function rowToAsset(row: any): MediaAsset {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    sha256: row.sha256,
+    kind: row.kind as MediaKind,
+    mimeType: row.mime_type,
+    byteSize: Number(row.byte_size),
+    storageRelPath: row.storage_rel_path,
+    sourceKind: row.source_kind as MediaSourceKind,
+    ...(asOptionalText(row.source_label) ? { sourceLabel: row.source_label } : {}),
+    ...(asOptionalText(row.provider) ? { provider: row.provider } : {}),
+    ...(asOptionalText(row.model) ? { model: row.model } : {}),
+    createdAt: Number(row.created_at),
+    updatedAt: Number(row.updated_at),
+    ...(row.deleted_at != null ? { deletedAt: Number(row.deleted_at) } : {}),
+  };
+}
+
+function rowToLink(row: any): MediaAssetLink {
+  return {
+    id: row.id,
+    assetId: row.asset_id,
+    projectId: row.project_id,
+    ...(row.observation_id != null ? { observationId: Number(row.observation_id) } : {}),
+    role: row.role as MediaLinkRole,
+    createdAt: Number(row.created_at),
+  };
+}
+
+function rowToDerivation(row: any): MediaDerivation {
+  return {
+    id: row.id,
+    assetId: row.asset_id,
+    projectId: row.project_id,
+    kind: row.kind,
+    ...(asOptionalText(row.profile_key) ? { profileKey: row.profile_key } : {}),
+    content: row.content,
+    status: row.status,
+    ...(asOptionalText(row.error) ? { error: row.error } : {}),
+    createdAt: Number(row.created_at),
+    updatedAt: Number(row.updated_at),
+  };
+}
+
+function rowToJob(row: any): MediaJob {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    kind: row.kind as MediaJobKind,
+    status: row.status as MediaJobStatus,
+    request: parseRequest(row.request_json),
+    ...(asOptionalText(row.provider_task_id) ? { providerTaskId: row.provider_task_id } : {}),
+    ...(asOptionalText(row.asset_id) ? { assetId: row.asset_id } : {}),
+    ...(asOptionalText(row.last_error) ? { lastError: row.last_error } : {}),
+    attempts: Number(row.attempts),
+    attachOnComplete: Number(row.attach_on_complete) === 1,
+    ...(asOptionalText(row.observation_title) ? { observationTitle: row.observation_title } : {}),
+    createdAt: Number(row.created_at),
+    updatedAt: Number(row.updated_at),
+    ...(row.completed_at != null ? { completedAt: Number(row.completed_at) } : {}),
+  };
+}
+
+export class MediaStore {
+  private readonly db: any;
+
+  constructor(dataDir: string) {
+    this.db = getDatabase(dataDir);
+  }
+
+  findAssetByHash(projectId: string, sha256: string): MediaAsset | undefined {
+    const row = this.db.prepare(`
+      SELECT * FROM media_assets WHERE project_id = ? AND sha256 = ? LIMIT 1
+    `).get(projectId, sha256);
+    return row ? rowToAsset(row) : undefined;
+  }
+
+  getAsset(projectId: string, id: string, options: { includeDeleted?: boolean } = {}): MediaAsset | undefined {
+    const row = this.db.prepare(`
+      SELECT * FROM media_assets
+      WHERE project_id = ? AND id = ? ${options.includeDeleted ? '' : 'AND deleted_at IS NULL'}
+      LIMIT 1
+    `).get(projectId, id);
+    return row ? rowToAsset(row) : undefined;
+  }
+
+  listAssets(projectId: string, options: { kind?: MediaKind; includeDeleted?: boolean; limit?: number } = {}): MediaAsset[] {
+    const clauses = ['project_id = ?'];
+    const values: unknown[] = [projectId];
+    if (!options.includeDeleted) clauses.push('deleted_at IS NULL');
+    if (options.kind) {
+      clauses.push('kind = ?');
+      values.push(options.kind);
+    }
+    const limit = Math.min(500, Math.max(1, Math.floor(options.limit ?? 100)));
+    const rows = this.db.prepare(`
+      SELECT * FROM media_assets WHERE ${clauses.join(' AND ')}
+      ORDER BY created_at DESC LIMIT ?
+    `).all(...values, limit);
+    return rows.map(rowToAsset);
+  }
+
+  createOrReviveAsset(input: Omit<MediaAsset, 'id' | 'createdAt' | 'updatedAt' | 'deletedAt'>): { asset: MediaAsset; deduplicated: boolean } {
+    const now = Date.now();
+    const existing = this.findAssetByHash(input.projectId, input.sha256);
+    if (existing) {
+      this.db.prepare(`
+        UPDATE media_assets
+        SET storage_rel_path = ?, byte_size = ?, mime_type = ?, kind = ?, source_kind = ?,
+            source_label = ?, provider = ?, model = ?, updated_at = ?, deleted_at = NULL
+        WHERE id = ?
+      `).run(
+        input.storageRelPath,
+        input.byteSize,
+        input.mimeType,
+        input.kind,
+        input.sourceKind,
+        input.sourceLabel ?? null,
+        input.provider ?? null,
+        input.model ?? null,
+        now,
+        existing.id,
+      );
+      return { asset: this.getAsset(input.projectId, existing.id)!, deduplicated: true };
+    }
+
+    const asset: MediaAsset = {
+      id: randomUUID(),
+      ...input,
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.db.prepare(`
+      INSERT INTO media_assets (
+        id, project_id, sha256, kind, mime_type, byte_size, storage_rel_path,
+        source_kind, source_label, provider, model, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      asset.id,
+      asset.projectId,
+      asset.sha256,
+      asset.kind,
+      asset.mimeType,
+      asset.byteSize,
+      asset.storageRelPath,
+      asset.sourceKind,
+      asset.sourceLabel ?? null,
+      asset.provider ?? null,
+      asset.model ?? null,
+      now,
+      now,
+    );
+    return { asset, deduplicated: false };
+  }
+
+  markAssetDeleted(projectId: string, assetId: string): void {
+    const result = this.db.prepare(`
+      UPDATE media_assets SET deleted_at = ?, updated_at = ?
+      WHERE project_id = ? AND id = ? AND deleted_at IS NULL
+    `).run(Date.now(), Date.now(), projectId, assetId);
+    if (Number(result.changes ?? 0) !== 1) throw new Error(`Media asset not found: ${assetId}`);
+  }
+
+  linkAsset(input: { projectId: string; assetId: string; observationId?: number; role: MediaLinkRole }): MediaAssetLink {
+    const existing = this.db.prepare(`
+      SELECT * FROM media_asset_links
+      WHERE asset_id = ? AND observation_id IS ? AND role = ? LIMIT 1
+    `).get(input.assetId, input.observationId ?? null, input.role);
+    if (existing) return rowToLink(existing);
+    const link: MediaAssetLink = {
+      id: randomUUID(),
+      assetId: input.assetId,
+      projectId: input.projectId,
+      ...(input.observationId !== undefined ? { observationId: input.observationId } : {}),
+      role: input.role,
+      createdAt: Date.now(),
+    };
+    this.db.prepare(`
+      INSERT INTO media_asset_links (id, asset_id, project_id, observation_id, role, created_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(link.id, link.assetId, link.projectId, link.observationId ?? null, link.role, link.createdAt);
+    return link;
+  }
+
+  listLinks(projectId: string, assetId: string): MediaAssetLink[] {
+    return this.db.prepare(`
+      SELECT * FROM media_asset_links WHERE project_id = ? AND asset_id = ? ORDER BY created_at ASC
+    `).all(projectId, assetId).map(rowToLink);
+  }
+
+  unlinkAsset(projectId: string, assetId: string): number {
+    return Number(this.db.prepare(`
+      DELETE FROM media_asset_links WHERE project_id = ? AND asset_id = ?
+    `).run(projectId, assetId).changes ?? 0);
+  }
+
+  addDerivation(input: Omit<MediaDerivation, 'id' | 'createdAt' | 'updatedAt'>): MediaDerivation {
+    const now = Date.now();
+    const existing = this.db.prepare(`
+      SELECT * FROM media_derivations
+      WHERE asset_id = ? AND kind = ? AND profile_key IS ? LIMIT 1
+    `).get(input.assetId, input.kind, input.profileKey ?? null);
+    if (existing) {
+      this.db.prepare(`
+        UPDATE media_derivations SET content = ?, status = ?, error = ?, updated_at = ? WHERE id = ?
+      `).run(input.content, input.status, input.error ?? null, now, existing.id);
+      return rowToDerivation(this.db.prepare('SELECT * FROM media_derivations WHERE id = ?').get(existing.id));
+    }
+    const derivation: MediaDerivation = { id: randomUUID(), ...input, createdAt: now, updatedAt: now };
+    this.db.prepare(`
+      INSERT INTO media_derivations (id, asset_id, project_id, kind, profile_key, content, status, error, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      derivation.id,
+      derivation.assetId,
+      derivation.projectId,
+      derivation.kind,
+      derivation.profileKey ?? null,
+      derivation.content,
+      derivation.status,
+      derivation.error ?? null,
+      now,
+      now,
+    );
+    return derivation;
+  }
+
+  listDerivations(projectId: string, assetId: string): MediaDerivation[] {
+    return this.db.prepare(`
+      SELECT * FROM media_derivations WHERE project_id = ? AND asset_id = ? ORDER BY created_at ASC
+    `).all(projectId, assetId).map(rowToDerivation);
+  }
+
+  upsertEmbeddingProfile(input: Omit<MediaEmbeddingProfile, 'createdAt'>): MediaEmbeddingProfile {
+    const existing = this.db.prepare('SELECT * FROM media_embedding_profiles WHERE profile_key = ?').get(input.key);
+    if (existing) return {
+      key: existing.profile_key,
+      provider: existing.provider,
+      model: existing.model,
+      dimensions: Number(existing.dimensions),
+      modality: existing.modality as MediaKind,
+      createdAt: Number(existing.created_at),
+    };
+    const profile = { ...input, createdAt: Date.now() };
+    this.db.prepare(`
+      INSERT INTO media_embedding_profiles (profile_key, provider, model, dimensions, modality, created_at)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `).run(profile.key, profile.provider, profile.model, profile.dimensions, profile.modality, profile.createdAt);
+    return profile;
+  }
+
+  upsertEmbedding(input: Omit<MediaEmbedding, 'createdAt' | 'updatedAt'>): MediaEmbedding {
+    const now = Date.now();
+    this.db.prepare(`
+      INSERT INTO media_embeddings (asset_id, project_id, profile_key, intent, dimensions, vector_json, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(asset_id, profile_key, intent) DO UPDATE SET
+        dimensions = excluded.dimensions, vector_json = excluded.vector_json, updated_at = excluded.updated_at
+    `).run(
+      input.assetId,
+      input.projectId,
+      input.profileKey,
+      input.intent,
+      input.dimensions,
+      JSON.stringify(input.vector),
+      now,
+      now,
+    );
+    return { ...input, createdAt: now, updatedAt: now };
+  }
+
+  listEmbeddings(projectId: string, profileKey: string): MediaEmbedding[] {
+    const rows = this.db.prepare(`
+      SELECT * FROM media_embeddings WHERE project_id = ? AND profile_key = ?
+    `).all(projectId, profileKey);
+    return rows.flatMap((row: any) => {
+      const vector = parseVector(row.vector_json);
+      return vector ? [{
+        assetId: row.asset_id,
+        projectId: row.project_id,
+        profileKey: row.profile_key,
+        intent: row.intent,
+        dimensions: Number(row.dimensions),
+        vector,
+        createdAt: Number(row.created_at),
+        updatedAt: Number(row.updated_at),
+      } satisfies MediaEmbedding] : [];
+    });
+  }
+
+  createJob(input: {
+    projectId: string;
+    kind: MediaJobKind;
+    request: Record<string, unknown>;
+    attachOnComplete?: boolean;
+    observationTitle?: string;
+  }): MediaJob {
+    const now = Date.now();
+    const job: MediaJob = {
+      id: randomUUID(),
+      projectId: input.projectId,
+      kind: input.kind,
+      status: 'queued',
+      request: input.request,
+      attempts: 0,
+      attachOnComplete: input.attachOnComplete === true,
+      ...(input.observationTitle ? { observationTitle: input.observationTitle } : {}),
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.db.prepare(`
+      INSERT INTO media_jobs (
+        id, project_id, kind, status, request_json, attempts, attach_on_complete,
+        observation_title, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      job.id, job.projectId, job.kind, job.status, JSON.stringify(job.request), job.attempts,
+      job.attachOnComplete ? 1 : 0, job.observationTitle ?? null, now, now,
+    );
+    return job;
+  }
+
+  getJob(projectId: string, id: string): MediaJob | undefined {
+    const row = this.db.prepare('SELECT * FROM media_jobs WHERE project_id = ? AND id = ?').get(projectId, id);
+    return row ? rowToJob(row) : undefined;
+  }
+
+  updateJob(projectId: string, id: string, input: {
+    status: MediaJobStatus;
+    providerTaskId?: string;
+    assetId?: string;
+    lastError?: string;
+    incrementAttempts?: boolean;
+  }): MediaJob {
+    const existing = this.getJob(projectId, id);
+    if (!existing) throw new Error(`Media job not found: ${id}`);
+    const now = Date.now();
+    const attempts = existing.attempts + (input.incrementAttempts ? 1 : 0);
+    const completedAt = input.status === 'completed' ? now : null;
+    this.db.prepare(`
+      UPDATE media_jobs
+      SET status = ?, provider_task_id = COALESCE(?, provider_task_id), asset_id = COALESCE(?, asset_id),
+          last_error = ?, attempts = ?, updated_at = ?, completed_at = ?
+      WHERE project_id = ? AND id = ?
+    `).run(
+      input.status,
+      input.providerTaskId ?? null,
+      input.assetId ?? null,
+      input.lastError ? sanitizeCredentials(input.lastError).slice(0, 1000) : null,
+      attempts,
+      now,
+      completedAt,
+      projectId,
+      id,
+    );
+    return this.getJob(projectId, id)!;
+  }
+
+  cancelJob(projectId: string, id: string): MediaJob {
+    const job = this.getJob(projectId, id);
+    if (!job) throw new Error(`Media job not found: ${id}`);
+    if (job.status === 'completed') throw new Error('Completed media jobs cannot be cancelled');
+    return this.updateJob(projectId, id, { status: 'cancelled' });
+  }
+
+  listUnlinkedAssets(projectId: string): MediaAsset[] {
+    const rows = this.db.prepare(`
+      SELECT a.* FROM media_assets a
+      LEFT JOIN media_asset_links l ON l.asset_id = a.id AND l.project_id = a.project_id
+      WHERE a.project_id = ? AND a.deleted_at IS NULL
+      GROUP BY a.id
+      HAVING COUNT(l.id) = 0
+      ORDER BY a.created_at ASC
+    `).all(projectId);
+    return rows.map(rowToAsset);
+  }
+
+  activeByteSize(projectId: string): number {
+    const row = this.db.prepare(`
+      SELECT COALESCE(SUM(byte_size), 0) AS total FROM media_assets
+      WHERE project_id = ? AND deleted_at IS NULL
+    `).get(projectId);
+    return Number(row?.total ?? 0);
+  }
+
+  deleteDerivedData(projectId: string, assetId: string): void {
+    this.db.prepare('DELETE FROM media_derivations WHERE project_id = ? AND asset_id = ?').run(projectId, assetId);
+    this.db.prepare('DELETE FROM media_embeddings WHERE project_id = ? AND asset_id = ?').run(projectId, assetId);
+  }
+}

--- a/src/media/minimax.ts
+++ b/src/media/minimax.ts
@@ -14,6 +14,9 @@ const DEFAULT_IMAGE_TIMEOUT_MS = 90_000;
 
 export type MiniMaxImageModel = typeof IMAGE_MODELS[number];
 export type MiniMaxRegion = 'global' | 'cn';
+export type MiniMaxVideoModel = 'MiniMax-H3';
+export type MiniMaxVideoResolution = '2K';
+export type MiniMaxVideoRatio = 'adaptive' | '16:9' | '9:16' | '1:1';
 
 export interface MiniMaxImageGenerationInput {
   dataDir: string;
@@ -38,6 +41,29 @@ export interface GeneratedMiniMaxImages {
   model: MiniMaxImageModel;
   responseId?: string;
   assets: MediaImportResult[];
+}
+
+export interface MiniMaxVideoGenerationRequest {
+  prompt: string;
+  model?: MiniMaxVideoModel;
+  region?: MiniMaxRegion;
+  apiKey?: string;
+  baseUrl?: string;
+  resolution?: MiniMaxVideoResolution;
+  duration?: 5 | 10;
+  ratio?: MiniMaxVideoRatio;
+  timeoutMs?: number;
+}
+
+export interface MiniMaxVideoTask {
+  taskId: string;
+  status: 'pending' | 'succeeded' | 'failed';
+  downloadUrl?: string;
+  error?: string;
+}
+
+export interface MiniMaxVideoTransport {
+  fetch?: typeof fetch;
 }
 
 export interface MiniMaxImageGenerator {
@@ -91,6 +117,22 @@ function resolveBaseUrl(value: string | undefined): string | undefined {
   return parsed.toString().replace(/\/$/, '');
 }
 
+function resolveVideoBaseUrl(region: MiniMaxRegion, value: string | undefined): string {
+  const configured = value?.trim()
+    || process.env.MINIMAX_VIDEO_BASE_URL?.trim()
+    || (region === 'cn' ? 'https://api.minimaxi.com' : 'https://api.minimax.io');
+  let parsed: URL;
+  try {
+    parsed = new URL(configured);
+  } catch {
+    throw new Error('MINIMAX_VIDEO_BASE_URL must be a valid HTTPS URL');
+  }
+  if (parsed.protocol !== 'https:' || parsed.username || parsed.password) {
+    throw new Error('MINIMAX_VIDEO_BASE_URL must be an HTTPS URL without credentials');
+  }
+  return parsed.toString().replace(/\/$/, '');
+}
+
 function normalizePrompt(value: string): string {
   const prompt = value.trim();
   if (!prompt) throw new Error('MiniMax image generation requires a non-empty prompt');
@@ -107,6 +149,173 @@ function sourceLabel(model: MiniMaxImageModel, index: number): string {
 function safeError(error: unknown): Error {
   const message = sanitizeCredentials(error instanceof Error ? error.message : String(error));
   return new Error(message.slice(0, 1_000));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function normalizeMiniMaxVideoRequest(input: MiniMaxVideoGenerationRequest): {
+  region: MiniMaxRegion;
+  model: MiniMaxVideoModel;
+  prompt: string;
+  resolution: MiniMaxVideoResolution;
+  duration: 5 | 10;
+  ratio: MiniMaxVideoRatio;
+} {
+  const region = resolveRegion(input.region);
+  const model = input.model ?? (process.env.MINIMAX_VIDEO_MODEL?.trim() as MiniMaxVideoModel | undefined) ?? 'MiniMax-H3';
+  if (model !== 'MiniMax-H3') throw new Error(`Unsupported MiniMax video model: ${model}`);
+  const prompt = normalizePrompt(input.prompt);
+  const resolution = input.resolution ?? '2K';
+  if (resolution !== '2K') throw new Error(`Unsupported MiniMax video resolution: ${resolution}`);
+  const duration = input.duration ?? 5;
+  if (duration !== 5 && duration !== 10) throw new Error('MiniMax video duration must be 5 or 10 seconds');
+  const ratio = input.ratio ?? 'adaptive';
+  if (ratio !== 'adaptive' && ratio !== '16:9' && ratio !== '9:16' && ratio !== '1:1') {
+    throw new Error('MiniMax video ratio must be adaptive, 16:9, 9:16, or 1:1');
+  }
+  return { region, model, prompt, resolution, duration, ratio };
+}
+
+function videoRequestConfig(input: MiniMaxVideoGenerationRequest): {
+  region: MiniMaxRegion;
+  apiKey: string;
+  baseUrl: string;
+  model: MiniMaxVideoModel;
+  prompt: string;
+  resolution: MiniMaxVideoResolution;
+  duration: 5 | 10;
+  ratio: MiniMaxVideoRatio;
+  timeoutMs: number;
+} {
+  const normalized = normalizeMiniMaxVideoRequest(input);
+  const timeoutMs = input.timeoutMs ?? DEFAULT_IMAGE_TIMEOUT_MS;
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1_000 || timeoutMs > 5 * 60_000) {
+    throw new Error('MiniMax video timeout must be between 1000 and 300000 milliseconds');
+  }
+  return {
+    ...normalized,
+    apiKey: requiredString(
+      input.apiKey ?? (normalized.region === 'cn' ? process.env.MINIMAX_CN_API_KEY : process.env.MINIMAX_API_KEY),
+      normalized.region === 'cn' ? 'MINIMAX_CN_API_KEY' : 'MINIMAX_API_KEY',
+    ),
+    baseUrl: resolveVideoBaseUrl(normalized.region, input.baseUrl),
+    timeoutMs,
+  };
+}
+
+async function readMiniMaxJson(response: Response): Promise<Record<string, unknown>> {
+  const text = await response.text();
+  let body: Record<string, unknown> = {};
+  if (text) {
+    try {
+      const parsed = JSON.parse(text);
+      if (isRecord(parsed)) body = parsed;
+    } catch {
+      throw new Error('MiniMax video API returned invalid JSON');
+    }
+  }
+  if (!response.ok) {
+    const error = isRecord(body.error) && typeof body.error.message === 'string'
+      ? body.error.message
+      : typeof body.message === 'string'
+        ? body.message
+        : `HTTP ${response.status}`;
+    throw new Error(`MiniMax video API failed: ${error}`);
+  }
+  if (isRecord(body.error) && typeof body.error.message === 'string') {
+    throw new Error(`MiniMax video API failed: ${body.error.message}`);
+  }
+  return body;
+}
+
+function videoHeaders(apiKey: string): Headers {
+  return new Headers({
+    Authorization: `Bearer ${apiKey}`,
+    'Content-Type': 'application/json',
+  });
+}
+
+function nestedTask(body: Record<string, unknown>): Record<string, unknown> | undefined {
+  if (!isRecord(body.task)) return undefined;
+  return isRecord(body.task.task) ? body.task.task : body.task;
+}
+
+function taskError(task: Record<string, unknown>): string | undefined {
+  if (typeof task.error === 'string') return task.error;
+  if (isRecord(task.error) && typeof task.error.message === 'string') return task.error.message;
+  return undefined;
+}
+
+function parseVideoTask(body: Record<string, unknown>): MiniMaxVideoTask {
+  const task = nestedTask(body);
+  const taskId = typeof body.task_id === 'string'
+    ? body.task_id
+    : typeof task?.id === 'string'
+      ? task.id
+      : undefined;
+  if (!taskId) throw new Error('MiniMax video API response did not include a task ID');
+  const providerStatus = typeof task?.status === 'string' ? task.status.toLowerCase() : 'pending';
+  if (providerStatus === 'succeeded' || providerStatus === 'success' || providerStatus === 'completed') {
+    const content = isRecord(task?.content) ? task.content : undefined;
+    const downloadUrl = typeof content?.url === 'string' ? content.url : undefined;
+    if (!downloadUrl) throw new Error('MiniMax video task succeeded without a download URL');
+    return { taskId, status: 'succeeded', downloadUrl };
+  }
+  if (providerStatus === 'failed' || providerStatus === 'error' || providerStatus === 'cancelled' || providerStatus === 'canceled') {
+    return { taskId, status: 'failed', ...(taskError(task ?? {}) ? { error: taskError(task ?? {}) } : {}) };
+  }
+  return { taskId, status: 'pending' };
+}
+
+/** Submit a billable MiniMax V2 task exactly once. Queue retry policy belongs to the caller. */
+export async function createMiniMaxVideoTask(
+  input: MiniMaxVideoGenerationRequest,
+  dependencies: MiniMaxVideoTransport = {},
+): Promise<MiniMaxVideoTask> {
+  const config = videoRequestConfig(input);
+  try {
+    const response = await (dependencies.fetch ?? fetch)(`${config.baseUrl}/v2/video_generation`, {
+      method: 'POST',
+      headers: videoHeaders(config.apiKey),
+      body: JSON.stringify({
+        model: config.model,
+        content: [{ type: 'text', text: config.prompt }],
+        resolution: config.resolution,
+        duration: config.duration,
+        ratio: config.ratio,
+      }),
+      signal: AbortSignal.timeout(config.timeoutMs),
+    });
+    return parseVideoTask(await readMiniMaxJson(response));
+  } catch (error) {
+    throw safeError(error);
+  }
+}
+
+/** Query only the durable provider task. The temporary result URL is returned to the caller, never persisted. */
+export async function queryMiniMaxVideoTask(
+  input: Omit<MiniMaxVideoGenerationRequest, 'prompt'> & { taskId: string },
+  dependencies: MiniMaxVideoTransport = {},
+): Promise<MiniMaxVideoTask> {
+  const taskId = requiredString(input.taskId, 'MiniMax video task ID');
+  const config = videoRequestConfig({ ...input, prompt: 'query' });
+  try {
+    const response = await (dependencies.fetch ?? fetch)(
+      `${config.baseUrl}/v2/query/video_generation/${encodeURIComponent(taskId)}`,
+      {
+        method: 'GET',
+        headers: videoHeaders(config.apiKey),
+        signal: AbortSignal.timeout(config.timeoutMs),
+      },
+    );
+    const result = parseVideoTask(await readMiniMaxJson(response));
+    if (result.taskId !== taskId) throw new Error('MiniMax video API returned a mismatched task ID');
+    return result;
+  } catch (error) {
+    throw safeError(error);
+  }
 }
 
 const defaultImageGenerator: MiniMaxImageGenerator = async (input) => {

--- a/src/media/minimax.ts
+++ b/src/media/minimax.ts
@@ -1,0 +1,202 @@
+import {
+  generateImages,
+  getImageModel,
+  type ImageContent,
+} from '@memorix/ai';
+
+import { sanitizeCredentials } from '../memory/secret-filter.js';
+import { importMediaBuffer } from './asset-store.js';
+import type { MediaImportResult } from './types.js';
+
+const IMAGE_MODELS = ['image-01', 'image-01-live'] as const;
+const MAX_PROMPT_LENGTH = 12_000;
+const DEFAULT_IMAGE_TIMEOUT_MS = 90_000;
+
+export type MiniMaxImageModel = typeof IMAGE_MODELS[number];
+export type MiniMaxRegion = 'global' | 'cn';
+
+export interface MiniMaxImageGenerationInput {
+  dataDir: string;
+  projectId: string;
+  prompt: string;
+  model?: MiniMaxImageModel;
+  region?: MiniMaxRegion;
+  apiKey?: string;
+  baseUrl?: string;
+  n?: number;
+  aspectRatio?: '1:1' | '16:9' | '4:3' | '3:2' | '2:3' | '3:4' | '9:16' | '21:9';
+  width?: number;
+  height?: number;
+  seed?: number;
+  promptOptimizer?: boolean;
+  timeoutMs?: number;
+  maxBytes?: number;
+}
+
+export interface GeneratedMiniMaxImages {
+  provider: 'minimax' | 'minimax-cn';
+  model: MiniMaxImageModel;
+  responseId?: string;
+  assets: MediaImportResult[];
+}
+
+export interface MiniMaxImageGenerator {
+  (input: {
+    provider: 'minimax' | 'minimax-cn';
+    model: MiniMaxImageModel;
+    apiKey: string;
+    baseUrl?: string;
+    prompt: string;
+    n?: number;
+    aspectRatio?: MiniMaxImageGenerationInput['aspectRatio'];
+    width?: number;
+    height?: number;
+    seed?: number;
+    promptOptimizer?: boolean;
+    timeoutMs: number;
+  }): Promise<{ responseId?: string; output: ImageContent[] }>;
+}
+
+function requiredString(value: string | undefined, label: string): string {
+  const result = value?.trim();
+  if (!result) throw new Error(`${label} is required`);
+  return result;
+}
+
+function resolveRegion(value: MiniMaxRegion | undefined): MiniMaxRegion {
+  const configured = value ?? process.env.MINIMAX_REGION?.trim().toLowerCase();
+  if (!configured || configured === 'global') return 'global';
+  if (configured === 'cn') return 'cn';
+  throw new Error('MiniMax region must be "global" or "cn"');
+}
+
+function resolveImageModel(value: string | undefined): MiniMaxImageModel {
+  const model = value?.trim() || process.env.MINIMAX_IMAGE_MODEL?.trim() || 'image-01';
+  if ((IMAGE_MODELS as readonly string[]).includes(model)) return model as MiniMaxImageModel;
+  throw new Error(`Unsupported MiniMax image model: ${model}. Supported models: ${IMAGE_MODELS.join(', ')}`);
+}
+
+function resolveBaseUrl(value: string | undefined): string | undefined {
+  const baseUrl = value?.trim();
+  if (!baseUrl) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(baseUrl);
+  } catch {
+    throw new Error('MINIMAX_IMAGE_BASE_URL must be a valid HTTPS URL');
+  }
+  if (parsed.protocol !== 'https:' || parsed.username || parsed.password) {
+    throw new Error('MINIMAX_IMAGE_BASE_URL must be an HTTPS URL without credentials');
+  }
+  return parsed.toString().replace(/\/$/, '');
+}
+
+function normalizePrompt(value: string): string {
+  const prompt = value.trim();
+  if (!prompt) throw new Error('MiniMax image generation requires a non-empty prompt');
+  if (prompt.length > MAX_PROMPT_LENGTH) {
+    throw new Error(`MiniMax image prompt exceeds the ${MAX_PROMPT_LENGTH}-character limit`);
+  }
+  return prompt;
+}
+
+function sourceLabel(model: MiniMaxImageModel, index: number): string {
+  return `minimax-${model}-${index + 1}`;
+}
+
+function safeError(error: unknown): Error {
+  const message = sanitizeCredentials(error instanceof Error ? error.message : String(error));
+  return new Error(message.slice(0, 1_000));
+}
+
+const defaultImageGenerator: MiniMaxImageGenerator = async (input) => {
+  const model = getImageModel(input.provider, input.model);
+  if (!model) throw new Error(`MiniMax image model is not registered: ${input.model}`);
+  const configuredModel = input.baseUrl ? { ...model, baseUrl: input.baseUrl } : model;
+  const response = await generateImages(
+    configuredModel,
+    { input: [{ type: 'text', text: input.prompt }] },
+    {
+      apiKey: input.apiKey,
+      timeoutMs: input.timeoutMs,
+      maxRetries: 0,
+      responseFormat: 'base64',
+      ...(input.n !== undefined ? { n: input.n } : {}),
+      ...(input.aspectRatio !== undefined ? { aspectRatio: input.aspectRatio } : {}),
+      ...(input.width !== undefined ? { width: input.width } : {}),
+      ...(input.height !== undefined ? { height: input.height } : {}),
+      ...(input.seed !== undefined ? { seed: input.seed } : {}),
+      ...(input.promptOptimizer !== undefined ? { promptOptimizer: input.promptOptimizer } : {}),
+    },
+  );
+  if (response.stopReason !== 'stop') {
+    throw new Error(response.errorMessage || 'MiniMax image generation did not complete');
+  }
+  return {
+    responseId: response.responseId,
+    output: response.output.filter((item): item is ImageContent => item.type === 'image'),
+  };
+};
+
+/**
+ * Generates images only after an explicit operator request, then immediately
+ * moves the provider result into Memorix's content-addressed asset store.
+ */
+export async function generateMiniMaxImages(
+  input: MiniMaxImageGenerationInput,
+  dependencies: { generate?: MiniMaxImageGenerator } = {},
+): Promise<GeneratedMiniMaxImages> {
+  const prompt = normalizePrompt(input.prompt);
+  const region = resolveRegion(input.region);
+  const provider = region === 'cn' ? 'minimax-cn' : 'minimax';
+  const model = resolveImageModel(input.model);
+  const apiKey = requiredString(
+    input.apiKey ?? (region === 'cn' ? process.env.MINIMAX_CN_API_KEY : process.env.MINIMAX_API_KEY),
+    region === 'cn' ? 'MINIMAX_CN_API_KEY' : 'MINIMAX_API_KEY',
+  );
+  const baseUrl = resolveBaseUrl(input.baseUrl ?? process.env.MINIMAX_IMAGE_BASE_URL);
+  const timeoutMs = input.timeoutMs ?? DEFAULT_IMAGE_TIMEOUT_MS;
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1_000 || timeoutMs > 5 * 60_000) {
+    throw new Error('MiniMax image timeout must be between 1000 and 300000 milliseconds');
+  }
+
+  let generated: { responseId?: string; output: ImageContent[] };
+  try {
+    generated = await (dependencies.generate ?? defaultImageGenerator)({
+      provider,
+      model,
+      apiKey,
+      ...(baseUrl ? { baseUrl } : {}),
+      prompt,
+      ...(input.n !== undefined ? { n: input.n } : {}),
+      ...(input.aspectRatio !== undefined ? { aspectRatio: input.aspectRatio } : {}),
+      ...(input.width !== undefined ? { width: input.width } : {}),
+      ...(input.height !== undefined ? { height: input.height } : {}),
+      ...(input.seed !== undefined ? { seed: input.seed } : {}),
+      ...(input.promptOptimizer !== undefined ? { promptOptimizer: input.promptOptimizer } : {}),
+      timeoutMs,
+    });
+  } catch (error) {
+    throw safeError(error);
+  }
+
+  if (generated.output.length === 0) throw new Error('MiniMax image generation returned no images');
+  const assets = await Promise.all(generated.output.map((image, index) => importMediaBuffer({
+    dataDir: input.dataDir,
+    projectId: input.projectId,
+    bytes: Buffer.from(image.data, 'base64'),
+    filename: sourceLabel(model, index),
+    sourceKind: 'minimax-image',
+    sourceLabel: sourceLabel(model, index),
+    provider,
+    model,
+    ...(input.maxBytes !== undefined ? { maxBytes: input.maxBytes } : {}),
+  })));
+
+  return {
+    provider,
+    model,
+    ...(generated.responseId ? { responseId: generated.responseId } : {}),
+    assets,
+  };
+}

--- a/src/media/remote-download.ts
+++ b/src/media/remote-download.ts
@@ -1,0 +1,108 @@
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+
+const DEFAULT_DOWNLOAD_TIMEOUT_MS = 60_000;
+
+export interface DownloadProviderMediaInput {
+  url: string;
+  maxBytes: number;
+  timeoutMs?: number;
+}
+
+export interface ProviderMediaDownloadDependencies {
+  fetch?: typeof fetch;
+  resolveHost?: (hostname: string) => Promise<string[]>;
+}
+
+function blockedAddress(address: string): boolean {
+  const normalized = address.replace(/^\[|\]$/g, '').toLowerCase();
+  if (!isIP(normalized)) return true;
+  if (normalized === '::' || normalized === '::1' || normalized.startsWith('fe80:') || /^f[cd][0-9a-f:]*$/i.test(normalized)) {
+    return true;
+  }
+  if (!/^\d+\.\d+\.\d+\.\d+$/.test(normalized)) return false;
+  const [first, second] = normalized.split('.').map(Number);
+  return first === 0
+    || first === 10
+    || first === 127
+    || (first === 169 && second === 254)
+    || (first === 172 && second >= 16 && second <= 31)
+    || (first === 192 && second === 168)
+    || first >= 224;
+}
+
+function parseProviderUrl(value: string): URL {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    throw new Error('Provider returned an invalid media download URL');
+  }
+  if (url.protocol !== 'https:' || url.username || url.password) {
+    throw new Error('Provider returned an unsafe media download URL');
+  }
+  return url;
+}
+
+async function defaultResolveHost(hostname: string): Promise<string[]> {
+  const results = await lookup(hostname, { all: true, verbatim: true });
+  return results.map((item) => item.address);
+}
+
+async function readBoundedBody(response: Response, maxBytes: number): Promise<Buffer> {
+  const contentLength = response.headers.get('content-length');
+  if (contentLength && (!/^\d+$/.test(contentLength) || Number(contentLength) > maxBytes)) {
+    throw new Error(`Provider media download exceeds the ${maxBytes}-byte limit`);
+  }
+  if (!response.body) throw new Error('Provider media download returned an empty response');
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > maxBytes) throw new Error(`Provider media download exceeds the ${maxBytes}-byte limit`);
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  if (total === 0) throw new Error('Provider media download returned an empty response');
+  return Buffer.concat(chunks);
+}
+
+/**
+ * Fetches a temporary provider result without ever accepting arbitrary user
+ * URLs. DNS and literal address checks are intentionally fail-closed, and
+ * redirect following is disabled so a signed result cannot become an SSRF hop.
+ */
+export async function downloadProviderMedia(
+  input: DownloadProviderMediaInput,
+  dependencies: ProviderMediaDownloadDependencies = {},
+): Promise<Buffer> {
+  if (!Number.isSafeInteger(input.maxBytes) || input.maxBytes < 1) {
+    throw new Error('Media download maxBytes must be a positive integer');
+  }
+  const url = parseProviderUrl(input.url);
+  const hostname = url.hostname.replace(/^\[|\]$/g, '');
+  const addresses = isIP(hostname)
+    ? [hostname]
+    : await (dependencies.resolveHost ?? defaultResolveHost)(hostname);
+  if (addresses.length === 0 || addresses.some(blockedAddress)) {
+    throw new Error('Provider media download URL resolved to a private or invalid address');
+  }
+
+  const timeoutMs = input.timeoutMs ?? DEFAULT_DOWNLOAD_TIMEOUT_MS;
+  if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1_000 || timeoutMs > 5 * 60_000) {
+    throw new Error('Media download timeout must be between 1000 and 300000 milliseconds');
+  }
+  const response = await (dependencies.fetch ?? fetch)(url, {
+    redirect: 'error',
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!response.ok) throw new Error(`Provider media download failed with HTTP ${response.status}`);
+  return readBoundedBody(response, input.maxBytes);
+}

--- a/src/media/types.ts
+++ b/src/media/types.ts
@@ -1,0 +1,109 @@
+export type MediaKind = 'image' | 'audio' | 'video' | 'document';
+
+export type MediaSourceKind =
+  | 'import'
+  | 'minimax-image'
+  | 'minimax-video';
+
+export type MediaLinkRole = 'source' | 'generated' | 'attachment';
+
+export type MediaDerivationKind = 'description' | 'ocr' | 'embedding';
+
+export type MediaJobKind = 'minimax-video-generation';
+
+export type MediaJobStatus =
+  | 'queued'
+  | 'submitting'
+  | 'provider-pending'
+  | 'downloading'
+  | 'completed'
+  | 'retry'
+  | 'failed'
+  | 'cancelled';
+
+export interface MediaAsset {
+  id: string;
+  projectId: string;
+  sha256: string;
+  kind: MediaKind;
+  mimeType: string;
+  byteSize: number;
+  /** Relative to the project-independent `media` directory under Memorix data. */
+  storageRelPath: string;
+  sourceKind: MediaSourceKind;
+  /** Human-readable source name only. Never a signed or credential-bearing URL. */
+  sourceLabel?: string;
+  provider?: string;
+  model?: string;
+  createdAt: number;
+  updatedAt: number;
+  deletedAt?: number;
+}
+
+export interface MediaAssetLink {
+  id: string;
+  assetId: string;
+  projectId: string;
+  observationId?: number;
+  role: MediaLinkRole;
+  createdAt: number;
+}
+
+export interface MediaDerivation {
+  id: string;
+  assetId: string;
+  projectId: string;
+  kind: MediaDerivationKind;
+  /** Embedding profile key for vector derivations; absent for textual data. */
+  profileKey?: string;
+  content: string;
+  status: 'ready' | 'failed';
+  error?: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface MediaEmbeddingProfile {
+  key: string;
+  provider: string;
+  model: string;
+  dimensions: number;
+  modality: MediaKind;
+  createdAt: number;
+}
+
+export interface MediaEmbedding {
+  assetId: string;
+  projectId: string;
+  profileKey: string;
+  intent: 'document';
+  dimensions: number;
+  vector: number[];
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface MediaJob {
+  id: string;
+  projectId: string;
+  kind: MediaJobKind;
+  status: MediaJobStatus;
+  request: Record<string, unknown>;
+  providerTaskId?: string;
+  assetId?: string;
+  lastError?: string;
+  attempts: number;
+  attachOnComplete: boolean;
+  observationTitle?: string;
+  createdAt: number;
+  updatedAt: number;
+  completedAt?: number;
+}
+
+export interface MediaImportResult {
+  asset: MediaAsset;
+  deduplicated: boolean;
+}
+
+export const DEFAULT_MAX_MEDIA_BYTES = 100 * 1024 * 1024;
+export const DEFAULT_MEDIA_QUOTA_BYTES = 1024 * 1024 * 1024;

--- a/src/media/video-jobs.ts
+++ b/src/media/video-jobs.ts
@@ -1,0 +1,355 @@
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { sanitizeCredentials } from '../memory/secret-filter.js';
+import {
+  MaintenanceJobStore,
+  type MaintenanceJob,
+  type MaintenanceJobRunResult,
+} from '../runtime/maintenance-jobs.js';
+import { attachMediaAssetToObservation } from './attachment.js';
+import { importMediaBuffer } from './asset-store.js';
+import {
+  createMiniMaxVideoTask,
+  normalizeMiniMaxVideoRequest,
+  queryMiniMaxVideoTask,
+  type MiniMaxVideoGenerationRequest,
+  type MiniMaxVideoTask,
+  type MiniMaxVideoTransport,
+} from './minimax.js';
+import { MediaStore } from './media-store.js';
+import { downloadProviderMedia } from './remote-download.js';
+import type { MediaAsset, MediaJob } from './types.js';
+
+export const MEDIA_VIDEO_MAINTENANCE_KIND = 'media-video-generation' as const;
+export const MINI_MAX_VIDEO_POLL_MS = 10_000;
+const MAX_MEDIA_VIDEO_ATTEMPTS = 4;
+
+interface StoredMiniMaxVideoRequest {
+  provider: 'minimax' | 'minimax-cn';
+  region: 'global' | 'cn';
+  model: 'MiniMax-H3';
+  prompt: string;
+  resolution: '2K';
+  duration: 5 | 10;
+  ratio: 'adaptive' | '16:9' | '9:16' | '1:1';
+  maxBytes: number;
+}
+
+export interface QueueMiniMaxVideoInput extends Omit<MiniMaxVideoGenerationRequest, 'apiKey' | 'baseUrl'> {
+  dataDir: string;
+  projectId: string;
+  maxBytes?: number;
+  attachOnComplete?: boolean;
+  observationTitle?: string;
+}
+
+export interface QueuedMiniMaxVideo {
+  mediaJob: MediaJob;
+  maintenanceJob: MaintenanceJob;
+}
+
+export interface MediaVideoGenerationDependencies {
+  createTask?: typeof createMiniMaxVideoTask;
+  queryTask?: typeof queryMiniMaxVideoTask;
+  download?: (input: { url: string; maxBytes: number }) => Promise<Buffer>;
+  attach?: typeof attachMediaAssetToObservation;
+}
+
+export interface MediaVideoRunnerRequest {
+  projectId: string;
+  projectRoot: string;
+  dataDir: string;
+  mediaJobId: string;
+}
+
+function safeError(error: unknown): string {
+  return sanitizeCredentials(error instanceof Error ? error.message : String(error)).slice(0, 1_000);
+}
+
+function requireConfiguredApiKey(region: 'global' | 'cn'): void {
+  const value = region === 'cn' ? process.env.MINIMAX_CN_API_KEY : process.env.MINIMAX_API_KEY;
+  if (!value?.trim()) throw new Error(region === 'cn' ? 'MINIMAX_CN_API_KEY is required' : 'MINIMAX_API_KEY is required');
+}
+
+function parseMaxBytes(value: number | undefined): number {
+  const maxBytes = value ?? 100 * 1024 * 1024;
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) throw new Error('Video output maxBytes must be a positive integer');
+  return maxBytes;
+}
+
+function parseStoredRequest(value: Record<string, unknown>): StoredMiniMaxVideoRequest {
+  const provider = value.provider;
+  const region = value.region;
+  const model = value.model;
+  const prompt = value.prompt;
+  const resolution = value.resolution;
+  const duration = value.duration;
+  const ratio = value.ratio;
+  const maxBytes = value.maxBytes;
+  if ((provider !== 'minimax' && provider !== 'minimax-cn')
+    || (region !== 'global' && region !== 'cn')
+    || model !== 'MiniMax-H3'
+    || typeof prompt !== 'string'
+    || resolution !== '2K'
+    || (duration !== 5 && duration !== 10)
+    || (ratio !== 'adaptive' && ratio !== '16:9' && ratio !== '9:16' && ratio !== '1:1')
+    || typeof maxBytes !== 'number' || !Number.isSafeInteger(maxBytes) || maxBytes < 1) {
+    throw new Error('Media video job has an invalid request payload');
+  }
+  return { provider, region, model, prompt, resolution, duration, ratio, maxBytes };
+}
+
+function mediaJobIdFromMaintenance(job: MaintenanceJob): string {
+  const mediaJobId = job.payload.mediaJobId;
+  if (typeof mediaJobId !== 'string' || !mediaJobId.trim()) {
+    throw new Error('Media video maintenance job is missing mediaJobId');
+  }
+  return mediaJobId;
+}
+
+function toVideoRequest(request: StoredMiniMaxVideoRequest): MiniMaxVideoGenerationRequest {
+  return {
+    prompt: request.prompt,
+    model: request.model,
+    region: request.region,
+    resolution: request.resolution,
+    duration: request.duration,
+    ratio: request.ratio,
+  };
+}
+
+function terminal(job: MediaJob): boolean {
+  return job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled';
+}
+
+function sourceLabel(request: StoredMiniMaxVideoRequest, providerTaskId: string): string {
+  return `minimax-${request.model}-${providerTaskId}`;
+}
+
+async function finishWithAsset(input: {
+  dataDir: string;
+  projectId: string;
+  store: MediaStore;
+  mediaJob: MediaJob;
+  request: StoredMiniMaxVideoRequest;
+  providerTask: MiniMaxVideoTask;
+  dependencies: MediaVideoGenerationDependencies;
+}): Promise<MaintenanceJobRunResult> {
+  const { dataDir, projectId, store, mediaJob, request, providerTask, dependencies } = input;
+  let asset: MediaAsset | undefined = mediaJob.assetId
+    ? store.getAsset(projectId, mediaJob.assetId)
+    : undefined;
+  if (!asset) {
+    if (!providerTask.downloadUrl) throw new Error('Succeeded MiniMax video task did not include a download URL');
+    store.updateJob(projectId, mediaJob.id, { status: 'downloading', providerTaskId: providerTask.taskId });
+    const bytes = await (dependencies.download ?? ((downloadInput) => downloadProviderMedia(downloadInput)))({
+      url: providerTask.downloadUrl,
+      maxBytes: request.maxBytes,
+    });
+    const imported = await importMediaBuffer({
+      dataDir,
+      projectId,
+      bytes,
+      filename: sourceLabel(request, providerTask.taskId),
+      sourceKind: 'minimax-video',
+      sourceLabel: sourceLabel(request, providerTask.taskId),
+      provider: request.provider,
+      model: request.model,
+      maxBytes: request.maxBytes,
+    });
+    asset = imported.asset;
+  }
+
+  if (mediaJob.attachOnComplete) {
+    const hasAttachment = store.listLinks(projectId, asset.id)
+      .some((link) => link.role === 'attachment' && link.observationId !== undefined);
+    if (!hasAttachment) {
+      await (dependencies.attach ?? attachMediaAssetToObservation)({
+        dataDir,
+        projectId,
+        asset,
+        title: mediaJob.observationTitle ?? `MiniMax video: ${asset.sourceLabel ?? asset.id}`,
+        narrative: `Generated with ${request.provider}/${request.model}. Prompt: ${request.prompt}`,
+        concepts: ['generated-video', 'minimax', request.model],
+      });
+    }
+  }
+  store.updateJob(projectId, mediaJob.id, {
+    status: 'completed',
+    providerTaskId: providerTask.taskId,
+    assetId: asset.id,
+  });
+  return { action: 'complete' };
+}
+
+function retryAfterProviderError(
+  store: MediaStore,
+  projectId: string,
+  mediaJob: MediaJob,
+  maintenanceJob: MaintenanceJob,
+  error: unknown,
+): MaintenanceJobRunResult {
+  const message = safeError(error);
+  if (maintenanceJob.attempts >= maintenanceJob.maxAttempts) {
+    store.updateJob(projectId, mediaJob.id, { status: 'failed', lastError: message, incrementAttempts: true });
+    return { action: 'complete' };
+  }
+  store.updateJob(projectId, mediaJob.id, { status: 'retry', lastError: message, incrementAttempts: true });
+  return { action: 'reschedule', delayMs: MINI_MAX_VIDEO_POLL_MS, status: 'retry', lastError: message };
+}
+
+/**
+ * Creates a durable user-facing media job plus a leased maintenance job. The
+ * payload deliberately excludes provider credentials and temporary URLs.
+ */
+export function queueMiniMaxVideoGeneration(input: QueueMiniMaxVideoInput): QueuedMiniMaxVideo {
+  const normalized = normalizeMiniMaxVideoRequest(input);
+  requireConfiguredApiKey(normalized.region);
+  const request: StoredMiniMaxVideoRequest = {
+    provider: normalized.region === 'cn' ? 'minimax-cn' : 'minimax',
+    region: normalized.region,
+    model: normalized.model,
+    prompt: normalized.prompt,
+    resolution: normalized.resolution,
+    duration: normalized.duration,
+    ratio: normalized.ratio,
+    maxBytes: parseMaxBytes(input.maxBytes),
+  };
+  const store = new MediaStore(input.dataDir);
+  const mediaJob = store.createJob({
+    projectId: input.projectId,
+    kind: 'minimax-video-generation',
+    request: { ...request },
+    attachOnComplete: input.attachOnComplete,
+    observationTitle: input.observationTitle,
+  });
+  const maintenanceJob = new MaintenanceJobStore(input.dataDir).enqueue({
+    projectId: input.projectId,
+    kind: MEDIA_VIDEO_MAINTENANCE_KIND,
+    dedupeKey: `media-video:${mediaJob.id}`,
+    payload: { mediaJobId: mediaJob.id },
+    maxAttempts: MAX_MEDIA_VIDEO_ATTEMPTS,
+  });
+  return { mediaJob, maintenanceJob };
+}
+
+/** Handles one durable video job; all query/download retry decisions are explicit here. */
+export async function runMiniMaxVideoGenerationJob(
+  maintenanceJob: MaintenanceJob,
+  context: { dataDir: string; projectId: string },
+  dependencies: MediaVideoGenerationDependencies = {},
+): Promise<MaintenanceJobRunResult> {
+  const mediaJobId = mediaJobIdFromMaintenance(maintenanceJob);
+  const store = new MediaStore(context.dataDir);
+  const mediaJob = store.getJob(context.projectId, mediaJobId);
+  if (!mediaJob || terminal(mediaJob)) return { action: 'complete' };
+  if (mediaJob.kind !== 'minimax-video-generation') throw new Error(`Unsupported media job kind: ${mediaJob.kind}`);
+  const request = parseStoredRequest(mediaJob.request);
+
+  if (!mediaJob.providerTaskId) {
+    store.updateJob(context.projectId, mediaJob.id, { status: 'submitting', incrementAttempts: true });
+    let submitted: MiniMaxVideoTask;
+    try {
+      submitted = await (dependencies.createTask ?? createMiniMaxVideoTask)(toVideoRequest(request));
+    } catch (error) {
+      // A submit timeout can mean the provider accepted a billable request. Do
+      // not retry automatically without a task ID; the operator can resubmit.
+      store.updateJob(context.projectId, mediaJob.id, { status: 'failed', lastError: safeError(error) });
+      return { action: 'complete' };
+    }
+    if (submitted.status === 'failed') {
+      store.updateJob(context.projectId, mediaJob.id, { status: 'failed', providerTaskId: submitted.taskId, lastError: submitted.error });
+      return { action: 'complete' };
+    }
+    const pending = store.updateJob(context.projectId, mediaJob.id, {
+      status: submitted.status === 'succeeded' ? 'downloading' : 'provider-pending',
+      providerTaskId: submitted.taskId,
+    });
+    if (submitted.status === 'succeeded') {
+      try {
+        return await finishWithAsset({
+          dataDir: context.dataDir,
+          projectId: context.projectId,
+          store,
+          mediaJob: pending,
+          request,
+          providerTask: submitted,
+          dependencies,
+        });
+      } catch (error) {
+        return retryAfterProviderError(store, context.projectId, pending, maintenanceJob, error);
+      }
+    }
+    return { action: 'reschedule', delayMs: MINI_MAX_VIDEO_POLL_MS, resetAttempts: true, clearLastError: true };
+  }
+
+  let task: MiniMaxVideoTask;
+  try {
+    task = await (dependencies.queryTask ?? queryMiniMaxVideoTask)({
+      ...toVideoRequest(request),
+      taskId: mediaJob.providerTaskId,
+    });
+  } catch (error) {
+    return retryAfterProviderError(store, context.projectId, mediaJob, maintenanceJob, error);
+  }
+  if (task.status === 'pending') {
+    store.updateJob(context.projectId, mediaJob.id, { status: 'provider-pending', providerTaskId: task.taskId });
+    return { action: 'reschedule', delayMs: MINI_MAX_VIDEO_POLL_MS, resetAttempts: true, clearLastError: true };
+  }
+  if (task.status === 'failed') {
+    store.updateJob(context.projectId, mediaJob.id, { status: 'failed', providerTaskId: task.taskId, lastError: task.error, incrementAttempts: true });
+    return { action: 'complete' };
+  }
+  try {
+    return await finishWithAsset({
+      dataDir: context.dataDir,
+      projectId: context.projectId,
+      store,
+      mediaJob,
+      request,
+      providerTask: task,
+      dependencies,
+    });
+  } catch (error) {
+    return retryAfterProviderError(store, context.projectId, mediaJob, maintenanceJob, error);
+  }
+}
+
+export function resolveMediaVideoRunnerPath(moduleUrl = import.meta.url): string {
+  const moduleDir = path.dirname(fileURLToPath(moduleUrl));
+  const parentDir = path.dirname(moduleDir);
+  const distDir = path.basename(moduleDir) === 'cli'
+    ? parentDir
+    : path.basename(moduleDir) === 'media' && path.basename(parentDir) === 'src'
+      ? path.join(path.dirname(parentDir), 'dist')
+      : moduleDir;
+  return path.join(distDir, 'media-video-runner.js');
+}
+
+/**
+ * Kick a short-lived local worker for CLI-only users. It has no terminal
+ * window on Windows and intentionally does not use detached CreateProcess.
+ */
+export function launchMediaVideoRunner(
+  request: MediaVideoRunnerRequest,
+  options: { runnerPath?: string } = {},
+): { launched: boolean; reason?: string } {
+  const runnerPath = options.runnerPath ?? resolveMediaVideoRunnerPath();
+  if (!existsSync(runnerPath)) {
+    return { launched: false, reason: 'Media video runner is unavailable until Memorix is built or reinstalled.' };
+  }
+  try {
+    const child = spawn(process.execPath, [runnerPath, JSON.stringify(request)], {
+      cwd: request.projectRoot,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    child.unref();
+    return { launched: true };
+  } catch (error) {
+    return { launched: false, reason: safeError(error) };
+  }
+}

--- a/src/memory/observations.ts
+++ b/src/memory/observations.ts
@@ -10,6 +10,7 @@
 
 import type {
   Observation,
+  ObservationAttachment,
   ObservationAdmissionState,
   ObservationReader,
   ObservationVisibility,
@@ -39,7 +40,7 @@ import {
 import { getObservationStore, initObservationStore } from '../store/obs-store.js';
 import { countTextTokens } from '../compact/token-budget.js';
 import { extractEntities, enrichConcepts } from './entity-extractor.js';
-import { getEmbeddingProvider, isEmbeddingExplicitlyDisabled } from '../embedding/provider.js';
+import { getEmbeddingProvider, isEmbeddingExplicitlyDisabled, validateEmbeddingInput } from '../embedding/provider.js';
 import { sanitizeCredentials } from './secret-filter.js';
 import { enqueueClaimDerivation, enqueueObservationQualification } from '../runtime/lifecycle.js';
 import { canManageObservation, resolveObservationVisibility } from './visibility.js';
@@ -376,6 +377,8 @@ export async function storeObservation(input: {
   commitHash?: string;
   relatedCommits?: string[];
   relatedEntities?: string[];
+  /** Safe HTTPS media references only; inline media is rejected. */
+  attachments?: ObservationAttachment[];
   sourceDetail?: 'explicit' | 'hook' | 'git-ingest';
   valueCategory?: 'core' | 'contextual' | 'ephemeral';
   admissionState?: ObservationAdmissionState;
@@ -391,6 +394,18 @@ export async function storeObservation(input: {
   // ── Central secret sanitization — strip credential values before any persistence ──
   // Covers all write paths: hooks, git-ingest, CLI, reasoning, compact-on-write, etc.
   input = { ...input, title: sanitizeCredentials(input.title), narrative: sanitizeCredentials(input.narrative), facts: input.facts?.map(sanitizeCredentials) };
+
+  const safeAttachments = input.attachments?.map((attachment) => {
+    validateEmbeddingInput({ modality: attachment.modality, url: attachment.url });
+    return {
+      modality: attachment.modality,
+      url: attachment.url,
+      ...(attachment.mimeType ? { mimeType: attachment.mimeType } : {}),
+      ...(attachment.name ? { name: attachment.name } : {}),
+    } satisfies ObservationAttachment;
+  });
+  if (safeAttachments) input = { ...input, attachments: safeAttachments };
+
 
   // Sync the local cache before using it as the topicKey fast path. This costs a
   // generation read in the normal case and only reloads when another process wrote.
@@ -490,6 +505,7 @@ export async function storeObservation(input: {
           commitHash: input.commitHash,
           relatedCommits: input.relatedCommits,
           relatedEntities: input.relatedEntities,
+          attachments: input.attachments,
           sourceDetail: input.sourceDetail,
           valueCategory: input.valueCategory,
           admissionState: input.admissionState,
@@ -548,6 +564,7 @@ export async function storeObservation(input: {
         commitHash: input.commitHash,
         relatedCommits: input.relatedCommits,
         relatedEntities: input.relatedEntities,
+      attachments: input.attachments,
         sourceDetail: input.sourceDetail,
         valueCategory: input.valueCategory,
         admissionState: input.admissionState,

--- a/src/memory/observations.ts
+++ b/src/memory/observations.ts
@@ -361,6 +361,15 @@ export async function withFreshObservations<T>(fn: () => T | Promise<T>): Promis
  *   3. Inserts into Orama for full-text search
  *   4. Persists to disk
  */
+function formatAttachmentProvenance(attachments?: ObservationAttachment[]): string {
+  return (attachments ?? []).map((attachment) => [
+    attachment.name,
+    attachment.modality,
+    attachment.mimeType,
+    attachment.url,
+  ].filter(Boolean).join(' ')).join('\n');
+}
+
 export async function storeObservation(input: {
   entityName: string;
   type: ObservationType;
@@ -588,6 +597,7 @@ export async function storeObservation(input: {
       facts: (input.facts ?? []).join('\n'),
       filesModified: enrichedFiles.join('\n'),
       concepts: enrichedConcepts.map(c => c.replace(/-/g, ' ')).join(', '),
+      attachments: formatAttachmentProvenance(input.attachments),
       tokens,
       createdAt: now,
       projectId: input.projectId,
@@ -648,6 +658,7 @@ async function upsertObservation(
     topicKey?: string;
     sessionId?: string;
     progress?: ProgressInfo;
+    attachments?: ObservationAttachment[];
     sourceDetail?: 'explicit' | 'hook' | 'git-ingest';
     valueCategory?: 'core' | 'contextual' | 'ephemeral';
     admissionState?: ObservationAdmissionState;
@@ -681,6 +692,7 @@ async function upsertObservation(
   existing.title = input.title;
   existing.narrative = input.narrative;
   existing.facts = input.facts ?? [];
+  existing.attachments = input.attachments;
   existing.filesModified = enrichedFiles;
   existing.concepts = enrichedConcepts;
   existing.tokens = tokens;
@@ -708,6 +720,7 @@ async function upsertObservation(
     facts: existing.facts.join('\n'),
     filesModified: enrichedFiles.join('\n'),
     concepts: enrichedConcepts.map(c => c.replace(/-/g, ' ')).join(', '),
+    attachments: formatAttachmentProvenance(existing.attachments),
     tokens,
     createdAt: existing.createdAt,
     projectId: existing.projectId,
@@ -884,6 +897,7 @@ export async function resolveObservations(
         facts: obs.facts.join('\n'),
         filesModified: obs.filesModified.join('\n'),
         concepts: obs.concepts.map(c => c.replace(/-/g, ' ')).join(', '),
+        attachments: formatAttachmentProvenance(obs.attachments),
         tokens: obs.tokens,
         createdAt: obs.createdAt,
         projectId: obs.projectId,
@@ -1092,6 +1106,7 @@ export async function reindexObservations(): Promise<number> {
         facts: obs.facts.join('\n'),
         filesModified: obs.filesModified.join('\n'),
         concepts: obs.concepts.map((c: string) => c.replace(/-/g, ' ')).join(', '),
+        attachments: formatAttachmentProvenance(obs.attachments),
         tokens: obs.tokens,
         createdAt: obs.createdAt,
         projectId: obs.projectId,
@@ -1353,6 +1368,7 @@ export async function backfillVectorEmbeddings(options: {
             facts: obs.facts.join('\n'),
             filesModified: obs.filesModified.join('\n'),
             concepts: obs.concepts.map(c => c.replace(/-/g, ' ')).join(', '),
+            attachments: formatAttachmentProvenance(obs.attachments),
             tokens: obs.tokens,
             createdAt: obs.createdAt,
             projectId: obs.projectId,

--- a/src/multimodal/image-loader.ts
+++ b/src/multimodal/image-loader.ts
@@ -7,9 +7,19 @@
 
 import { getLLMApiKey, getLLMBaseUrl, getLLMModel } from '../config.js';
 import { isLLMEnabled, getLLMConfig } from '../llm/provider.js';
+import { sanitizeCredentials } from '../memory/secret-filter.js';
+import {
+  decodeBase64ImagePayload,
+  MAX_VISION_IMAGE_BYTES,
+  normalizeVisionImageMimeType,
+} from './image-payload.js';
 
 // Providers that use the OpenAI-compatible /chat/completions Vision endpoint
 const OPENAI_COMPATIBLE_PROVIDERS = new Set(['openai', 'openrouter', 'custom']);
+const MAX_VISION_PROMPT_CHARS = 12_000;
+const MAX_VISION_DESCRIPTION_CHARS = 12_000;
+const MAX_VISION_LABELS = 50;
+const MAX_VISION_LABEL_CHARS = 256;
 
 // ── Types ────────────────────────────────────────────────────────────
 
@@ -75,7 +85,7 @@ async function callVisionLLM(
 
   if (!response.ok) {
     const errorText = await response.text().catch(() => 'unknown error');
-    throw new Error(`Vision LLM error (${response.status}): ${errorText}`);
+    throw new Error(`Vision LLM error (${response.status}): ${sanitizeCredentials(errorText).slice(0, 1_000)}`);
   }
 
   const data = await response.json() as {
@@ -90,6 +100,23 @@ async function callVisionLLM(
 const DEFAULT_PROMPT =
   'Analyze this image. Return ONLY a JSON object with this exact format: ' +
   '{"description": "detailed description", "tags": ["tag1", "tag2"], "entities": ["entity1", "entity2"]}';
+
+function normalizeText(value: unknown, fallback = ''): string {
+  const text = typeof value === 'string' && value.trim() ? value.trim() : fallback;
+  return sanitizeCredentials(text).slice(0, MAX_VISION_DESCRIPTION_CHARS);
+}
+
+function normalizeLabels(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const labels = new Set<string>();
+  for (const item of value) {
+    if (typeof item !== 'string') continue;
+    const label = sanitizeCredentials(item.trim()).slice(0, MAX_VISION_LABEL_CHARS);
+    if (label) labels.add(label);
+    if (labels.size >= MAX_VISION_LABELS) break;
+  }
+  return [...labels];
+}
 
 /**
  * Analyze an image using Vision LLM.
@@ -113,10 +140,16 @@ export async function analyzeImage(input: ImageInput): Promise<ImageAnalysisResu
     );
   }
 
-  const mimeType = input.mimeType ?? 'image/png';
-  const prompt = input.prompt ?? DEFAULT_PROMPT;
+  const bytes = decodeBase64ImagePayload(input.base64, MAX_VISION_IMAGE_BYTES);
+  const imageBase64 = bytes.toString('base64');
+  const mimeType = normalizeVisionImageMimeType(input.mimeType);
+  const prompt = (input.prompt ?? DEFAULT_PROMPT).trim();
+  if (!prompt) throw new Error('Image analysis prompt must be non-empty');
+  if (prompt.length > MAX_VISION_PROMPT_CHARS) {
+    throw new Error(`Image analysis prompt exceeds the ${MAX_VISION_PROMPT_CHARS}-character limit`);
+  }
 
-  const response = await callVisionLLM(prompt, input.base64, mimeType);
+  const response = await callVisionLLM(prompt, imageBase64, mimeType);
 
   // Try to parse structured JSON response
   try {
@@ -125,9 +158,9 @@ export async function analyzeImage(input: ImageInput): Promise<ImageAnalysisResu
     if (jsonMatch) {
       const parsed = JSON.parse(jsonMatch[0]);
       return {
-        description: parsed.description ?? response,
-        tags: Array.isArray(parsed.tags) ? parsed.tags : [],
-        entities: Array.isArray(parsed.entities) ? parsed.entities : [],
+        description: normalizeText(parsed.description, response),
+        tags: normalizeLabels(parsed.tags),
+        entities: normalizeLabels(parsed.entities),
       };
     }
   } catch {
@@ -136,7 +169,7 @@ export async function analyzeImage(input: ImageInput): Promise<ImageAnalysisResu
 
   // Fallback: treat entire response as description
   return {
-    description: response,
+    description: normalizeText(response),
     tags: [],
     entities: [],
   };

--- a/src/multimodal/image-payload.ts
+++ b/src/multimodal/image-payload.ts
@@ -1,0 +1,69 @@
+import { Buffer } from 'node:buffer';
+
+/** Keep visual-analysis requests bounded even when controlled assets allow larger files. */
+export const MAX_VISION_IMAGE_BYTES = 20 * 1024 * 1024;
+
+const SUPPORTED_IMAGE_MIME_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/gif',
+  'image/webp',
+]);
+
+function isBase64Character(code: number): boolean {
+  return (
+    (code >= 0x41 && code <= 0x5a)
+    || (code >= 0x61 && code <= 0x7a)
+    || (code >= 0x30 && code <= 0x39)
+    || code === 0x2b
+    || code === 0x2f
+  );
+}
+
+/**
+ * Decode only canonical standard base64. This is deliberately separate from
+ * MIME detection in the controlled asset store, which remains authoritative.
+ */
+export function decodeBase64ImagePayload(
+  value: string,
+  maxBytes = MAX_VISION_IMAGE_BYTES,
+): Buffer {
+  const raw = value.trim();
+  if (!raw) throw new Error('base64 image data is required');
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1) {
+    throw new Error('image payload limit must be a positive integer');
+  }
+
+  const maximumLength = Math.ceil(maxBytes / 3) * 4;
+  if (raw.length > maximumLength) {
+    throw new Error(`base64 image data exceeds the ${maxBytes}-byte visual analysis limit`);
+  }
+  if (raw.length % 4 !== 0) throw new Error('base64 image data is invalid');
+
+  let padding = 0;
+  let sawPadding = false;
+  for (let index = 0; index < raw.length; index += 1) {
+    const code = raw.charCodeAt(index);
+    if (code === 0x3d) {
+      sawPadding = true;
+      padding += 1;
+      continue;
+    }
+    if (sawPadding || !isBase64Character(code)) throw new Error('base64 image data is invalid');
+  }
+  if (padding > 2) throw new Error('base64 image data is invalid');
+
+  const bytes = Buffer.from(raw, 'base64');
+  if (bytes.length === 0 || bytes.length > maxBytes || bytes.toString('base64') !== raw) {
+    throw new Error('base64 image data is invalid or exceeds the visual analysis limit');
+  }
+  return bytes;
+}
+
+export function normalizeVisionImageMimeType(value: string | undefined): string {
+  const mimeType = (value ?? 'image/png').trim().toLowerCase();
+  if (!SUPPORTED_IMAGE_MIME_TYPES.has(mimeType)) {
+    throw new Error(`Unsupported image MIME type for visual analysis: ${mimeType || '(empty)'}`);
+  }
+  return mimeType;
+}

--- a/src/runtime/control-plane-maintenance.ts
+++ b/src/runtime/control-plane-maintenance.ts
@@ -8,6 +8,7 @@ import { runMaintenanceInChildProcess } from './isolated-maintenance.js';
 import { MaintenanceTargetStore } from './maintenance-targets.js';
 
 export const CONTROL_PLANE_MAINTENANCE_KINDS: readonly MaintenanceJobKind[] = [
+  'media-video-generation',
   'retention-archive',
   'consolidation',
   'codegraph-refresh',

--- a/src/runtime/isolated-maintenance.ts
+++ b/src/runtime/isolated-maintenance.ts
@@ -9,6 +9,7 @@ import { sanitizeCredentials } from '../memory/secret-filter.js';
 export const MAINTENANCE_RESULT_PREFIX = '__MEMORIX_MAINTENANCE_RESULT__';
 
 export const ISOLATED_MAINTENANCE_JOB_KINDS: readonly MaintenanceJobKind[] = [
+  'media-video-generation',
   'retention-archive',
   'consolidation',
   'codegraph-refresh',

--- a/src/runtime/maintenance-jobs.ts
+++ b/src/runtime/maintenance-jobs.ts
@@ -5,6 +5,7 @@ import { sanitizeCredentials } from '../memory/secret-filter.js';
 
 export const MAINTENANCE_JOB_KINDS = [
   'vector-backfill',
+  'media-video-generation',
   'retention-archive',
   'consolidation',
   'codegraph-refresh',

--- a/src/runtime/media-video-runner.ts
+++ b/src/runtime/media-video-runner.ts
@@ -1,0 +1,117 @@
+import path from 'node:path';
+
+import { loadDotenv } from '../config/dotenv-loader.js';
+import { initProjectRoot } from '../config/yaml-loader.js';
+import { initObservations } from '../memory/observations.js';
+import { MediaStore } from '../media/media-store.js';
+import {
+  MEDIA_VIDEO_MAINTENANCE_KIND,
+  type MediaVideoRunnerRequest,
+} from '../media/video-jobs.js';
+import { closeAllDatabases } from '../store/sqlite-db.js';
+import { MaintenanceJobStore, MaintenanceJobWorker } from './maintenance-jobs.js';
+import { createProjectMaintenanceHandler } from './project-maintenance.js';
+
+const POLL_DELAY_MS = 1_000;
+const MAX_RUNNER_LIFETIME_MS = 35 * 60_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function terminal(status: string): status is 'completed' | 'failed' | 'cancelled' {
+  return status === 'completed' || status === 'failed' || status === 'cancelled';
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function parseMediaVideoRunnerRequest(raw: string): MediaVideoRunnerRequest {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new Error('Media video runner received invalid JSON input');
+  }
+  if (!isRecord(value)
+    || typeof value.projectId !== 'string' || !value.projectId
+    || typeof value.projectRoot !== 'string' || !path.isAbsolute(value.projectRoot)
+    || typeof value.dataDir !== 'string' || !path.isAbsolute(value.dataDir)
+    || typeof value.mediaJobId !== 'string' || !value.mediaJobId) {
+    throw new Error('Media video runner received an invalid request');
+  }
+  return {
+    projectId: value.projectId,
+    projectRoot: value.projectRoot,
+    dataDir: value.dataDir,
+    mediaJobId: value.mediaJobId,
+  };
+}
+
+/**
+ * A CLI-only nudge is intentionally bounded. A long video request continues
+ * in the durable queue and can be resumed by another CLI invocation or MCP
+ * control-plane worker after this helper exits.
+ */
+export async function executeMediaVideoRunner(
+  request: MediaVideoRunnerRequest,
+  options: { maxLifetimeMs?: number; pollDelayMs?: number } = {},
+): Promise<'completed' | 'failed' | 'cancelled' | 'missing' | 'timed-out'> {
+  initProjectRoot(request.projectRoot);
+  loadDotenv(request.projectRoot);
+  await initObservations(request.dataDir, {
+    embeddingWriteMode: 'deferred',
+    projectRoot: request.projectRoot,
+  });
+
+  const mediaStore = new MediaStore(request.dataDir);
+  const queue = new MaintenanceJobStore(request.dataDir);
+  const worker = new MaintenanceJobWorker(
+    queue,
+    createProjectMaintenanceHandler(request.projectId, request.dataDir, request.projectRoot),
+    {
+      projectId: request.projectId,
+      kinds: [MEDIA_VIDEO_MAINTENANCE_KIND],
+      pollIntervalMs: POLL_DELAY_MS,
+    },
+  );
+  const maxLifetimeMs = Number.isSafeInteger(options.maxLifetimeMs)
+    ? Math.max(POLL_DELAY_MS, options.maxLifetimeMs!)
+    : MAX_RUNNER_LIFETIME_MS;
+  const pollDelayMs = Number.isSafeInteger(options.pollDelayMs)
+    ? Math.max(25, options.pollDelayMs!)
+    : POLL_DELAY_MS;
+  const deadline = Date.now() + maxLifetimeMs;
+
+  while (Date.now() < deadline) {
+    const before = mediaStore.getJob(request.projectId, request.mediaJobId);
+    if (!before) return 'missing';
+    if (terminal(before.status)) return before.status;
+
+    await worker.runOnce();
+
+    const after = mediaStore.getJob(request.projectId, request.mediaJobId);
+    if (!after) return 'missing';
+    if (terminal(after.status)) return after.status;
+    await sleep(pollDelayMs);
+  }
+  return 'timed-out';
+}
+
+export async function main(): Promise<void> {
+  try {
+    const raw = process.argv[2];
+    if (!raw) throw new Error('Media video runner requires a request payload');
+    await executeMediaVideoRunner(parseMediaVideoRunnerRequest(raw));
+  } catch (error) {
+    process.stderr.write(`[memorix] media video runner failed: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  } finally {
+    closeAllDatabases();
+  }
+}
+
+if (process.argv[1] && process.argv[1].endsWith('media-video-runner.js')) {
+  void main();
+}

--- a/src/runtime/project-maintenance.ts
+++ b/src/runtime/project-maintenance.ts
@@ -234,6 +234,11 @@ export function createProjectMaintenanceHandler(
       return { action: 'reschedule', delayMs: VECTOR_RETRY_DELAY_MS };
     }
 
+    if (job.kind === 'media-video-generation') {
+      const { runMiniMaxVideoGenerationJob } = await import('../media/video-jobs.js');
+      return runMiniMaxVideoGenerationJob(job, { dataDir: projectDir, projectId });
+    }
+
     if (job.kind === 'retention-archive') {
       const { archiveExpiredBatch } = await import('../memory/retention.js');
       const limit = retentionBatchSize(job.payload);

--- a/src/server.ts
+++ b/src/server.ts
@@ -707,9 +707,18 @@ export async function createMemorixServer(
         overrideReadOnly: z.boolean().optional().describe(
           'Use only when the user explicitly asks to save memory during a read-only or no-modification task.',
         ),
+        attachments: z.array(z.object({
+          modality: z.enum(['image', 'audio', 'video', 'document']),
+          url: z.string().describe(
+            'Public HTTPS provenance reference without query parameters or fragments. ' +
+            'Memorix does not fetch this URL: attachment metadata is persisted and BM25-searchable, while observation vectors remain text-only.',
+          ),
+          mimeType: z.string().optional(),
+          name: z.string().optional(),
+        })).optional().describe('Safe public provenance references. They are stored as metadata for lexical retrieval; raw inline media is never stored.'),
       },
     },
-    async ({ entityName: rawEntityName, type: rawType, title: rawTitle, narrative, facts, filesModified, concepts, topicKey, progress, relatedCommits, relatedEntities, visibility, longTerm, overrideReadOnly }) => {
+    async ({ entityName: rawEntityName, type: rawType, title: rawTitle, narrative, facts, filesModified, concepts, topicKey, progress, relatedCommits, relatedEntities, visibility, longTerm, overrideReadOnly, attachments }) => {
       const unresolved = requireResolvedProject('store memory in the current project');
       if (unresolved) return unresolved;
       const readOnlyBoundary = blockReadOnlyAutopilotWrite(overrideReadOnly);
@@ -1115,6 +1124,7 @@ export async function createMemorixServer(
         progress: progress as import('./types.js').ProgressInfo | undefined,
         relatedCommits,
         relatedEntities,
+        attachments,
         sourceDetail: 'explicit',
         valueCategory: formationResult?.evaluation.category,
         createdByAgentId: currentAgentId,

--- a/src/server.ts
+++ b/src/server.ts
@@ -51,6 +51,12 @@ import { runFormation, getMetricsSummary, getBeforeAfterMetrics } from './memory
 import type { FormationConfig, SearchHit, FormedMemory, FormationStage, FormationStageEvent } from './memory/formation/types.js';
 import { parseFormationTimeoutMs } from './server/formation-timeout.js';
 import { withTimeout } from './timeout.js';
+import { sanitizeCredentials } from './memory/secret-filter.js';
+import {
+  createProjectBindingController,
+  type ProjectBindingController,
+  type ProjectBindingSource,
+} from './server/request-context.js';
 
 // ── Timeout budgets for LLM-heavy paths ──────────────────────────
 const FORMATION_TIMEOUT_MS = parseFormationTimeoutMs(process.env.MEMORIX_FORMATION_TIMEOUT_MS); // Formation pipeline (extract+resolve+evaluate)
@@ -203,6 +209,11 @@ export interface CreateMemorixServerOptions {
   dashboardMode?: 'standalone' | 'control-plane';
   dashboardPort?: number;
   toolProfile?: ToolProfile;
+  /**
+   * Product-scoped project binding. HTTP transports may keep it beside a
+   * legacy session adapter today; no project operation reads session headers.
+   */
+  projectBinding?: ProjectBindingController;
 }
 
 /**
@@ -237,6 +248,7 @@ export async function createMemorixServer(
   deferredInit: () => Promise<void>;
   switchProject: (newCwd: string) => Promise<boolean>;
   isExplicitlyBound: () => boolean;
+  getRequestContext: () => import('./server/request-context.js').MemorixRequestContext;
   handleTransportClose: () => void;
 }> {
   // Detect current project — strict .git-based detection
@@ -251,11 +263,11 @@ export async function createMemorixServer(
     fallback: sharedTeam ? 'team' : 'lite',
   });
   const teamFeaturesEnabled = isToolInProfile('team_manage', toolProfile);
+  const projectBinding = options.projectBinding ?? createProjectBindingController(cwd ?? process.cwd());
   const detectedProject = detectProject(cwd);
   let rawProject: import('./types.js').ProjectInfo;
   let projectResolved = true;
   let projectResolutionError: string | null = null;
-  let explicitProjectBound = false; // Set true when memorix_session_start binds via projectRoot
   let currentAgentId: string | undefined; // Session-scoped coordination identity for attribution after explicit join
   let teamStore!: import('./team/team-store.js').TeamStore;
   let initTeamStoreForProject: ((dataDir: string) => Promise<import('./team/team-store.js').TeamStore>) | undefined;
@@ -300,6 +312,9 @@ export async function createMemorixServer(
     if (canonicalId !== rawProject.id) {
       console.error(`[memorix] Alias resolved: ${rawProject.id} -> ${canonicalId}`);
     }
+  }
+  if (projectResolved) {
+    projectBinding.recordResolvedProject(project.id, project.rootPath);
   }
 
   const registerMaintenanceTarget = async (): Promise<void> => {
@@ -578,19 +593,21 @@ export async function createMemorixServer(
     return (originalRegisterTool as (...innerArgs: unknown[]) => unknown)(name, ...args) as never;
   }) as typeof server.registerTool;
 
+  const getRequestContext = () => projectBinding.requestContext(currentAgentId);
   const getObservationReader = (scope: 'project' | 'global' = 'project'): ObservationReader => {
+    const requestContext = getRequestContext();
     let isTeamMember = false;
-    if (teamFeaturesEnabled && currentAgentId) {
+    if (teamFeaturesEnabled && requestContext.actorId) {
       try {
-        const agent = teamStore.getAgent(currentAgentId);
+        const agent = teamStore.getAgent(requestContext.actorId);
         isTeamMember = agent?.project_id === project.id && agent.status === 'active';
       } catch {
         // A missing coordination store must never grant team visibility.
       }
     }
     return {
-      ...(scope === 'project' ? { projectId: project.id } : {}),
-      ...(currentAgentId ? { agentId: currentAgentId } : {}),
+      ...(scope === 'project' ? { projectId: requestContext.projectId ?? project.id } : {}),
+      ...(requestContext.actorId ? { agentId: requestContext.actorId } : {}),
       isTeamMember,
     };
   };
@@ -3769,7 +3786,7 @@ export async function createMemorixServer(
       // BEFORE checking whether the project is resolved. This is the primary
       // mechanism for HTTP/control-plane multi-project support.
       if (explicitRoot && typeof explicitRoot === 'string') {
-        let bound = await switchProject(explicitRoot);
+        let bound = await switchProject(explicitRoot, 'explicit-project-root');
         // switchProject returns false for both "same project, no-op" and "no git repo".
         // Only scan subdirectories when explicitRoot is not itself a git repo; otherwise
         // a same-project no-op can be hijacked by the first nested/vendored repo.
@@ -3788,7 +3805,7 @@ export async function createMemorixServer(
             const { findGitInSubdirs } = await import('./project/detector.js');
             const subGit = findGitInSubdirs(explicitRoot);
             if (subGit) {
-              bound = await switchProject(subGit);
+              bound = await switchProject(subGit, 'explicit-project-root');
             }
           }
         }
@@ -3816,8 +3833,8 @@ export async function createMemorixServer(
             isError: true as const,
           };
         }
-        // Bound successfully — mark as explicitly bound so roots won't override
-        explicitProjectBound = true;
+        // `switchProject` records the explicit binding in the transport-neutral
+        // ProjectBindingController, so Roots can no longer override it.
       }
 
       const unresolved = requireResolvedProject('start a project session');
@@ -4970,47 +4987,273 @@ export async function createMemorixServer(
     },
   );
   server.registerTool(
+    'memorix_media',
+    {
+      title: 'Manage Controlled Media',
+      description:
+        'Use the controlled local media library for an explicit import, attachment, inspection, or MiniMax generation request. ' +
+        'Assets stay outside the Git worktree and enter normal memory only when attach is explicitly true. ' +
+        'Use the CLI for destructive removal, quota cleanup, job cancellation, and direct generation. ' +
+        'MCP generation is disabled by default and requires MEMORIX_MCP_MEDIA_GENERATION=1 after the operator reviews provider billing.',
+      inputSchema: {
+        action: z.enum(['import', 'attach', 'list', 'show', 'generate-image', 'generate-video', 'status']),
+        path: z.string().optional().describe('Explicit local image/audio/video/PDF path for import.'),
+        assetId: z.string().optional().describe('Controlled MediaAsset ID for attach/show.'),
+        jobId: z.string().optional().describe('Durable media job ID for status.'),
+        kind: z.enum(['image', 'audio', 'video', 'document']).optional().describe('Optional asset list filter.'),
+        limit: z.number().int().min(1).max(100).optional().describe('Maximum assets to list.'),
+        title: z.string().optional().describe('Observation title when attaching generated/imported output.'),
+        narrative: z.string().optional().describe('Short retrieval text when attaching an asset.'),
+        prompt: z.string().optional().describe('Explicit MiniMax generation prompt.'),
+        model: z.enum(['image-01', 'image-01-live', 'MiniMax-H3']).optional().describe('MiniMax image or video model.'),
+        region: z.enum(['global', 'cn']).optional().describe('MiniMax deployment region.'),
+        n: z.number().int().min(1).max(4).optional().describe('Image output count.'),
+        ratio: z.enum(['adaptive', '1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9']).optional().describe('Image or video aspect ratio.'),
+        width: z.number().int().min(1).max(8192).optional().describe('Requested image width.'),
+        height: z.number().int().min(1).max(8192).optional().describe('Requested image height.'),
+        duration: z.union([z.literal(5), z.literal(10)]).optional().describe('MiniMax video duration in seconds.'),
+        attach: z.boolean().optional().describe('Attach generated/imported output to normal project memory explicitly.'),
+      },
+    },
+    async ({ action, path: assetPath, assetId, jobId, kind, limit, title, narrative, prompt, model, region, n, ratio, width, height, duration, attach }) => {
+      const unresolved = requireResolvedProject('manage controlled media');
+      if (unresolved) return unresolved;
+      const safeError = (error: unknown) => sanitizeCredentials(
+        error instanceof Error ? error.message : String(error),
+      ).slice(0, 1_000);
+      const attachAsset = async (asset: import('./media/types.js').MediaAsset, attachmentTitle?: string, attachmentNarrative?: string) => {
+        const { attachMediaAssetToObservation } = await import('./media/attachment.js');
+        const requestContext = getRequestContext();
+        return attachMediaAssetToObservation({
+          dataDir: projectDir,
+          projectId: project.id,
+          asset,
+          title: attachmentTitle?.trim() || `Media asset: ${asset.sourceLabel ?? asset.id}`,
+          narrative: attachmentNarrative,
+          concepts: ['mcp-media'],
+          visibility: 'project',
+          visibilityReader: getObservationReader(),
+          ...(requestContext.actorId ? { createdByAgentId: requestContext.actorId } : {}),
+        });
+      };
+      const result = (value: Record<string, unknown>) => ({
+        content: [{ type: 'text' as const, text: JSON.stringify(value) }],
+      });
+      const mcpGenerationEnabled = process.env.MEMORIX_MCP_MEDIA_GENERATION === '1';
+
+      try {
+        const { MediaStore } = await import('./media/media-store.js');
+        const store = new MediaStore(projectDir);
+        if (action === 'list') {
+          return result({
+            action,
+            projectId: project.id,
+            assets: store.listAssets(project.id, { kind, limit: limit ?? 50 }),
+          });
+        }
+        if (action === 'show') {
+          if (!assetId?.trim()) throw new Error('assetId is required for media show');
+          const asset = store.getAsset(project.id, assetId);
+          if (!asset) throw new Error(`Media asset not found: ${assetId}`);
+          return result({
+            action,
+            projectId: project.id,
+            asset,
+            links: store.listLinks(project.id, asset.id),
+            derivations: store.listDerivations(project.id, asset.id),
+          });
+        }
+        if (action === 'status') {
+          if (!jobId?.trim()) throw new Error('jobId is required for media status');
+          const job = store.getJob(project.id, jobId);
+          if (!job) throw new Error(`Media job not found: ${jobId}`);
+          return result({ action, projectId: project.id, job });
+        }
+        if (action === 'attach') {
+          if (!assetId?.trim()) throw new Error('assetId is required for media attach');
+          const asset = store.getAsset(project.id, assetId);
+          if (!asset) throw new Error(`Media asset not found: ${assetId}`);
+          const description = store.listDerivations(project.id, asset.id)
+            .find((item) => item.kind === 'description' && item.status === 'ready')?.content;
+          const observation = await attachAsset(asset, title, narrative ?? description);
+          return result({ action, projectId: project.id, asset, observation });
+        }
+        if (action === 'import') {
+          if (!assetPath?.trim()) throw new Error('path is required for media import');
+          const { importMediaFile } = await import('./media/asset-store.js');
+          const imported = await importMediaFile({
+            dataDir: projectDir,
+            projectId: project.id,
+            filePath: assetPath,
+          });
+          const observation = attach === true
+            ? await attachAsset(imported.asset, title, narrative)
+            : undefined;
+          return result({ action, projectId: project.id, ...imported, ...(observation ? { observation } : {}) });
+        }
+        if (action === 'generate-image') {
+          if (!mcpGenerationEnabled) {
+            throw new Error('MCP media generation is disabled. Use the CLI, or set MEMORIX_MCP_MEDIA_GENERATION=1 after reviewing provider billing.');
+          }
+          if (!prompt?.trim()) throw new Error('prompt is required for image generation');
+          const imageModel: 'image-01' | 'image-01-live' | undefined = model === 'image-01' || model === 'image-01-live'
+            ? model
+            : undefined;
+          if (model && !imageModel) throw new Error('generate-image accepts image-01 or image-01-live');
+          const imageRatio: '1:1' | '16:9' | '4:3' | '3:2' | '2:3' | '3:4' | '9:16' | '21:9' | undefined =
+            ratio === '1:1' || ratio === '16:9' || ratio === '4:3' || ratio === '3:2' || ratio === '2:3'
+              || ratio === '3:4' || ratio === '9:16' || ratio === '21:9'
+              ? ratio
+              : undefined;
+          if (ratio && !imageRatio) throw new Error('generate-image received an unsupported aspect ratio');
+          const { generateMiniMaxImages } = await import('./media/minimax.js');
+          const generated = await generateMiniMaxImages({
+            dataDir: projectDir,
+            projectId: project.id,
+            prompt,
+            model: imageModel,
+            region,
+            n,
+            aspectRatio: imageRatio,
+            width,
+            height,
+          });
+          const observations = attach === true
+            ? await Promise.all(generated.assets.map(({ asset }) => attachAsset(
+              asset,
+              title ?? `MiniMax image: ${asset.sourceLabel ?? asset.id}`,
+              narrative ?? `Generated with ${generated.provider}/${generated.model}. Prompt: ${prompt}`,
+            )))
+            : [];
+          return result({ action, projectId: project.id, ...generated, observations });
+        }
+        if (action === 'generate-video') {
+          if (!mcpGenerationEnabled) {
+            throw new Error('MCP media generation is disabled. Use the CLI, or set MEMORIX_MCP_MEDIA_GENERATION=1 after reviewing provider billing.');
+          }
+          if (!prompt?.trim()) throw new Error('prompt is required for video generation');
+          if (model && model !== 'MiniMax-H3') throw new Error('generate-video accepts MiniMax-H3');
+          const videoRatio: 'adaptive' | '1:1' | '16:9' | '9:16' | undefined =
+            ratio === 'adaptive' || ratio === '1:1' || ratio === '16:9' || ratio === '9:16'
+              ? ratio
+              : undefined;
+          if (ratio && !videoRatio) throw new Error('generate-video received an unsupported aspect ratio');
+          const { queueMiniMaxVideoGeneration } = await import('./media/video-jobs.js');
+          const queued = queueMiniMaxVideoGeneration({
+            dataDir: projectDir,
+            projectId: project.id,
+            prompt,
+            ...(model === 'MiniMax-H3' ? { model } : {}),
+            ...(region ? { region } : {}),
+            ...(videoRatio ? { ratio: videoRatio } : {}),
+            ...(duration ? { duration } : {}),
+            attachOnComplete: attach === true,
+            observationTitle: title,
+          });
+          return result({ action, projectId: project.id, ...queued });
+        }
+        throw new Error(`Unsupported media action: ${action}`);
+      } catch (error) {
+        return {
+          content: [{ type: 'text' as const, text: `Media operation failed: ${safeError(error)}` }],
+          isError: true as const,
+        };
+      }
+    },
+  );
+
+  server.registerTool(
     'memorix_ingest_image',
     {
       title: 'Ingest Image',
       description:
-        'Analyze an image via Vision LLM and store the analysis as a memory observation. ' +
-        'Returns description, tags, and entities extracted from the image.',
+        'Legacy compatibility path: import caller-provided image bytes into the controlled local asset library, then store a text retrieval projection. ' +
+        'For durable media operations, prefer memorix_media or the media CLI.',
       inputSchema: {
         base64: z.string().describe('Base64-encoded image data'),
-        mimeType: z.string().optional().describe('Image MIME type (e.g. image/png, image/jpeg)'),
+        mimeType: z.string().optional().describe('Deprecated compatibility hint. Memorix detects the actual MIME type from the image bytes.'),
         filename: z.string().optional().describe('Original filename'),
         prompt: z.string().optional().describe('Custom analysis prompt'),
       },
     },
     async (args) => {
       try {
-        const { analyzeImage } = await import('./multimodal/image-loader.js');
-        const analysis = await analyzeImage(args);
-        const entityName = args.filename?.replace(/\.[^.]+$/, '') ?? `image-${Date.now()}`;
-        const { observation } = await storeObservation({
-          entityName,
-          type: 'discovery',
-          title: `Image analysis: ${entityName}`,
+        const { decodeBase64ImagePayload } = await import('./multimodal/image-payload.js');
+        const bytes = decodeBase64ImagePayload(args.base64);
+        const filename = args.filename?.trim() || `image-${Date.now()}.png`;
+        const { importMediaBuffer, readMediaAsset } = await import('./media/asset-store.js');
+        const imported = await importMediaBuffer({
+          dataDir: projectDir,
+          projectId: project.id,
+          bytes,
+          filename,
+          sourceKind: 'import',
+        });
+        if (imported.asset.kind !== 'image') {
+          throw new Error(`Expected an image payload, detected ${imported.asset.mimeType}`);
+        }
+
+        let analysis: { description: string; tags: string[]; entities: string[] };
+        let analysisWarning: string | undefined;
+        try {
+          const { analyzeImage } = await import('./multimodal/image-loader.js');
+          const controlledBytes = await readMediaAsset(projectDir, imported.asset);
+          analysis = await analyzeImage({
+            base64: controlledBytes.toString('base64'),
+            mimeType: imported.asset.mimeType,
+            filename,
+            prompt: args.prompt,
+          });
+        } catch (analysisError) {
+          analysis = {
+            description: `Imported image asset ${filename}. Visual analysis is unavailable; use the controlled asset reference for high-fidelity inspection.`,
+            tags: ['image', imported.asset.mimeType],
+            entities: [],
+          };
+          analysisWarning = sanitizeCredentials(
+            analysisError instanceof Error ? analysisError.message : String(analysisError),
+          ).slice(0, 500);
+        }
+
+        const { MediaStore } = await import('./media/media-store.js');
+        new MediaStore(projectDir).addDerivation({
+          projectId: project.id,
+          assetId: imported.asset.id,
+          kind: 'description',
+          content: analysis.description,
+          status: 'ready',
+        });
+        const { attachMediaAssetToObservation } = await import('./media/attachment.js');
+        const requestContext = getRequestContext();
+        const observation = await attachMediaAssetToObservation({
+          dataDir: projectDir,
+          projectId: project.id,
+          asset: imported.asset,
+          entityName: filename.replace(/\.[^.]+$/, '') || `image-${Date.now()}`,
+          title: `Image analysis: ${filename}`,
           narrative: analysis.description,
           concepts: analysis.tags,
           facts: analysis.entities,
-          projectId: project.id,
+          visibility: 'project',
+          visibilityReader: getObservationReader(),
+          ...(requestContext.actorId ? { createdByAgentId: requestContext.actorId } : {}),
         });
         return {
           content: [{
             type: 'text' as const,
-            text: `\uD83D\uDDBC\uFE0F Image analyzed\n` +
+            text: `\uD83D\uDDBC\uFE0F Image imported and analyzed\n` +
+              `Asset: ${imported.asset.id}\n` +
               `Observation #${observation.id}\n` +
               `Tags: ${analysis.tags.join(', ') || 'none'}\n` +
-              `Preview: ${analysis.description.slice(0, 300)}${analysis.description.length > 300 ? '\u2026' : ''}`,
+              `Preview: ${analysis.description.slice(0, 300)}${analysis.description.length > 300 ? '\u2026' : ''}` +
+              (analysisWarning ? '\nVisual analysis fallback was used.' : ''),
           }],
         };
       } catch (err: unknown) {
         return {
           content: [{
             type: 'text' as const,
-            text: `[ERROR] Image ingestion failed: ${err instanceof Error ? err.message : String(err)}`,
+            text: `[ERROR] Image ingestion failed: ${sanitizeCredentials(err instanceof Error ? err.message : String(err))}`,
           }],
           isError: true,
         };
@@ -5104,7 +5347,11 @@ export async function createMemorixServer(
 
   // Runtime project switch — called when MCP roots change, projectRoot binding, or new workspace detected.
   // Updates all mutable state; tool closures automatically pick up new values.
-  const switchProject = async (newCwd: string): Promise<boolean> => {
+  const switchProject = async (
+    newCwd: string,
+    source: ProjectBindingSource = 'mcp-roots',
+  ): Promise<boolean> => {
+    if (source === 'mcp-roots' && projectBinding.isExplicit()) return false;
     const { detectProjectWithDiagnostics } = await import('./project/detector.js');
     const result = detectProjectWithDiagnostics(newCwd);
     if (!result.project) {
@@ -5114,8 +5361,6 @@ export async function createMemorixServer(
       return false;
     }
     const newDetected = result.project;
-    maintenanceWorker?.stop();
-    maintenanceWorker = null;
 
     // Resolve data dir FIRST (was buggy: used before declaration)
     const newProjectDir = await getProjectDataDir(newDetected.id);
@@ -5123,7 +5368,16 @@ export async function createMemorixServer(
     const newCanonicalId = await registerAlias(newDetected);
 
     // Allow switch if: different project OR current project is unresolved (__unresolved__)
-    if (newCanonicalId === project.id && projectResolved) return false; // same project, no-op
+    if (newCanonicalId === project.id && projectResolved) {
+      if (source === 'explicit-project-root') projectBinding.bindExplicit(newDetected.rootPath);
+      else if (source === 'mcp-roots') projectBinding.bindFromRoots(newDetected.rootPath);
+      else projectBinding.bindStartup(newDetected.rootPath);
+      projectBinding.recordResolvedProject(project.id, project.rootPath);
+      return false; // same project, no-op
+    }
+
+    maintenanceWorker?.stop();
+    maintenanceWorker = null;
 
     console.error(`[memorix] Switching project: ${project.id} → ${newCanonicalId}`);
 
@@ -5141,6 +5395,10 @@ export async function createMemorixServer(
     projectResolutionError = null;
     project = { ...newDetected, id: newCanonicalId };
     projectDir = canonicalProjectDir;
+    if (source === 'explicit-project-root') projectBinding.bindExplicit(project.rootPath);
+    else if (source === 'mcp-roots') projectBinding.bindFromRoots(project.rootPath);
+    else projectBinding.bindStartup(project.rootPath);
+    projectBinding.recordResolvedProject(project.id, project.rootPath);
     await registerMaintenanceTarget();
 
     // Update YAML config root and reload .env for the new project
@@ -5197,7 +5455,8 @@ export async function createMemorixServer(
 
   return {
     server, graphManager, projectId: project.id, deferredInit, switchProject,
-    isExplicitlyBound: () => explicitProjectBound,
+    isExplicitlyBound: () => projectBinding.isExplicit(),
+    getRequestContext,
     handleTransportClose,
   };
 }

--- a/src/server/request-context.ts
+++ b/src/server/request-context.ts
@@ -1,0 +1,95 @@
+import path from 'node:path';
+
+/**
+ * These sources describe how Memorix learned a workspace binding. They are
+ * product facts, intentionally separate from any MCP transport session ID.
+ */
+export type ProjectBindingSource = 'startup-cwd' | 'mcp-roots' | 'explicit-project-root';
+
+export interface ProjectBindingSnapshot {
+  projectRoot: string;
+  source: ProjectBindingSource;
+  explicit: boolean;
+  projectId?: string;
+}
+
+export interface MemorixRequestContext extends ProjectBindingSnapshot {
+  actorId?: string;
+}
+
+function resolveRoot(projectRoot: string): string {
+  const value = projectRoot.trim();
+  if (!value) throw new Error('Project binding requires a non-empty project root');
+  return path.resolve(value);
+}
+
+/**
+ * One connection may keep this object today, while a future stateless adapter
+ * can construct it from fixed server configuration. No HTTP session identifier
+ * is accepted or stored here.
+ */
+export class ProjectBindingController {
+  private current: ProjectBindingSnapshot;
+
+  constructor(projectRoot: string) {
+    this.current = {
+      projectRoot: resolveRoot(projectRoot),
+      source: 'startup-cwd',
+      explicit: false,
+    };
+  }
+
+  snapshot(): ProjectBindingSnapshot {
+    return { ...this.current };
+  }
+
+  requestContext(actorId?: string): MemorixRequestContext {
+    return {
+      ...this.snapshot(),
+      ...(actorId ? { actorId } : {}),
+    };
+  }
+
+  isExplicit(): boolean {
+    return this.current.explicit;
+  }
+
+  /** Roots are advisory and may never overwrite an explicit user binding. */
+  bindFromRoots(projectRoot: string): boolean {
+    if (this.current.explicit) return false;
+    this.replace(projectRoot, 'mcp-roots');
+    return true;
+  }
+
+  bindExplicit(projectRoot: string): void {
+    this.replace(projectRoot, 'explicit-project-root');
+  }
+
+  bindStartup(projectRoot: string): void {
+    if (this.current.explicit) return;
+    this.replace(projectRoot, 'startup-cwd');
+  }
+
+  /** Set only after the caller has verified the path maps to a real project. */
+  recordResolvedProject(projectId: string, projectRoot?: string): void {
+    const normalizedProjectId = projectId.trim();
+    if (!normalizedProjectId) throw new Error('Project binding requires a non-empty project ID');
+    this.current = {
+      ...this.current,
+      ...(projectRoot ? { projectRoot: resolveRoot(projectRoot) } : {}),
+      projectId: normalizedProjectId,
+    };
+  }
+
+  private replace(projectRoot: string, source: ProjectBindingSource): void {
+    this.current = {
+      projectRoot: resolveRoot(projectRoot),
+      source,
+      explicit: source === 'explicit-project-root',
+    };
+  }
+}
+
+export function createProjectBindingController(projectRoot: string): ProjectBindingController {
+  return new ProjectBindingController(projectRoot);
+}

--- a/src/server/tool-profile.ts
+++ b/src/server/tool-profile.ts
@@ -8,9 +8,9 @@
  * We provide four profiles:
  *   - "micro" (stdio default): Agent-ready project context + basic memory CRUD — 7 tools.
  *     Suitable for normal MCP clients where every tool schema costs context tokens.
- *   - "lite": Core memory CRUD, sessions, reasoning, retention, backup — 17 tools.
+ *   - "lite": Core memory CRUD, sessions, reasoning, retention, backup — 18 tools.
  *     Suitable for solo users who want the full memory surface without team tools.
- *   - "team" (HTTP default): lite + orchestration coordination tools, dashboard, and Knowledge Workspace — 25 tools.
+ *   - "team" (HTTP default): lite + orchestration coordination tools, dashboard, and Knowledge Workspace — 26 tools.
  *     Suitable when an operator explicitly wants task/message/lock surfaces.
  *   - "full": Everything, including niche / advanced tools (consolidate, dedup,
  *     formation metrics, skills, rules/workspace sync, KG-official, image ingest).
@@ -47,6 +47,7 @@ export const TOOL_PROFILES: Record<string, ReadonlyArray<ToolProfile>> = Object.
   memorix_search_reasoning:   ['lite', 'team', 'full'],
   memorix_transfer:           ['lite', 'team', 'full'],
   memorix_retention:          ['lite', 'team', 'full'],
+  memorix_media:              ['lite', 'team', 'full'],
 
   // ── team: orchestration coordination surfaces — HTTP default ──────
   memorix_dashboard:          ['team', 'full'],
@@ -136,8 +137,8 @@ export function resolveToolProfile(opts: ResolveToolProfileOpts): ToolProfile {
 export function describeProfile(profile: ToolProfile): string {
   switch (profile) {
     case 'micro': return 'micro (agent-ready context + basic memory, ~7 tools)';
-    case 'lite': return 'lite (core memory + sessions, ~17 tools)';
-    case 'team': return 'team (lite + coordination tools + dashboard + knowledge workspace, ~25 tools)';
+    case 'lite': return 'lite (core memory + sessions, ~18 tools)';
+    case 'team': return 'team (lite + coordination tools + dashboard + knowledge workspace, ~26 tools)';
     case 'full': return 'full (all tools including advanced / KG-compat)';
   }
 }

--- a/src/store/orama-store.ts
+++ b/src/store/orama-store.ts
@@ -174,6 +174,7 @@ async function initializeDb(
     facts: 'string' as const,
     filesModified: 'string' as const,
     concepts: 'string' as const,
+    attachments: 'string' as const,
     tokens: 'number' as const,
     createdAt: 'string' as const,
     projectId: 'string' as const,
@@ -611,7 +612,7 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
     includeVectors: quality !== 'fast',
     ...(Object.keys(filters).length > 0 ? { where: filters } : {}),
     // Search specific fields (not tokens, accessCount, etc.)
-    properties: ['title', 'entityName', 'narrative', 'facts', 'concepts', 'filesModified'],
+    properties: ['title', 'entityName', 'narrative', 'facts', 'concepts', 'filesModified', 'attachments'],
     // Field boosting: intent-aware or default
     boost: fieldBoost,
     // Fuzzy tolerance: allow 1-char typos for short queries, 2 for longer

--- a/src/store/orama-store.ts
+++ b/src/store/orama-store.ts
@@ -13,7 +13,13 @@ import type { MemorixDocument, SearchOptions, IndexEntry, KnowledgeLayer, Observ
 import { OBSERVATION_ICONS, type ObservationType } from '../types.js';
 import { resolveKnowledgeLayer } from '../skills/mini-skills.js';
 import { canReadObservation } from '../memory/visibility.js';
-import { getEmbeddingProvider, type EmbeddingProvider } from '../embedding/provider.js';
+import {
+  getEmbeddingProvider,
+  UnsupportedEmbeddingModalityError,
+  type EmbeddingInput,
+  type EmbeddingOptions,
+  type EmbeddingProvider,
+} from '../embedding/provider.js';
 import { calculateProjectAffinity, extractProjectKeywords, type AffinityContext, type MemoryContent } from './project-affinity.js';
 import { detectQueryIntent, applyIntentBoost } from '../search/intent-detector.js';
 import { maybeExpandSearchQuery } from '../search/query-expansion.js';
@@ -261,7 +267,26 @@ export function getVectorDimensions(): number | null {
 export async function generateEmbedding(text: string): Promise<number[] | null> {
   const provider = await getEmbeddingProvider();
   if (!provider) return null;
-  return provider.embed(text);
+  return provider.embedInput
+    ? provider.embedInput({ modality: 'text', text }, { intent: 'document' })
+    : provider.embed(text);
+}
+
+/** Generate a typed embedding; unsupported media returns null so callers retain BM25. */
+export async function generateEmbeddingInput(
+  input: EmbeddingInput,
+  options: EmbeddingOptions = {},
+): Promise<number[] | null> {
+  const provider = await getEmbeddingProvider();
+  if (!provider) return null;
+  try {
+    if (provider.embedInput) return await provider.embedInput(input, options);
+    if (input.modality === 'text') return provider.embed(input.text);
+    return null;
+  } catch (error) {
+    if (error instanceof UnsupportedEmbeddingModalityError) return null;
+    throw error;
+  }
 }
 
 /**
@@ -615,7 +640,15 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
           // Embedding timeout: 15 seconds
           const EMBEDDING_TIMEOUT_MS = 15000;
           queryVector = await withTimeout(
-            provider.embed(expandedEmbeddingQuery!),
+            provider.embedInput
+              ? provider.embedInput(
+                { modality: 'text', text: expandedEmbeddingQuery! },
+                { intent: 'query', timeoutMs: EMBEDDING_TIMEOUT_MS, retry: false },
+              )
+              : provider.embed(expandedEmbeddingQuery!, {
+                timeoutMs: EMBEDDING_TIMEOUT_MS,
+                retry: false,
+              }),
             EMBEDDING_TIMEOUT_MS,
             'Embedding',
           );

--- a/src/store/sqlite-db.ts
+++ b/src/store/sqlite-db.ts
@@ -779,6 +779,12 @@ const SCHEMA_MIGRATIONS: SchemaMigration[] = [
       db.exec('CREATE INDEX IF NOT EXISTS idx_long_term_memory_events_memory ON long_term_memory_events(memoryId, createdAt)');
     },
   },
+  {
+    id: '1.2-observation-attachments',
+    apply: (db) => {
+      try { db.exec('ALTER TABLE observations ADD COLUMN attachments TEXT'); } catch { /* already exists */ }
+    },
+  },
 ];
 
 function applySchemaMigrations(db: any): void {

--- a/src/store/sqlite-db.ts
+++ b/src/store/sqlite-db.ts
@@ -553,6 +553,104 @@ CREATE TABLE IF NOT EXISTS long_term_memory_events (
 );
 `;
 
+// ── 1.3.3 Controlled media assets ─────────────────────────────────
+
+const CREATE_MEDIA_ASSETS_TABLE = `
+CREATE TABLE IF NOT EXISTS media_assets (
+  id               TEXT PRIMARY KEY,
+  project_id       TEXT NOT NULL,
+  sha256           TEXT NOT NULL,
+  kind             TEXT NOT NULL,
+  mime_type        TEXT NOT NULL,
+  byte_size        INTEGER NOT NULL,
+  storage_rel_path TEXT NOT NULL,
+  source_kind      TEXT NOT NULL,
+  source_label     TEXT,
+  provider         TEXT,
+  model            TEXT,
+  created_at       INTEGER NOT NULL,
+  updated_at       INTEGER NOT NULL,
+  deleted_at       INTEGER,
+  UNIQUE(project_id, sha256)
+);
+`;
+
+const CREATE_MEDIA_ASSET_LINKS_TABLE = `
+CREATE TABLE IF NOT EXISTS media_asset_links (
+  id             TEXT PRIMARY KEY,
+  asset_id       TEXT NOT NULL,
+  project_id     TEXT NOT NULL,
+  observation_id INTEGER,
+  role           TEXT NOT NULL,
+  created_at     INTEGER NOT NULL,
+  FOREIGN KEY (asset_id) REFERENCES media_assets(id) ON DELETE CASCADE,
+  FOREIGN KEY (observation_id) REFERENCES observations(id) ON DELETE CASCADE
+);
+`;
+
+const CREATE_MEDIA_DERIVATIONS_TABLE = `
+CREATE TABLE IF NOT EXISTS media_derivations (
+  id          TEXT PRIMARY KEY,
+  asset_id    TEXT NOT NULL,
+  project_id  TEXT NOT NULL,
+  kind        TEXT NOT NULL,
+  profile_key TEXT,
+  content     TEXT NOT NULL DEFAULT '',
+  status      TEXT NOT NULL DEFAULT 'ready',
+  error       TEXT,
+  created_at  INTEGER NOT NULL,
+  updated_at  INTEGER NOT NULL,
+  FOREIGN KEY (asset_id) REFERENCES media_assets(id) ON DELETE CASCADE
+);
+`;
+
+const CREATE_MEDIA_EMBEDDING_PROFILES_TABLE = `
+CREATE TABLE IF NOT EXISTS media_embedding_profiles (
+  profile_key TEXT PRIMARY KEY,
+  provider    TEXT NOT NULL,
+  model       TEXT NOT NULL,
+  dimensions  INTEGER NOT NULL,
+  modality    TEXT NOT NULL,
+  created_at  INTEGER NOT NULL
+);
+`;
+
+const CREATE_MEDIA_EMBEDDINGS_TABLE = `
+CREATE TABLE IF NOT EXISTS media_embeddings (
+  asset_id    TEXT NOT NULL,
+  project_id  TEXT NOT NULL,
+  profile_key TEXT NOT NULL,
+  intent      TEXT NOT NULL,
+  dimensions  INTEGER NOT NULL,
+  vector_json TEXT NOT NULL,
+  created_at  INTEGER NOT NULL,
+  updated_at  INTEGER NOT NULL,
+  PRIMARY KEY (asset_id, profile_key, intent),
+  FOREIGN KEY (asset_id) REFERENCES media_assets(id) ON DELETE CASCADE,
+  FOREIGN KEY (profile_key) REFERENCES media_embedding_profiles(profile_key) ON DELETE CASCADE
+);
+`;
+
+const CREATE_MEDIA_JOBS_TABLE = `
+CREATE TABLE IF NOT EXISTS media_jobs (
+  id                   TEXT PRIMARY KEY,
+  project_id           TEXT NOT NULL,
+  kind                 TEXT NOT NULL,
+  status               TEXT NOT NULL,
+  request_json         TEXT NOT NULL DEFAULT '{}',
+  provider_task_id     TEXT,
+  asset_id             TEXT,
+  last_error           TEXT,
+  attempts             INTEGER NOT NULL DEFAULT 0,
+  attach_on_complete   INTEGER NOT NULL DEFAULT 0,
+  observation_title    TEXT,
+  created_at           INTEGER NOT NULL,
+  updated_at           INTEGER NOT NULL,
+  completed_at         INTEGER,
+  FOREIGN KEY (asset_id) REFERENCES media_assets(id) ON DELETE SET NULL
+);
+`;
+
 // ── Runtime maintenance jobs ───────────────────────────────────────
 
 const CREATE_MAINTENANCE_JOBS_TABLE = `
@@ -660,6 +758,13 @@ CREATE INDEX IF NOT EXISTS idx_long_term_memories_project_state ON long_term_mem
 CREATE INDEX IF NOT EXISTS idx_long_term_memories_scope_portability ON long_term_memories(scope, portability, state, updatedAt DESC);
 CREATE INDEX IF NOT EXISTS idx_long_term_memory_evidence_memory ON long_term_memory_evidence(memoryId, createdAt);
 CREATE INDEX IF NOT EXISTS idx_long_term_memory_events_memory ON long_term_memory_events(memoryId, createdAt);
+CREATE INDEX IF NOT EXISTS idx_media_assets_project_active ON media_assets(project_id, deleted_at, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_media_assets_project_hash ON media_assets(project_id, sha256);
+CREATE INDEX IF NOT EXISTS idx_media_links_asset ON media_asset_links(project_id, asset_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_media_links_observation ON media_asset_links(project_id, observation_id, created_at);
+CREATE INDEX IF NOT EXISTS idx_media_derivations_asset ON media_derivations(project_id, asset_id, kind);
+CREATE INDEX IF NOT EXISTS idx_media_embeddings_profile ON media_embeddings(project_id, profile_key, asset_id);
+CREATE INDEX IF NOT EXISTS idx_media_jobs_project_status ON media_jobs(project_id, status, updated_at DESC);
 CREATE INDEX IF NOT EXISTS idx_maintenance_jobs_ready ON maintenance_jobs(status, run_after);
 CREATE INDEX IF NOT EXISTS idx_maintenance_jobs_project ON maintenance_jobs(project_id, status, run_after);
 CREATE INDEX IF NOT EXISTS idx_maintenance_targets_updated ON maintenance_targets(updated_at);
@@ -783,6 +888,24 @@ const SCHEMA_MIGRATIONS: SchemaMigration[] = [
     id: '1.2-observation-attachments',
     apply: (db) => {
       try { db.exec('ALTER TABLE observations ADD COLUMN attachments TEXT'); } catch { /* already exists */ }
+    },
+  },
+  {
+    id: '1.3.3-media-assets',
+    apply: (db) => {
+      db.exec(CREATE_MEDIA_ASSETS_TABLE);
+      db.exec(CREATE_MEDIA_ASSET_LINKS_TABLE);
+      db.exec(CREATE_MEDIA_DERIVATIONS_TABLE);
+      db.exec(CREATE_MEDIA_EMBEDDING_PROFILES_TABLE);
+      db.exec(CREATE_MEDIA_EMBEDDINGS_TABLE);
+      db.exec(CREATE_MEDIA_JOBS_TABLE);
+      db.exec('CREATE INDEX IF NOT EXISTS idx_media_assets_project_active ON media_assets(project_id, deleted_at, created_at DESC)');
+      db.exec('CREATE INDEX IF NOT EXISTS idx_media_assets_project_hash ON media_assets(project_id, sha256)');
+      db.exec('CREATE INDEX IF NOT EXISTS idx_media_links_asset ON media_asset_links(project_id, asset_id, created_at)');
+      db.exec('CREATE INDEX IF NOT EXISTS idx_media_links_observation ON media_asset_links(project_id, observation_id, created_at)');
+      db.exec('CREATE INDEX IF NOT EXISTS idx_media_derivations_asset ON media_derivations(project_id, asset_id, kind)');
+      db.exec('CREATE INDEX IF NOT EXISTS idx_media_embeddings_profile ON media_embeddings(project_id, profile_key, asset_id)');
+      db.exec('CREATE INDEX IF NOT EXISTS idx_media_jobs_project_status ON media_jobs(project_id, status, updated_at DESC)');
     },
   },
 ];

--- a/src/store/sqlite-store.ts
+++ b/src/store/sqlite-store.ts
@@ -47,6 +47,7 @@ function obsToRow(obs: Observation): Record<string, unknown> {
     commitHash: obs.commitHash ?? null,
     relatedCommits: obs.relatedCommits ? JSON.stringify(obs.relatedCommits) : null,
     relatedEntities: obs.relatedEntities ? JSON.stringify(obs.relatedEntities) : null,
+    attachments: obs.attachments ? JSON.stringify(obs.attachments) : null,
     sourceDetail: obs.sourceDetail ?? null,
     valueCategory: obs.valueCategory ?? null,
     admissionState: obs.admissionState ?? null,
@@ -82,6 +83,7 @@ function rowToObs(row: any): Observation {
     ...(row.commitHash ? { commitHash: row.commitHash } : {}),
     ...(row.relatedCommits ? { relatedCommits: safeJsonParse(row.relatedCommits, []) } : {}),
     ...(row.relatedEntities ? { relatedEntities: safeJsonParse(row.relatedEntities, []) } : {}),
+    ...(row.attachments ? { attachments: safeJsonParse(row.attachments, []) } : {}),
     ...(row.sourceDetail ? { sourceDetail: row.sourceDetail } : {}),
     ...(row.valueCategory ? { valueCategory: row.valueCategory } : {}),
     ...(row.admissionState ? { admissionState: row.admissionState } : {}),
@@ -140,13 +142,13 @@ export class SqliteBackend implements ObservationStore {
         (id, entityName, type, title, narrative, facts, filesModified, concepts, tokens,
          createdAt, updatedAt, projectId, hasCausalLanguage, topicKey, revisionCount,
          sessionId, status, progress, source, commitHash, relatedCommits, relatedEntities,
-         sourceDetail, valueCategory, admissionState, admissionReason, visibility, sharedWithAgentIds,
+         attachments, sourceDetail, valueCategory, admissionState, admissionReason, visibility, sharedWithAgentIds,
          createdByAgentId, writeGeneration)
       VALUES
         (@id, @entityName, @type, @title, @narrative, @facts, @filesModified, @concepts, @tokens,
          @createdAt, @updatedAt, @projectId, @hasCausalLanguage, @topicKey, @revisionCount,
          @sessionId, @status, @progress, @source, @commitHash, @relatedCommits, @relatedEntities,
-         @sourceDetail, @valueCategory, @admissionState, @admissionReason, @visibility, @sharedWithAgentIds,
+         @attachments, @sourceDetail, @valueCategory, @admissionState, @admissionReason, @visibility, @sharedWithAgentIds,
          @createdByAgentId, @writeGeneration)
     `);
     this.stmtUpdate = this.stmtInsert; // INSERT OR REPLACE works for both

--- a/src/types.ts
+++ b/src/types.ts
@@ -349,6 +349,8 @@ export interface MemorixDocument {
   facts: string;
   filesModified: string;
   concepts: string;
+  /** Searchable, display-safe attachment provenance (one entry per line). */
+  attachments?: string;
   tokens: number;
   createdAt: string;
   projectId: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,6 +119,15 @@ export interface ProgressInfo {
   completion?: number;
 }
 
+/** Safe media reference for an observation. Raw inline media is never persisted. */
+export interface ObservationAttachment {
+  modality: 'image' | 'audio' | 'video' | 'document';
+  /** Public HTTPS reference. Local paths, private hosts, and credentials are rejected. */
+  url: string;
+  mimeType?: string;
+  name?: string;
+}
+
 /** A rich observation record attached to an entity */
 export interface Observation {
   id: number;
@@ -155,6 +164,8 @@ export interface Observation {
   relatedCommits?: string[];
   /** Related entity names — explicit cross-references to other memory entities */
   relatedEntities?: string[];
+  /** Safe media references and metadata; never contains inline payloads or credentials. */
+  attachments?: ObservationAttachment[];
   /** Provenance detail: how this observation entered the system */
   sourceDetail?: 'explicit' | 'hook' | 'git-ingest';
   /** Value category from formation pipeline evaluation */

--- a/tests/cli/operator-parity.test.ts
+++ b/tests/cli/operator-parity.test.ts
@@ -13,6 +13,7 @@ import formationCommand from '../../src/cli/commands/formation.js';
 import auditCommand from '../../src/cli/commands/audit.js';
 import transferCommand from '../../src/cli/commands/transfer.js';
 import skillsCommand from '../../src/cli/commands/skills.js';
+import mediaCommand from '../../src/cli/commands/media.js';
 import { CLI_NATIVE_PARITY } from '../../src/cli/capability-map.js';
 import { TOOL_PROFILES } from '../../src/server/tool-profile.js';
 import { closeAllDatabases } from '../../src/store/sqlite-db.js';
@@ -255,6 +256,28 @@ describe('CLI native parity', () => {
     // Visual analysis is optional. A controlled asset and text fallback remain
     // useful when a project's LLM lane has not been configured.
     expect(ingestedImage.analysisWarning).toContain('LLM');
+
+    const mediaList = await runCommand(mediaCommand, {
+      _: ['list'],
+      kind: 'image',
+      json: true,
+    });
+    expect(mediaList.exitCode).toBe(0);
+    const listedAssets = JSON.parse(mediaList.stdout).assets;
+    expect(listedAssets).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: ingestedImage.asset.id, kind: 'image' }),
+    ]));
+
+    const mediaShow = await runCommand(mediaCommand, {
+      _: ['show'],
+      asset: ingestedImage.asset.id,
+      json: true,
+    });
+    expect(mediaShow.exitCode).toBe(0);
+    expect(JSON.parse(mediaShow.stdout)).toMatchObject({
+      asset: { id: ingestedImage.asset.id },
+      links: [expect.any(Object)],
+    });
   }, 30000);
 
   it('generates and shows project skills through the dedicated skills namespace', async () => {

--- a/tests/cli/operator-parity.test.ts
+++ b/tests/cli/operator-parity.test.ts
@@ -248,8 +248,13 @@ describe('CLI native parity', () => {
       path: imagePath,
       json: true,
     });
-    expect(ingestImage.exitCode).toBe(1);
-    expect(JSON.parse(ingestImage.stderr).error).toContain('LLM');
+    expect(ingestImage.exitCode).toBe(0);
+    const ingestedImage = JSON.parse(ingestImage.stdout);
+    expect(ingestedImage.asset.kind).toBe('image');
+    expect(ingestedImage.observation.id).toBeTypeOf('number');
+    // Visual analysis is optional. A controlled asset and text fallback remain
+    // useful when a project's LLM lane has not been configured.
+    expect(ingestedImage.analysisWarning).toContain('LLM');
   }, 30000);
 
   it('generates and shows project skills through the dedicated skills namespace', async () => {

--- a/tests/embedding/multimodal-input.test.ts
+++ b/tests/embedding/multimodal-input.test.ts
@@ -74,6 +74,26 @@ describe('typed embedding inputs', () => {
     ).toThrow(/too large/i);
   });
 
+  it('rejects credential-bearing and private IPv6 media URLs', () => {
+    for (const url of [
+      'https://example.com/a?X-Amz-Signature=secret',
+      'https://example.com/a#token',
+      'https://[::]/a',
+      'https://[fe80::1]/a',
+      'https://[fd00::1]/a',
+      'https://[::ffff:127.0.0.1]/a',
+      'https://[::ffff:10.0.0.1]/a',
+      'https://100.64.0.1/a',
+      'https://198.18.0.1/a',
+      'https://224.0.0.1/a',
+      'https://[ff02::1]/a',
+      'https://[2001:db8::1]/a',
+    ]) {
+      expect(() => validateEmbeddingInput({ modality: 'image', url })).toThrow(EmbeddingInputError);
+    }
+    expect(validateEmbeddingInput({ modality: 'image', url: 'https://[2606:4700:4700::1111]/a' })).toBeTruthy();
+  });
+
   it('reads the cache directory environment at provider creation time', async () => {
     await withEmbeddingEnv({
       MEMORIX_DATA_DIR: '/tmp/memorix-runtime-cache-dir',
@@ -158,32 +178,60 @@ describe('API multimodal mapping', () => {
     });
   });
 
-  it('maps Google retrieval task types and instructions', async () => {
+  it('uses the native Gemini embedContent contract and omits task type for Gemini 2', async () => {
     await withEmbeddingEnv({
       MEMORIX_DATA_DIR: `/tmp/memorix-google-${Date.now()}`,
       MEMORIX_EMBEDDING_API_KEY: 'test-key',
-      MEMORIX_EMBEDDING_BASE_URL: 'https://generativelanguage.googleapis.com/v1beta/openai',
+      MEMORIX_EMBEDDING_BASE_URL: 'https://generativelanguage.googleapis.com/v1beta',
       MEMORIX_EMBEDDING_MODEL: 'gemini-embedding-2-preview',
       MEMORIX_EMBEDDING_DIMENSIONS: '3',
     }, async () => {
       const fetchMock = vi.fn().mockResolvedValue({
         ok: true,
-        json: async () => ({ data: [{ embedding: [1, 2, 3] }] }),
+        json: async () => ({ embedding: { values: [1, 2, 3] } }),
         headers: { get: () => null },
       });
       vi.stubGlobal('fetch', fetchMock);
       const provider = await APIEmbeddingProvider.create();
       await provider!.embedInput(
-        { modality: 'text', text: 'needle' },
-        { intent: 'query', instruction: 'Find code' },
+        { modality: 'image', data: 'aW1hZ2U=', mimeType: 'image/png' },
+        { intent: 'query' },
       );
-      const body = fetchMock.mock.calls
-        .map((call) => JSON.parse(String(call[1].body)))
-        .find((candidate) => candidate.input !== 'dimension probe');
+      const [, options] = fetchMock.mock.calls.at(-1)!;
+      expect(fetchMock.mock.calls.at(-1)![0]).toBe(
+        'https://generativelanguage.googleapis.com/v1beta/models/gemini-embedding-2-preview:embedContent',
+      );
+      expect(options.headers).toMatchObject({ 'x-goog-api-key': 'test-key' });
+      const body = JSON.parse(String(options.body));
       expect(body).toMatchObject({
-        task_type: 'RETRIEVAL_QUERY',
-        instruction: 'Find code',
+        content: { parts: [{ inlineData: { mimeType: 'image/png', data: 'aW1hZ2U=' } }] },
+        outputDimensionality: 3,
       });
+      expect(body).not.toHaveProperty('taskType');
+      expect(body).not.toHaveProperty('task_type');
+    });
+  });
+
+  it('keeps Google OpenAI compatibility routing separate', async () => {
+    await withEmbeddingEnv({
+      MEMORIX_DATA_DIR: `/tmp/memorix-google-openai-${Date.now()}`,
+      MEMORIX_EMBEDDING_API_KEY: 'test-key',
+      MEMORIX_EMBEDDING_BASE_URL: 'https://generativelanguage.googleapis.com/v1beta/openai',
+      MEMORIX_EMBEDDING_MODEL: 'text-embedding-004',
+      MEMORIX_EMBEDDING_DIMENSIONS: '3',
+    }, async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [{ index: 0, embedding: [1, 2, 3] }] }),
+        headers: { get: () => null },
+      });
+      vi.stubGlobal('fetch', fetchMock);
+      const provider = await APIEmbeddingProvider.create();
+      await provider!.embedInput({ modality: 'text', text: 'needle' }, { intent: 'query' });
+      expect(fetchMock.mock.calls.at(-1)![0]).toBe(
+        'https://generativelanguage.googleapis.com/v1beta/openai/embeddings',
+      );
+      expect(fetchMock.mock.calls.at(-1)![1].headers).toMatchObject({ Authorization: 'Bearer test-key' });
     });
   });
 });

--- a/tests/embedding/multimodal-input.test.ts
+++ b/tests/embedding/multimodal-input.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  EmbeddingInputError,
+  UnsupportedEmbeddingModalityError,
+  validateEmbeddingInput,
+  type EmbeddingProvider,
+} from '../../src/embedding/provider.ts';
+import { APIEmbeddingProvider } from '../../src/embedding/api-provider.ts';
+
+function withEmbeddingEnv(env: Record<string, string>, fn: () => Promise<void>): Promise<void> {
+  const previous = new Map<string, string | undefined>();
+  for (const key of Object.keys(env)) {
+    previous.set(key, process.env[key]);
+    process.env[key] = env[key];
+  }
+  return fn().finally(() => {
+    for (const [key, value] of previous) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe('typed embedding inputs', () => {
+  it('preserves string APIs while exposing query/document intent', async () => {
+    const provider: EmbeddingProvider = {
+      name: 'test',
+      dimensions: 2,
+      embed: vi.fn(async () => [1, 2]),
+      embedBatch: vi.fn(async (texts) => texts.map(() => [1, 2])),
+      embedInput: vi.fn(async () => [1, 2]),
+      embedInputs: vi.fn(async (inputs) => inputs.map(() => [1, 2])),
+    };
+
+    await provider.embed('legacy');
+    await provider.embedInput!(
+      { modality: 'text', text: 'query' },
+      { intent: 'query' },
+    );
+    expect(provider.embed).toHaveBeenCalledWith('legacy');
+    expect(provider.embedInput).toHaveBeenCalledWith(
+      { modality: 'text', text: 'query' },
+      { intent: 'query' },
+    );
+  });
+
+  it('rejects unsafe media references and oversized inline payloads', () => {
+    expect(() =>
+      validateEmbeddingInput({ modality: 'image', url: 'file:///etc/passwd' }),
+    ).toThrow(EmbeddingInputError);
+    expect(() =>
+      validateEmbeddingInput({
+        modality: 'document',
+        url: 'http://127.0.0.1/private',
+      }),
+    ).toThrow(/private|scheme/i);
+    expect(() =>
+      validateEmbeddingInput({
+        modality: 'image',
+        url: 'https://user:secret@example.com/a.png',
+      }),
+    ).toThrow(/credentials/i);
+    expect(() =>
+      validateEmbeddingInput({
+        modality: 'audio',
+        data: 'A'.repeat(5 * 1024 * 1024 + 1),
+        mimeType: 'audio/wav',
+      }),
+    ).toThrow(/too large/i);
+  });
+
+  it('reads the cache directory environment at provider creation time', async () => {
+    await withEmbeddingEnv({
+      MEMORIX_DATA_DIR: '/tmp/memorix-runtime-cache-dir',
+      MEMORIX_EMBEDDING_API_KEY: 'test-key',
+      MEMORIX_EMBEDDING_BASE_URL: 'https://api.openai.com/v1',
+      MEMORIX_EMBEDDING_MODEL: 'text-embedding-3-small',
+      MEMORIX_EMBEDDING_DIMENSIONS: '2',
+    }, async () => {
+      const provider = await APIEmbeddingProvider.create({ allowNetworkProbe: false });
+      // Without a dims cache this may return null; creation path must not throw on env resolution.
+      expect(provider === null || provider.dimensions === 2).toBe(true);
+    });
+  });
+
+  it('reports unsupported modality as a typed capability error', async () => {
+    await withEmbeddingEnv({
+      MEMORIX_EMBEDDING_API_KEY: 'test-key',
+      MEMORIX_EMBEDDING_BASE_URL: 'https://api.openai.com/v1',
+      MEMORIX_EMBEDDING_MODEL: 'text-embedding-3-small',
+      MEMORIX_EMBEDDING_DIMENSIONS: '2',
+    }, async () => {
+      // Seed dims metadata path by probing through network-allowed create with mocked fetch
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [{ embedding: [0.1, 0.2] }] }),
+        headers: { get: () => null },
+      });
+      vi.stubGlobal('fetch', fetchMock);
+      const provider = await APIEmbeddingProvider.create();
+      await expect(
+        provider!.embedInput({
+          modality: 'image',
+          url: 'https://example.com/a.png',
+        }),
+      ).rejects.toBeInstanceOf(UnsupportedEmbeddingModalityError);
+    });
+  });
+});
+
+describe('API multimodal mapping', () => {
+  it('maps Jina query/document intent and includes modality in cache identity', async () => {
+    await withEmbeddingEnv({
+      MEMORIX_DATA_DIR: `/tmp/memorix-jina-${Date.now()}`,
+      MEMORIX_EMBEDDING_API_KEY: 'test-key',
+      MEMORIX_EMBEDDING_BASE_URL: 'https://api.jina.ai/v1',
+      MEMORIX_EMBEDDING_MODEL: 'jina-embeddings-v4',
+      MEMORIX_EMBEDDING_DIMENSIONS: '3',
+    }, async () => {
+      const fetchMock = vi.fn().mockImplementation(async (_url, init) => {
+        const body = JSON.parse(String(init.body));
+        const isProbe = body.input === 'dimension probe';
+        return {
+          ok: true,
+          json: async () => ({
+            data: [{ embedding: isProbe || body.task === 'retrieval.query' ? [1, 2, 3] : [3, 2, 1] }],
+          }),
+          headers: { get: () => null },
+        };
+      });
+      vi.stubGlobal('fetch', fetchMock);
+      const provider = await APIEmbeddingProvider.create();
+
+      await provider!.embedInput(
+        { modality: 'image', url: 'https://example.com/a.png' },
+        { intent: 'query' },
+      );
+      await provider!.embedInput(
+        { modality: 'image', url: 'https://example.com/a.png' },
+        { intent: 'document' },
+      );
+
+      const bodies = fetchMock.mock.calls
+        .map((call) => JSON.parse(String(call[1].body)))
+        .filter((body) => body.input !== 'dimension probe');
+      const queryBody = bodies.find((body) => body.task === 'retrieval.query');
+      const documentBody = bodies.find((body) => body.task === 'retrieval.passage');
+      expect(queryBody).toMatchObject({
+        task: 'retrieval.query',
+        input: [{ image: 'https://example.com/a.png' }],
+      });
+      expect(documentBody.task).toBe('retrieval.passage');
+    });
+  });
+
+  it('maps Google retrieval task types and instructions', async () => {
+    await withEmbeddingEnv({
+      MEMORIX_DATA_DIR: `/tmp/memorix-google-${Date.now()}`,
+      MEMORIX_EMBEDDING_API_KEY: 'test-key',
+      MEMORIX_EMBEDDING_BASE_URL: 'https://generativelanguage.googleapis.com/v1beta/openai',
+      MEMORIX_EMBEDDING_MODEL: 'gemini-embedding-2-preview',
+      MEMORIX_EMBEDDING_DIMENSIONS: '3',
+    }, async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ data: [{ embedding: [1, 2, 3] }] }),
+        headers: { get: () => null },
+      });
+      vi.stubGlobal('fetch', fetchMock);
+      const provider = await APIEmbeddingProvider.create();
+      await provider!.embedInput(
+        { modality: 'text', text: 'needle' },
+        { intent: 'query', instruction: 'Find code' },
+      );
+      const body = fetchMock.mock.calls
+        .map((call) => JSON.parse(String(call[1].body)))
+        .find((candidate) => candidate.input !== 'dimension probe');
+      expect(body).toMatchObject({
+        task_type: 'RETRIEVAL_QUERY',
+        instruction: 'Find code',
+      });
+    });
+  });
+});

--- a/tests/integration/media-mcp.test.ts
+++ b/tests/integration/media-mcp.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/embedding/provider.js', () => ({
+  getEmbeddingProvider: async () => null,
+  isVectorSearchAvailable: async () => false,
+  isEmbeddingExplicitlyDisabled: () => true,
+  resetProvider: () => {},
+}));
+
+vi.mock('../../src/llm/provider.js', () => ({
+  initLLM: () => null,
+  isLLMEnabled: () => false,
+  getLLMConfig: () => null,
+}));
+
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { resetDotenv } from '../../src/config/dotenv-loader.js';
+import { createMemorixServer } from '../../src/server.js';
+import { resetDb } from '../../src/store/orama-store.js';
+import { resetObservationStore } from '../../src/store/obs-store.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+
+const PNG_BYTES = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+XWZ0AAAAASUVORK5CYII=',
+  'base64',
+);
+
+function getHandler(server: any, name: string): (args: Record<string, unknown>) => Promise<any> {
+  const handler = server._registeredTools?.[name]?.handler;
+  expect(handler).toBeTypeOf('function');
+  return handler;
+}
+
+function readJson(result: any): any {
+  expect(result?.isError).not.toBe(true);
+  const text = result?.content?.find((part: any) => part?.type === 'text')?.text;
+  expect(typeof text).toBe('string');
+  return JSON.parse(text);
+}
+
+describe('controlled media through MCP', () => {
+  const priorDataDir = process.env.MEMORIX_DATA_DIR;
+  const priorApiKey = process.env.MINIMAX_API_KEY;
+  const priorMcpMediaGeneration = process.env.MEMORIX_MCP_MEDIA_GENERATION;
+  let root = '';
+  let projectRoot = '';
+  let dataDir = '';
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-media-mcp-'));
+    projectRoot = path.join(root, 'project');
+    dataDir = path.join(root, 'data');
+    await fs.mkdir(path.join(projectRoot, '.git'), { recursive: true });
+    await fs.writeFile(path.join(projectRoot, 'diagram.png'), PNG_BYTES);
+    process.env.MEMORIX_DATA_DIR = dataDir;
+    process.env.MINIMAX_API_KEY = 'mcp-test-key';
+    delete process.env.MEMORIX_MCP_MEDIA_GENERATION;
+    resetDotenv();
+    resetObservationStore();
+    await resetDb();
+  });
+
+  afterEach(async () => {
+    if (priorDataDir === undefined) delete process.env.MEMORIX_DATA_DIR;
+    else process.env.MEMORIX_DATA_DIR = priorDataDir;
+    if (priorApiKey === undefined) delete process.env.MINIMAX_API_KEY;
+    else process.env.MINIMAX_API_KEY = priorApiKey;
+    if (priorMcpMediaGeneration === undefined) delete process.env.MEMORIX_MCP_MEDIA_GENERATION;
+    else process.env.MEMORIX_MCP_MEDIA_GENERATION = priorMcpMediaGeneration;
+    resetDotenv();
+    resetObservationStore();
+    await resetDb();
+    closeAllDatabases();
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it('uses the explicit project binding rather than a transport session for media lifecycle actions', async () => {
+    const { server, projectId, getRequestContext } = await createMemorixServer(
+      projectRoot,
+      undefined,
+      undefined,
+      { toolProfile: 'lite' },
+    );
+    expect(getRequestContext()).toMatchObject({ projectId, explicit: false, source: 'startup-cwd' });
+    const sessionStart = getHandler(server as any, 'memorix_session_start');
+    const started = await sessionStart({ projectRoot, agent: 'media-mcp-test' });
+    expect(started.isError).not.toBe(true);
+    expect(getRequestContext()).toMatchObject({
+      projectId,
+      projectRoot,
+      explicit: true,
+      source: 'explicit-project-root',
+    });
+    const media = getHandler(server as any, 'memorix_media');
+
+    const imported = readJson(await media({
+      action: 'import',
+      path: path.join(projectRoot, 'diagram.png'),
+      title: 'Architecture diagram',
+      attach: true,
+    }));
+    expect(imported).toMatchObject({ action: 'import', projectId, asset: { kind: 'image' } });
+    expect(imported.observation).toMatchObject({ projectId, title: 'Architecture diagram' });
+
+    const listed = readJson(await media({ action: 'list', kind: 'image' }));
+    expect(listed.assets).toHaveLength(1);
+
+    const shown = readJson(await media({ action: 'show', assetId: imported.asset.id }));
+    expect(shown.links).toHaveLength(1);
+    expect(shown.links[0]).toMatchObject({ role: 'attachment', observationId: imported.observation.id });
+  });
+
+  it('queues video generation without placing provider credentials in MCP output', async () => {
+    const { server } = await createMemorixServer(projectRoot, undefined, undefined, { toolProfile: 'lite' });
+    const media = getHandler(server as any, 'memorix_media');
+
+    const disabled = await media({
+      action: 'generate-video',
+      prompt: 'A tiny blue cube rotates slowly',
+      model: 'MiniMax-H3',
+    });
+    expect(disabled.isError).toBe(true);
+    expect(disabled.content?.[0]?.text).toContain('MCP media generation is disabled');
+
+    process.env.MEMORIX_MCP_MEDIA_GENERATION = '1';
+
+    const queued = readJson(await media({
+      action: 'generate-video',
+      prompt: 'A tiny blue cube rotates slowly',
+      model: 'MiniMax-H3',
+      ratio: '16:9',
+    }));
+    expect(queued).toMatchObject({
+      action: 'generate-video',
+      mediaJob: { kind: 'minimax-video-generation', status: 'queued' },
+      maintenanceJob: { kind: 'media-video-generation' },
+    });
+    expect(JSON.stringify(queued)).not.toContain('mcp-test-key');
+  });
+
+  it('keeps the legacy image tool on the controlled asset lifecycle', async () => {
+    const { server, projectId } = await createMemorixServer(projectRoot, undefined, undefined, { toolProfile: 'full' });
+    const legacyIngest = getHandler(server as any, 'memorix_ingest_image');
+    const legacyResult = await legacyIngest({
+      base64: PNG_BYTES.toString('base64'),
+      filename: 'legacy-diagram.png',
+    });
+    expect(legacyResult.isError).not.toBe(true);
+    const text = legacyResult.content?.[0]?.text ?? '';
+    expect(text).toContain('Image imported and analyzed');
+    expect(text).toContain('Visual analysis fallback was used.');
+
+    const media = getHandler(server as any, 'memorix_media');
+    const listed = readJson(await media({ action: 'list', kind: 'image' }));
+    expect(listed).toMatchObject({ projectId, assets: [{ sourceLabel: 'legacy-diagram.png' }] });
+    const shown = readJson(await media({ action: 'show', assetId: listed.assets[0].id }));
+    expect(shown.links).toHaveLength(1);
+    expect(shown.derivations).toMatchObject([{ kind: 'description', status: 'ready' }]);
+  });
+
+  it('rejects invalid legacy base64 before it can become a controlled asset', async () => {
+    const { server, projectId } = await createMemorixServer(projectRoot, undefined, undefined, { toolProfile: 'full' });
+    const legacyIngest = getHandler(server as any, 'memorix_ingest_image');
+    const result = await legacyIngest({ base64: 'not base64' });
+    expect(result.isError).toBe(true);
+    expect(result.content?.[0]?.text).toContain('base64 image data is invalid');
+
+    const media = getHandler(server as any, 'memorix_media');
+    const listed = readJson(await media({ action: 'list', kind: 'image' }));
+    expect(listed).toMatchObject({ projectId, assets: [] });
+  });
+
+  it('treats a subdirectory-discovered explicit root as an explicit binding', async () => {
+    const { server, getRequestContext, handleTransportClose } = await createMemorixServer(
+      root,
+      undefined,
+      undefined,
+      {
+        allowUntrackedFallback: false,
+        deferProjectInitUntilBound: true,
+        dashboardMode: 'control-plane',
+        toolProfile: 'lite',
+      },
+    );
+    try {
+      const sessionStart = getHandler(server as any, 'memorix_session_start');
+      const started = await sessionStart({ projectRoot: root, agent: 'nested-workspace-test' });
+      expect(started.isError).not.toBe(true);
+      expect(getRequestContext()).toMatchObject({
+        projectRoot,
+        explicit: true,
+        source: 'explicit-project-root',
+      });
+    } finally {
+      handleTransportClose();
+    }
+  });
+});

--- a/tests/integration/serve-http.test.ts
+++ b/tests/integration/serve-http.test.ts
@@ -32,6 +32,7 @@ let StreamableHTTPClientTransport: any;
 let Client: any;
 let isInitializeRequest: any;
 let createMemorixServer: any;
+let createProjectBindingController: any;
 let initTeamStore: any;
 let CallToolResultSchema: any;
 let ListRootsRequestSchema: any;
@@ -47,7 +48,7 @@ let projectBDir: string;
 const originalHome = process.env.HOME;
 const originalUserProfile = process.env.USERPROFILE;
 const originalHomePath = process.env.HOMEPATH;
-const sessions = new Map<string, { transport: any; server: any; switchProject: any }>();
+const sessions = new Map<string, { transport: any; server: any; switchProject: any; binding: any }>();
 
 async function createFakeGitRepo(root: string, remote?: string) {
   await fs.mkdir(path.join(root, '.git'), { recursive: true });
@@ -143,6 +144,8 @@ beforeAll(async () => {
   ListRootsRequestSchema = typesMod.ListRootsRequestSchema;
   const serverMod = await import('../../src/server.js');
   createMemorixServer = serverMod.createMemorixServer;
+  const bindingMod = await import('../../src/server/request-context.js');
+  createProjectBindingController = bindingMod.createProjectBindingController;
   const teamMod = await import('../../src/team/team-store.js');
   initTeamStore = teamMod.initTeamStore;
 
@@ -186,7 +189,7 @@ beforeAll(async () => {
         if (sessionId && sessions.has(sessionId)) {
           await sessions.get(sessionId)!.transport.handleRequest(req, res, body);
         } else if (!sessionId && isInitializeRequest(body)) {
-          let createdState: { transport: any; server: any; switchProject: any; isExplicitlyBound: any } | null = null;
+          let createdState: { transport: any; server: any; switchProject: any; binding: any } | null = null;
           let handleTransportClose = () => {};
           const transport = new StreamableHTTPServerTransport({
             sessionIdGenerator: () => randomUUID(),
@@ -199,7 +202,8 @@ beforeAll(async () => {
             if (sid) sessions.delete(sid);
             handleTransportClose();
           };
-          const { server, switchProject, isExplicitlyBound, handleTransportClose: onTransportClose } = await createMemorixServer(
+          const binding = createProjectBindingController(testDir);
+          const { server, switchProject, handleTransportClose: onTransportClose } = await createMemorixServer(
             testDir,
             undefined,
             { teamStore: sharedTeamStore },
@@ -207,16 +211,17 @@ beforeAll(async () => {
               allowUntrackedFallback: false,
               deferProjectInitUntilBound: true,
               toolProfile: 'team',
+              projectBinding: binding,
             },
           );
           handleTransportClose = onTransportClose;
-          createdState = { transport, server, switchProject, isExplicitlyBound };
+          createdState = { transport, server, switchProject, binding };
           await server.connect(transport);
 
           const tryRootsSwitch = async () => {
             try {
               // Guard: explicit projectRoot binding prevents roots override
-              if (isExplicitlyBound()) return;
+              if (binding.isExplicit()) return;
               const { roots } = await server.server.listRoots();
               if (!roots || roots.length === 0) return;
               for (const root of roots) {

--- a/tests/integration/tool-profile.test.ts
+++ b/tests/integration/tool-profile.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../src/embedding/provider.js', () => ({
   getEmbeddingProvider: async () => null,
@@ -37,12 +37,33 @@ import { resetSessionStore } from '../../src/store/session-store.js';
 import { closeAllDatabases } from '../../src/store/sqlite-db.js';
 import { CompactionCheckpointStore } from '../../src/store/compaction-checkpoint-store.js';
 
-let testDir: string;
+const originalDataDir = process.env.MEMORIX_DATA_DIR;
+const temporaryProjectDirs: string[] = [];
+let testDataDir = '';
 
 beforeEach(async () => {
-  testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-profile-'));
-  await fs.mkdir(path.join(testDir, '.git'));
+  testDataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-profile-data-'));
+  process.env.MEMORIX_DATA_DIR = testDataDir;
+  resetObservationStore();
+  resetSessionStore();
+  resetTomlConfigCache();
+  resetResolvedConfigCache();
   await resetDb();
+});
+
+afterEach(async () => {
+  closeAllDatabases();
+  resetObservationStore();
+  resetSessionStore();
+  resetTomlConfigCache();
+  resetResolvedConfigCache();
+  await resetDb();
+  if (originalDataDir === undefined) delete process.env.MEMORIX_DATA_DIR;
+  else process.env.MEMORIX_DATA_DIR = originalDataDir;
+  await Promise.all([
+    fs.rm(testDataDir, { recursive: true, force: true }),
+    ...temporaryProjectDirs.splice(0).map((dir) => fs.rm(dir, { recursive: true, force: true })),
+  ]);
 });
 
 function getToolNames(server: any): string[] {
@@ -70,6 +91,7 @@ function extractAgentId(text: string): string {
 
 async function createGitProjectDir(prefix: string): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  temporaryProjectDirs.push(dir);
   await fs.mkdir(path.join(dir, '.git'));
   return dir;
 }

--- a/tests/media/asset-store.test.ts
+++ b/tests/media/asset-store.test.ts
@@ -108,6 +108,32 @@ describe('controlled media asset store', () => {
     });
     expect(removed.detachedLinks).toBe(1);
     expect(store.getAsset(fixture.projectId, linked.asset.id)).toBeUndefined();
+    expect(store.getAsset(fixture.projectId, linked.asset.id, { includeDeleted: true })?.deletedAt).toBeTypeOf('number');
+    expect(store.listLinks(fixture.projectId, linked.asset.id)).toEqual([]);
+  });
+
+  it('restores the file when the metadata transaction fails', async () => {
+    const fixture = await createFixture();
+    const imported = await importMediaBuffer({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      bytes: PNG_BYTES,
+      filename: 'recoverable.png',
+      sourceKind: 'import',
+    });
+    const failure = vi.spyOn(MediaStore.prototype, 'removeAssetMetadata')
+      .mockImplementationOnce(() => { throw new Error('simulated metadata failure'); });
+
+    await expect(removeMediaAsset({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      assetId: imported.asset.id,
+    })).rejects.toThrow('simulated metadata failure');
+    failure.mockRestore();
+
+    const store = new MediaStore(fixture.dataDir);
+    expect(store.getAsset(fixture.projectId, imported.asset.id)).toBeDefined();
+    await expect(readMediaAsset(fixture.dataDir, imported.asset)).resolves.toEqual(PNG_BYTES);
   });
 
   it('rejects unknown media instead of trusting a filename or caller claim', async () => {
@@ -143,6 +169,47 @@ describe('controlled media asset store', () => {
     failure.mockRestore();
 
     await expect(readMediaAsset(fixture.dataDir, first.asset)).resolves.toEqual(PNG_BYTES);
+  });
+
+  it('sanitizes media derivation content and diagnostics before persistence', async () => {
+    const fixture = await createFixture();
+    const imported = await importMediaBuffer({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      bytes: PNG_BYTES,
+      filename: 'secret-safe.png',
+      sourceKind: 'import',
+    });
+    const store = new MediaStore(fixture.dataDir);
+    store.addDerivation({
+      projectId: fixture.projectId,
+      assetId: imported.asset.id,
+      kind: 'description',
+      content: 'Visible api_key=supersecretvalue',
+      status: 'failed',
+      error: 'Bearer abcdefghijklmnopqrstuvwxyz123456',
+    });
+
+    const saved = store.listDerivations(fixture.projectId, imported.asset.id)[0];
+    expect(saved.content).toContain('[REDACTED]');
+    expect(saved.error).toContain('[REDACTED]');
+    expect(JSON.stringify(saved)).not.toContain('supersecretvalue');
+    expect(JSON.stringify(saved)).not.toContain('abcdefghijklmnopqrstuvwxyz123456');
+  });
+
+  it('sanitizes credential-like source labels before they enter asset metadata', async () => {
+    const fixture = await createFixture();
+    const secret = 'sk-abcdefghijklmnopqrstuvwxyz1234';
+    const imported = await importMediaBuffer({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      bytes: PNG_BYTES,
+      filename: `${secret}.png`,
+      sourceKind: 'import',
+    });
+
+    expect(imported.asset.sourceLabel).toContain('[REDACTED]');
+    expect(JSON.stringify(imported.asset)).not.toContain(secret);
   });
 
   it('writes media vectors only for declared modality support and searches compatible profiles', async () => {

--- a/tests/media/asset-store.test.ts
+++ b/tests/media/asset-store.test.ts
@@ -1,0 +1,208 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  cleanupMediaQuota,
+  importMediaBuffer,
+  readMediaAsset,
+  removeMediaAsset,
+} from '../../src/media/asset-store.js';
+import { embedMediaAsset, findSimilarMediaAssets } from '../../src/media/embedding.js';
+import { MediaStore } from '../../src/media/media-store.js';
+import { closeDatabase } from '../../src/store/sqlite-db.js';
+import type { EmbeddingProvider } from '../../src/embedding/provider.js';
+
+const roots: Array<{ root: string; dataDir: string }> = [];
+
+const PNG_BYTES = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+XWZ0AAAAASUVORK5CYII=',
+  'base64',
+);
+
+async function createFixture(): Promise<{ root: string; dataDir: string; projectId: string }> {
+  const root = await mkdtemp(path.join(tmpdir(), 'memorix-media-'));
+  const dataDir = path.join(root, 'data');
+  roots.push({ root, dataDir });
+  return { root, dataDir, projectId: 'test/media-project' };
+}
+
+afterEach(async () => {
+  for (const item of roots.splice(0)) {
+    closeDatabase(item.dataDir);
+    await rm(item.root, { recursive: true, force: true });
+  }
+});
+
+describe('controlled media asset store', () => {
+  it('deduplicates by content hash while retaining a verified local copy', async () => {
+    const fixture = await createFixture();
+
+    const first = await importMediaBuffer({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      bytes: PNG_BYTES,
+      filename: 'diagram.png',
+      sourceKind: 'import',
+    });
+    const second = await importMediaBuffer({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      bytes: PNG_BYTES,
+      filename: 'renamed-diagram.png',
+      sourceKind: 'import',
+    });
+
+    expect(first.deduplicated).toBe(false);
+    expect(second.deduplicated).toBe(true);
+    expect(second.asset.id).toBe(first.asset.id);
+    expect(second.asset.sourceLabel).toBe('renamed-diagram.png');
+    await expect(readMediaAsset(fixture.dataDir, first.asset)).resolves.toEqual(PNG_BYTES);
+  });
+
+  it('never quota-cleans a linked asset and requires force to detach it', async () => {
+    const fixture = await createFixture();
+    const linked = await importMediaBuffer({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      bytes: PNG_BYTES,
+      filename: 'linked.png',
+      sourceKind: 'import',
+    });
+    const unlinked = await importMediaBuffer({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      bytes: Buffer.concat([PNG_BYTES, Buffer.from('different-content')]),
+      filename: 'unlinked.png',
+      sourceKind: 'import',
+    });
+    const store = new MediaStore(fixture.dataDir);
+    store.linkAsset({
+      projectId: fixture.projectId,
+      assetId: linked.asset.id,
+      role: 'source',
+    });
+
+    const cleanup = await cleanupMediaQuota({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      maxBytes: linked.asset.byteSize,
+    });
+    expect(cleanup.removed.map((asset) => asset.id)).toEqual([unlinked.asset.id]);
+    expect(store.getAsset(fixture.projectId, linked.asset.id)).toBeDefined();
+    expect(store.getAsset(fixture.projectId, unlinked.asset.id)).toBeUndefined();
+
+    await expect(removeMediaAsset({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      assetId: linked.asset.id,
+    })).rejects.toThrow(/attached/i);
+
+    const removed = await removeMediaAsset({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      assetId: linked.asset.id,
+      force: true,
+    });
+    expect(removed.detachedLinks).toBe(1);
+    expect(store.getAsset(fixture.projectId, linked.asset.id)).toBeUndefined();
+  });
+
+  it('rejects unknown media instead of trusting a filename or caller claim', async () => {
+    const fixture = await createFixture();
+    await expect(importMediaBuffer({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      bytes: Buffer.from('not a media file'),
+      filename: 'looks-like-an-image.png',
+      sourceKind: 'import',
+    })).rejects.toThrow(/unsupported|unrecognized/i);
+  });
+
+  it('does not delete a pre-existing deduplicated file when database registration fails', async () => {
+    const fixture = await createFixture();
+    const first = await importMediaBuffer({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      bytes: PNG_BYTES,
+      filename: 'durable.png',
+      sourceKind: 'import',
+    });
+    const failure = vi.spyOn(MediaStore.prototype, 'createOrReviveAsset')
+      .mockImplementationOnce(() => { throw new Error('simulated database failure'); });
+
+    await expect(importMediaBuffer({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      bytes: PNG_BYTES,
+      filename: 'same-content.png',
+      sourceKind: 'import',
+    })).rejects.toThrow('simulated database failure');
+    failure.mockRestore();
+
+    await expect(readMediaAsset(fixture.dataDir, first.asset)).resolves.toEqual(PNG_BYTES);
+  });
+
+  it('writes media vectors only for declared modality support and searches compatible profiles', async () => {
+    const fixture = await createFixture();
+    const first = await importMediaBuffer({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      bytes: PNG_BYTES,
+      filename: 'first.png',
+      sourceKind: 'import',
+    });
+    const second = await importMediaBuffer({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      bytes: Buffer.concat([PNG_BYTES, Buffer.from('second')]),
+      filename: 'second.png',
+      sourceKind: 'import',
+    });
+    const visualProvider: EmbeddingProvider = {
+      name: 'test-visual-provider',
+      dimensions: 2,
+      supportedModalities: ['text', 'image'],
+      embed: async () => [1, 0],
+      embedBatch: async (texts) => texts.map(() => [1, 0]),
+      embedInput: async (input) => {
+        if (input.modality !== 'image' || !('data' in input)) throw new Error('unexpected input');
+        return Buffer.from(input.data, 'base64').includes(Buffer.from('second')) ? [0.9, 0.1] : [1, 0];
+      },
+    };
+
+    await expect(embedMediaAsset({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      assetId: first.asset.id,
+    }, { provider: visualProvider })).resolves.toMatchObject({ status: 'embedded' });
+    await expect(embedMediaAsset({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      assetId: second.asset.id,
+    }, { provider: visualProvider })).resolves.toMatchObject({ status: 'embedded' });
+
+    const similar = findSimilarMediaAssets({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      assetId: first.asset.id,
+    });
+    expect(similar).toHaveLength(1);
+    expect(similar[0].asset.id).toBe(second.asset.id);
+
+    const textOnlyProvider: EmbeddingProvider = {
+      name: 'test-text-only-provider',
+      dimensions: 2,
+      supportedModalities: ['text'],
+      embed: async () => [1, 0],
+      embedBatch: async (texts) => texts.map(() => [1, 0]),
+    };
+    await expect(embedMediaAsset({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      assetId: first.asset.id,
+    }, { provider: textOnlyProvider })).resolves.toMatchObject({ status: 'unsupported' });
+  });
+});

--- a/tests/media/minimax.test.ts
+++ b/tests/media/minimax.test.ts
@@ -5,7 +5,11 @@ import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { readMediaAsset } from '../../src/media/asset-store.js';
-import { generateMiniMaxImages } from '../../src/media/minimax.js';
+import {
+  createMiniMaxVideoTask,
+  generateMiniMaxImages,
+  queryMiniMaxVideoTask,
+} from '../../src/media/minimax.js';
 import { closeDatabase } from '../../src/store/sqlite-db.js';
 
 const roots: Array<{ root: string; dataDir: string }> = [];
@@ -71,5 +75,52 @@ describe('MiniMax controlled image generation', () => {
       prompt: 'A small blue square',
       apiKey: '',
     })).rejects.toThrow('MINIMAX_API_KEY is required');
+  });
+
+  it('submits the documented V2 video task shape without retrying the request', async () => {
+    const fetchMock = async (url: string | URL, request?: RequestInit) => {
+      expect(url.toString()).toBe('https://api.example.test/v2/video_generation');
+      expect(request).toMatchObject({ method: 'POST' });
+      expect(new Headers(request?.headers).get('authorization')).toBe('Bearer test-key');
+      expect(JSON.parse(String(request?.body))).toEqual({
+        model: 'MiniMax-H3',
+        content: [{ type: 'text', text: 'A small test video' }],
+        resolution: '2K',
+        duration: 5,
+        ratio: 'adaptive',
+      });
+      return new Response(JSON.stringify({ task_id: 'video-task-1' }), { status: 200 });
+    };
+
+    await expect(createMiniMaxVideoTask({
+      apiKey: 'test-key',
+      baseUrl: 'https://api.example.test',
+      prompt: 'A small test video',
+    }, { fetch: fetchMock as typeof fetch })).resolves.toEqual({ taskId: 'video-task-1', status: 'pending' });
+  });
+
+  it('normalizes a succeeded V2 video task and returns its temporary download URL', async () => {
+    const fetchMock = async (url: string | URL, request?: RequestInit) => {
+      expect(url.toString()).toBe('https://api.example.test/v2/query/video_generation/video-task-1');
+      expect(request).toMatchObject({ method: 'GET' });
+      return new Response(JSON.stringify({
+        task: {
+          id: 'video-task-1',
+          status: 'succeeded',
+          content: { url: 'https://cdn.example.test/result.mp4?temporary=1' },
+        },
+      }), { status: 200 });
+    };
+
+    await expect(queryMiniMaxVideoTask({
+      apiKey: 'test-key',
+      baseUrl: 'https://api.example.test',
+      model: 'MiniMax-H3',
+      taskId: 'video-task-1',
+    }, { fetch: fetchMock as typeof fetch })).resolves.toEqual({
+      taskId: 'video-task-1',
+      status: 'succeeded',
+      downloadUrl: 'https://cdn.example.test/result.mp4?temporary=1',
+    });
   });
 });

--- a/tests/media/minimax.test.ts
+++ b/tests/media/minimax.test.ts
@@ -1,0 +1,75 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { readMediaAsset } from '../../src/media/asset-store.js';
+import { generateMiniMaxImages } from '../../src/media/minimax.js';
+import { closeDatabase } from '../../src/store/sqlite-db.js';
+
+const roots: Array<{ root: string; dataDir: string }> = [];
+const PNG_BYTES = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+XWZ0AAAAASUVORK5CYII=',
+  'base64',
+);
+
+async function createFixture(): Promise<{ root: string; dataDir: string; projectId: string }> {
+  const root = await mkdtemp(path.join(tmpdir(), 'memorix-minimax-'));
+  const dataDir = path.join(root, 'data');
+  roots.push({ root, dataDir });
+  return { root, dataDir, projectId: 'test/minimax-project' };
+}
+
+afterEach(async () => {
+  for (const item of roots.splice(0)) {
+    closeDatabase(item.dataDir);
+    await rm(item.root, { recursive: true, force: true });
+  }
+});
+
+describe('MiniMax controlled image generation', () => {
+  it('imports explicit generated output as a controlled asset without auto-attaching memory', async () => {
+    const fixture = await createFixture();
+    const generate = async (request: any) => {
+      expect(request).toMatchObject({
+        provider: 'minimax',
+        model: 'image-01',
+        apiKey: 'test-key',
+        prompt: 'A small blue square',
+      });
+      return {
+        responseId: 'provider-image-request',
+        output: [{ type: 'image' as const, mimeType: 'image/png', data: PNG_BYTES.toString('base64') }],
+      };
+    };
+
+    const result = await generateMiniMaxImages({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      apiKey: 'test-key',
+      prompt: 'A small blue square',
+    }, { generate });
+
+    expect(result).toMatchObject({ provider: 'minimax', model: 'image-01', responseId: 'provider-image-request' });
+    expect(result.assets).toHaveLength(1);
+    expect(result.assets[0].asset).toMatchObject({
+      kind: 'image',
+      sourceKind: 'minimax-image',
+      sourceLabel: 'minimax-image-01-1',
+      provider: 'minimax',
+      model: 'image-01',
+    });
+    await expect(readMediaAsset(fixture.dataDir, result.assets[0].asset)).resolves.toEqual(PNG_BYTES);
+  });
+
+  it('requires a configured API key before creating a billable request', async () => {
+    const fixture = await createFixture();
+    await expect(generateMiniMaxImages({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      prompt: 'A small blue square',
+      apiKey: '',
+    })).rejects.toThrow('MINIMAX_API_KEY is required');
+  });
+});

--- a/tests/media/remote-download.test.ts
+++ b/tests/media/remote-download.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { downloadProviderMedia } from '../../src/media/remote-download.js';
+
+describe('provider media downloads', () => {
+  it('refuses private literal URLs before a network request', async () => {
+    const fetchMock = vi.fn();
+    await expect(downloadProviderMedia({
+      url: 'https://127.0.0.1/private-video.mp4',
+      maxBytes: 1_024,
+    }, { fetch: fetchMock as typeof fetch })).rejects.toThrow(/private|invalid/i);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('downloads bounded provider bytes only after a public address resolution', async () => {
+    const fetchMock = vi.fn(async () => new Response(Buffer.from('safe bytes'), {
+      status: 200,
+      headers: { 'content-length': '10' },
+    }));
+    const result = await downloadProviderMedia({
+      url: 'https://cdn.example.test/video.mp4?temporary=1',
+      maxBytes: 1_024,
+    }, {
+      fetch: fetchMock as typeof fetch,
+      resolveHost: async () => ['203.0.113.10'],
+    });
+    expect(result.toString()).toBe('safe bytes');
+    expect(fetchMock).toHaveBeenCalledWith(expect.any(URL), expect.objectContaining({ redirect: 'error' }));
+  });
+
+  it('rejects a response whose declared size exceeds the caller limit', async () => {
+    await expect(downloadProviderMedia({
+      url: 'https://cdn.example.test/video.mp4',
+      maxBytes: 10,
+    }, {
+      fetch: (async () => new Response(Buffer.alloc(1), {
+        status: 200,
+        headers: { 'content-length': '11' },
+      })) as typeof fetch,
+      resolveHost: async () => ['203.0.113.10'],
+    })).rejects.toThrow(/exceeds/i);
+  });
+});

--- a/tests/media/video-jobs.test.ts
+++ b/tests/media/video-jobs.test.ts
@@ -121,4 +121,21 @@ describe('MiniMax durable video jobs', () => {
 
     expect(createCalled).toBe(false);
   });
+
+  it('sanitizes request text and the deferred observation title before job persistence', async () => {
+    const fixture = await createFixture();
+    const promptSecret = 'sk-abcdefghijklmnopqrstuvwxyz1234';
+    const titleSecret = 'api_key=supersecretvalue';
+    const queued = queueMiniMaxVideoGeneration({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      prompt: `Render this token ${promptSecret}`,
+      observationTitle: `Generated media ${titleSecret}`,
+    });
+
+    const stored = new MediaStore(fixture.dataDir).getJob(fixture.projectId, queued.mediaJob.id)!;
+    expect(JSON.stringify(stored)).toContain('[REDACTED]');
+    expect(JSON.stringify(stored)).not.toContain(promptSecret);
+    expect(JSON.stringify(stored)).not.toContain('supersecretvalue');
+  });
 });

--- a/tests/media/video-jobs.test.ts
+++ b/tests/media/video-jobs.test.ts
@@ -1,0 +1,124 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { MediaStore } from '../../src/media/media-store.js';
+import {
+  queueMiniMaxVideoGeneration,
+  runMiniMaxVideoGenerationJob,
+} from '../../src/media/video-jobs.js';
+import { closeDatabase } from '../../src/store/sqlite-db.js';
+
+const roots: Array<{ root: string; dataDir: string }> = [];
+const originalApiKey = process.env.MINIMAX_API_KEY;
+const MP4_BYTES = Buffer.from([
+  0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70,
+  0x69, 0x73, 0x6f, 0x6d, 0x00, 0x00, 0x02, 0x00,
+]);
+
+async function createFixture(): Promise<{ root: string; dataDir: string; projectId: string }> {
+  const root = await mkdtemp(path.join(tmpdir(), 'memorix-video-job-'));
+  const dataDir = path.join(root, 'data');
+  roots.push({ root, dataDir });
+  process.env.MINIMAX_API_KEY = 'test-video-key';
+  return { root, dataDir, projectId: 'test/video-job-project' };
+}
+
+afterEach(async () => {
+  if (originalApiKey === undefined) delete process.env.MINIMAX_API_KEY;
+  else process.env.MINIMAX_API_KEY = originalApiKey;
+  for (const item of roots.splice(0)) {
+    closeDatabase(item.dataDir);
+    await rm(item.root, { recursive: true, force: true });
+  }
+});
+
+describe('MiniMax durable video jobs', () => {
+  it('stores only a safe durable request, then imports a completed result into the asset store', async () => {
+    const fixture = await createFixture();
+    const queued = queueMiniMaxVideoGeneration({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      prompt: 'A tiny blue cube rotates',
+      ratio: '16:9',
+    });
+
+    expect(queued.mediaJob).toMatchObject({ status: 'queued', kind: 'minimax-video-generation' });
+    expect(queued.maintenanceJob).toMatchObject({ kind: 'media-video-generation' });
+    expect(queued.maintenanceJob.payload).toEqual({ mediaJobId: queued.mediaJob.id });
+    expect(JSON.stringify(queued.mediaJob)).not.toContain('test-video-key');
+
+    const submitted = await runMiniMaxVideoGenerationJob(
+      queued.maintenanceJob,
+      fixture,
+      { createTask: async () => ({ taskId: 'provider-video-1', status: 'pending' }) },
+    );
+    expect(submitted).toMatchObject({ action: 'reschedule' });
+
+    const afterSubmit = new MediaStore(fixture.dataDir).getJob(fixture.projectId, queued.mediaJob.id)!;
+    expect(afterSubmit).toMatchObject({ status: 'provider-pending', providerTaskId: 'provider-video-1', attempts: 1 });
+
+    const finished = await runMiniMaxVideoGenerationJob(
+      queued.maintenanceJob,
+      fixture,
+      {
+        queryTask: async () => ({
+          taskId: 'provider-video-1',
+          status: 'succeeded',
+          downloadUrl: 'https://cdn.example.test/private-result.mp4?signature=not-persisted',
+        }),
+        download: async () => MP4_BYTES,
+      },
+    );
+    expect(finished).toEqual({ action: 'complete' });
+
+    const completed = new MediaStore(fixture.dataDir).getJob(fixture.projectId, queued.mediaJob.id)!;
+    expect(completed).toMatchObject({ status: 'completed', providerTaskId: 'provider-video-1' });
+    expect(completed.assetId).toBeTruthy();
+    expect(JSON.stringify(completed)).not.toContain('private-result');
+
+    const asset = new MediaStore(fixture.dataDir).getAsset(fixture.projectId, completed.assetId!)!;
+    expect(asset).toMatchObject({ kind: 'video', mimeType: 'video/mp4', sourceKind: 'minimax-video' });
+    expect(asset.sourceLabel).not.toContain('private-result');
+  });
+
+  it('fails a submission exactly once instead of resubmitting a possibly billable request', async () => {
+    const fixture = await createFixture();
+    const queued = queueMiniMaxVideoGeneration({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      prompt: 'A failed submission must not be duplicated',
+    });
+
+    await expect(runMiniMaxVideoGenerationJob(
+      queued.maintenanceJob,
+      fixture,
+      { createTask: async () => { throw new Error('provider submission timeout'); } },
+    )).resolves.toEqual({ action: 'complete' });
+
+    const job = new MediaStore(fixture.dataDir).getJob(fixture.projectId, queued.mediaJob.id)!;
+    expect(job).toMatchObject({ status: 'failed', attempts: 1 });
+    expect(job.providerTaskId).toBeUndefined();
+  });
+
+  it('does not call the provider after an operator cancels the job', async () => {
+    const fixture = await createFixture();
+    const queued = queueMiniMaxVideoGeneration({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      prompt: 'Do not submit after cancellation',
+    });
+    new MediaStore(fixture.dataDir).cancelJob(fixture.projectId, queued.mediaJob.id);
+    let createCalled = false;
+
+    await expect(runMiniMaxVideoGenerationJob(
+      queued.maintenanceJob,
+      fixture,
+      { createTask: async () => { createCalled = true; return { taskId: 'unexpected', status: 'pending' }; } },
+    )).resolves.toEqual({ action: 'complete' });
+
+    expect(createCalled).toBe(false);
+  });
+});

--- a/tests/multimodal/image-loader.test.ts
+++ b/tests/multimodal/image-loader.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, afterEach, beforeEach } from 'vitest';
 import { analyzeImage } from '../../src/multimodal/image-loader.js';
+import {
+  decodeBase64ImagePayload,
+  MAX_VISION_IMAGE_BYTES,
+} from '../../src/multimodal/image-payload.js';
 import { resetConfigCache } from '../../src/config.js';
 import { setLLMConfig } from '../../src/llm/provider.js';
 
@@ -146,5 +150,45 @@ describe('image-loader', () => {
     await expect(
       analyzeImage({ base64: 'dGVzdA==' }),
     ).rejects.toThrow('Vision LLM error (404)');
+  });
+
+  it('rejects non-canonical and oversized base64 before a vision request', async () => {
+    expect(() => decodeBase64ImagePayload('not base64')).toThrow('invalid');
+    expect(() => decodeBase64ImagePayload('AAAA', 1)).toThrow('exceeds');
+    expect(MAX_VISION_IMAGE_BYTES).toBe(20 * 1024 * 1024);
+
+    process.env.OPENAI_API_KEY = 'test-key';
+    setLLMConfig({ provider: 'openai', apiKey: 'test-key', model: 'gpt-4o', baseUrl: 'https://api.openai.com/v1' });
+    let called = false;
+    globalThis.fetch = (async () => {
+      called = true;
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+
+    await expect(analyzeImage({ base64: 'not base64' })).rejects.toThrow('invalid');
+    expect(called).toBe(false);
+  });
+
+  it('sanitizes provider descriptions, labels, and diagnostics before returning them', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    setLLMConfig({ provider: 'openai', apiKey: 'test-key', model: 'gpt-4o', baseUrl: 'https://api.openai.com/v1' });
+    globalThis.fetch = (async () => {
+      return new Response(JSON.stringify({
+        choices: [{
+          message: {
+            content: JSON.stringify({
+              description: 'Screenshot shows api_key=supersecretvalue',
+              tags: ['api_key=supersecretvalue', 'diagram'],
+              entities: ['sk-abcdefghijklmnopqrstuvwxyz123456'],
+            }),
+          },
+        }],
+      }), { status: 200 });
+    }) as typeof fetch;
+
+    const result = await analyzeImage({ base64: 'dGVzdA==' });
+    expect(JSON.stringify(result)).toContain('[REDACTED]');
+    expect(JSON.stringify(result)).not.toContain('supersecretvalue');
+    expect(JSON.stringify(result)).not.toContain('abcdefghijklmnopqrstuvwxyz123456');
   });
 });

--- a/tests/runtime/media-video-runner.test.ts
+++ b/tests/runtime/media-video-runner.test.ts
@@ -1,0 +1,27 @@
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { parseMediaVideoRunnerRequest } from '../../src/runtime/media-video-runner.js';
+
+describe('media video runner request', () => {
+  it('accepts a fully bound local project request', () => {
+    const request = parseMediaVideoRunnerRequest(JSON.stringify({
+      projectId: 'test/project',
+      projectRoot: path.resolve('project'),
+      dataDir: path.resolve('data'),
+      mediaJobId: 'job-1',
+    }));
+    expect(request).toMatchObject({ projectId: 'test/project', mediaJobId: 'job-1' });
+  });
+
+  it('rejects relative paths and malformed payloads', () => {
+    expect(() => parseMediaVideoRunnerRequest('{}')).toThrow('invalid request');
+    expect(() => parseMediaVideoRunnerRequest(JSON.stringify({
+      projectId: 'test/project',
+      projectRoot: 'relative-project',
+      dataDir: 'relative-data',
+      mediaJobId: 'job-1',
+    }))).toThrow('invalid request');
+  });
+});

--- a/tests/server/request-context.test.ts
+++ b/tests/server/request-context.test.ts
@@ -1,0 +1,34 @@
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { createProjectBindingController } from '../../src/server/request-context.js';
+
+describe('ProjectBindingController', () => {
+  it('keeps MCP transport identity out of the product binding', () => {
+    const binding = createProjectBindingController(path.resolve('startup'));
+    binding.recordResolvedProject('owner/startup', path.resolve('startup-project'));
+
+    expect(binding.requestContext('agent-1')).toEqual({
+      projectRoot: path.resolve('startup-project'),
+      source: 'startup-cwd',
+      explicit: false,
+      projectId: 'owner/startup',
+      actorId: 'agent-1',
+    });
+  });
+
+  it('allows Roots discovery until an explicit project root wins', () => {
+    const binding = createProjectBindingController(path.resolve('startup'));
+    expect(binding.bindFromRoots(path.resolve('roots-project'))).toBe(true);
+    expect(binding.snapshot()).toMatchObject({ source: 'mcp-roots', explicit: false });
+
+    binding.bindExplicit(path.resolve('explicit-project'));
+    expect(binding.bindFromRoots(path.resolve('later-roots-project'))).toBe(false);
+    expect(binding.snapshot()).toMatchObject({
+      projectRoot: path.resolve('explicit-project'),
+      source: 'explicit-project-root',
+      explicit: true,
+    });
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -19,6 +19,9 @@ export default defineConfig([
       // Short-lived CLI writes hand remote embedding work to this detached
       // worker so a slow provider never holds the user's terminal open.
       'vector-backfill-runner': 'src/runtime/vector-backfill-runner.ts',
+      // Durable MiniMax video generation is polled outside the CLI process.
+      // This runner intentionally has no detached Windows console.
+      'media-video-runner': 'src/runtime/media-video-runner.ts',
     },
     format: ['esm'],
     target: 'node20',


### PR DESCRIPTION
## Summary
- adds a controlled, content-addressed local media lifecycle for explicit images, audio, video, and PDFs
- adds explicit MiniMax image generation and durable MiniMax-H3 video jobs
- completes typed multimodal embedding capability boundaries with truthful text fallback
- adds one agent-facing MCP media operation while keeping destructive and billing-sensitive work CLI-first
- isolates product project binding from legacy HTTP session routing

## Safety and release work
- MCP generation is opt-in via `MEMORIX_MCP_MEDIA_GENERATION=1`
- visual input is canonicalized and capped before decoding; durable derived content and media task data are credential-sanitized
- media removal restores the staged file when its metadata transaction fails
- plugin manifests, npm metadata, and MCP registry metadata align at 1.3.3

## Verification
- focused media, MCP binding, tool-profile, operator-parity, plugin metadata, lint, build, and registry checks pass
- fresh packed-package installation smoke passed: import -> attach -> list -> show -> remove
- full suite was run; its only failures were stale plugin manifest versions, fixed here and covered by focused metadata tests

## Attribution
Preserves existing contributor commits from Ravi Tharuma (#134) and octo-patch (#165) without squash or attribution removal.