### PR TITLE
fix: harden 1.3.4 MCP and media UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.4] - 2026-08-02
+
+### Fixed
+- **Fail-closed project binding** -- Stdio and HTTP MCP servers no longer restore or keep writing a remembered project root. A launch without a reliable workspace now waits for an explicit root, MCP Roots, or `memorix_session_start`, preventing cross-project memory access.
+- **Portable MCP Roots** -- File URI roots now remain POSIX paths on Linux/macOS and convert correctly on Windows, including drive-letter paths and UNC roots.
+- **Atomic media attachments** -- A media retrieval observation and its asset link now commit in one SQLite transaction. If linking fails, no dangling observation survives. Completed video downloads also persist their local asset before a retryable attachment step.
+- **Authoritative video cancellation** -- A cancellation that lands while a video worker is downloading or finishing can no longer be overwritten back to `completed`; MCP can cancel an existing job even when new MCP media generation is disabled.
+- **Recoverable media cleanup** -- Files Windows cannot immediately release are visibly staged for retry, and media cleanup reports reclaimed or still-pending staged bytes instead of silently implying deletion succeeded.
+- **Non-destructive Codex migration** -- Legacy Codex hook cleanup now preserves customized hook files instead of deleting a file merely because its commands begin with `memorix hook`.
+- **One stdio runtime** -- Direct `node dist/index.js` invocation now delegates to `memorix serve`; importing the package no longer starts an MCP server as a side effect.
+
+### Changed
+- **Bounded default MCP surface** -- The `micro` profile exposes nine tools: agent-ready context, retrieval, one explicit session recovery path, and one controlled media operation. Advanced tools remain opt-in through higher profiles.
+
 ## [1.3.3] - 2026-08-02
 
 ### Added

--- a/docs/AGENT_OPERATOR_PLAYBOOK.md
+++ b/docs/AGENT_OPERATOR_PLAYBOOK.md
@@ -404,10 +404,11 @@ At startup, `serve-http` seeds its default project root from:
 
 1. `--cwd`
 2. `MEMORIX_PROJECT_ROOT`
-3. `~/.memorix/last-project-root`
-4. `process.cwd()`
+3. `process.cwd()`
 
-That startup root is useful for dashboard and server boot, but it does not replace explicit session binding.
+Memorix deliberately does not restore a previously remembered project root: a
+server launched from an unrelated directory must wait for an explicit project
+root or MCP/session binding rather than risk cross-project memory access.
 
 ### Step 4. Bind each HTTP session explicitly
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memorix",
   "mcpName": "io.github.AVIDS2/memorix",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AVIDS2/memorix",
     "source": "github"
   },
