### PR TITLE
chore(release): ship 1.4.1

### DIFF
--- a/ACTIVE_WORK.md
+++ b/ACTIVE_WORK.md
@@ -9,27 +9,27 @@
 ## Current Product State
 
 - `1.4.0` is the current published release.
-- The next product track is `1.4.1`: admit or reject pending contributions one
-  at a time, with focused tests and user-visible acceptance evidence.
-- `1.4.1` is not a release authorization by itself. A release needs its own
-  changelog, package smoke, and verification evidence.
+- `1.4.1` is the release candidate. It includes the accepted MiniMax M3 video
+  input contribution (#153), the maintained public roadmap contribution (#140),
+  and deterministic provider-test boundaries.
+- Publication is still gated on the release PR, full local checks, fresh-package
+  smoke, GitHub Actions, and npm publication evidence.
 
 ## Active Objectives
 
 1. Keep the public repository free of operator state, local paths, credentials,
    raw session captures, and one-off development artifacts.
-2. Review pending feature contributions individually. Do not merge unrelated
-   work as a bundle.
-3. Turn MemorixBench from a local harness into a reproducible study with public
+2. Turn MemorixBench from a local harness into a reproducible study with public
    permissive-license task sources, isolated trials, and provenance receipts.
 
 ## Pending Admission Work
 
-- #153: assess MiniMax M3 video input separately from the completed image/video
-  generation path.
-- #140: refresh the public roadmap without restating stale product plans.
-- #33, #31, #30: review PDF ingestion, audio ingestion, and graph-search fusion
-  as independent changes with their own tests and release rationale.
+- #153: accepted and merged with focused MiniMax M3 video-input tests.
+- #140: accepted and merged after replacing its stale release timeline with a
+  maintained boundary-and-roadmap document.
+- #33, #31, #30: not merged into the superseding media/retrieval architecture.
+  Their original authorship is preserved through #173 (PDF derivations), #174
+  (audio derivatives), and #175 (graph-assisted evidence expansion).
 - #136 and #151: research-only work. Keep it outside npm releases until the
   experimental protocol and evidence are independently complete.
 
@@ -52,6 +52,6 @@ models, blinded grading where applicable, and reported failures as well as wins.
 
 ## Immediate Next Step
 
-The repository privacy-hygiene baseline is merged. Resume contribution admission
-with one focused PR at a time, then advance the benchmark from local fixtures to
-public, reproducible task sources.
+Complete the 1.4.1 release gates. Once published, advance MemorixBench from
+local fixtures to public, reproducible task sources and keep research work
+separate from npm release claims.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.1] - 2026-08-03
+
+### Added
+- **MiniMax M3 video input** -- The bundled `@memorix/ai` provider layer now advertises and routes MiniMax M3 video content through MiniMax's Anthropic-compatible API. Base64 video is covered by focused request-shape tests, and image-only models still receive a clear text fallback instead of an invalid video block. Contributed by [@octo-patch](https://github.com/octo-patch) in #153.
+
+### Changed
+- **Maintained product roadmap** -- Replaced the stale version-by-version roadmap with current product boundaries, operating constraints, and public directions. Release facts now live in this changelog and active maintainer work lives in `ACTIVE_WORK.md`. Contributed by [@FBISiri](https://github.com/FBISiri) in #140.
+
+### Fixed
+- **Deterministic provider tests** -- `@memorix/ai` unit tests no longer discover local API keys or Pi OAuth credentials and unexpectedly call paid, changing provider endpoints. Routine tests are offline by default; deliberate live validation requires `MEMORIX_AI_LIVE_TESTS=1` plus the required credentials.
+- **Stable model metadata assertion** -- Removed a test-only assumption that OpenRouter will permanently list `moonshotai/kimi-k2.6:free`; the bundled catalog snapshot no longer contains that route, while coverage remains for the supported Kimi K2.6 compatibility metadata.
+
 ## [1.4.0] - 2026-08-02
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memorix",
   "mcpName": "io.github.AVIDS2/memorix",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,
@@ -70,9 +70,11 @@
     "generate:star-history": "node scripts/generate-star-history.mjs",
     "sync:mcp-registry": "node scripts/sync-mcp-registry-manifest.mjs",
     "check:mcp-registry": "node scripts/check-mcp-registry-manifest.mjs",
+    "sync:plugin-release": "node scripts/sync-plugin-release-manifests.mjs",
+    "check:plugin-release": "node scripts/sync-plugin-release-manifests.mjs --check",
     "audit:pi-upstream": "node scripts/pi-upstream-audit.mjs",
     "lint": "tsc --noEmit",
-    "prepublishOnly": "npm run sync:mcp-registry && npm run check:mcp-registry && npm run build && npm test"
+    "prepublishOnly": "npm run sync:mcp-registry && npm run sync:plugin-release && npm run check:mcp-registry && npm run check:plugin-release && npm run build && npm test"
   },
   "keywords": [
     "mcp",

--- a/packages/ai/README.md
+++ b/packages/ai/README.md
@@ -32,3 +32,7 @@ npx memorix-ai login anthropic
 ## Notes
 
 This package is a Memorix-scoped distribution of the agent provider layer inherited from the Pi codebase. Public imports should use `@memorix/ai`.
+
+## Testing
+
+`npm test` is intentionally offline and deterministic, even when the shell has provider credentials. To run provider-backed integration tests deliberately, set `MEMORIX_AI_LIVE_TESTS=1` together with the required provider credentials. This can make network requests and incur provider charges.

--- a/packages/ai/test/live-test-gate.test.ts
+++ b/packages/ai/test/live-test-gate.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { disableAmbientLiveCredentials, liveTestsEnabled } from "./live-test-gate.ts";
+
+describe("live test gate", () => {
+	it("keeps routine test runs offline even when the shell has provider credentials", () => {
+		const env = {
+			OPENROUTER_API_KEY: "secret",
+			COPILOT_GITHUB_TOKEN: "token",
+			GOOGLE_APPLICATION_CREDENTIALS: "C:\\credentials.json",
+			KEEP_ME: "safe",
+		} as NodeJS.ProcessEnv;
+
+		disableAmbientLiveCredentials(env);
+
+		expect(liveTestsEnabled(env)).toBe(false);
+		expect(env.OPENROUTER_API_KEY).toBeUndefined();
+		expect(env.COPILOT_GITHUB_TOKEN).toBeUndefined();
+		expect(env.GOOGLE_APPLICATION_CREDENTIALS).toBeUndefined();
+		expect(env.KEEP_ME).toBe("safe");
+	});
+
+	it("preserves credentials only when live tests are explicitly enabled", () => {
+		const env = {
+			MEMORIX_AI_LIVE_TESTS: "1",
+			OPENROUTER_API_KEY: "secret",
+		} as NodeJS.ProcessEnv;
+
+		disableAmbientLiveCredentials(env);
+
+		expect(liveTestsEnabled(env)).toBe(true);
+		expect(env.OPENROUTER_API_KEY).toBe("secret");
+	});
+});

--- a/packages/ai/test/live-test-gate.ts
+++ b/packages/ai/test/live-test-gate.ts
@@ -1,0 +1,25 @@
+export const LIVE_TESTS_ENV_VAR = "MEMORIX_AI_LIVE_TESTS";
+
+export function liveTestsEnabled(env: NodeJS.ProcessEnv = process.env): boolean {
+	return env[LIVE_TESTS_ENV_VAR] === "1";
+}
+
+/**
+ * Provider integration tests must opt in. Developers commonly have credentials
+ * in their shell, and a routine unit-test run must not unexpectedly make paid
+ * network requests or depend on a provider's current response wording.
+ */
+export function disableAmbientLiveCredentials(env: NodeJS.ProcessEnv = process.env): void {
+	if (liveTestsEnabled(env)) return;
+
+	for (const key of Object.keys(env)) {
+		if (
+			key === "GOOGLE_APPLICATION_CREDENTIALS" ||
+			key.endsWith("_API_KEY") ||
+			key.endsWith("_TOKEN") ||
+			key.endsWith("_SECRET")
+		) {
+			delete env[key];
+		}
+	}
+}

--- a/packages/ai/test/oauth.ts
+++ b/packages/ai/test/oauth.ts
@@ -10,6 +10,7 @@ import { homedir } from "os";
 import { dirname, join } from "path";
 import { getOAuthApiKey } from "../src/utils/oauth/index.ts";
 import type { OAuthCredentials, OAuthProvider } from "../src/utils/oauth/types.ts";
+import { liveTestsEnabled } from "./live-test-gate.ts";
 
 const AUTH_PATH = join(homedir(), ".pi", "agent", "auth.json");
 
@@ -55,6 +56,8 @@ function saveAuthStorage(storage: AuthStorage): void {
  *
  */
 export async function resolveApiKey(provider: string): Promise<string | undefined> {
+	if (!liveTestsEnabled()) return undefined;
+
 	const storage = loadAuthStorage();
 	const entry = storage[provider];
 

--- a/packages/ai/test/openai-completions-tool-choice.test.ts
+++ b/packages/ai/test/openai-completions-tool-choice.test.ts
@@ -890,7 +890,7 @@ describe("openai-completions tool_choice", () => {
 	});
 
 	it("stores OpenRouter Kimi K2.6 reasoning replay compat in built-in metadata", () => {
-		for (const modelId of ["moonshotai/kimi-k2.6", "moonshotai/kimi-k2.6:free"] as const) {
+		for (const modelId of ["moonshotai/kimi-k2.6"] as const) {
 			const model = getModel("openrouter", modelId)!;
 			expect(model.compat?.supportsDeveloperRole).toBe(false);
 			expect(model.compat?.requiresReasoningContentOnAssistantMessages).toBe(true);

--- a/packages/ai/test/setup.ts
+++ b/packages/ai/test/setup.ts
@@ -1,0 +1,3 @@
+import { disableAmbientLiveCredentials } from "./live-test-gate.ts";
+
+disableAmbientLiveCredentials();

--- a/packages/ai/vitest.config.ts
+++ b/packages/ai/vitest.config.ts
@@ -4,6 +4,7 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    setupFiles: ["./test/setup.ts"],
     testTimeout: 30000, // 30 seconds for API calls
   }
 });

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/scripts/sync-plugin-release-manifests.mjs
+++ b/scripts/sync-plugin-release-manifests.mjs
@@ -1,0 +1,45 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const packageJson = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'));
+const checkOnly = process.argv.includes('--check');
+
+const versionedPluginManifests = [
+  'plugins/claude/memorix/.claude-plugin/plugin.json',
+  'plugins/codex/memorix/.codex-plugin/plugin.json',
+  'plugins/copilot/memorix/plugin.json',
+  'plugins/gemini/memorix/gemini-extension.json',
+  'plugins/omp/memorix/package.json',
+  'plugins/openclaw/memorix/.codex-plugin/plugin.json',
+  'plugins/pi/memorix/package.json',
+];
+
+const mismatches = [];
+
+for (const relativePath of versionedPluginManifests) {
+  const manifestPath = join(root, relativePath);
+  const raw = await readFile(manifestPath, 'utf8');
+  const manifest = JSON.parse(raw);
+
+  if (manifest.version === packageJson.version) continue;
+
+  mismatches.push(`${relativePath}: ${String(manifest.version)} -> ${packageJson.version}`);
+  if (!checkOnly) {
+    manifest.version = packageJson.version;
+    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+  }
+}
+
+if (checkOnly && mismatches.length > 0) {
+  throw new Error(`Plugin release metadata is out of sync:\n- ${mismatches.join('\n- ')}`);
+}
+
+if (mismatches.length === 0) {
+  console.log(`Plugin release metadata already matches memorix@${packageJson.version}.`);
+} else if (checkOnly) {
+  console.log(`Plugin release metadata matches memorix@${packageJson.version}.`);
+} else {
+  console.log(`Synchronized plugin release metadata for memorix@${packageJson.version}.`);
+}

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AVIDS2/memorix",
     "source": "github"
   },
-  "version": "1.4.0",
+  "version": "1.4.1",
   "websiteUrl": "https://github.com/AVIDS2/memorix#readme",
   "icons": [
     {
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "memorix",
-      "version": "1.4.0",
+      "version": "1.4.1",
       "runtimeHint": "npx",
       "packageArguments": [
         {


### PR DESCRIPTION
## 1.4.1 release candidate

### Included work
- Ships MiniMax M3 video-input routing from @octo-patch via #153, with maintainer-owned deterministic coverage.
- Ships the current-boundaries roadmap refresh from @FBISiri via #140.
- Carries the older media/graph proposals forward with contributor credit: #30 -> #175, #31 -> #174, #33 -> #173.
- Makes provider tests deterministic by default: ambient credentials and local Pi OAuth are ignored unless `MEMORIX_AI_LIVE_TESTS=1` explicitly opts in.
- Synchronizes all versioned plugin manifests and MCP Registry metadata with the root package version before publish.

### Verification
- `npm run build`
- `npm test`
- `npm run lint`
- `npm run check:mcp-registry`
- `npm run check:plugin-release`
- `npm pack --dry-run --json`
- Fresh tarball smoke in a new temp Git repo: CLI write/search plus MCP `initialize` and `tools/list` (`memorix_project_context`, 45 tools).

Publishing remains blocked until this PR CI is green. The manual publish workflow will independently rebuild, test, publish npm with provenance, and publish the official MCP Registry manifest.