### PR TITLE
release: Memorix 1.4.0 stable multimodal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.0] - 2026-08-02
+
+### Changed
+- **Stable multimodal release** -- Promoted the controlled media lifecycle, explicit MiniMax image/video generation, and honest multimodal embedding foundation introduced in 1.3.3 to the stable line after the 1.3.4 Windows, MCP binding, cancellation, cleanup, configuration-migration, and fresh-package hardening work.
+
+### Verified
+- **Release evidence** -- Full local regression, fresh npm-package MCP smoke, GitHub Actions on Windows and Ubuntu, Docker control-plane startup, native SQLite compatibility, npm provenance publication, and official MCP Registry publication all passed before this release.
+- **Release boundary** -- “Stable” means no known release blocker after those gates. It does not claim that any software is mathematically free of future defects.
+
 ## [1.3.4] - 2026-08-02
 
 ### Fixed

--- a/docs/1.3.3-MULTIMODAL-MEDIA-AND-MCP-COMPAT.md
+++ b/docs/1.3.3-MULTIMODAL-MEDIA-AND-MCP-COMPAT.md
@@ -318,20 +318,20 @@ then document the 2026-07-28 migration boundary.
 - no personal Codex/Claude/OpenCode configuration mutation;
 - documentation and changelog reviewed.
 
-### Phase G: 1.3.4 hardening
+### Phase G: 1.3.4 hardening (completed 2026-08-02)
 
-1.3.4 is not a feature release. It exercises fresh install, Windows CLI
-windows-hide behavior, CLI/stdio/HTTP MCP routes, cancellation/restart of media
-jobs, quota cleanup, failure messages, and agent-facing UX. Only defects found
-through that work are fixed.
+1.3.4 exercised fresh install, Windows CLI windows-hide behavior,
+CLI/stdio/HTTP MCP routes, cancellation/restart of media jobs, quota cleanup,
+failure messages, and agent-facing UX. The resulting fixes are published in
+the 1.3.4 release notes and passed Windows and Ubuntu CI.
 
-### Phase H: 1.4 stable release
+### Phase H: 1.4 stable release (completed 2026-08-02)
 
-1.4 is cut only when 1.3.3 and 1.3.4 gates are green, all supported paths have
-packaged CLI evidence, the compatibility matrix is updated, and there is no
-known high-severity data-loss, credential-retention, Windows-popup, or MCP
-binding regression. “No bug” means no known release blocker after these tests,
-not an impossible claim of mathematical perfection.
+1.4.0 was cut after the 1.3.3 and 1.3.4 gates were green, supported paths had
+packaged CLI evidence, and no high-severity data-loss, credential-retention,
+Windows-popup, or MCP binding regression was known. “Stable” means no known
+release blocker after these tests, not an impossible claim of mathematical
+perfection.
 
 ## Acceptance criteria
 
@@ -351,8 +351,8 @@ not an impossible claim of mathematical perfection.
 8. No generated asset enters project memory without an explicit attach action.
 9. The same media action works through CLI and MCP using an explicit resolved
    project binding, independent of a legacy HTTP session identifier.
-10. 1.3.4 regression tests cover Windows, fresh package install, CLI, stdio,
-    HTTP MCP, quota cleanup, and error UX before 1.4 is published.
+10. 1.3.4 regression tests covered Windows, fresh package install, CLI, stdio,
+    HTTP MCP, quota cleanup, and error UX before 1.4.0 was published.
 
 ## Research and implementation basis
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.3.4",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memorix",
   "mcpName": "io.github.AVIDS2/memorix",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AVIDS2/memorix",
     "source": "github"
   },
-  "version": "1.3.4",
+  "version": "1.4.0",
   "websiteUrl": "https://github.com/AVIDS2/memorix#readme",
   "icons": [
     {
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "memorix",
-      "version": "1.3.4",
+      "version": "1.4.0",
       "runtimeHint": "npx",
       "packageArguments": [
         {


### PR DESCRIPTION
Promotes the 1.3.3 controlled multimodal foundation and 1.3.4 hardening to the stable 1.4.0 line. Aligns all published plugin manifests and MCP Registry metadata, and records the completed release gates. Verified locally with release metadata tests, Registry check, build, full test suite, and fresh npm-package MCP smoke.