-  "version": "1.3.3",
+  "version": "1.3.4",
   "websiteUrl": "https://github.com/AVIDS2/memorix#readme",
   "icons": [
     {
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "memorix",
-      "version": "1.3.3",
+      "version": "1.3.4",
       "runtimeHint": "npx",
       "packageArguments": [
         {

--- a/src/cli/commands/media.ts
+++ b/src/cli/commands/media.ts
@@ -359,7 +359,13 @@ export default defineCommand({
             assetId,
             force: args.force === true,
           });
-          emitResult({ project, ...result }, `Removed media asset ${assetId}`, asJson);
+          emitResult(
+            { project, ...result },
+            result.pendingDelete
+              ? `Removed media asset ${assetId}; its staged file is pending cleanup because another process still holds it.`
+              : `Removed media asset ${assetId}`,
+            asJson,
+          );
           return;
         }
         case 'embed': {
@@ -404,7 +410,9 @@ export default defineCommand({
           });
           emitResult(
             { project, ...result },
-            `Media cleanup: ${result.removed.length} asset(s), ${result.beforeBytes} -> ${result.afterBytes} bytes`,
+            `Media cleanup: ${result.removed.length} asset(s), ${result.beforeBytes} -> ${result.afterBytes} active bytes` +
+              `${result.reclaimedTrashBytes > 0 ? `; reclaimed ${result.reclaimedTrashBytes} staged bytes` : ''}` +
+              `${result.pendingTrashFiles > 0 ? `; ${result.pendingTrashFiles} staged file(s) (${result.pendingTrashBytes} bytes) still pending` : ''}`,
             asJson,
           );
           return;

--- a/src/cli/commands/serve-http.ts
+++ b/src/cli/commands/serve-http.ts
@@ -27,6 +27,7 @@ import { scopeKnowledgeGraphToProject } from '../../memory/graph-scope.js';
 import { projectObservationRetention, summarizeRetentionProjections } from '../../memory/retention.js';
 import { canManageObservation, filterReadableObservations } from '../../memory/visibility.js';
 import { parseTcpPortOrReport } from '../port.js';
+import { mcpFileUriToPath } from '../mcp-root-path.js';
 
 export const DEFAULT_SESSION_TIMEOUT_MS = 30 * 60 * 1000;
 
@@ -76,10 +77,9 @@ export default defineCommand({
     );
     const { createMemorixServer } = await import('../../server.js');
     const { createProjectBindingController } = await import('../../server/request-context.js');
-    const { findGitInSubdirs, detectProjectWithDiagnostics } = await import('../../project/detector.js');
-    const { existsSync, readFileSync, writeFileSync, mkdirSync } = await import('node:fs');
+    const { findGitInSubdirs } = await import('../../project/detector.js');
+    const { writeFileSync, mkdirSync } = await import('node:fs');
     const { homedir } = await import('node:os');
-    const earlyPath = await import('node:path');
 
     const port = parseTcpPortOrReport(args.port, 3211);
     if (port === undefined) {
@@ -89,26 +89,11 @@ export default defineCommand({
     const host = args.host || '127.0.0.1';
     const toolProfile = resolveToolProfile({ explicit: args.mode, envValue: process.env.MEMORIX_MODE, fallback: 'team' });
 
-    // Priority: explicit --cwd arg > MEMORIX_PROJECT_ROOT env > last-project-root fallback > process.cwd()
+    // Priority: explicit --cwd arg > MEMORIX_PROJECT_ROOT env > process.cwd().
+    // Do not silently bind a control plane to another project's remembered root.
     let safeCwd: string;
     try { safeCwd = process.cwd(); } catch { safeCwd = homedir(); }
     let projectRoot = args.cwd || process.env.MEMORIX_PROJECT_ROOT || safeCwd;
-
-    // Fallback: if projectRoot has no git, try last-project-root
-    const lastRootFile = earlyPath.join(homedir(), '.memorix', 'last-project-root');
-    const initialCheck = detectProjectWithDiagnostics(projectRoot);
-    if (!initialCheck.project && existsSync(lastRootFile)) {
-      try {
-        const lastRoot = readFileSync(lastRootFile, 'utf-8').trim();
-        if (lastRoot && existsSync(lastRoot)) {
-          const lastCheck = detectProjectWithDiagnostics(lastRoot);
-          if (lastCheck.project) {
-            console.error(`[memorix] No git at "${projectRoot}", restored last known project: ${lastRoot}`);
-            projectRoot = lastRoot;
-          }
-        }
-      } catch { /* ignore */ }
-    }
 
     console.error(`[memorix] HTTP transport starting on ${host}:${port}`);
     console.error(`[memorix] Project root: ${projectRoot}`);
@@ -398,17 +383,6 @@ export default defineCommand({
         createdState = { transport, server, switchProject, binding };
         await server.connect(transport);
 
-        const persistRoot = async (rootPath: string) => {
-          try {
-            const { writeFileSync, mkdirSync } = await import('node:fs');
-            const pathMod = await import('node:path');
-            const { homedir } = await import('node:os');
-            const memorixDir = pathMod.join(homedir(), '.memorix');
-            mkdirSync(memorixDir, { recursive: true });
-            writeFileSync(pathMod.join(memorixDir, 'last-project-root'), rootPath, 'utf-8');
-          } catch { /* non-critical */ }
-        };
-
         const tryRootsSwitch = async () => {
           try {
             // If session was explicitly bound via projectRoot in memorix_session_start,
@@ -422,16 +396,12 @@ export default defineCommand({
 
             for (const root of roots) {
               if (!root.uri.startsWith('file://')) continue;
-              let rootPath = decodeURIComponent(root.uri.replace('file://', ''));
-              // Cross-platform: strip leading slash on Windows drive paths
-              if (/^\/[A-Za-z]:/.test(rootPath)) rootPath = rootPath.slice(1);
-              // Normalize to OS-native separators
-              rootPath = earlyPath.normalize(rootPath);
+              const rootPath = mcpFileUriToPath(root.uri);
+              if (!rootPath) continue;
 
               const switched = await switchProject(rootPath);
               if (switched) {
                 console.error(`[memorix] Session ${transport.sessionId?.slice(0, 8) ?? 'pending'} roots switched to: ${rootPath}`);
-                await persistRoot(rootPath);
                 return;
               }
 
@@ -440,7 +410,6 @@ export default defineCommand({
                 const subSwitched = await switchProject(subGit);
                 if (subSwitched) {
                   console.error(`[memorix] Session ${transport.sessionId?.slice(0, 8) ?? 'pending'} roots switched via subdir: ${subGit}`);
-                  await persistRoot(subGit);
                   return;
                 }
               }

--- a/src/cli/commands/serve-shared.ts
+++ b/src/cli/commands/serve-shared.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import type { ProjectInfo } from '../../types.js';
 
 export interface ResolveServeProjectOptions {
@@ -6,7 +8,6 @@ export interface ResolveServeProjectOptions {
   initCwd?: string;
   processCwd: string;
   homeDir: string;
-  lastKnownProjectRoot?: string;
 }
 
 export interface ResolveServeProjectDeps {
@@ -18,7 +19,7 @@ export interface ResolveServeProjectDeps {
 export interface ServeProjectResolution {
   projectRoot: string;
   detectedProject: ProjectInfo | null;
-  source: 'direct' | 'subdir' | 'last-known' | 'home' | 'home-subdir' | 'unresolved';
+  source: 'direct' | 'subdir' | 'unresolved';
   messages: string[];
   error?: string;
 }
@@ -45,6 +46,21 @@ export function resolveServeProject(
     };
   }
 
+  const hasExplicitRoot = Boolean(options.cwdArg || options.envProjectRoot || options.initCwd);
+  const startsAtHome = path.resolve(projectRoot) === path.resolve(options.homeDir);
+  if (deps.isSystemDirectory(projectRoot) || (!hasExplicitRoot && startsAtHome)) {
+    messages.push(`[memorix] Unreliable launch directory detected: ${projectRoot}`);
+    messages.push('[memorix] Memorix will wait for MCP Roots or an explicit memorix_session_start projectRoot.');
+    messages.push('[memorix] It will not restore a previous project automatically, to prevent cross-project memory access.');
+    return {
+      projectRoot,
+      detectedProject: null,
+      source: 'unresolved',
+      messages,
+      error: 'No reliable git project was provided by the launcher.',
+    };
+  }
+
   const subGit = deps.findGitInSubdirs(projectRoot);
   if (subGit) {
     projectRoot = subGit;
@@ -57,50 +73,6 @@ export function resolveServeProject(
         source: 'subdir',
         messages,
       };
-    }
-  }
-
-  if (deps.isSystemDirectory(projectRoot)) {
-    messages.push(`[memorix] System directory detected: ${projectRoot}`);
-    messages.push('[memorix] Your IDE launched memorix from a non-workspace directory.');
-    messages.push('[memorix] Fix: add --cwd to your MCP config, or use an IDE/client that exposes workspace roots.');
-
-    if (options.lastKnownProjectRoot) {
-      detected = deps.detectProject(options.lastKnownProjectRoot);
-      if (detected) {
-        messages.push(`[memorix] Restored last known project: ${options.lastKnownProjectRoot}`);
-        return {
-          projectRoot: options.lastKnownProjectRoot,
-          detectedProject: detected,
-          source: 'last-known',
-          messages,
-        };
-      }
-    }
-
-    detected = deps.detectProject(options.homeDir);
-    if (detected) {
-      messages.push(`[memorix] Restored project from home directory: ${options.homeDir}`);
-      return {
-        projectRoot: options.homeDir,
-        detectedProject: detected,
-        source: 'home',
-        messages,
-      };
-    }
-
-    const homeSubGit = deps.findGitInSubdirs(options.homeDir);
-    if (homeSubGit) {
-      detected = deps.detectProject(homeSubGit);
-      if (detected) {
-        messages.push(`[memorix] Found .git in home subdirectory: ${homeSubGit}`);
-        return {
-          projectRoot: homeSubGit,
-          detectedProject: detected,
-          source: 'home-subdir',
-          messages,
-        };
-      }
     }
   }
 

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -4,6 +4,7 @@
 
 import { defineCommand } from 'citty';
 import { resolveToolProfile } from '../../server/tool-profile.js';
+import { mcpFileUriToPath } from '../mcp-root-path.js';
 
 export default defineCommand({
   meta: {
@@ -45,18 +46,6 @@ export default defineCommand({
     // Priority: explicit --cwd arg > MEMORIX_PROJECT_ROOT env > INIT_CWD (npm lifecycle) > process.cwd()
     let safeCwd: string;
     try { safeCwd = process.cwd(); } catch { safeCwd = homedir(); }
-    const { existsSync, readFileSync } = await import('node:fs');
-    const path = await import('node:path');
-    const lastRootFile = path.join(homedir(), '.memorix', 'last-project-root');
-    let lastKnownProjectRoot: string | undefined;
-    if (existsSync(lastRootFile)) {
-      try {
-        const lastRoot = readFileSync(lastRootFile, 'utf-8').trim();
-        if (lastRoot && existsSync(lastRoot)) {
-          lastKnownProjectRoot = lastRoot;
-        }
-      } catch { /* ignore read errors */ }
-    }
 
     const resolution = resolveServeProject(
       {
@@ -65,7 +54,6 @@ export default defineCommand({
         initCwd: process.env.INIT_CWD,
         processCwd: safeCwd,
         homeDir: homedir(),
-        lastKnownProjectRoot,
       },
       { detectProject, findGitInSubdirs, isSystemDirectory },
     );
@@ -83,16 +71,6 @@ export default defineCommand({
 
     const detected = resolution.detectedProject;
     const projectRoot = resolution.projectRoot;
-
-    // Persist successful project root for future system-directory fallback
-    if (detected) {
-      try {
-        const { writeFileSync, mkdirSync } = await import('node:fs');
-        const memorixDir = path.join(homedir(), '.memorix');
-        mkdirSync(memorixDir, { recursive: true });
-        writeFileSync(path.join(memorixDir, 'last-project-root'), detected.rootPath, 'utf-8');
-      } catch { /* non-critical */ }
-    }
 
     // Always register ALL tools BEFORE connecting transport.
     // This ensures tools/list returns the full tool set immediately on connect.
@@ -113,16 +91,6 @@ export default defineCommand({
     // After connect, request workspace roots from the client (IDE).
     // This is the proper way to discover the user's workspace —
     // no --cwd needed if the IDE supports roots capability.
-    const persistRoot = async (rootPath: string) => {
-      try {
-        const { writeFileSync, mkdirSync } = await import('node:fs');
-        const pathMod = await import('node:path');
-        const memorixDir = pathMod.join(homedir(), '.memorix');
-        mkdirSync(memorixDir, { recursive: true });
-        writeFileSync(pathMod.join(memorixDir, 'last-project-root'), rootPath, 'utf-8');
-      } catch { /* non-critical */ }
-    };
-
     const tryRootsSwitch = async () => {
       try {
         const { roots } = await server.server.listRoots();
@@ -130,18 +98,14 @@ export default defineCommand({
 
         for (const root of roots) {
           if (!root.uri.startsWith('file://')) continue;
-          // Convert file:// URI to filesystem path
-          let rootPath = decodeURIComponent(root.uri.replace('file://', ''));
-          // Windows: file:///E:/... → E:/...
-          if (/^\/[A-Za-z]:/.test(rootPath)) rootPath = rootPath.slice(1);
-          rootPath = rootPath.replace(/\//g, '\\'); // normalize to Windows backslashes
+          const rootPath = mcpFileUriToPath(root.uri);
+          if (!rootPath) continue;
 
           const rootDetected = detectProject(rootPath);
           if (rootDetected) {
             const switched = await switchProject(rootPath);
             if (switched) {
               console.error(`[memorix] [UPDATED] Project updated via MCP roots: ${rootDetected.id}`);
-              await persistRoot(rootDetected.rootPath);
             }
             return; // use first valid root
           }
@@ -151,8 +115,6 @@ export default defineCommand({
             const switched = await switchProject(subGit);
             if (switched) {
               console.error(`[memorix] [UPDATED] Project updated via MCP roots (subdir): ${subGit}`);
-              const subDetected = detectProject(subGit);
-              if (subDetected) await persistRoot(subDetected.rootPath);
             }
             return;
           }

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -560,30 +560,33 @@ export async function removeLegacyCodexMemorixMcpConfig(
   return { configPath, removed: true };
 }
 
-function collectHookCommands(value: unknown, commands: string[]): void {
-  if (Array.isArray(value)) {
-    for (const item of value) collectHookCommands(item, commands);
-    return;
-  }
-  if (!value || typeof value !== 'object') return;
-
-  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
-    if ((key === 'command' || key === 'commandWindows') && typeof child === 'string') {
-      commands.push(child);
-    } else {
-      collectHookCommands(child, commands);
-    }
-  }
-}
-
 function isOwnedLegacyCodexHooks(content: string): boolean {
   try {
     const parsed = JSON.parse(content) as { hooks?: unknown };
-    if (!parsed.hooks || typeof parsed.hooks !== 'object') return false;
-    const commands: string[] = [];
-    collectHookCommands(parsed.hooks, commands);
-    return commands.length > 0
-      && commands.every((command) => /^memorix(?:\.cmd)?\s+hook(?:\s|$)/i.test(command.trim()));
+    if (!parsed.hooks || typeof parsed.hooks !== 'object' || Array.isArray(parsed.hooks)) return false;
+    // There was no ownership marker in the old project-local file. Treat any
+    // timeout, matcher, extra field, or extra top-level metadata as user-owned
+    // rather than guessing from a command prefix and deleting their config.
+    if (Object.keys(parsed).some((key) => key !== 'hooks')) return false;
+    const hooks = parsed.hooks as Record<string, unknown>;
+    const allowedEntryKeys = new Set(['type', 'command', 'commandWindows']);
+    let entryCount = 0;
+    for (const entries of Object.values(hooks)) {
+      if (!Array.isArray(entries) || entries.length === 0) return false;
+      for (const entry of entries) {
+        if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return false;
+        const record = entry as Record<string, unknown>;
+        if (Object.keys(record).some((key) => !allowedEntryKeys.has(key))) return false;
+        if (record.type !== 'command') return false;
+        const commands = [record.command, record.commandWindows]
+          .filter((command): command is string => typeof command === 'string');
+        if (commands.length === 0 || !commands.every((command) => /^memorix(?:\.cmd)?\s+hook(?:\s|$)/i.test(command.trim()))) {
+          return false;
+        }
+        entryCount += 1;
+      }
+    }
+    return entryCount > 0;
   } catch {
     return false;
   }

--- a/src/cli/mcp-root-path.ts
+++ b/src/cli/mcp-root-path.ts
@@ -1,0 +1,36 @@
+import path from 'node:path';
+
+/**
+ * Convert an MCP file URI to a path for the host platform. MCP Roots always
+ * use file URIs; replacing slashes unconditionally corrupts POSIX roots.
+ */
+export function mcpFileUriToPath(uri: string, platform: NodeJS.Platform = process.platform): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== 'file:') return null;
+
+  let pathname: string;
+  try {
+    pathname = decodeURIComponent(parsed.pathname);
+  } catch {
+    return null;
+  }
+
+  const hostname = parsed.hostname;
+  if (platform === 'win32') {
+    if (hostname && hostname !== 'localhost') {
+      return path.win32.normalize(`\\\\${hostname}${pathname.replace(/\//g, '\\')}`);
+    }
+    if (/^\/[A-Za-z]:/.test(pathname)) pathname = pathname.slice(1);
+    return path.win32.normalize(pathname.replace(/\//g, '\\'));
+  }
+
+  if (hostname && hostname !== 'localhost') {
+    return path.posix.normalize(`//${hostname}${pathname}`);
+  }
+  return path.posix.normalize(pathname);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,68 +1,50 @@
 #!/usr/bin/env node
 
 /**
- * Memorix — Cross-Agent Memory Bridge
+ * Package entry point.
  *
- * Entry point for the MCP Server.
- * Connects via stdio transport for compatibility with all MCP-supporting agents.
- *
- * Usage:
- *   node dist/index.js          # Start as MCP server (stdio)
- *   memorix init                # CLI: Initialize project (P1)
- *   memorix sync                # CLI: Sync rules across agents (P2)
+ * `memorix serve` is the documented MCP command. Keep the historical
+ * `node dist/index.js` route working by delegating to that exact runtime,
+ * while making a normal package import side-effect free.
  */
 
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { createMemorixServer } from './server.js';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 
-async function main(): Promise<void> {
-  const { homedir } = await import('node:os');
-  const { existsSync, readFileSync } = await import('node:fs');
-  const path = await import('node:path');
-  const { detectProject, findGitInSubdirs, isSystemDirectory } = await import('./project/detector.js');
-  const { resolveServeProject } = await import('./cli/commands/serve-shared.js');
+export { createMemorixServer } from './server.js';
+export type { CreateMemorixServerOptions } from './server.js';
 
-  let safeCwd: string;
-  try { safeCwd = process.cwd(); } catch { safeCwd = homedir(); }
-
-  const lastRootFile = path.join(homedir(), '.memorix', 'last-project-root');
-  let lastKnownProjectRoot: string | undefined;
-  if (existsSync(lastRootFile)) {
-    try {
-      const lastRoot = readFileSync(lastRootFile, 'utf-8').trim();
-      if (lastRoot && existsSync(lastRoot)) {
-        lastKnownProjectRoot = lastRoot;
-      }
-    } catch { /* ignore */ }
-  }
-
-  const resolution = resolveServeProject(
-    {
-      processCwd: safeCwd,
-      homeDir: homedir(),
-      lastKnownProjectRoot,
-    },
-    { detectProject, findGitInSubdirs, isSystemDirectory },
-  );
-
-  for (const message of resolution.messages) {
-    console.error(message);
-  }
-
-  if (!resolution.detectedProject) {
-    throw new Error(resolution.error);
-  }
-
-  const { server, projectId, deferredInit } = await createMemorixServer(resolution.projectRoot);
-
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-
-  console.error(`[memorix] MCP Server running on stdio (project: ${projectId})`);
-  deferredInit().catch(e => console.error(`[memorix] Deferred init error:`, e));
+function isDirectEntrypoint(): boolean {
+  const entry = process.argv[1];
+  return Boolean(entry && import.meta.url === pathToFileURL(path.resolve(entry)).href);
 }
 
-main().catch((error) => {
-  console.error('[memorix] Fatal error:', error);
-  process.exit(1);
-});
+function directServeArgs(argv: string[]): { cwd?: string; mode?: string; 'allow-untracked': boolean } {
+  const args: { cwd?: string; mode?: string; 'allow-untracked': boolean } = { 'allow-untracked': false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const value = argv[index];
+    if (value === '--allow-untracked') {
+      args['allow-untracked'] = true;
+      continue;
+    }
+    if ((value === '--cwd' || value === '--mode') && argv[index + 1]) {
+      args[value.slice(2) as 'cwd' | 'mode'] = argv[index + 1];
+      index += 1;
+    }
+  }
+  return args;
+}
+
+async function runDirectStdioServer(): Promise<void> {
+  const { default: serveCommand } = await import('./cli/commands/serve.js');
+  const run = serveCommand.run as ((input: { args: ReturnType<typeof directServeArgs> }) => Promise<void>) | undefined;
+  if (!run) throw new Error('Memorix stdio server command is unavailable');
+  await run({ args: directServeArgs(process.argv.slice(2)) });
+}
+
+if (isDirectEntrypoint()) {
+  runDirectStdioServer().catch((error) => {
+    console.error('[memorix] Fatal error:', error);
+    process.exitCode = 1;
+  });
+}

--- a/src/media/asset-store.ts
+++ b/src/media/asset-store.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { copyFile, lstat, mkdir, open, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { copyFile, lstat, mkdir, open, readFile, readdir, rename, rm, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 
 import { sanitizeCredentials } from '../memory/secret-filter.js';
@@ -273,7 +273,7 @@ export async function removeMediaAsset(input: {
   projectId: string;
   assetId: string;
   force?: boolean;
-}): Promise<{ asset: MediaAsset; detachedLinks: number }> {
+}): Promise<{ asset: MediaAsset; detachedLinks: number; pendingDelete: boolean }> {
   const store = new MediaStore(input.dataDir);
   const asset = store.getAsset(input.projectId, input.assetId);
   if (!asset) throw new Error(`Media asset not found: ${input.assetId}`);
@@ -305,21 +305,81 @@ export async function removeMediaAsset(input: {
   // A locked file can be retried by a later cleanup; it is already outside the
   // active asset tree and no database row refers to it anymore.
   await rm(stagedPath, { force: true }).catch(() => {});
-  return { asset, detachedLinks };
+  return { asset, detachedLinks, pendingDelete: await destinationExists(stagedPath) };
+}
+
+export interface MediaTrashCleanupResult {
+  reclaimedBytes: number;
+  pendingBytes: number;
+  pendingFiles: number;
+}
+
+/** Retry files that were atomically staged after a metadata deletion but were
+ * locked by Windows or another process. Only Memorix's own staging suffix is
+ * considered, so cleanup never sweeps arbitrary files from the data directory.
+ */
+export async function cleanupMediaTrash(dataDir: string): Promise<MediaTrashCleanupResult> {
+  const root = mediaRoot(dataDir);
+  const trashDir = validateUnderRoot(root, path.join(root, '.trash'));
+  let entries: string[];
+  try {
+    entries = await readdir(trashDir);
+  } catch (error: any) {
+    if (error?.code === 'ENOENT') return { reclaimedBytes: 0, pendingBytes: 0, pendingFiles: 0 };
+    throw error;
+  }
+
+  let reclaimedBytes = 0;
+  let pendingBytes = 0;
+  let pendingFiles = 0;
+  for (const name of entries) {
+    if (!name.endsWith('.pending-delete')) continue;
+    const candidate = validateUnderRoot(trashDir, path.join(trashDir, name));
+    try {
+      const metadata = await lstat(candidate);
+      if (!metadata.isFile()) continue;
+      await rm(candidate, { force: true });
+      reclaimedBytes += metadata.size;
+    } catch (error: any) {
+      if (error?.code === 'ENOENT') continue;
+      try {
+        pendingBytes += (await stat(candidate)).size;
+      } catch { /* The file disappeared or cannot be measured; keep its count. */ }
+      pendingFiles += 1;
+    }
+  }
+  return { reclaimedBytes, pendingBytes, pendingFiles };
 }
 
 export async function cleanupMediaQuota(input: {
   dataDir: string;
   projectId: string;
   maxBytes?: number;
-}): Promise<{ beforeBytes: number; afterBytes: number; removed: MediaAsset[] }> {
+}): Promise<{
+  beforeBytes: number;
+  afterBytes: number;
+  removed: MediaAsset[];
+  reclaimedTrashBytes: number;
+  pendingTrashBytes: number;
+  pendingTrashFiles: number;
+}> {
   const store = new MediaStore(input.dataDir);
   const maxBytes = input.maxBytes ?? DEFAULT_MEDIA_QUOTA_BYTES;
   if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) throw new Error('maxBytes must be a non-negative integer');
+  const initialTrash = await cleanupMediaTrash(input.dataDir);
   const beforeBytes = store.activeByteSize(input.projectId);
   let currentBytes = beforeBytes;
   const removed: MediaAsset[] = [];
-  if (currentBytes <= maxBytes) return { beforeBytes, afterBytes: currentBytes, removed };
+  if (currentBytes <= maxBytes) {
+    return {
+      beforeBytes,
+      afterBytes: currentBytes,
+      removed,
+      reclaimedTrashBytes: initialTrash.reclaimedBytes,
+      pendingTrashBytes: initialTrash.pendingBytes,
+      pendingTrashFiles: initialTrash.pendingFiles,
+    };
+  }
 
   // Fail closed: all candidates come from the link-aware query. A query error leaves all assets intact.
   const candidates = store.listUnlinkedAssets(input.projectId);
@@ -334,5 +394,13 @@ export async function cleanupMediaQuota(input: {
     currentBytes -= asset.byteSize;
     removed.push(asset);
   }
-  return { beforeBytes, afterBytes: Math.max(0, currentBytes), removed };
+  const finalTrash = await cleanupMediaTrash(input.dataDir);
+  return {
+    beforeBytes,
+    afterBytes: Math.max(0, currentBytes),
+    removed,
+    reclaimedTrashBytes: initialTrash.reclaimedBytes + finalTrash.reclaimedBytes,
+    pendingTrashBytes: finalTrash.pendingBytes,
+    pendingTrashFiles: finalTrash.pendingFiles,
+  };
 }

--- a/src/media/attachment.ts
+++ b/src/media/attachment.ts
@@ -19,9 +19,9 @@ export interface AttachMediaAssetInput {
 }
 
 /**
- * Create normal text retrieval evidence first, then add an explicit asset link.
- * The media row remains the binary source of truth; the Observation is only a
- * small, auditable retrieval projection.
+ * Create normal text retrieval evidence and its explicit asset link in the
+ * same SQLite transaction. The media row remains the binary source of truth;
+ * the Observation is only a small, auditable retrieval projection.
  */
 export async function attachMediaAssetToObservation(input: AttachMediaAssetInput): Promise<Observation> {
   const asset = input.asset;
@@ -34,6 +34,7 @@ export async function attachMediaAssetToObservation(input: AttachMediaAssetInput
     `MIME type: ${asset.mimeType}`,
     ...(input.facts ?? []),
   ];
+  const store = new MediaStore(input.dataDir);
   const result = await storeObservation({
     entityName: input.entityName?.trim() || sourceLabel.replace(/\.[^.]+$/, '') || 'media-asset',
     type: 'discovery',
@@ -47,12 +48,14 @@ export async function attachMediaAssetToObservation(input: AttachMediaAssetInput
     ...(input.visibility ? { visibility: input.visibility } : {}),
     ...(input.createdByAgentId ? { createdByAgentId: input.createdByAgentId } : {}),
     ...(input.visibilityReader ? { visibilityReader: input.visibilityReader } : {}),
-  });
-  new MediaStore(input.dataDir).linkAsset({
-    projectId: input.projectId,
-    assetId: asset.id,
-    observationId: result.observation.id,
-    role: input.role ?? 'attachment',
+    onPersisted: (observation) => {
+      store.linkAsset({
+        projectId: input.projectId,
+        assetId: asset.id,
+        observationId: observation.id,
+        role: input.role ?? 'attachment',
+      });
+    },
   });
   return result.observation;
 }

--- a/src/media/media-store.ts
+++ b/src/media/media-store.ts
@@ -242,6 +242,13 @@ export class MediaStore {
       `).run(projectId, assetId).changes ?? 0);
       this.db.prepare('DELETE FROM media_derivations WHERE project_id = ? AND asset_id = ?').run(projectId, assetId);
       this.db.prepare('DELETE FROM media_embeddings WHERE project_id = ? AND asset_id = ?').run(projectId, assetId);
+      // Assets are soft-deleted so SQLite's ON DELETE SET NULL does not fire.
+      // Do not leave completed jobs advertising an asset that `media show` can
+      // no longer retrieve.
+      this.db.prepare(`
+        UPDATE media_jobs SET asset_id = NULL, updated_at = ?
+        WHERE project_id = ? AND asset_id = ?
+      `).run(Date.now(), projectId, assetId);
       const result = this.db.prepare(`
         UPDATE media_assets SET deleted_at = ?, updated_at = ?
         WHERE project_id = ? AND id = ? AND deleted_at IS NULL
@@ -431,16 +438,42 @@ export class MediaStore {
     lastError?: string;
     incrementAttempts?: boolean;
   }): MediaJob {
+    const updated = this.updateJobInternal(projectId, id, input, false);
+    if (!updated) throw new Error(`Media job not found: ${id}`);
+    return updated;
+  }
+
+  /**
+   * Atomically preserve a user cancellation against a worker that was already
+   * downloading or attaching media when the cancellation arrived.
+   */
+  updateJobIfNotCancelled(projectId: string, id: string, input: {
+    status: MediaJobStatus;
+    providerTaskId?: string;
+    assetId?: string;
+    lastError?: string;
+    incrementAttempts?: boolean;
+  }): MediaJob | undefined {
+    return this.updateJobInternal(projectId, id, input, true);
+  }
+
+  private updateJobInternal(projectId: string, id: string, input: {
+    status: MediaJobStatus;
+    providerTaskId?: string;
+    assetId?: string;
+    lastError?: string;
+    incrementAttempts?: boolean;
+  }, rejectCancelled: boolean): MediaJob | undefined {
     const existing = this.getJob(projectId, id);
-    if (!existing) throw new Error(`Media job not found: ${id}`);
+    if (!existing) return undefined;
     const now = Date.now();
     const attempts = existing.attempts + (input.incrementAttempts ? 1 : 0);
     const completedAt = input.status === 'completed' ? now : null;
-    this.db.prepare(`
+    const result = this.db.prepare(`
       UPDATE media_jobs
       SET status = ?, provider_task_id = COALESCE(?, provider_task_id), asset_id = COALESCE(?, asset_id),
           last_error = ?, attempts = ?, updated_at = ?, completed_at = ?
-      WHERE project_id = ? AND id = ?
+      WHERE project_id = ? AND id = ? ${rejectCancelled ? "AND status <> 'cancelled'" : ''}
     `).run(
       input.status,
       input.providerTaskId ?? null,
@@ -452,7 +485,8 @@ export class MediaStore {
       projectId,
       id,
     );
-    return this.getJob(projectId, id)!;
+    if (Number(result.changes ?? 0) !== 1) return undefined;
+    return this.getJob(projectId, id);
   }
 
   cancelJob(projectId: string, id: string): MediaJob {

--- a/src/media/video-jobs.ts
+++ b/src/media/video-jobs.ts
@@ -139,12 +139,19 @@ async function finishWithAsset(input: {
   dependencies: MediaVideoGenerationDependencies;
 }): Promise<MaintenanceJobRunResult> {
   const { dataDir, projectId, store, mediaJob, request, providerTask, dependencies } = input;
-  let asset: MediaAsset | undefined = mediaJob.assetId
-    ? store.getAsset(projectId, mediaJob.assetId)
+  let activeJob = store.getJob(projectId, mediaJob.id);
+  if (!activeJob || terminal(activeJob)) return { action: 'complete' };
+  let asset: MediaAsset | undefined = activeJob.assetId
+    ? store.getAsset(projectId, activeJob.assetId)
     : undefined;
   if (!asset) {
     if (!providerTask.downloadUrl) throw new Error('Succeeded MiniMax video task did not include a download URL');
-    store.updateJob(projectId, mediaJob.id, { status: 'downloading', providerTaskId: providerTask.taskId });
+    const downloading = store.updateJobIfNotCancelled(projectId, activeJob.id, {
+      status: 'downloading',
+      providerTaskId: providerTask.taskId,
+    });
+    if (!downloading) return { action: 'complete' };
+    activeJob = downloading;
     const bytes = await (dependencies.download ?? ((downloadInput) => downloadProviderMedia(downloadInput)))({
       url: providerTask.downloadUrl,
       maxBytes: request.maxBytes,
@@ -161,9 +168,20 @@ async function finishWithAsset(input: {
       maxBytes: request.maxBytes,
     });
     asset = imported.asset;
+    // Persist the local result before optional attachment. A later retry can
+    // resume attachment even if the provider's signed URL has expired.
+    const persistedAsset = store.updateJobIfNotCancelled(projectId, activeJob.id, {
+      status: 'downloading',
+      providerTaskId: providerTask.taskId,
+      assetId: asset.id,
+    });
+    if (!persistedAsset) return { action: 'complete' };
+    activeJob = persistedAsset;
   }
 
-  if (mediaJob.attachOnComplete) {
+  if (activeJob.attachOnComplete) {
+    activeJob = store.getJob(projectId, activeJob.id);
+    if (!activeJob || terminal(activeJob)) return { action: 'complete' };
     const hasAttachment = store.listLinks(projectId, asset.id)
       .some((link) => link.role === 'attachment' && link.observationId !== undefined);
     if (!hasAttachment) {
@@ -171,13 +189,13 @@ async function finishWithAsset(input: {
         dataDir,
         projectId,
         asset,
-        title: mediaJob.observationTitle ?? `MiniMax video: ${asset.sourceLabel ?? asset.id}`,
+        title: activeJob.observationTitle ?? `MiniMax video: ${asset.sourceLabel ?? asset.id}`,
         narrative: `Generated with ${request.provider}/${request.model}. Prompt: ${request.prompt}`,
         concepts: ['generated-video', 'minimax', request.model],
       });
     }
   }
-  store.updateJob(projectId, mediaJob.id, {
+  store.updateJobIfNotCancelled(projectId, activeJob.id, {
     status: 'completed',
     providerTaskId: providerTask.taskId,
     assetId: asset.id,
@@ -194,10 +212,12 @@ function retryAfterProviderError(
 ): MaintenanceJobRunResult {
   const message = safeError(error);
   if (maintenanceJob.attempts >= maintenanceJob.maxAttempts) {
-    store.updateJob(projectId, mediaJob.id, { status: 'failed', lastError: message, incrementAttempts: true });
+    store.updateJobIfNotCancelled(projectId, mediaJob.id, { status: 'failed', lastError: message, incrementAttempts: true });
     return { action: 'complete' };
   }
-  store.updateJob(projectId, mediaJob.id, { status: 'retry', lastError: message, incrementAttempts: true });
+  if (!store.updateJobIfNotCancelled(projectId, mediaJob.id, { status: 'retry', lastError: message, incrementAttempts: true })) {
+    return { action: 'complete' };
+  }
   return { action: 'reschedule', delayMs: MINI_MAX_VIDEO_POLL_MS, status: 'retry', lastError: message };
 }
 
@@ -250,24 +270,27 @@ export async function runMiniMaxVideoGenerationJob(
   const request = parseStoredRequest(mediaJob.request);
 
   if (!mediaJob.providerTaskId) {
-    store.updateJob(context.projectId, mediaJob.id, { status: 'submitting', incrementAttempts: true });
+    if (!store.updateJobIfNotCancelled(context.projectId, mediaJob.id, { status: 'submitting', incrementAttempts: true })) {
+      return { action: 'complete' };
+    }
     let submitted: MiniMaxVideoTask;
     try {
       submitted = await (dependencies.createTask ?? createMiniMaxVideoTask)(toVideoRequest(request));
     } catch (error) {
       // A submit timeout can mean the provider accepted a billable request. Do
       // not retry automatically without a task ID; the operator can resubmit.
-      store.updateJob(context.projectId, mediaJob.id, { status: 'failed', lastError: safeError(error) });
+      store.updateJobIfNotCancelled(context.projectId, mediaJob.id, { status: 'failed', lastError: safeError(error) });
       return { action: 'complete' };
     }
     if (submitted.status === 'failed') {
-      store.updateJob(context.projectId, mediaJob.id, { status: 'failed', providerTaskId: submitted.taskId, lastError: submitted.error });
+      store.updateJobIfNotCancelled(context.projectId, mediaJob.id, { status: 'failed', providerTaskId: submitted.taskId, lastError: submitted.error });
       return { action: 'complete' };
     }
-    const pending = store.updateJob(context.projectId, mediaJob.id, {
+    const pending = store.updateJobIfNotCancelled(context.projectId, mediaJob.id, {
       status: submitted.status === 'succeeded' ? 'downloading' : 'provider-pending',
       providerTaskId: submitted.taskId,
     });
+    if (!pending) return { action: 'complete' };
     if (submitted.status === 'succeeded') {
       try {
         return await finishWithAsset({
@@ -296,11 +319,13 @@ export async function runMiniMaxVideoGenerationJob(
     return retryAfterProviderError(store, context.projectId, mediaJob, maintenanceJob, error);
   }
   if (task.status === 'pending') {
-    store.updateJob(context.projectId, mediaJob.id, { status: 'provider-pending', providerTaskId: task.taskId });
+    if (!store.updateJobIfNotCancelled(context.projectId, mediaJob.id, { status: 'provider-pending', providerTaskId: task.taskId })) {
+      return { action: 'complete' };
+    }
     return { action: 'reschedule', delayMs: MINI_MAX_VIDEO_POLL_MS, resetAttempts: true, clearLastError: true };
   }
   if (task.status === 'failed') {
-    store.updateJob(context.projectId, mediaJob.id, { status: 'failed', providerTaskId: task.taskId, lastError: task.error, incrementAttempts: true });
+    store.updateJobIfNotCancelled(context.projectId, mediaJob.id, { status: 'failed', providerTaskId: task.taskId, lastError: task.error, incrementAttempts: true });
     return { action: 'complete' };
   }
   try {

--- a/src/memory/observations.ts
+++ b/src/memory/observations.ts
@@ -397,6 +397,12 @@ export async function storeObservation(input: {
   createdByAgentId?: string;
   /** Optional caller-bound write scope for topic-key upserts. */
   visibilityReader?: ObservationReader;
+  /**
+   * Internal transaction callback for a second SQLite record that must either
+   * commit with this observation or not exist at all. It is intentionally not
+   * exposed through the SDK input surface.
+   */
+  onPersisted?: (observation: Observation) => void | Promise<void>;
 }): Promise<{ observation: Observation; upserted: boolean }> {
   const now = new Date().toISOString();
 
@@ -431,7 +437,9 @@ export async function storeObservation(input: {
       if (input.visibilityReader && !canManageObservation(existing, input.visibilityReader)) {
         throw new Error('Cannot update a memory outside this session\'s write scope.');
       }
-      return { observation: await upsertObservation(existing, input, now), upserted: true };
+      const observation = await upsertObservation(existing, input, now);
+      await input.onPersisted?.(observation);
+      return { observation, upserted: true };
     }
   }
 
@@ -460,6 +468,7 @@ export async function storeObservation(input: {
 
   let upsertedInsideLock = false;
   let reloadCacheAfterCommit = false;
+  let persistedCallbackInvoked = false;
   const assignAndPersist = async () => {
     if (projectDir) {
       const store = getObservationStore();
@@ -528,6 +537,8 @@ export async function storeObservation(input: {
         };
 
         await tx.insert(observation);
+        await input.onPersisted?.(observation);
+        persistedCallbackInvoked = true;
         await tx.saveIdCounter(id + 1);
       });
 
@@ -584,6 +595,8 @@ export async function storeObservation(input: {
         writeGeneration: 0,
       };
       observations.push(observation);
+      await input.onPersisted?.(observation);
+      persistedCallbackInvoked = true;
     }
 
     // Build Orama doc AFTER id is assigned
@@ -621,8 +634,14 @@ export async function storeObservation(input: {
 
   // If the lock discovered a topicKey duplicate on disk, delegate to upsert
   if (upsertedInsideLock) {
-    return { observation: await upsertObservation(observation, input, now), upserted: true };
+    const updated = await upsertObservation(observation, input, now);
+    await input.onPersisted?.(updated);
+    return { observation: updated, upserted: true };
   }
+
+  // The normal persistent path invokes the callback inside the SQLite
+  // transaction. Keep the in-memory fallback defensively covered too.
+  if (!persistedCallbackInvoked) await input.onPersisted?.(observation);
 
   await bindObservationCodeRefsBestEffort(observation);
   queueObservationQualification(observation);

--- a/src/orchestrate/adapters/spawn-helper.ts
+++ b/src/orchestrate/adapters/spawn-helper.ts
@@ -43,6 +43,7 @@ export function spawnAgent(
     stdio: [stdinData ? 'pipe' : 'ignore', 'pipe', 'pipe'],
     // Windows: use shell to resolve CLI tools on PATH
     shell: process.platform === 'win32',
+    windowsHide: true,
   });
 
   // Write prompt via stdin to avoid shell argument escaping issues.
@@ -134,6 +135,7 @@ export function spawnAgentWithStream(
     env: { ...process.env, ...opts.env },
     stdio: [stdinData ? 'pipe' : 'ignore', 'pipe', 'pipe'],
     shell: process.platform === 'win32',
+    windowsHide: true,
   });
 
   let stdinError: string | undefined;

--- a/src/server.ts
+++ b/src/server.ts
@@ -4993,10 +4993,10 @@ export async function createMemorixServer(
       description:
         'Use the controlled local media library for an explicit import, attachment, inspection, or MiniMax generation request. ' +
         'Assets stay outside the Git worktree and enter normal memory only when attach is explicitly true. ' +
-        'Use the CLI for destructive removal, quota cleanup, job cancellation, and direct generation. ' +
+        'Use the CLI for destructive removal, quota cleanup, and direct generation. ' +
         'MCP generation is disabled by default and requires MEMORIX_MCP_MEDIA_GENERATION=1 after the operator reviews provider billing.',
       inputSchema: {
-        action: z.enum(['import', 'attach', 'list', 'show', 'generate-image', 'generate-video', 'status']),
+        action: z.enum(['import', 'attach', 'list', 'show', 'generate-image', 'generate-video', 'status', 'cancel']),
         path: z.string().optional().describe('Explicit local image/audio/video/PDF path for import.'),
         assetId: z.string().optional().describe('Controlled MediaAsset ID for attach/show.'),
         jobId: z.string().optional().describe('Durable media job ID for status.'),
@@ -5068,6 +5068,10 @@ export async function createMemorixServer(
           const job = store.getJob(project.id, jobId);
           if (!job) throw new Error(`Media job not found: ${jobId}`);
           return result({ action, projectId: project.id, job });
+        }
+        if (action === 'cancel') {
+          if (!jobId?.trim()) throw new Error('jobId is required for media cancel');
+          return result({ action, projectId: project.id, job: store.cancelJob(project.id, jobId) });
         }
         if (action === 'attach') {
           if (!assetId?.trim()) throw new Error('assetId is required for media attach');

--- a/src/server/tool-profile.ts
+++ b/src/server/tool-profile.ts
@@ -6,7 +6,7 @@
  * tools/list time causes cognitive overload.
  *
  * We provide four profiles:
- *   - "micro" (stdio default): Agent-ready project context + basic memory CRUD — 7 tools.
+ *   - "micro" (stdio default): Agent-ready project context + bounded recovery/media controls — 9 tools.
  *     Suitable for normal MCP clients where every tool schema costs context tokens.
  *   - "lite": Core memory CRUD, sessions, reasoning, retention, backup — 18 tools.
  *     Suitable for solo users who want the full memory surface without team tools.
@@ -35,19 +35,22 @@ export const TOOL_PROFILES: Record<string, ReadonlyArray<ToolProfile>> = Object.
   memorix_context_pack:       ['micro', 'lite', 'team', 'full'],
   memorix_codegraph_status:   ['micro', 'lite', 'team', 'full'],
   memorix_resolve:            ['micro', 'lite', 'team', 'full'],
+  // A fail-closed stdio server needs an explicit recovery path when a client
+  // did not launch it from the workspace. The unified media tool keeps
+  // multimodal support to one additional schema rather than enabling lite.
+  memorix_session_start:      ['micro', 'lite', 'team', 'full'],
+  memorix_media:              ['micro', 'lite', 'team', 'full'],
 
   // ── lite: extended solo memory surface ────────────────────────────
   memorix_graph_context:      ['lite', 'team', 'full'],
   memorix_timeline:           ['lite', 'team', 'full'],
   memorix_suggest_topic_key:  ['lite', 'team', 'full'],
-  memorix_session_start:      ['lite', 'team', 'full'],
   memorix_session_end:        ['lite', 'team', 'full'],
   memorix_session_context:    ['lite', 'team', 'full'],
   memorix_store_reasoning:    ['lite', 'team', 'full'],
   memorix_search_reasoning:   ['lite', 'team', 'full'],
   memorix_transfer:           ['lite', 'team', 'full'],
   memorix_retention:          ['lite', 'team', 'full'],
-  memorix_media:              ['lite', 'team', 'full'],
 
   // ── team: orchestration coordination surfaces — HTTP default ──────
   memorix_dashboard:          ['team', 'full'],
@@ -136,7 +139,7 @@ export function resolveToolProfile(opts: ResolveToolProfileOpts): ToolProfile {
  */
 export function describeProfile(profile: ToolProfile): string {
   switch (profile) {
-    case 'micro': return 'micro (agent-ready context + basic memory, ~7 tools)';
+    case 'micro': return 'micro (agent-ready context + bounded recovery/media, ~9 tools)';
     case 'lite': return 'lite (core memory + sessions, ~18 tools)';
     case 'team': return 'team (lite + coordination tools + dashboard + knowledge workspace, ~26 tools)';
     case 'full': return 'full (all tools including advanced / KG-compat)';

--- a/tests/cli/serve.test.ts
+++ b/tests/cli/serve.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import { mcpFileUriToPath } from '../../src/cli/mcp-root-path.js';
 import { resolveServeProject } from '../../src/cli/commands/serve-shared.js';
 import type { ProjectInfo } from '../../src/types.js';
 
@@ -48,12 +49,11 @@ describe('serve-shared', () => {
     expect(result.source).toBe('subdir');
   });
 
-  it('restores the last known project when launched from a system directory', () => {
+  it('refuses to restore a last known project when launched from a system directory', () => {
     const result = resolveServeProject(
       {
         processCwd: 'C:/Windows/System32',
         homeDir: 'C:/Users/tester',
-        lastKnownProjectRoot: 'E:/repo',
       },
       {
         detectProject: (cwd) => (cwd === 'E:/repo' ? makeProject('AVIDS2/repo', cwd) : null),
@@ -62,9 +62,10 @@ describe('serve-shared', () => {
       },
     );
 
-    expect(result.detectedProject?.id).toBe('AVIDS2/repo');
-    expect(result.projectRoot).toBe('E:/repo');
-    expect(result.source).toBe('last-known');
+    expect(result.detectedProject).toBeNull();
+    expect(result.projectRoot).toBe('C:/Windows/System32');
+    expect(result.source).toBe('unresolved');
+    expect(result.messages.join('\n')).toContain('will not restore a previous project automatically');
   });
 
   it('fails fast instead of falling back to untracked/* when no reliable project can be found', () => {
@@ -86,7 +87,7 @@ describe('serve-shared', () => {
     expect(result.messages.join('\n')).toContain('refuses to silently fall back');
   });
 
-  it('fails fast for system directories when neither last-known nor home scan yields a repo', () => {
+  it('fails closed for system directories without probing home or a prior project', () => {
     const result = resolveServeProject(
       {
         processCwd: 'C:/Windows/System32',
@@ -100,7 +101,13 @@ describe('serve-shared', () => {
     );
 
     expect(result.detectedProject).toBeNull();
-    expect(result.error).toContain('No git project could be resolved');
-    expect(result.messages.join('\n')).toContain('System directory detected');
+    expect(result.error).toContain('No reliable git project');
+    expect(result.messages.join('\n')).toContain('Unreliable launch directory');
+  });
+
+  it('keeps MCP file roots native to the host platform', () => {
+    expect(mcpFileUriToPath('file:///home/tester/project', 'linux')).toBe('/home/tester/project');
+    expect(mcpFileUriToPath('file:///E:/repo/project', 'win32')).toBe('E:\\repo\\project');
+    expect(mcpFileUriToPath('https://example.com/repo', 'linux')).toBeNull();
   });
 });

--- a/tests/cli/setup-command.test.ts
+++ b/tests/cli/setup-command.test.ts
@@ -413,8 +413,8 @@ describe('Codex legacy integration migration', () => {
       ].join('\n'), 'utf-8');
       await fs.writeFile(hooksPath, JSON.stringify({
         hooks: {
-          SessionStart: [{ type: 'command', command: 'memorix hook', timeout: 10 }],
-          Stop: [{ type: 'command', command: 'memorix hook', timeout: 10 }],
+          SessionStart: [{ type: 'command', command: 'memorix hook' }],
+          Stop: [{ type: 'command', command: 'memorix hook' }],
         },
       }), 'utf-8');
       await fs.writeFile(path.join(legacyPluginPath, '.codex-plugin', 'plugin.json'), JSON.stringify({
@@ -467,6 +467,28 @@ describe('Codex legacy integration migration', () => {
       expect(result.projectHooks).toBe('preserved');
       await expect(fs.readFile(configPath, 'utf-8')).resolves.toContain('MEMORIX_MODE');
       await expect(fs.readFile(hooksPath, 'utf-8')).resolves.toContain('other-agent hook');
+    } finally {
+      await cleanup(tmpDir);
+    }
+  });
+
+  it('preserves an all-Memorix legacy hooks file when the user added hook options', async () => {
+    const tmpDir = makeTmpDir();
+    const homeDir = path.join(tmpDir, 'home');
+    const projectRoot = path.join(tmpDir, 'project');
+    try {
+      const hooksPath = path.join(projectRoot, '.codex', 'hooks.json');
+      await fs.mkdir(path.dirname(hooksPath), { recursive: true });
+      await fs.writeFile(hooksPath, JSON.stringify({
+        hooks: {
+          SessionStart: [{ type: 'command', command: 'memorix hook', timeout: 10 }],
+        },
+      }), 'utf-8');
+
+      const result = await migrateLegacyCodexIntegration({ homeDir, projectRoot });
+
+      expect(result.projectHooks).toBe('preserved');
+      await expect(fs.readFile(hooksPath, 'utf-8')).resolves.toContain('"timeout":10');
     } finally {
       await cleanup(tmpDir);
     }

--- a/tests/codegraph/auto-context.test.ts
+++ b/tests/codegraph/auto-context.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -34,12 +34,12 @@ describe('auto project context', () => {
     mkdirSync(path.join(repoDir, 'src'), { recursive: true });
     writeFileSync(path.join(repoDir, 'src', 'auth.ts'), 'export function authMiddleware(token: string) { return token.length > 0; }\n', 'utf8');
     writeFileSync(path.join(repoDir, 'src', 'worker.py'), 'def dispatch_job(name: str):\n    return name.upper()\n', 'utf8');
-    execSync('git init', { cwd: repoDir, stdio: 'ignore' });
+    execFileSync('git', ['init'], { cwd: repoDir, stdio: 'ignore', windowsHide: true });
     process.chdir(repoDir);
     process.env.MEMORIX_EMBEDDING = 'off';
     await initObservationStore(dataDir);
     await initObservations(dataDir);
-  });
+  }, 30_000);
 
   afterEach(async () => {
     process.chdir(originalCwd);

--- a/tests/integration/long-term-mcp.test.ts
+++ b/tests/integration/long-term-mcp.test.ts
@@ -82,7 +82,7 @@ describe('long-term memory through the MCP micro profile', () => {
       undefined,
       { toolProfile: 'micro' } as any,
     );
-    expect(Object.keys((server as any)._registeredTools ?? {})).toHaveLength(7);
+    expect(Object.keys((server as any)._registeredTools ?? {})).toHaveLength(9);
     const store = getHandler(server as any, 'memorix_store');
     const projectContext = getHandler(server as any, 'memorix_project_context');
     const detail = getHandler(server as any, 'memorix_detail');

--- a/tests/integration/media-mcp.test.ts
+++ b/tests/integration/media-mcp.test.ts
@@ -139,6 +139,14 @@ describe('controlled media through MCP', () => {
       maintenanceJob: { kind: 'media-video-generation' },
     });
     expect(JSON.stringify(queued)).not.toContain('mcp-test-key');
+
+    delete process.env.MEMORIX_MCP_MEDIA_GENERATION;
+    const cancelled = readJson(await media({ action: 'cancel', jobId: queued.mediaJob.id }));
+    expect(cancelled).toMatchObject({
+      action: 'cancel',
+      projectId: queued.projectId,
+      job: { id: queued.mediaJob.id, status: 'cancelled' },
+    });
   });
 
   it('keeps the legacy image tool on the controlled asset lifecycle', async () => {

--- a/tests/integration/tool-profile.test.ts
+++ b/tests/integration/tool-profile.test.ts
@@ -114,9 +114,11 @@ describe('Tool profile registration', () => {
       'memorix_codegraph_status',
       'memorix_context_pack',
       'memorix_detail',
+      'memorix_media',
       'memorix_project_context',
       'memorix_resolve',
       'memorix_search',
+      'memorix_session_start',
       'memorix_store',
     ]);
 

--- a/tests/media/asset-store.test.ts
+++ b/tests/media/asset-store.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises';
+import { access as fsAccess, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   cleanupMediaQuota,
+  cleanupMediaTrash,
   importMediaBuffer,
   readMediaAsset,
   removeMediaAsset,
@@ -134,6 +135,51 @@ describe('controlled media asset store', () => {
     const store = new MediaStore(fixture.dataDir);
     expect(store.getAsset(fixture.projectId, imported.asset.id)).toBeDefined();
     await expect(readMediaAsset(fixture.dataDir, imported.asset)).resolves.toEqual(PNG_BYTES);
+  });
+
+  it('retries only Memorix-staged trash and reports reclaimed bytes', async () => {
+    const fixture = await createFixture();
+    const trashDir = path.join(fixture.dataDir, 'media', '.trash');
+    const staged = path.join(trashDir, 'asset.pending-delete');
+    await mkdir(trashDir, { recursive: true });
+    await writeFile(staged, Buffer.from('staged-delete'));
+    await writeFile(path.join(trashDir, 'leave-alone.txt'), Buffer.from('not-a-staged-delete'));
+
+    const direct = await cleanupMediaTrash(fixture.dataDir);
+    expect(direct.reclaimedBytes).toBe(Buffer.byteLength('staged-delete'));
+    expect(direct.pendingFiles).toBe(0);
+    await expect(fsAccess(staged)).rejects.toThrow();
+    await expect(fsAccess(path.join(trashDir, 'leave-alone.txt'))).resolves.toBeUndefined();
+
+    const quota = await cleanupMediaQuota({ dataDir: fixture.dataDir, projectId: fixture.projectId });
+    expect(quota.reclaimedTrashBytes).toBe(0);
+    expect(quota.pendingTrashFiles).toBe(0);
+  });
+
+  it('clears a generated job reference when its controlled asset is deleted', async () => {
+    const fixture = await createFixture();
+    const imported = await importMediaBuffer({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      bytes: PNG_BYTES,
+      filename: 'generated.png',
+      sourceKind: 'import',
+    });
+    const store = new MediaStore(fixture.dataDir);
+    const job = store.createJob({
+      projectId: fixture.projectId,
+      kind: 'minimax-video-generation',
+      request: { prompt: 'test' },
+    });
+    store.updateJob(fixture.projectId, job.id, { status: 'completed', assetId: imported.asset.id });
+
+    await removeMediaAsset({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      assetId: imported.asset.id,
+    });
+
+    expect(store.getJob(fixture.projectId, job.id)?.assetId).toBeUndefined();
   });
 
   it('rejects unknown media instead of trusting a filename or caller claim', async () => {

--- a/tests/media/attachment.test.ts
+++ b/tests/media/attachment.test.ts
@@ -1,0 +1,83 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { attachMediaAssetToObservation } from '../../src/media/attachment.js';
+import { importMediaBuffer } from '../../src/media/asset-store.js';
+import { MediaStore } from '../../src/media/media-store.js';
+import { initObservations } from '../../src/memory/observations.js';
+import { getObservationStore, resetObservationStore } from '../../src/store/obs-store.js';
+import { closeDatabase } from '../../src/store/sqlite-db.js';
+
+const roots: Array<{ root: string; dataDir: string }> = [];
+const originalEmbeddingMode = process.env.MEMORIX_EMBEDDING;
+const PNG_BYTES = Buffer.from([
+  0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+  0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+]);
+
+async function createFixture(): Promise<{ dataDir: string; projectId: string }> {
+  const root = await mkdtemp(path.join(tmpdir(), 'memorix-media-attachment-'));
+  const dataDir = path.join(root, 'data');
+  roots.push({ root, dataDir });
+  process.env.MEMORIX_EMBEDDING = 'off';
+  await initObservations(dataDir, { embeddingWriteMode: 'deferred' });
+  return { dataDir, projectId: 'test/media-attachment' };
+}
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  resetObservationStore();
+  if (originalEmbeddingMode === undefined) delete process.env.MEMORIX_EMBEDDING;
+  else process.env.MEMORIX_EMBEDDING = originalEmbeddingMode;
+  for (const item of roots.splice(0)) {
+    closeDatabase(item.dataDir);
+    await rm(item.root, { recursive: true, force: true });
+  }
+});
+
+describe('media attachment persistence', () => {
+  it('commits the observation and its asset link together', async () => {
+    const fixture = await createFixture();
+    const imported = await importMediaBuffer({
+      ...fixture,
+      bytes: PNG_BYTES,
+      filename: 'diagram.png',
+      sourceKind: 'import',
+    });
+
+    const observation = await attachMediaAssetToObservation({
+      ...fixture,
+      asset: imported.asset,
+      title: 'Architecture diagram',
+    });
+
+    expect(observation.title).toBe('Architecture diagram');
+    expect(new MediaStore(fixture.dataDir).listLinks(fixture.projectId, imported.asset.id))
+      .toMatchObject([{ observationId: observation.id, role: 'attachment' }]);
+  });
+
+  it('rolls back the observation when the asset link cannot be written', async () => {
+    const fixture = await createFixture();
+    const imported = await importMediaBuffer({
+      ...fixture,
+      bytes: PNG_BYTES,
+      filename: 'rollback.png',
+      sourceKind: 'import',
+    });
+    vi.spyOn(MediaStore.prototype, 'linkAsset').mockImplementationOnce(() => {
+      throw new Error('simulated media link failure');
+    });
+
+    await expect(attachMediaAssetToObservation({
+      ...fixture,
+      asset: imported.asset,
+      title: 'Must not persist halfway',
+    })).rejects.toThrow('simulated media link failure');
+
+    await expect(getObservationStore().loadByProject(fixture.projectId)).resolves.toEqual([]);
+    expect(new MediaStore(fixture.dataDir).listLinks(fixture.projectId, imported.asset.id)).toEqual([]);
+  });
+});

--- a/tests/media/video-jobs.test.ts
+++ b/tests/media/video-jobs.test.ts
@@ -122,6 +122,104 @@ describe('MiniMax durable video jobs', () => {
     expect(createCalled).toBe(false);
   });
 
+  it('keeps a cancellation authoritative when it arrives during a completed-result download', async () => {
+    const fixture = await createFixture();
+    const queued = queueMiniMaxVideoGeneration({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      prompt: 'Cancel during the result download',
+    });
+    let releaseDownload: (() => void) | undefined;
+    const downloadMayFinish = new Promise<void>((resolve) => { releaseDownload = resolve; });
+    let signalDownloadStarted: (() => void) | undefined;
+    const downloadStarted = new Promise<void>((resolve) => { signalDownloadStarted = resolve; });
+
+    const running = runMiniMaxVideoGenerationJob(
+      queued.maintenanceJob,
+      fixture,
+      {
+        createTask: async () => ({
+          taskId: 'provider-video-cancel-race',
+          status: 'succeeded',
+          downloadUrl: 'https://cdn.example.test/cancel-race.mp4',
+        }),
+        download: async () => {
+          signalDownloadStarted?.();
+          await downloadMayFinish;
+          return MP4_BYTES;
+        },
+      },
+    );
+    await downloadStarted;
+    new MediaStore(fixture.dataDir).cancelJob(fixture.projectId, queued.mediaJob.id);
+    releaseDownload?.();
+    await expect(running).resolves.toEqual({ action: 'complete' });
+
+    const job = new MediaStore(fixture.dataDir).getJob(fixture.projectId, queued.mediaJob.id)!;
+    expect(job).toMatchObject({ status: 'cancelled' });
+    expect(job.assetId).toBeUndefined();
+    const store = new MediaStore(fixture.dataDir);
+    const [downloadedAsset] = store.listAssets(fixture.projectId);
+    expect(downloadedAsset).toBeDefined();
+    expect(store.listLinks(fixture.projectId, downloadedAsset.id)).toEqual([]);
+  });
+
+  it('persists the downloaded asset before attachment so a retry does not need the provider URL', async () => {
+    const fixture = await createFixture();
+    const queued = queueMiniMaxVideoGeneration({
+      dataDir: fixture.dataDir,
+      projectId: fixture.projectId,
+      prompt: 'Resume after an attachment failure',
+      attachOnComplete: true,
+    });
+    let downloadCalls = 0;
+    let attachCalls = 0;
+
+    const first = await runMiniMaxVideoGenerationJob(
+      queued.maintenanceJob,
+      fixture,
+      {
+        createTask: async () => ({
+          taskId: 'provider-video-resume',
+          status: 'succeeded',
+          downloadUrl: 'https://cdn.example.test/resume.mp4',
+        }),
+        download: async () => {
+          downloadCalls += 1;
+          return MP4_BYTES;
+        },
+        attach: async () => {
+          attachCalls += 1;
+          throw new Error('simulated attachment interruption');
+        },
+      },
+    );
+    expect(first.action).toBe('reschedule');
+    const interrupted = new MediaStore(fixture.dataDir).getJob(fixture.projectId, queued.mediaJob.id)!;
+    expect(interrupted).toMatchObject({ status: 'retry', providerTaskId: 'provider-video-resume' });
+    expect(interrupted.assetId).toBeTruthy();
+
+    const second = await runMiniMaxVideoGenerationJob(
+      queued.maintenanceJob,
+      fixture,
+      {
+        queryTask: async () => ({ taskId: 'provider-video-resume', status: 'succeeded' }),
+        download: async () => {
+          downloadCalls += 1;
+          throw new Error('retry must not redownload an already-persisted result');
+        },
+        attach: async () => {
+          attachCalls += 1;
+          return { id: 1 } as any;
+        },
+      },
+    );
+    expect(second).toEqual({ action: 'complete' });
+    expect(downloadCalls).toBe(1);
+    expect(attachCalls).toBe(2);
+    expect(new MediaStore(fixture.dataDir).getJob(fixture.projectId, queued.mediaJob.id)).toMatchObject({ status: 'completed' });
+  });
+
   it('sanitizes request text and the deferred observation title before job persistence', async () => {
     const fixture = await createFixture();
     const promptSecret = 'sk-abcdefghijklmnopqrstuvwxyz1234';

--- a/tests/server/context-pack-tool-profile.test.ts
+++ b/tests/server/context-pack-tool-profile.test.ts
@@ -12,10 +12,12 @@ describe('context pack tool profile', () => {
 
   it('keeps the default micro profile compact enough for agent tool lists', () => {
     expect(countToolsInProfile('micro')).toBeLessThan(countToolsInProfile('lite'));
-    expect(countToolsInProfile('micro')).toBeLessThanOrEqual(8);
+    expect(countToolsInProfile('micro')).toBeLessThanOrEqual(9);
     expect(isToolInProfile('memorix_store', 'micro')).toBe(true);
     expect(isToolInProfile('memorix_search', 'micro')).toBe(true);
     expect(isToolInProfile('memorix_detail', 'micro')).toBe(true);
+    expect(isToolInProfile('memorix_session_start', 'micro')).toBe(true);
+    expect(isToolInProfile('memorix_media', 'micro')).toBe(true);
     expect(isToolInProfile('memorix_session_end', 'micro')).toBe(false);
     expect(isToolInProfile('memorix_transfer', 'micro')).toBe(false);
     expect(isToolInProfile('team_manage', 'micro')).toBe(false);


### PR DESCRIPTION
Release hardening for 1.3.4. Fixes cross-project stale binding, cross-platform MCP Roots parsing, cautious legacy Codex hook migration, Windows hidden child processes, media job cancellation/retry lifecycle, transactional media attachment, and micro-profile recovery. Verified with full npm test, lint, build, MCP Registry check, and fresh npm package MCP smoke.