### PR TITLE
docs: fix public registry links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 </p>
 
 <p align="center">
-  <a href="https://registry.modelcontextprotocol.io/v0/servers?search=io.github.AVIDS2%2Fmemorix">Listed in the official MCP Registry</a>
+  <a href="https://registry.modelcontextprotocol.io/?q=io.github.AVIDS2%2Fmemorix">Listed in the official MCP Registry</a>
   <br>
-  <img src="https://mcptoplist.com/badge/io.github.AVIDS2%2Fmemorix.svg" alt="MCP Toplist ranking">
+  <a href="https://mcptoplist.com/server/io.github.AVIDS2%2Fmemorix"><img src="https://mcptoplist.com/badge/io.github.AVIDS2%2Fmemorix.svg" alt="View Memorix on MCP Toplist"></a>
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -18,9 +18,9 @@
 </p>
 
 <p align="center">
-  <a href="https://registry.modelcontextprotocol.io/v0/servers?search=io.github.AVIDS2%2Fmemorix">已收录至官方 MCP Registry</a>
+  <a href="https://registry.modelcontextprotocol.io/?q=io.github.AVIDS2%2Fmemorix">已收录至官方 MCP Registry</a>
   <br>
-  <img src="https://mcptoplist.com/badge/io.github.AVIDS2%2Fmemorix.svg" alt="MCP Toplist ranking">
+  <a href="https://mcptoplist.com/server/io.github.AVIDS2%2Fmemorix"><img src="https://mcptoplist.com/badge/io.github.AVIDS2%2Fmemorix.svg" alt="在 MCP Toplist 查看 Memorix"></a>
 </p>
 
 <p align="center">

--- a/tests/release-contract.test.ts
+++ b/tests/release-contract.test.ts
@@ -24,11 +24,13 @@ describe('release contract', () => {
     expect(workflow).not.toContain('npm publish --workspace @memorix/');
   });
 
-  it('links both READMEs to the official MCP Registry and verified Toplist badge', async () => {
+  it('links both READMEs to human-facing Registry and Toplist pages', async () => {
     for (const readme of ['README.md', 'README.zh-CN.md']) {
       const content = await readFile(path.join(repoRoot, readme), 'utf-8');
-      expect(content).toContain('https://registry.modelcontextprotocol.io/v0/servers?search=io.github.AVIDS2%2Fmemorix');
+      expect(content).toContain('https://registry.modelcontextprotocol.io/?q=io.github.AVIDS2%2Fmemorix');
       expect(content).toContain('https://mcptoplist.com/badge/io.github.AVIDS2%2Fmemorix.svg');
+      expect(content).toContain('https://mcptoplist.com/server/io.github.AVIDS2%2Fmemorix');
+      expect(content).not.toContain('registry.modelcontextprotocol.io/v0/servers?search=');
       expect(content).not.toContain('api.star-history.com');
       expect(content).toContain('https://github.com/AVIDS2/memorix/stargazers');
       expect(content).toContain('assets/star-history-light.svg');


### PR DESCRIPTION
## What changed
- replace the official Registry API endpoint with its browser search page
- make the MCP Toplist badge open Memorix's canonical server page
- keep a release-contract test for both user-facing destinations

## Verification
- 
pm test -- tests/release-contract.test.ts (requires CI in this isolated worktree; local dependencies are intentionally absent)
- standalone README contract check passed
- live HTTP checks passed for the Registry browser UI and canonical MCP Toplist page
- git diff --check passed