### PR TITLE
feat: evidence-governed memory and CodeGraph evolution

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: star-history
@@ -26,9 +27,29 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
       - name: Commit changed assets
         run: |
+          set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add assets/star-history.json assets/star-history-light.svg assets/star-history-dark.svg
           git diff --cached --quiet && exit 0
+          git switch -C automation/star-history
           git commit -m "docs: update star history chart [skip ci]"
-          git push
+          git push --force origin HEAD:automation/star-history
+
+          pr_number="$(gh pr list \
+            --repo "${GITHUB_REPOSITORY}" \
+            --base main \
+            --head automation/star-history \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')"
+          if [ -z "${pr_number}" ]; then
+            gh pr create \
+              --repo "${GITHUB_REPOSITORY}" \
+              --base main \
+              --head automation/star-history \
+              --title "docs: update star history chart" \
+              --body "Automated refresh of the self-hosted star history assets."
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/docs/1.4.2-EVIDENCE-GOVERNED-MEMORY-SPEC.md
+++ b/docs/1.4.2-EVIDENCE-GOVERNED-MEMORY-SPEC.md
@@ -1,0 +1,434 @@
+# Memorix 1.4.2: Evidence-Governed Memory and CodeGraph
+
+Status: implementation complete on this branch; clean-package verification pending
+Branch: `codex/1.4.2-evidence-governor`
+Baseline: `v1.4.1`
+Updated: 2026-08-06
+
+## One-Sentence Product Contract
+
+Memorix should give an agent the smallest useful set of **current, source-backed
+project knowledge**, and should say "do not use memory here" when it cannot
+justify a useful answer.
+
+This is not a new prompt wrapper or a second knowledge store. It is the policy
+layer that unifies existing observations, claims, workflows, CodeGraph evidence,
+Git state, and verification results before they reach an agent.
+
+## Why This Release Exists
+
+The product already has much of the necessary foundation:
+
+- source-backed claims and code-reference freshness;
+- versioned CodeGraph snapshots and bounded Worksets;
+- retention, archive, workflow, and background-maintenance primitives;
+- project context through MCP and CLI.
+
+Those pieces currently answer related questions in different modules. A memory
+can be relevant but old, source-backed but never verified, or compact but still
+harmful for the current task. 1.4.2 makes the final decision explicit,
+consistent, inspectable, and shared by CLI, MCP, hooks, and dashboard surfaces.
+
+## Research Constraints
+
+This release follows published findings without overstating what they prove.
+
+1. Similar retrieved experiences can cause agents to imitate prior outputs,
+   including wrong or misaligned ones. Memory quality and deletion policy are
+   product safety concerns, not cleanup cosmetics.
+2. Long-horizon memory needs indexing, retrieval, reading, temporal updates,
+   and abstention. Retrieval quality alone is not enough.
+3. Dynamic note links and hierarchical storage are useful only when the source,
+   freshness, and revision path remain visible.
+4. Persistent memory is a privacy boundary. Retrieval must preserve scope,
+   visibility, and provenance instead of treating all stored text as promptable.
+
+The primary research references are listed at the end of this document. Recent
+2026 preprints may guide investigation but do not become product truth without
+reproducible local tests.
+
+## Terms
+
+| Term | Meaning |
+| --- | --- |
+| Candidate | Any possible context item: observation, claim, workflow, code fact, Git fact, test result, or wiki page. |
+| Evidence | A source that can be checked later: file/symbol hash, CodeGraph snapshot, commit, test/run result, document, or explicit user action. |
+| Qualification | The deterministic check that decides whether a candidate is current enough, visible to this caller, and safe enough to use. |
+| Context plan | The bounded answer to: inject nothing, inject a compact card, inject selected evidence, or schedule more work. |
+| Outcome signal | A later, auditable fact such as a focused test passing, a claim being corrected, or a memory helping a verified task. |
+| Observation period | The period after capture before a memory is promoted to trusted reusable knowledge. |
+
+## Non-Negotiable Invariants
+
+1. **No automatic context dump.** Existing memory is not a reason to inject it.
+2. **No silent truth rewrite.** A model may propose a link, summary, or
+   promotion; it cannot overwrite evidence-backed claims without an auditable
+   transition.
+3. **No model-only authority.** Test, Git, code, and explicit user signals outrank
+   a generated confidence score.
+4. **No new default MCP tool explosion.** `memorix_project_context` remains the
+   primary agent surface. Advanced diagnostics stay grouped and opt-in.
+5. **CLI and MCP parity.** Both construct the same context plan from the same
+   policy. Hooks only trigger the plan; they do not own a separate policy.
+6. **Foreground stays fast.** Context assembly may schedule refresh or analysis,
+   but never waits for a corpus scan, remote provider, or LLM synthesis.
+7. **Code facts are versioned.** A narrative cannot claim that code is current
+   without a matching snapshot or an explicit caution.
+8. **Scope is enforced before relevance.** Personal, project, team, and public
+   knowledge do not mix merely because embeddings are similar.
+
+## Target Architecture
+
+```text
+observations / claims / workflows / wiki / Git / tests / CodeGraph
+                              |
+                              v
+                    candidate collection
+                              |
+                              v
+                  evidence qualification gate
+          scope -> provenance -> freshness -> conflict -> quality
+                              |
+                              v
+                   budgeted context planner
+             abstain | compact card | selected detail
+                              |
+                              v
+               MCP / CLI / hook / dashboard explain view
+                              |
+                              v
+          verified outcomes feed lifecycle and CodeGraph links
+```
+
+The governor is deliberately a pure, deterministic core. Storage adapters and
+renderers call it; it does not import an MCP server, hook implementation, or UI.
+
+## Data Contracts
+
+### 1. Context Candidate
+
+```text
+ContextCandidate
+  id, kind, projectId, scope, visibility
+  title, compactText, sourceRefs
+  capturedAt, observedAt
+  freshness                 current | suspect | stale | unknown
+  conflict                  none | possible | confirmed
+  quality                   probation | verified | degraded | blocked
+  relevanceSignals          lexical, semantic, task-lens, code-link
+  estimatedTokens
+```
+
+Existing records are adapted into candidates. This is not a duplicated store.
+
+### 2. Qualification Result
+
+```text
+QualificationResult
+  candidateId
+  disposition              include | compact | defer | exclude
+  reasons[]                stable machine-readable reason codes
+  evidenceSummary[]        source type, id, snapshot/revision, locator
+  qualitySignals[]         verified test, successful reuse, user pin, correction
+  freshness
+  tokenCost
+```
+
+An excluded item is visible in diagnostics only. It is never silently presented
+as if it had not existed.
+
+### 3. Context Plan
+
+```text
+ContextPlan
+  task, taskLens, projectState
+  mode                     abstain | card | workset
+  selected[]               QualificationResult
+  deferred[]               bounded follow-up suggestions
+  cautions[]
+  budget                   requested, used, remaining
+  scheduledMaintenance[]
+  explanationId
+```
+
+`abstain` is a successful result. It means Memorix did not find sufficiently
+qualified context and recommends normal repository inspection instead.
+
+### 4. Outcome Signal
+
+```text
+MemoryOutcomeSignal
+  id, candidateId, projectId, kind
+  kind                     test-pass | test-fail | verified-reuse |
+                           user-pin | user-correction | source-changed |
+                           conflict-confirmed | manual-review
+  sourceRef, snapshotId, observedAt
+  detail                   sanitized, bounded explanation
+```
+
+Outcome signals are append-only audit facts. They update a derived quality
+state; they do not erase the original memory. A generic manual review is
+auditable but does not by itself raise quality: verification or an explicit
+user pin is still required.
+
+## Lifecycle Policy
+
+1. **Capture:** new observations remain usable as local session material but are
+   labelled `probation` for durable retrieval.
+2. **Qualify:** source and scope are checked. Code-bound items are matched to a
+   snapshot; unbound assertions remain lower confidence.
+3. **Promote:** explicit user pin, review approval, successful verified reuse,
+   or source-backed test/Git evidence can promote a candidate.
+4. **Degrade:** changed/deleted source, failing verification, contradiction, or
+   a user correction downgrades the derived quality state.
+5. **Archive:** retention rules continue to govern cleanup, but archive decisions
+   consume this shared state instead of copying their own freshness formula.
+6. **Recover:** an archived fact can be revisited with its original evidence;
+   archive never means invisible deletion by default.
+
+No score alone can cause destructive deletion. A score can only suggest a
+review or make a candidate ineligible for automatic injection.
+
+## CodeGraph Upgrade
+
+### Product Goal
+
+CodeGraph becomes the code evidence service for the governor. It should answer
+four practical questions quickly:
+
+1. What files and symbols are relevant to this task now?
+2. What changed since this memory or workflow was formed?
+3. What may be affected if this symbol or file changes?
+4. How complete and trustworthy is that structural answer?
+
+### New Capabilities
+
+#### A. Snapshot Diff
+
+The first 1.4.2 slice adds a hash-only **file** manifest to each completed
+snapshot. It can report added, modified, and removed indexed files between two
+complete snapshots. It stores paths and hashes, never a second copy of source.
+
+Symbol and relation history are not yet retained per snapshot, so this release
+does **not** pretend to provide historical symbol/edge diffs. Current graph
+relations are used only for the bounded impact slice below.
+
+Target shape for later schema evolution:
+
+```text
+CodeStateDiff
+  fromSnapshotId, toSnapshotId
+  added/changed/removed files
+  added/changed/removed symbols
+  added/changed/removed relations
+  completeness delta
+  affected observation/claim/workflow references
+```
+
+This must report unknowns from incomplete scans. It is not allowed to label an
+unscanned path as unchanged.
+
+#### B. Impact Slice
+
+Given a file or symbol, return a bounded, explainable graph slice:
+
+```text
+ImpactSlice
+  root references
+  inbound and outbound relations
+  direct test/config/workflow references when available
+  confidence, coverage, traversal limit, and reasons
+```
+
+The first release supports direct edges and a small bounded traversal only. It
+does not claim whole-program call-graph precision.
+
+#### Implemented Slice
+
+- `memorix codegraph diff` compares the newest two snapshots by default, or
+  accepts explicit `--from` and `--to` snapshot ids.
+- `memorix codegraph impact --path <relative-source-path>` exposes the same
+  bounded current one-hop graph slice to CLI-only agents. It rejects paths that
+  are not in the current index instead of reporting a misleading empty result.
+- A diff is refused when either snapshot is incomplete or predates the manifest
+  schema. The result explains why instead of treating absent data as unchanged.
+- The impact view resolves both file edges and symbol edges to current files,
+  follows only one hop, and caps relation traversal. It is an inspection aid,
+  not a guarantee of complete impact coverage.
+- Lite deterministically resolves local relative import paths, including the
+  Node ESM `.js`-from-`.ts` convention. It still does not claim semantic symbol
+  resolution or whole-program call-graph precision.
+- A continuation Workset reports how many stale memory bindings point directly
+  at the changed snapshot files. It does not attribute unrelated old stale
+  memory to the current change.
+- The Workset governor now filters optional claims, workflows, durable memory,
+  and code-bound memory before prompt rendering. Its receipt records the safe
+  disposition and reason without exposing hidden content. In this first slice,
+  task facts, Git state, current code state, and safety cautions remain outside
+  the optional-evidence gate so an abstention never hides current source facts.
+
+#### C. Test and Verification Links
+
+Workflow runs now record an append-only pass/fail signal for their selected
+claims and durable memories. The newest signal is applied only as a delivery
+qualification: a failed verification degrades optional context instead of
+silently rewriting or deleting the original record. A later code change can
+then downgrade the confidence of a memory that says "this is verified" rather
+than leaving an old green test as permanent proof. File/symbol references on
+individual test outcomes remain a later extension.
+
+#### D. Provider Coverage Contract
+
+Every provider returns:
+
+```text
+ProviderCoverage
+  provider, parserMode, supportedLanguages
+  indexedFiles, skippedFiles, skippedReasons
+  relationTypes, confidencePolicy
+  snapshotCompleteness
+```
+
+CodeGraph Lite remains a mandatory local fallback. Parser-backed or external
+providers are optional accelerators and may only add normalized facts through
+this contract. They cannot bypass project scope, source epoch, or secret rules.
+
+#### E. Claim-to-Code Requalification
+
+Existing claim and observation code references should consume snapshot diffs:
+
+- removed source -> `blocked` or `needs-review`;
+- changed bound source -> `degraded` until rechecked;
+- current source plus fresh verification -> `verified`;
+- incomplete provider coverage -> `unknown`, never falsely `current`.
+
+## Retrieval Policy
+
+The governor collects candidates first, then applies this order:
+
+1. project identity, scope, visibility, and secret policy;
+2. hard exclusions: deleted evidence, forbidden scope, confirmed contradiction;
+3. source freshness and provider completeness;
+4. task lens and direct code/Git/test links;
+5. quality signals and explicit user review;
+6. relevance ranking and diversity;
+7. strict section and total token budgets.
+
+Default delivery is progressive:
+
+- **abstain:** no qualified advantage; return normal start files only;
+- **card:** one compact "where we were / what changed / what to verify" card;
+- **workset:** selected details with source references and cautions;
+- **defer:** schedule a refresh or requalification without blocking the agent.
+
+## Public Experience
+
+Normal users still say a natural-language task, for example:
+
+> Continue the auth migration. What remains and what must be checked first?
+
+They receive a short, useful answer. They do not see score arithmetic.
+
+An explicit diagnostic path can answer:
+
+```text
+Why did Memorix include or skip this memory?
+Which code snapshot supports it?
+What changed since it was verified?
+How much context budget did it consume?
+```
+
+This diagnostic output is grouped under existing context/knowledge diagnostics;
+it is not a new default tool for every graph operation.
+
+## Delivery Phases
+
+### Phase 0: Baseline and Compatibility
+
+- Inventory all existing context ranking, retention, claim, freshness, and
+  CodeGraph paths.
+- Add a behavior matrix covering current output and no-regression fixtures.
+- Establish deterministic context-plan fixtures: abstain, compact card, stale
+  code caution, conflict exclusion, and incomplete graph coverage.
+
+### Phase 1: Governor Core
+
+- Implement candidate adapters and pure qualification/context-plan modules.
+- Route `project_context`, `context_pack`, and CLI context/resume through the
+  same plan builder without changing their stable output contracts.
+- Add explicit abstention and reason codes.
+
+### Phase 2: Outcome and Lifecycle Unification
+
+- Add append-only outcome signals and derived candidate quality.
+- Route retention report, HTTP/dashboard status, archive eligibility, and
+  claim requalification through one lifecycle evaluation path.
+- Treat test/Git/source changes as higher-quality signals than model estimates.
+
+### Phase 3: CodeGraph Evidence Upgrade
+
+- Add snapshot diffs, bounded impact slices, coverage reporting, and test/run
+  reference links.
+- Requalify claim/observation references from diffs.
+- Add fixture coverage for changed symbol, removed file, incomplete scan, and
+  uncertain relation handling.
+
+### Phase 4: Explainability and Operator UX
+
+- Add context-plan explanations to CLI JSON and grouped diagnostics.
+- Add dashboard views for quality state, source freshness, impact slice, and
+  exclusion reason without leaking hidden/private evidence.
+- Keep the normal agent path quiet.
+
+### Phase 5: Verification and Release Gate
+
+- Run unit, SQLite reopen, provider fallback, CLI, MCP, hook, and packaged
+  installation checks.
+- Run isolated agent smoke tests with qualified context, stale context, and
+  abstention scenarios.
+- Measure first-turn latency, token usage, stale-context catches, and false
+  inclusion/exclusion rates against Phase 0 fixtures.
+
+## Acceptance Criteria
+
+1. Every automatic inclusion has a machine-readable reason and at least one
+   visible source or explicit `unknown` caution.
+2. A changed or deleted code source changes the retrieval disposition without a
+   human rediscovering the mismatch.
+3. A task with no qualified memory returns less context, not a generic summary.
+4. CLI, MCP, and hooks select the same qualified evidence for the same task and
+   project state.
+5. An incomplete CodeGraph provider result can never be formatted as complete
+   code truth.
+6. Test failure, user correction, and source change can lower reusable-memory
+   quality; no score-only path deletes a memory.
+7. Existing stored observations, claims, workflows, context commands, and lite
+   MCP profile remain backward compatible.
+8. Default MCP tool count does not increase.
+
+## Explicit Non-Goals
+
+- A remote graph database requirement.
+- Silent LLM rewriting of a project's wiki or workflow.
+- Claiming exact whole-program impact analysis from CodeGraph Lite.
+- Replacing a real language server, CodeGraph product, Git, or test runner.
+- Auto-capturing all conversations, screenshots, or tool outputs.
+- Treating a visual graph as proof of a maintained semantic knowledge graph.
+
+## Research References
+
+- Xiong et al., "How Memory Management Impacts LLM Agents: An Empirical Study
+  of Experience-Following Behavior," ACL 2026.
+  https://aclanthology.org/2026.acl-long.27/
+- Wu et al., "LongMemEval: Benchmarking Chat Assistants on Long-Term
+  Interactive Memory," ICLR 2025.
+  https://iclr.cc/virtual/2025/poster/28290
+- Xu et al., "A-MEM: Agentic Memory for LLM Agents," NeurIPS 2025.
+  https://neurips.cc/virtual/2025/poster/119020
+- Kang et al., "Memory OS of AI Agent," EMNLP 2025.
+  https://aclanthology.org/2025.emnlp-main.1318
+- Tan et al., "MemBench: Towards More Comprehensive Evaluation on the Memory
+  of LLM-based Agents," Findings of ACL 2025.
+  https://aclanthology.org/2025.findings-acl.989.pdf
+- Wang et al., "Unveiling Privacy Risks in LLM Agent Memory," ACL 2025.
+  https://aclanthology.org/2025.acl-long.1227.pdf

--- a/src/cli/commands/codegraph.ts
+++ b/src/cli/commands/codegraph.ts
@@ -58,10 +58,50 @@ function formatUsageHint(): string {
     'Usage:',
     '  memorix codegraph refresh',
     '  memorix codegraph status --json',
+    '  memorix codegraph diff [--from <snapshot>] [--to <snapshot>]',
+    '  memorix codegraph impact --path <relative-source-path>',
     '  memorix codegraph context-pack --task "continue auth bug"',
     '',
     'Tip: use `memorix context "..."` for new work or `memorix resume "..."` for prior work.',
   ].join('\n');
+}
+
+function formatDiff(diff: ReturnType<CodeGraphStore['diffSnapshots']>, impact: ReturnType<CodeGraphStore['impactSlice']>): string {
+  if (!diff.available) {
+    return `CodeGraph diff is unavailable: ${diff.reason ?? 'unknown reason'}. Refresh twice to establish comparable snapshots.`;
+  }
+  const summary = diff.changes.reduce((counts, change) => {
+    counts[change.kind] += 1;
+    return counts;
+  }, { added: 0, modified: 0, removed: 0 });
+  const lines = [
+    `CodeGraph diff: ${diff.fromSnapshotId} -> ${diff.toSnapshotId}`,
+    `- Changed files: ${diff.changes.length} (${summary.added} added, ${summary.modified} modified, ${summary.removed} removed)`,
+  ];
+  for (const change of diff.changes.slice(0, 20)) lines.push(`- ${change.kind}: ${change.path}`);
+  if (diff.changes.length > 20) lines.push(`- ${diff.changes.length - 20} additional file change(s) omitted`);
+  if (impact.directlyConnectedPaths.length > 0) {
+    lines.push('', 'Current one-hop structural impact');
+    for (const path of impact.directlyConnectedPaths.slice(0, 20)) lines.push(`- ${path}`);
+  }
+  if (impact.relationCount === 0) lines.push('', 'No current file-edge relation was found for the changed paths.');
+  if (impact.truncated) lines.push('- Impact relation limit reached; inspect the graph before assuming coverage.');
+  return lines.join('\n');
+}
+
+function formatImpact(impact: ReturnType<CodeGraphStore['impactSlice']>): string {
+  const lines = [
+    `CodeGraph current one-hop impact: ${impact.changedPaths.join(', ')}`,
+    `- Relations inspected: ${impact.relationCount}`,
+  ];
+  if (impact.directlyConnectedPaths.length > 0) {
+    lines.push('- Directly connected paths:');
+    for (const path of impact.directlyConnectedPaths) lines.push(`  - ${path}`);
+  } else {
+    lines.push('- No current file-edge relation was found for this indexed path.');
+  }
+  if (impact.truncated) lines.push('- Impact relation limit reached; inspect the graph before assuming coverage.');
+  return lines.join('\n');
 }
 
 function compactFacts(project: { rootPath: string }): { facts: string[]; dirty: boolean } {
@@ -82,9 +122,13 @@ export default defineCommand({
     description: 'Inspect and refresh CodeGraph Memory for the current project',
   },
   args: {
-    action: { type: 'string', description: 'Action: status, refresh, or context-pack' },
+    action: { type: 'string', description: 'Action: status, refresh, diff, impact, or context-pack' },
     task: { type: 'string', description: 'Task text for context-pack' },
+    path: { type: 'string', description: 'Indexed relative source path for impact' },
     limit: { type: 'string', description: 'Max active memories to inspect for context-pack' },
+    from: { type: 'string', description: 'Earlier CodeGraph snapshot id for diff' },
+    to: { type: 'string', description: 'Later CodeGraph snapshot id for diff' },
+    impactLimit: { type: 'string', description: 'Maximum graph relations to inspect for diff impact' },
     json: { type: 'boolean', description: 'Emit machine-readable JSON output' },
   },
   run: async ({ args }) => {
@@ -162,6 +206,43 @@ export default defineCommand({
           return;
         }
 
+        case 'diff': {
+          const snapshots = store.listSnapshots(project.id, 2);
+          const fromSnapshotId = (args.from as string | undefined)?.trim() || snapshots[1]?.id;
+          const toSnapshotId = (args.to as string | undefined)?.trim() || snapshots[0]?.id;
+          if (!fromSnapshotId || !toSnapshotId) {
+            emitError('two completed CodeGraph snapshots are required; run "memorix codegraph refresh" again after a code change.', asJson);
+            return;
+          }
+          const diff = store.diffSnapshots(project.id, fromSnapshotId, toSnapshotId);
+          const impact = store.impactSlice(
+            project.id,
+            diff.changes.map(change => change.path),
+            parsePositiveInt(args.impactLimit as string | undefined, 24),
+          );
+          emitResult({ project, diff, impact }, formatDiff(diff, impact), asJson);
+          return;
+        }
+
+        case 'impact': {
+          const sourcePath = (args.path as string | undefined)?.trim() || positional.slice(1).join(' ').trim();
+          if (!sourcePath) {
+            emitError('path is required for "memorix codegraph impact"', asJson);
+            return;
+          }
+          if (!store.getFile(project.id, sourcePath)) {
+            emitError(`path is not in the current CodeGraph index: ${sourcePath}. Run "memorix codegraph refresh" and retry.`, asJson);
+            return;
+          }
+          const impact = store.impactSlice(
+            project.id,
+            [sourcePath],
+            parsePositiveInt(args.impactLimit as string | undefined, 24),
+          );
+          emitResult({ project, impact }, formatImpact(impact), asJson);
+          return;
+        }
+
         case 'context-pack': {
           const task = (args.task as string | undefined)?.trim() || positional.slice(1).join(' ').trim();
           if (!task) {
@@ -224,7 +305,7 @@ export default defineCommand({
         }
 
         default:
-          emitError(`unknown codegraph action "${action}". Use "status", "refresh", or "context-pack".`, asJson);
+          emitError(`unknown codegraph action "${action}". Use "status", "refresh", "diff", "impact", or "context-pack".`, asJson);
       }
     } catch (error) {
       emitError(error instanceof Error ? error.message : String(error), asJson);

--- a/src/codegraph/auto-context.ts
+++ b/src/codegraph/auto-context.ts
@@ -259,6 +259,25 @@ export async function buildAutoProjectContext(input: {
   const overview = explain.overview;
   const currentFacts = collectCurrentProjectFacts({ project: input.project, now });
   const latestSnapshot = overview.code.latestSnapshot;
+  let codeEvolution: TaskWorkset['codeEvolution'];
+  if (continuationRequested && latestSnapshot?.previousSnapshotId && latestSnapshot.changedPathCount > 0) {
+    const diff = store.diffSnapshots(input.project.id, latestSnapshot.previousSnapshotId, latestSnapshot.id);
+    if (diff.available && diff.changes.length > 0) {
+      const impact = store.impactSlice(input.project.id, diff.changes.map(change => change.path));
+      const changedFileIds = new Set([
+        ...store.listSnapshotFiles(diff.fromSnapshotId),
+        ...store.listSnapshotFiles(diff.toSnapshotId),
+      ].filter(file => diff.changes.some(change => change.path === file.path)).map(file => file.fileId));
+      codeEvolution = {
+        fromSnapshotId: diff.fromSnapshotId,
+        toSnapshotId: diff.toSnapshotId,
+        changes: diff.changes.slice(0, 5).map(change => ({ path: change.path, kind: change.kind })),
+        directlyConnectedPaths: impact.directlyConnectedPaths.slice(0, 3),
+        affectedMemoryCount: store.countStaleObservationRefsForFiles(input.project.id, [...changedFileIds]),
+        truncated: impact.truncated || diff.changes.length > 5,
+      };
+    }
+  }
   const sourceSets = lensSourceSets({ task, lens, explain });
   let externalOutline: ExternalCodeGraphOutline | undefined;
   let externalCaution: string | undefined;
@@ -348,6 +367,7 @@ export async function buildAutoProjectContext(input: {
     currentFacts: worksetFactLines(currentFacts),
     ...(continuation ? { continuation } : {}),
     codeState: codeStateLine(overview),
+    ...(codeEvolution ? { codeEvolution } : {}),
     reliableMemory: sourceSets.reliableSources
       .slice(0, lens.sourceLimit)
       .map(source => ({

--- a/src/codegraph/external-provider.ts
+++ b/src/codegraph/external-provider.ts
@@ -302,6 +302,7 @@ function providerQuality(input: {
       capabilities: {
         declarations: true,
         importHints: true,
+        localRelativeImportTargets: true,
         resolvedRelations: false,
         exactLocations: false,
       },

--- a/src/codegraph/store.ts
+++ b/src/codegraph/store.ts
@@ -1,9 +1,14 @@
 import { randomUUID } from 'node:crypto';
+import { posix as pathPosix } from 'node:path';
 import { getDatabase } from '../store/sqlite-db.js';
 import type {
   CodeEdge,
   CodeFile,
+  CodeGraphImpactSlice,
   CodeGraphStatus,
+  CodeStateDiff,
+  CodeStateFileChange,
+  CodeStateSnapshotFile,
   CodeStateScanCompleteness,
   CodeStateSnapshot,
   CodeStateSnapshotInput,
@@ -71,6 +76,41 @@ function rowToEdge(row: any): CodeEdge {
   } as CodeEdge;
 }
 
+function resolveRelativeImportTarget(
+  sourcePath: string,
+  evidence: string | undefined,
+  fileByPath: Map<string, CodeFile>,
+): CodeFile | undefined {
+  const target = evidence?.trim().replace(/\\/g, '/');
+  if (!target?.startsWith('.')) return undefined;
+  const base = normalizeCodePath(pathPosix.normalize(pathPosix.join(pathPosix.dirname(sourcePath), target)));
+  if (!base || base === '..' || base.startsWith('../')) return undefined;
+  const candidates = [base];
+  const extensionMatch = base.match(/(\.[A-Za-z0-9]+)$/);
+  const hasExtension = Boolean(extensionMatch);
+  if (!hasExtension) {
+    const extensions = [...new Set([...fileByPath.keys()]
+      .map(path => path.match(/(\.[A-Za-z0-9]+)$/)?.[1])
+      .filter((extension): extension is string => Boolean(extension)))];
+    for (const extension of extensions) {
+      candidates.push(`${base}${extension}`, `${base}/index${extension}`);
+    }
+  } else {
+    // Node ESM projects commonly import the emitted .js path from a .ts source.
+    // Keep an exact path first, then resolve only equivalent local source forms.
+    const sourceStem = base.slice(0, -extensionMatch![1].length);
+    const sourceExtensions = extensionMatch![1] === '.js'
+      ? ['.ts', '.tsx', '.js', '.jsx']
+      : extensionMatch![1] === '.mjs'
+        ? ['.mts', '.mjs']
+        : extensionMatch![1] === '.cjs'
+          ? ['.cts', '.cjs']
+          : [];
+    for (const extension of sourceExtensions) candidates.push(`${sourceStem}${extension}`);
+  }
+  return candidates.map(candidate => fileByPath.get(candidate)).find((file): file is CodeFile => Boolean(file));
+}
+
 function rowToRef(row: any): ObservationCodeRef {
   return {
     id: row.id,
@@ -132,6 +172,22 @@ function rowToSnapshot(row: any): CodeStateSnapshot {
     completeness: parseCompleteness(row.completenessJson),
     ...(row.previousSnapshotId ? { previousSnapshotId: row.previousSnapshotId } : {}),
   } as CodeStateSnapshot;
+}
+
+function rowToSnapshotFile(row: any): CodeStateSnapshotFile {
+  return {
+    snapshotId: row.snapshotId,
+    projectId: row.projectId,
+    fileId: row.fileId,
+    path: row.path,
+    contentHash: row.contentHash,
+  };
+}
+
+function snapshotIsIncomplete(snapshot: CodeStateSnapshot): boolean {
+  return snapshot.completeness.skippedOversizedFiles > 0
+    || (snapshot.completeness.unreadableFiles ?? 0) > 0
+    || snapshot.completeness.removalScanDeferred;
 }
 
 export class CodeGraphStore {
@@ -312,6 +368,7 @@ export class CodeGraphStore {
     });
 
     tx();
+    this.reconcileLocalImportTargets(projectId);
   }
 
   /**
@@ -329,7 +386,10 @@ export class CodeGraphStore {
     const changed = input.changed.filter((delta) => delta.file.projectId === projectId);
     const metadataOnly = (input.metadataOnly ?? []).filter((file) => file.projectId === projectId);
     const removedFileIds = input.removedFileIds ?? [];
-    if (changed.length === 0 && metadataOnly.length === 0 && removedFileIds.length === 0) return;
+    if (changed.length === 0 && metadataOnly.length === 0 && removedFileIds.length === 0) {
+      this.reconcileLocalImportTargets(projectId);
+      return;
+    }
 
     const staleRefsForFile = this.db.prepare(`
       UPDATE observation_code_refs
@@ -340,9 +400,18 @@ export class CodeGraphStore {
         )
       )
     `);
-    const deleteEdgesForFile = this.db.prepare(`
+    const deleteEdgesFromFile = this.db.prepare(`
       DELETE FROM code_edges
-      WHERE projectId = ? AND (fromFileId = ? OR toFileId = ?)
+      WHERE projectId = ? AND fromFileId = ?
+    `);
+    const clearImportTargetsForFile = this.db.prepare(`
+      UPDATE code_edges
+      SET toFileId = NULL
+      WHERE projectId = ? AND toFileId = ? AND type = 'imports'
+    `);
+    const deleteOtherIncomingEdgesForFile = this.db.prepare(`
+      DELETE FROM code_edges
+      WHERE projectId = ? AND toFileId = ? AND type != 'imports'
     `);
     const deleteSymbolsForFile = this.db.prepare(`DELETE FROM code_symbols WHERE projectId = ? AND fileId = ?`);
     const deleteFile = this.db.prepare(`DELETE FROM code_files WHERE projectId = ? AND id = ?`);
@@ -380,7 +449,9 @@ export class CodeGraphStore {
       const staleAt = new Date().toISOString();
       for (const fileId of removedFileIds) {
         staleRefsForFile.run(staleAt, projectId, fileId, projectId, fileId);
-        deleteEdgesForFile.run(projectId, fileId, fileId);
+        deleteEdgesFromFile.run(projectId, fileId);
+        clearImportTargetsForFile.run(projectId, fileId);
+        deleteOtherIncomingEdgesForFile.run(projectId, fileId);
         deleteSymbolsForFile.run(projectId, fileId);
         deleteFile.run(projectId, fileId);
       }
@@ -388,7 +459,9 @@ export class CodeGraphStore {
       for (const delta of changed) {
         const fileId = delta.file.id;
         staleRefsForFile.run(staleAt, projectId, fileId, projectId, fileId);
-        deleteEdgesForFile.run(projectId, fileId, fileId);
+        deleteEdgesFromFile.run(projectId, fileId);
+        clearImportTargetsForFile.run(projectId, fileId);
+        deleteOtherIncomingEdgesForFile.run(projectId, fileId);
         deleteSymbolsForFile.run(projectId, fileId);
         writeFile(delta.file);
 
@@ -429,6 +502,7 @@ export class CodeGraphStore {
       for (const file of metadataOnly) writeFile(file);
     });
     tx();
+    this.reconcileLocalImportTargets(projectId);
   }
 
   upsertObservationRefs(refs: ObservationCodeRef[]): void {
@@ -488,6 +562,26 @@ export class CodeGraphStore {
           updatedAt: ref.updatedAt ?? null,
           snapshotId: ref.snapshotId ?? this.latestSnapshot(ref.projectId)?.id ?? null,
         });
+      }
+    });
+    tx();
+  }
+
+  /**
+   * Lite import extraction records the original import text first. Resolve only
+   * local relative imports against the current index after each refresh, so an
+   * added or removed target cannot leave a fabricated file-to-file relation.
+   */
+  reconcileLocalImportTargets(projectId: string): void {
+    const fileById = new Map(this.listFiles(projectId).map(file => [file.id, file]));
+    const fileByPath = new Map([...fileById.values()].map(file => [file.path, file]));
+    const update = this.db.prepare('UPDATE code_edges SET toFileId = ? WHERE id = ?');
+    const tx = this.db.transaction(() => {
+      for (const edge of this.listEdges(projectId)) {
+        if (edge.type !== 'imports' || !edge.fromFileId) continue;
+        const source = fileById.get(edge.fromFileId);
+        const target = source ? resolveRelativeImportTarget(source.path, edge.evidence, fileByPath) : undefined;
+        update.run(target?.id ?? null, edge.id);
       }
     });
     tx();
@@ -577,6 +671,19 @@ export class CodeGraphStore {
     `).all(projectId).map(rowToRef);
   }
 
+  /** Count distinct observations whose binding to these exact files is stale. */
+  countStaleObservationRefsForFiles(projectId: string, fileIds: string[]): number {
+    const ids = [...new Set(fileIds.filter(Boolean))];
+    if (ids.length === 0) return 0;
+    const placeholders = ids.map(() => '?').join(', ');
+    const row = this.db.prepare(`
+      SELECT COUNT(DISTINCT observationId) AS count
+      FROM observation_code_refs
+      WHERE projectId = ? AND status = 'stale' AND fileId IN (${placeholders})
+    `).get(projectId, ...ids);
+    return Number(row?.count ?? 0);
+  }
+
   listReferencedSymbols(projectId: string): CodeSymbol[] {
     return this.db.prepare(`
       SELECT DISTINCT symbols.*
@@ -599,6 +706,100 @@ export class CodeGraphStore {
     return this.db.prepare(
       'SELECT * FROM code_state_snapshots WHERE projectId = ? ORDER BY sourceEpoch DESC LIMIT ?',
     ).all(projectId, safeLimit).map(rowToSnapshot);
+  }
+
+  listSnapshotFiles(snapshotId: string): CodeStateSnapshotFile[] {
+    return this.db.prepare(`
+      SELECT snapshotId, projectId, fileId, path, contentHash
+      FROM code_state_snapshot_files
+      WHERE snapshotId = ?
+      ORDER BY path
+    `).all(snapshotId).map(rowToSnapshotFile);
+  }
+
+  diffSnapshots(projectId: string, fromSnapshotId: string, toSnapshotId: string): CodeStateDiff {
+    const snapshots = this.db.prepare(`
+      SELECT * FROM code_state_snapshots WHERE id IN (?, ?)
+    `).all(fromSnapshotId, toSnapshotId).map(rowToSnapshot) as CodeStateSnapshot[];
+    if (snapshots.length !== 2) {
+      return { projectId, fromSnapshotId, toSnapshotId, available: false, reason: 'missing-snapshot', changes: [] };
+    }
+    if (snapshots.some(snapshot => snapshot.projectId !== projectId)) {
+      return { projectId, fromSnapshotId, toSnapshotId, available: false, reason: 'project-mismatch', changes: [] };
+    }
+    if (snapshots.some(snapshotIsIncomplete)) {
+      return { projectId, fromSnapshotId, toSnapshotId, available: false, reason: 'incomplete-snapshot', changes: [] };
+    }
+    const before = this.listSnapshotFiles(fromSnapshotId);
+    const after = this.listSnapshotFiles(toSnapshotId);
+    if (before.length === 0 || after.length === 0) {
+      return {
+        projectId,
+        fromSnapshotId,
+        toSnapshotId,
+        available: false,
+        reason: 'legacy-snapshot-without-manifest',
+        changes: [],
+      };
+    }
+    const beforeByPath = new Map(before.map(file => [file.path, file]));
+    const afterByPath = new Map(after.map(file => [file.path, file]));
+    const paths = [...new Set([...beforeByPath.keys(), ...afterByPath.keys()])].sort();
+    const changes: CodeStateFileChange[] = [];
+    for (const path of paths) {
+      const oldFile = beforeByPath.get(path);
+      const newFile = afterByPath.get(path);
+      if (!oldFile && newFile) {
+        changes.push({ path, kind: 'added', afterHash: newFile.contentHash });
+      } else if (oldFile && !newFile) {
+        changes.push({ path, kind: 'removed', beforeHash: oldFile.contentHash });
+      } else if (oldFile && newFile && oldFile.contentHash !== newFile.contentHash) {
+        changes.push({ path, kind: 'modified', beforeHash: oldFile.contentHash, afterHash: newFile.contentHash });
+      }
+    }
+    return { projectId, fromSnapshotId, toSnapshotId, available: true, changes };
+  }
+
+  impactSlice(projectId: string, changedPaths: string[], maxRelations = 24): CodeGraphImpactSlice {
+    const safeLimit = Number.isFinite(maxRelations) ? Math.max(1, Math.min(100, Math.floor(maxRelations))) : 24;
+    const normalizedPaths = [...new Set(changedPaths.map(normalizeCodePath).filter(Boolean))].sort();
+    const files = this.listFiles(projectId);
+    const fileById = new Map(files.map(file => [file.id, file.path]));
+    const fileIdBySymbolId = new Map(this.listSymbols(projectId).map(symbol => [symbol.id, symbol.fileId]));
+    const changedIds = new Set(files.filter(file => normalizedPaths.includes(file.path)).map(file => file.id));
+    const direct = new Set<string>();
+    let relationCount = 0;
+    let truncated = false;
+    for (const edge of this.listEdges(projectId)) {
+      const endpoints = [
+        edge.fromFileId,
+        edge.toFileId,
+        edge.fromSymbolId ? fileIdBySymbolId.get(edge.fromSymbolId) : undefined,
+        edge.toSymbolId ? fileIdBySymbolId.get(edge.toSymbolId) : undefined,
+      ].filter((id): id is string => Boolean(id));
+      if (!endpoints.some(id => changedIds.has(id))) continue;
+      const relatedPaths = endpoints
+        .filter(id => !changedIds.has(id))
+        .map(id => fileById.get(id))
+        .filter((path): path is string => Boolean(path));
+      if (relatedPaths.length === 0) continue;
+      if (relationCount >= safeLimit) {
+        truncated = true;
+        break;
+      }
+      relationCount += 1;
+      for (const path of relatedPaths) direct.add(path);
+    }
+    const snapshot = this.latestSnapshot(projectId);
+    return {
+      projectId,
+      ...(snapshot ? { snapshotId: snapshot.id } : {}),
+      changedPaths: normalizedPaths,
+      directlyConnectedPaths: [...direct].sort(),
+      relationCount,
+      truncated,
+      provider: snapshot?.provider ?? 'lite',
+    };
   }
 
   /**
@@ -642,6 +843,16 @@ export class CodeGraphStore {
       this.db.prepare(
         "UPDATE observation_code_refs SET snapshotId = ? WHERE projectId = ? AND status = 'current'",
       ).run(id, input.projectId);
+      const snapshotFileRows = this.db.prepare(`
+        SELECT id, projectId, path, contentHash FROM code_files WHERE projectId = ? ORDER BY path
+      `).all(input.projectId) as Array<{ id: string; projectId: string; path: string; contentHash: string }>;
+      const insertSnapshotFile = this.db.prepare(`
+        INSERT INTO code_state_snapshot_files (snapshotId, projectId, fileId, path, contentHash)
+        VALUES (?, ?, ?, ?, ?)
+      `);
+      for (const file of snapshotFileRows) {
+        insertSnapshotFile.run(id, file.projectId, file.id, file.path, file.contentHash);
+      }
       snapshot = {
         ...input,
         id,

--- a/src/codegraph/types.ts
+++ b/src/codegraph/types.ts
@@ -116,6 +116,46 @@ export interface CodeStateSnapshot extends CodeStateSnapshotInput {
   previousSnapshotId?: string;
 }
 
+/** Hash-only file state retained for an explicit Code State snapshot. */
+export interface CodeStateSnapshotFile {
+  snapshotId: string;
+  projectId: string;
+  fileId: string;
+  path: string;
+  contentHash: string;
+}
+
+export interface CodeStateFileChange {
+  path: string;
+  kind: 'added' | 'modified' | 'removed';
+  beforeHash?: string;
+  afterHash?: string;
+}
+
+/**
+ * An exact file-level comparison when both snapshots have hash manifests.
+ * It intentionally makes no claim about source-level semantic equivalence.
+ */
+export interface CodeStateDiff {
+  projectId: string;
+  fromSnapshotId: string;
+  toSnapshotId: string;
+  available: boolean;
+  reason?: 'missing-snapshot' | 'project-mismatch' | 'legacy-snapshot-without-manifest' | 'incomplete-snapshot';
+  changes: CodeStateFileChange[];
+}
+
+/** Bounded one-hop structural evidence around changed file paths. */
+export interface CodeGraphImpactSlice {
+  projectId: string;
+  snapshotId?: string;
+  changedPaths: string[];
+  directlyConnectedPaths: string[];
+  relationCount: number;
+  truncated: boolean;
+  provider: CodeGraphProviderKind;
+}
+
 export interface CodeGraphStatus {
   provider: CodeGraphProviderKind;
   files: number;
@@ -164,6 +204,8 @@ export interface CodeGraphProviderQuality {
     capabilities: {
       declarations: boolean;
       importHints: boolean;
+      /** Deterministic local-path mapping only; not semantic name resolution. */
+      localRelativeImportTargets: boolean;
       resolvedRelations: false;
       exactLocations: false;
     };

--- a/src/knowledge/context-assembly.ts
+++ b/src/knowledge/context-assembly.ts
@@ -43,6 +43,22 @@ export interface ContextReceiptOmission {
   count: number;
 }
 
+export interface ContextReceiptGovernanceDecision {
+  kind: ContextCandidateKind;
+  id?: string;
+  disposition: 'include' | 'compact' | 'defer' | 'exclude';
+  reasons: string[];
+}
+
+/** Privacy-safe evidence qualification, never appended to the agent prompt. */
+export interface ContextReceiptGovernance {
+  /** Current implementation qualifies optional memory/knowledge, not caller task facts. */
+  scope: 'optional-evidence';
+  mode: 'abstain' | 'card' | 'workset';
+  decisions: ContextReceiptGovernanceDecision[];
+  cautions: string[];
+}
+
 export interface ContextReceipt {
   version: '1.3';
   target: ContextDeliveryTarget;
@@ -53,6 +69,7 @@ export interface ContextReceipt {
   };
   selected: ContextReceiptSelection[];
   omitted: ContextReceiptOmission[];
+  governance?: ContextReceiptGovernance;
   scheduledActions: string[];
 }
 
@@ -89,6 +106,14 @@ export function formatContextReceipt(receipt: ContextReceipt): string {
     lines.push('', 'Withheld by budget');
     for (const item of receipt.omitted) {
       lines.push(`- ${item.kind}: ${item.count} item(s) (${item.reason})`);
+    }
+  }
+
+  if (receipt.governance?.decisions.length) {
+    lines.push('', 'Optional evidence qualification');
+    for (const item of receipt.governance.decisions.slice(0, 20)) {
+      const id = item.id ? ` ${item.id}` : '';
+      lines.push(`- ${item.kind}${id}: ${item.disposition} (${item.reasons.join(', ')})`);
     }
   }
 

--- a/src/knowledge/governor.ts
+++ b/src/knowledge/governor.ts
@@ -1,0 +1,156 @@
+import type {
+  ContextCandidateFreshness,
+  ContextCandidateKind,
+  ContextCandidateTrust,
+} from './context-assembly.js';
+
+/**
+ * A small, serializable description of an item competing for agent context.
+ * This is intentionally independent from stores and prompt rendering so every
+ * delivery surface can apply the same evidence rules.
+ */
+export interface GovernanceCandidate {
+  kind: ContextCandidateKind;
+  id?: string;
+  estimatedTokens: number;
+  relevance: number;
+  scopeAllowed: boolean;
+  freshness?: ContextCandidateFreshness;
+  trust?: ContextCandidateTrust;
+  quality?: 'verified' | 'probationary' | 'degraded' | 'blocked';
+  conflict?: 'none' | 'possible' | 'confirmed';
+  evidenceCount?: number;
+}
+
+export type GovernanceDisposition = 'include' | 'compact' | 'defer' | 'exclude';
+
+export type GovernanceReason =
+  | 'scope-forbidden'
+  | 'confirmed-conflict'
+  | 'blocked-quality'
+  | 'degraded-quality'
+  | 'stale-evidence'
+  | 'unknown-freshness'
+  | 'possible-conflict'
+  | 'probationary-evidence'
+  | 'token-budget'
+  | 'current-source-backed-evidence'
+  | 'relevant-evidence'
+  | 'no-qualified-evidence';
+
+export interface GovernanceDecision {
+  candidate: GovernanceCandidate;
+  disposition: GovernanceDisposition;
+  reasons: GovernanceReason[];
+}
+
+export interface GovernancePlan {
+  mode: 'abstain' | 'card' | 'workset';
+  budget: { maxTokens: number; usedTokens: number };
+  decisions: GovernanceDecision[];
+  cautions: GovernanceReason[];
+}
+
+function clampRelevance(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(0, Math.min(1, value));
+}
+
+function classify(candidate: GovernanceCandidate): Omit<GovernanceDecision, 'candidate'> {
+  const freshness = candidate.freshness ?? 'unknown';
+  const trust = candidate.trust ?? 'historical';
+  const quality = candidate.quality ?? 'probationary';
+  const conflict = candidate.conflict ?? 'none';
+
+  if (!candidate.scopeAllowed) {
+    return { disposition: 'exclude', reasons: ['scope-forbidden'] };
+  }
+  if (conflict === 'confirmed') {
+    return { disposition: 'exclude', reasons: ['confirmed-conflict'] };
+  }
+  if (quality === 'blocked') {
+    return { disposition: 'exclude', reasons: ['blocked-quality'] };
+  }
+  if (quality === 'degraded') {
+    return { disposition: 'defer', reasons: ['degraded-quality'] };
+  }
+  if (freshness === 'stale') {
+    return { disposition: 'defer', reasons: ['stale-evidence'] };
+  }
+
+  const reasons: GovernanceReason[] = [];
+  let disposition: GovernanceDisposition = 'include';
+  if (freshness === 'unknown') {
+    disposition = 'compact';
+    reasons.push('unknown-freshness');
+  }
+  if (conflict === 'possible') {
+    disposition = 'compact';
+    reasons.push('possible-conflict');
+  }
+  if (quality === 'probationary') {
+    disposition = 'compact';
+    reasons.push('probationary-evidence');
+  }
+  if (disposition === 'include' && freshness === 'current' && trust === 'source-backed') {
+    reasons.push('current-source-backed-evidence');
+  } else if (reasons.length === 0) {
+    reasons.push('relevant-evidence');
+  }
+  return { disposition, reasons };
+}
+
+function priority(decision: GovernanceDecision): number {
+  const dispositionWeight: Record<GovernanceDisposition, number> = {
+    include: 3,
+    compact: 2,
+    defer: 1,
+    exclude: 0,
+  };
+  const evidence = Math.min(3, decision.candidate.evidenceCount ?? 0) / 10;
+  return dispositionWeight[decision.disposition] + clampRelevance(decision.candidate.relevance) + evidence;
+}
+
+/**
+ * Decide which evidence may enter a bounded context response. The result never
+ * mutates memory and deliberately prefers an explicit abstention to a generic
+ * history dump.
+ */
+export function governContextCandidates(
+  candidates: GovernanceCandidate[],
+  maxTokens: number,
+): GovernancePlan {
+  const safeBudget = Math.max(0, Math.floor(maxTokens));
+  const decisions = candidates.map(candidate => ({ candidate, ...classify(candidate) }));
+  const eligible = decisions
+    .filter(decision => decision.disposition === 'include' || decision.disposition === 'compact')
+    .sort((left, right) => priority(right) - priority(left));
+  let usedTokens = 0;
+
+  for (const decision of eligible) {
+    const tokens = Math.max(0, Math.ceil(decision.candidate.estimatedTokens));
+    if (usedTokens + tokens <= safeBudget) {
+      usedTokens += tokens;
+      continue;
+    }
+    decision.disposition = 'defer';
+    decision.reasons = [...decision.reasons, 'token-budget'];
+  }
+
+  const delivered = decisions.filter(decision => decision.disposition === 'include' || decision.disposition === 'compact');
+  const mode = delivered.length === 0
+    ? 'abstain'
+    : delivered.some(decision => decision.disposition === 'include')
+      ? 'workset'
+      : 'card';
+  const cautions = [...new Set(decisions
+    .filter(decision => decision.disposition !== 'include')
+    .flatMap(decision => decision.reasons))];
+
+  return {
+    mode,
+    budget: { maxTokens: safeBudget, usedTokens },
+    decisions,
+    cautions: cautions.length > 0 ? cautions : ['no-qualified-evidence'],
+  };
+}

--- a/src/knowledge/outcome-store.ts
+++ b/src/knowledge/outcome-store.ts
@@ -1,0 +1,102 @@
+import { randomUUID } from 'node:crypto';
+import { sanitizeCredentials } from '../memory/secret-filter.js';
+import { getDatabase } from '../store/sqlite-db.js';
+import {
+  MEMORY_OUTCOME_CANDIDATE_KINDS,
+  MEMORY_OUTCOME_SIGNAL_KINDS,
+  type MemoryOutcomeCandidateKind,
+  type MemoryOutcomeSignal,
+  type MemoryOutcomeSignalKind,
+} from './outcome-types.js';
+
+function optionalText(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function text(value: string, field: string, max = 1_000): string {
+  const safe = sanitizeCredentials(value).replace(/\s+/g, ' ').trim();
+  if (!safe) throw new Error('Outcome signal ' + field + ' is required.');
+  if (safe.length > max) throw new Error('Outcome signal ' + field + ' is too long.');
+  return safe;
+}
+
+function oneOf<T extends readonly string[]>(value: unknown, values: T, field: string): T[number] {
+  if (typeof value !== 'string' || !(values as readonly string[]).includes(value)) {
+    throw new Error('Outcome signal ' + field + ' is invalid.');
+  }
+  return value as T[number];
+}
+
+function rowToSignal(row: any): MemoryOutcomeSignal {
+  return {
+    id: row.id,
+    projectId: row.projectId,
+    candidateKind: row.candidateKind,
+    candidateId: row.candidateId,
+    kind: row.kind,
+    sourceRef: row.sourceRef,
+    ...(optionalText(row.snapshotId) ? { snapshotId: row.snapshotId } : {}),
+    ...(optionalText(row.detail) ? { detail: row.detail } : {}),
+    observedAt: row.observedAt,
+  } as MemoryOutcomeSignal;
+}
+
+/** Persistence only; callers decide which real-world event is worth recording. */
+export class OutcomeStore {
+  private db: any = null;
+
+  async init(dataDir: string): Promise<void> {
+    this.db = getDatabase(dataDir);
+  }
+
+  record(input: Omit<MemoryOutcomeSignal, 'id' | 'observedAt'> & { observedAt?: string }): MemoryOutcomeSignal {
+    const signal: MemoryOutcomeSignal = {
+      id: randomUUID(),
+      projectId: text(input.projectId, 'project id'),
+      candidateKind: oneOf(input.candidateKind, MEMORY_OUTCOME_CANDIDATE_KINDS, 'candidate kind'),
+      candidateId: text(input.candidateId, 'candidate id'),
+      kind: oneOf(input.kind, MEMORY_OUTCOME_SIGNAL_KINDS, 'kind'),
+      sourceRef: text(input.sourceRef, 'source reference'),
+      ...(input.snapshotId ? { snapshotId: text(input.snapshotId, 'snapshot id') } : {}),
+      ...(input.detail ? { detail: text(input.detail, 'detail') } : {}),
+      observedAt: input.observedAt ?? new Date().toISOString(),
+    };
+    this.db.prepare(`
+      INSERT INTO memory_outcome_signals (
+        id, projectId, candidateKind, candidateId, kind, sourceRef, snapshotId, detail, observedAt
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      signal.id,
+      signal.projectId,
+      signal.candidateKind,
+      signal.candidateId,
+      signal.kind,
+      signal.sourceRef,
+      signal.snapshotId ?? null,
+      signal.detail ?? null,
+      signal.observedAt,
+    );
+    return signal;
+  }
+
+  latestForCandidates(
+    projectId: string,
+    candidateKind: MemoryOutcomeCandidateKind,
+    candidateIds: string[],
+  ): Map<string, MemoryOutcomeSignal> {
+    const ids = [...new Set(candidateIds.filter(Boolean))];
+    if (ids.length === 0) return new Map();
+    const placeholders = ids.map(() => '?').join(', ');
+    const rows = this.db.prepare(`
+      SELECT * FROM memory_outcome_signals
+      WHERE projectId = ? AND candidateKind = ? AND candidateId IN (${placeholders})
+      ORDER BY observedAt DESC, id DESC
+    `).all(projectId, candidateKind, ...ids);
+    const latest = new Map<string, MemoryOutcomeSignal>();
+    for (const row of rows) {
+      const signal = rowToSignal(row);
+      if (!latest.has(signal.candidateId)) latest.set(signal.candidateId, signal);
+    }
+    return latest;
+  }
+}

--- a/src/knowledge/outcome-types.ts
+++ b/src/knowledge/outcome-types.ts
@@ -1,0 +1,49 @@
+/**
+ * Append-only evidence about whether a context artifact helped or was
+ * contradicted. Signals never replace the artifact they describe.
+ */
+export const MEMORY_OUTCOME_CANDIDATE_KINDS = ['claim', 'durable-memory', 'workflow'] as const;
+export type MemoryOutcomeCandidateKind = typeof MEMORY_OUTCOME_CANDIDATE_KINDS[number];
+
+export const MEMORY_OUTCOME_SIGNAL_KINDS = [
+  'verification-passed',
+  'verification-failed',
+  'verified-reuse',
+  'user-pin',
+  'user-correction',
+  'source-changed',
+  'conflict-confirmed',
+  'manual-review',
+] as const;
+export type MemoryOutcomeSignalKind = typeof MEMORY_OUTCOME_SIGNAL_KINDS[number];
+
+export interface MemoryOutcomeSignal {
+  id: string;
+  projectId: string;
+  candidateKind: MemoryOutcomeCandidateKind;
+  candidateId: string;
+  kind: MemoryOutcomeSignalKind;
+  sourceRef: string;
+  snapshotId?: string;
+  detail?: string;
+  observedAt: string;
+}
+
+export type OutcomeQuality = 'verified' | 'probationary' | 'degraded';
+
+/** The newest auditable signal wins; missing signals leave lifecycle state in charge. */
+export function qualityFromOutcome(signal?: Pick<MemoryOutcomeSignal, 'kind'>): OutcomeQuality | undefined {
+  if (!signal) return undefined;
+  if (signal.kind === 'verification-failed'
+    || signal.kind === 'user-correction'
+    || signal.kind === 'source-changed'
+    || signal.kind === 'conflict-confirmed') {
+    return 'degraded';
+  }
+  if (signal.kind === 'verification-passed'
+    || signal.kind === 'verified-reuse'
+    || signal.kind === 'user-pin') {
+    return 'verified';
+  }
+  return undefined;
+}

--- a/src/knowledge/workflows.ts
+++ b/src/knowledge/workflows.ts
@@ -7,6 +7,8 @@ import { atomicWriteFile, withFileLock } from '../store/file-lock.js';
 import { WorkflowSyncer } from '../workspace/workflow-sync.js';
 import { getKnowledgeWorkspacePaths, resolveKnowledgeWorkspaceFile } from './workspace.js';
 import { WorkflowStore } from './workflow-store.js';
+import { OutcomeStore } from './outcome-store.js';
+import type { MemoryOutcomeCandidateKind, MemoryOutcomeSignalKind } from './outcome-types.js';
 import { containsTaskKeyword } from '../codegraph/task-lens.js';
 import type {
   WorkflowAdapterPreview,
@@ -751,7 +753,36 @@ export async function recordWorkflowRun(input: {
     throw new Error('Workflow was not found for this workspace');
   }
   if (!input.run.task.trim()) throw new Error('Workflow run task is required');
-  return store.recordRun(input.run);
+  const run = store.recordRun(input.run);
+  const kind: MemoryOutcomeSignalKind | undefined = run.outcome === 'passed' && run.verificationVerdict === 'passed'
+    ? 'verification-passed'
+    : run.outcome === 'failed' || run.verificationVerdict === 'failed'
+      ? 'verification-failed'
+      : undefined;
+  if (!kind) return run;
+
+  const evidence = new Map<string, MemoryOutcomeCandidateKind>();
+  evidence.set(workflow.id, 'workflow');
+  for (const reference of run.selectedEvidence) {
+    const match = /^(claim|durable):(.+)$/.exec(reference);
+    if (!match) continue;
+    evidence.set(match[2], match[1] === 'claim' ? 'claim' : 'durable-memory');
+  }
+  const outcomes = new OutcomeStore();
+  await outcomes.init(workflowStoreDataDir(input.workspace));
+  for (const [candidateId, candidateKind] of evidence) {
+    outcomes.record({
+      projectId: run.projectId,
+      candidateKind,
+      candidateId,
+      kind,
+      sourceRef: 'workflow-run:' + run.id,
+      ...(run.startingSnapshotId ? { snapshotId: run.startingSnapshotId } : {}),
+      ...(run.failureReason ? { detail: run.failureReason } : {}),
+      observedAt: run.completedAt ?? run.startedAt,
+    });
+  }
+  return run;
 }
 
 export async function selectWorkspaceWorkflows(input: {

--- a/src/knowledge/workset.ts
+++ b/src/knowledge/workset.ts
@@ -5,8 +5,11 @@ import { selectClaimsForTask } from './claims.js';
 import { KnowledgeWorkspaceStore } from './workspace-store.js';
 import { loadKnowledgeWorkspace } from './workspace.js';
 import { WorkflowStore } from './workflow-store.js';
+import { OutcomeStore } from './outcome-store.js';
+import { qualityFromOutcome, type OutcomeQuality } from './outcome-types.js';
 import { selectWorkflows } from './workflows.js';
 import { renderLongTermMemorySummary, selectLongTermMemoriesForTask } from '../memory/long-term.js';
+import { governContextCandidates, type GovernancePlan } from './governor.js';
 import type {
   ContextCandidateFreshness,
   ContextCandidateKind,
@@ -86,6 +89,7 @@ export interface WorksetLongTermMemory {
   kind: LongTermMemory['kind'];
   scope: LongTermMemory['scope'];
   state: LongTermMemory['state'];
+  quality: OutcomeQuality;
   title: string;
   summary: string;
   evidenceRefs: string[];
@@ -117,6 +121,17 @@ export interface WorksetContinuation {
   };
 }
 
+/** A small, exact file-level delta between the two latest complete Code State snapshots. */
+export interface WorksetCodeEvolution {
+  fromSnapshotId: string;
+  toSnapshotId: string;
+  changes: Array<{ path: string; kind: 'added' | 'modified' | 'removed' }>;
+  directlyConnectedPaths: string[];
+  /** Current stale memory bindings directly tied to the changed file paths. */
+  affectedMemoryCount?: number;
+  truncated: boolean;
+}
+
 export interface TaskWorkset {
   version: '1.3';
   task: string;
@@ -124,6 +139,7 @@ export interface TaskWorkset {
   currentFacts: string[];
   continuation?: WorksetContinuation;
   codeState?: string;
+  codeEvolution?: WorksetCodeEvolution;
   startHere: string[];
   /** Bounded task-specific relations from a validated local semantic graph. */
   semanticCode?: ExternalCodeGraphOutline;
@@ -161,6 +177,7 @@ export interface BuildTaskWorksetInput {
   currentFacts?: string[];
   continuation?: WorksetContinuation;
   codeState?: string;
+  codeEvolution?: WorksetCodeEvolution;
   startHere: string[];
   semanticCode?: ExternalCodeGraphOutline;
   providerQuality?: CodeGraphProviderQuality;
@@ -258,7 +275,7 @@ function pageMatchesClaim(page: KnowledgePageRecord, claimIds: Set<string>): boo
     && page.claimIds.some(claimId => claimIds.has(claimId));
 }
 
-function evidenceIdsForClaim(claim: KnowledgeClaim, evidence: ClaimEvidenceRef[]): string[] {
+function evidenceIdsForClaim(claim: Pick<KnowledgeClaim, 'id'>, evidence: ClaimEvidenceRef[]): string[] {
   return unique([
     'claim:' + claim.id,
     ...evidence.map(item => item.evidenceKind + ':' + item.evidenceId),
@@ -351,6 +368,87 @@ function scheduledActions(cautions: WorksetCaution[]): string[] {
   return cautions
     .filter(caution => caution.kind === 'codegraph-refresh-queued')
     .map(caution => short(caution.message, 28));
+}
+
+function isGovernedDelivery(disposition: GovernancePlan['decisions'][number]['disposition']): boolean {
+  return disposition === 'include' || disposition === 'compact';
+}
+
+/**
+ * Optional knowledge is where stale or over-confident context does the most
+ * harm. Qualify it before prompt rendering; current project facts and cautions
+ * remain visible so the agent can still inspect live source.
+ */
+function governOptionalArtifacts(input: {
+  reliableMemory: WorksetMemorySource[];
+  claims: WorksetClaim[];
+  durableMemory: WorksetLongTermMemory[];
+  workflows: WorksetWorkflow[];
+}): {
+  plan: GovernancePlan;
+  reliableMemory: WorksetMemorySource[];
+  claims: WorksetClaim[];
+  durableMemory: WorksetLongTermMemory[];
+  workflows: WorksetWorkflow[];
+} {
+  const candidates = [
+    ...input.reliableMemory.map((memory, index) => ({
+      kind: 'memory' as const,
+      id: 'memory:' + memory.id,
+      estimatedTokens: 10,
+      relevance: Math.max(0.2, 0.9 - index * 0.1),
+      scopeAllowed: true,
+      freshness: freshnessForMemory(memory.status),
+      trust: 'historical' as const,
+      quality: memory.status === 'current' ? 'verified' as const : 'degraded' as const,
+    })),
+    ...input.claims.map((claim, index) => ({
+      kind: 'claim' as const,
+      id: 'claim:' + claim.id,
+      estimatedTokens: 12,
+      relevance: Math.max(0.2, 0.95 - index * 0.1),
+      scopeAllowed: true,
+      freshness: claim.status === 'active' ? 'current' as const : 'unknown' as const,
+      trust: 'source-backed' as const,
+      quality: claim.reviewState === 'approved' ? 'verified' as const : 'probationary' as const,
+      conflict: claim.status === 'disputed' ? 'confirmed' as const : 'none' as const,
+      evidenceCount: claim.evidenceRefs.length,
+    })),
+    ...input.durableMemory.map((memory, index) => ({
+      kind: 'durable-memory' as const,
+      id: 'durable:' + memory.id,
+      estimatedTokens: 14,
+      relevance: Math.max(0.2, 0.8 - index * 0.1),
+      scopeAllowed: true,
+      freshness: memory.state === 'approved' ? 'current' as const : 'unknown' as const,
+      trust: 'source-backed' as const,
+      quality: memory.quality,
+      evidenceCount: memory.evidenceRefs.length,
+    })),
+    ...input.workflows.map((workflow, index) => ({
+      kind: 'workflow' as const,
+      id: 'workflow:' + workflow.id,
+      estimatedTokens: 14,
+      relevance: Math.max(0.2, 0.85 - index * 0.1),
+      scopeAllowed: true,
+      freshness: 'current' as const,
+      trust: 'source-backed' as const,
+      quality: 'verified' as const,
+    })),
+  ];
+  // Prompt rendering owns the final whole-item token budget. This preflight
+  // only decides whether optional evidence is safe enough to render at all.
+  const plan = governContextCandidates(candidates, Number.MAX_SAFE_INTEGER);
+  const permitted = new Set(plan.decisions
+    .filter(decision => isGovernedDelivery(decision.disposition))
+    .map(decision => decision.candidate.id));
+  return {
+    plan,
+    reliableMemory: input.reliableMemory.filter(memory => permitted.has('memory:' + memory.id)),
+    claims: input.claims.filter(claim => permitted.has('claim:' + claim.id)),
+    durableMemory: input.durableMemory.filter(memory => permitted.has('durable:' + memory.id)),
+    workflows: input.workflows.filter(workflow => permitted.has('workflow:' + workflow.id)),
+  };
 }
 
 /**
@@ -503,6 +601,57 @@ export function renderTaskWorksetPrompt(input: Omit<TaskWorkset, 'prompt' | 'bud
       reason: 'latest available Code State snapshot',
       trust: 'source-backed',
     });
+  }
+
+  if (input.codeEvolution && input.codeEvolution.changes.length > 0) {
+    appendLine(lines, '', maxTokens, omitted, 'code-evolution-heading');
+    appendLine(lines, 'Code changes since prior scan', maxTokens, omitted, 'code-evolution-heading');
+    for (const change of input.codeEvolution.changes.slice(0, 3)) {
+      appendLine(
+        lines,
+        '- ' + change.kind + ': ' + change.path,
+        maxTokens,
+        omitted,
+        'code-evolution-change',
+        selected,
+        {
+          kind: 'code-state',
+          id: 'snapshot:' + input.codeEvolution.toSnapshotId,
+          reason: 'exact file hash change between complete CodeGraph snapshots',
+          freshness: 'current',
+          trust: 'source-backed',
+        },
+      );
+    }
+    for (const path of input.codeEvolution.directlyConnectedPaths.slice(0, 2)) {
+      appendLine(
+        lines,
+        '- connected now: ' + path,
+        maxTokens,
+        omitted,
+        'code-evolution-impact',
+        selected,
+        {
+          kind: 'code-state',
+          id: 'snapshot:' + input.codeEvolution.toSnapshotId,
+          reason: 'bounded current CodeGraph impact relation',
+          freshness: 'current',
+          trust: 'derived',
+        },
+      );
+    }
+    if ((input.codeEvolution.affectedMemoryCount ?? 0) > 0) {
+      appendLine(
+        lines,
+        '- ' + input.codeEvolution.affectedMemoryCount + ' stored memory link(s) reference this changed code; reread source before relying on their conclusions.',
+        maxTokens,
+        omitted,
+        'code-evolution-stale-memory',
+      );
+    }
+    if (input.codeEvolution.truncated) {
+      appendLine(lines, '- More connected files exist; inspect CodeGraph before assuming complete impact.', maxTokens, omitted, 'code-evolution-truncated');
+    }
   }
 
   if (input.semanticCode && (input.semanticCode.entryPoints.length > 0 || input.semanticCode.relations.length > 0)) {
@@ -716,6 +865,21 @@ export async function buildTaskWorkset(input: BuildTaskWorksetInput): Promise<Ta
 
   let durableMemory: WorksetLongTermMemory[] = [];
   let durableEvidence: LongTermMemoryEvidence[] = [];
+  let outcomeStore: OutcomeStore | undefined;
+  try {
+    outcomeStore = new OutcomeStore();
+    await outcomeStore.init(input.dataDir);
+  } catch {
+    // Outcome evidence enriches the decision; normal current-source context
+    // remains usable if an older local database cannot expose it yet.
+  }
+  const claimQuality = outcomeStore
+    ? outcomeStore.latestForCandidates(input.projectId, 'claim', claims.map(claim => claim.id))
+    : new Map();
+  for (const claim of claims) {
+    const outcomeQuality = qualityFromOutcome(claimQuality.get(claim.id));
+    if (outcomeQuality === 'degraded') claim.reviewState = 'needs-review';
+  }
   if (task) {
     try {
       const selected = await selectLongTermMemoriesForTask({
@@ -726,11 +890,16 @@ export async function buildTaskWorkset(input: BuildTaskWorksetInput): Promise<Ta
         ...(input.reader?.isTeamMember ? { isTeamMember: true } : {}),
         limit: 3,
       });
+      const durableQuality = outcomeStore
+        ? outcomeStore.latestForCandidates(input.projectId, 'durable-memory', selected.map(item => item.memory.id))
+        : new Map();
       durableMemory = selected.map(item => ({
         id: item.memory.id,
         kind: item.memory.kind,
         scope: item.memory.scope,
         state: item.memory.state,
+        quality: qualityFromOutcome(durableQuality.get(item.memory.id))
+          ?? (item.memory.state === 'approved' ? 'verified' : 'probationary'),
         title: item.memory.title,
         summary: renderLongTermMemorySummary(item.memory, 20),
         evidenceRefs: item.evidence.map(evidence => evidence.id),
@@ -785,13 +954,6 @@ export async function buildTaskWorkset(input: BuildTaskWorksetInput): Promise<Ta
     // Knowledge is optional. Existing Code Memory remains usable without it.
   }
 
-  const evidenceIds = unique(selection.claims.flatMap(claim => evidenceIdsForClaim(
-    claim,
-    evidenceByClaim.get(claim.id) ?? [],
-  )).concat(
-    durableMemory.map(memory => 'durable:' + memory.id),
-    durableEvidence.map(evidence => 'durable-evidence:' + evidence.id),
-  ));
   const verification = unique([
     ...workflows.flatMap(workflow => workflow.verificationGates),
     ...input.verificationHints,
@@ -799,6 +961,22 @@ export async function buildTaskWorkset(input: BuildTaskWorksetInput): Promise<Ta
   const normalizedCautions = unique(cautions.map(caution => caution.kind))
     .map(kind => cautions.find(caution => caution.kind === kind)!)
     .slice(0, 6);
+  const governed = governOptionalArtifacts({
+    reliableMemory: input.reliableMemory?.slice(0, 3) ?? [],
+    claims,
+    durableMemory,
+    workflows,
+  });
+  const governedDurableIds = new Set(governed.durableMemory.map(memory => memory.id));
+  const evidenceIds = unique(governed.claims.flatMap(claim => evidenceIdsForClaim(
+    claim,
+    evidenceByClaim.get(claim.id) ?? [],
+  )).concat(
+    governed.durableMemory.map(memory => 'durable:' + memory.id),
+    durableEvidence
+      .filter(evidence => governedDurableIds.has(evidence.memoryId))
+      .map(evidence => 'durable-evidence:' + evidence.id),
+  ));
   const continuation = input.continuation
     && (
       input.continuation.previousSession
@@ -838,15 +1016,16 @@ export async function buildTaskWorkset(input: BuildTaskWorksetInput): Promise<Ta
       : short(fact, 28)).slice(0, 4) ?? [],
     ...(continuation ? { continuation } : {}),
     ...(input.codeState ? { codeState: short(input.codeState, 28) } : {}),
+    ...(input.codeEvolution ? { codeEvolution: input.codeEvolution } : {}),
     startHere: unique(input.startHere).slice(0, 5),
     ...(input.semanticCode ? { semanticCode: input.semanticCode } : {}),
-    reliableMemory: input.reliableMemory?.slice(0, 3) ?? [],
+    reliableMemory: governed.reliableMemory,
     cautionMemory: input.cautionMemory?.slice(0, 3) ?? [],
     hiddenCautionMemoryCount: input.hiddenCautionMemoryCount ?? 0,
-    claims,
-    pages,
-    durableMemory,
-    workflows,
+    claims: governed.claims,
+    pages: pages.filter(page => page.claimIds.some(claimId => governed.claims.some(claim => claim.id === claimId))),
+    durableMemory: governed.durableMemory,
+    workflows: governed.workflows,
     cautions: normalizedCautions,
     verification,
     evidenceIds,
@@ -871,6 +1050,17 @@ export async function buildTaskWorkset(input: BuildTaskWorksetInput): Promise<Ta
     },
     selected: rendered.selected,
     omitted: receiptOmissions(rendered.omittedItems, base.hiddenCautionMemoryCount),
+    governance: {
+      scope: 'optional-evidence',
+      mode: governed.plan.mode,
+      decisions: governed.plan.decisions.map(decision => ({
+        kind: decision.candidate.kind,
+        ...(decision.candidate.id ? { id: decision.candidate.id } : {}),
+        disposition: decision.disposition,
+        reasons: decision.reasons,
+      })),
+      cautions: governed.plan.cautions,
+    },
     scheduledActions: scheduledActions(normalizedCautions),
   };
   return {

--- a/src/store/sqlite-db.ts
+++ b/src/store/sqlite-db.ts
@@ -321,6 +321,18 @@ const CREATE_CODE_STATE_SNAPSHOTS_TABLE = [
   ');',
 ].join('\n');
 
+const CREATE_CODE_STATE_SNAPSHOT_FILES_TABLE = [
+  'CREATE TABLE IF NOT EXISTS code_state_snapshot_files (',
+  '  snapshotId  TEXT NOT NULL,',
+  '  projectId   TEXT NOT NULL,',
+  '  fileId      TEXT NOT NULL,',
+  '  path        TEXT NOT NULL,',
+  '  contentHash TEXT NOT NULL,',
+  '  PRIMARY KEY (snapshotId, path),',
+  '  FOREIGN KEY (snapshotId) REFERENCES code_state_snapshots(id) ON DELETE CASCADE',
+  ');',
+].join('\n');
+
 // ── 1.2 Knowledge Claim Ledger ──────────────────────────────────────
 
 const CREATE_KNOWLEDGE_CLAIMS_TABLE = `
@@ -550,6 +562,22 @@ CREATE TABLE IF NOT EXISTS long_term_memory_events (
   detail      TEXT,
   createdAt   TEXT NOT NULL,
   FOREIGN KEY (memoryId) REFERENCES long_term_memories(id) ON DELETE CASCADE
+);
+`;
+
+// ── 1.4 Evidence-governed memory ───────────────────────────────────
+
+const CREATE_MEMORY_OUTCOME_SIGNALS_TABLE = `
+CREATE TABLE IF NOT EXISTS memory_outcome_signals (
+  id            TEXT PRIMARY KEY,
+  projectId     TEXT NOT NULL,
+  candidateKind TEXT NOT NULL,
+  candidateId   TEXT NOT NULL,
+  kind          TEXT NOT NULL,
+  sourceRef     TEXT NOT NULL,
+  snapshotId    TEXT,
+  detail        TEXT,
+  observedAt    TEXT NOT NULL
 );
 `;
 
@@ -824,6 +852,20 @@ const SCHEMA_MIGRATIONS: SchemaMigration[] = [
       db.exec('CREATE INDEX IF NOT EXISTS idx_code_files_snapshot ON code_files(projectId, snapshotId)');
       db.exec('CREATE INDEX IF NOT EXISTS idx_code_symbols_snapshot ON code_symbols(projectId, snapshotId)');
       db.exec('CREATE INDEX IF NOT EXISTS idx_code_edges_snapshot ON code_edges(projectId, snapshotId)');
+    },
+  },
+  {
+    id: '1.4-codegraph-snapshot-manifest',
+    apply: (db) => {
+      db.exec(CREATE_CODE_STATE_SNAPSHOT_FILES_TABLE);
+      db.exec('CREATE INDEX IF NOT EXISTS idx_code_snapshot_files_project_path ON code_state_snapshot_files(projectId, path)');
+    },
+  },
+  {
+    id: '1.4-memory-outcome-signals',
+    apply: (db) => {
+      db.exec(CREATE_MEMORY_OUTCOME_SIGNALS_TABLE);
+      db.exec('CREATE INDEX IF NOT EXISTS idx_memory_outcomes_candidate ON memory_outcome_signals(projectId, candidateKind, candidateId, observedAt DESC)');
     },
   },
   {

--- a/tests/cli/codegraph-command.test.ts
+++ b/tests/cli/codegraph-command.test.ts
@@ -109,7 +109,53 @@ describe('codegraph CLI command', () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain('Usage:');
     expect(result.stdout).toContain('memorix codegraph refresh');
+    expect(result.stdout).toContain('memorix codegraph diff');
+    expect(result.stdout).toContain('memorix codegraph impact --path');
     expect(result.stdout).toContain('memorix codegraph context-pack --task');
+  });
+
+  it('compares the last two refreshes and reports bounded current graph impact', async () => {
+    await runCommand({ _: ['refresh'], json: true });
+    writeFileSync(path.join(repoDir, 'src', 'auth.ts'), [
+      "import { verifyJwt } from './jwt';",
+      'export function authMiddleware(token: string) { return verifyJwt(token) && token !== "revoked"; }',
+      '',
+    ].join('\n'), 'utf8');
+    await runCommand({ _: ['refresh'], json: true });
+
+    const result = await runCommand({ _: ['diff'], json: true });
+    expect(result.exitCode).toBe(0);
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.diff).toMatchObject({
+      available: true,
+      changes: expect.arrayContaining([
+        expect.objectContaining({ path: 'src/auth.ts', kind: 'modified' }),
+      ]),
+    });
+    expect(parsed.impact).toMatchObject({ changedPaths: ['src/auth.ts'] });
+  });
+
+  it('shows bounded current graph impact for one indexed source path', async () => {
+    await runCommand({ _: ['refresh'], json: true });
+
+    const result = await runCommand({ _: ['impact'], path: 'src/auth.ts', impactLimit: '1', json: true });
+
+    expect(result.exitCode).toBe(0);
+    expect(JSON.parse(result.stdout).impact).toMatchObject({
+      changedPaths: ['src/auth.ts'],
+      directlyConnectedPaths: ['src/jwt.ts'],
+      relationCount: 1,
+      truncated: false,
+    });
+  });
+
+  it('does not claim no impact when the source path has not been indexed', async () => {
+    await runCommand({ _: ['refresh'], json: true });
+
+    const result = await runCommand({ _: ['impact'], path: 'src/missing.ts', json: true });
+
+    expect(result.exitCode).toBe(1);
+    expect(JSON.parse(result.stderr).error).toContain('not in the current CodeGraph index');
   });
 
   it('keeps explicit text status output focused on status only', async () => {

--- a/tests/codegraph/auto-context.test.ts
+++ b/tests/codegraph/auto-context.test.ts
@@ -160,6 +160,42 @@ describe('auto project context', () => {
     expect(summary).toContain('Release verification procedure');
   });
 
+  it('adds a bounded exact code-evolution card only when continuing across complete snapshots', async () => {
+    const project = { id: 'local/repo', name: 'repo', rootPath: repoDir };
+    await storeObservation({
+      entityName: 'auth',
+      type: 'decision',
+      title: 'Authentication middleware behavior',
+      narrative: 'authMiddleware in src/auth.ts checks active tokens.',
+      filesModified: ['src/auth.ts'],
+      projectId: project.id,
+    });
+    await buildAutoProjectContext({
+      project,
+      dataDir,
+      observations: getAllObservations(),
+      refresh: 'always',
+      task: 'continue auth work',
+    });
+    writeFileSync(path.join(repoDir, 'src', 'auth.ts'), 'export function authMiddleware(token: string) { return token === "active"; }\n', 'utf8');
+    const continuation = await buildAutoProjectContext({
+      project,
+      dataDir,
+      observations: getAllObservations(),
+      refresh: 'always',
+      continuation: 'always',
+      task: 'continue auth work',
+    });
+
+    expect(continuation.workset.codeEvolution).toMatchObject({
+      changes: expect.arrayContaining([expect.objectContaining({ path: 'src/auth.ts', kind: 'modified' })]),
+      affectedMemoryCount: 1,
+    });
+    expect(formatAutoProjectContextPrompt(continuation)).toContain('Code changes since prior scan');
+    expect(formatAutoProjectContextPrompt(continuation)).toContain('modified: src/auth.ts');
+    expect(formatAutoProjectContextPrompt(continuation)).toContain('stored memory link(s) reference this changed code');
+  });
+
   it('does not source an unqualified automatic capture in an agent brief', async () => {
     await storeObservation({
       entityName: 'auth',

--- a/tests/codegraph/code-state.test.ts
+++ b/tests/codegraph/code-state.test.ts
@@ -111,8 +111,10 @@ describe('CodeStateSnapshot', () => {
     const db = getDatabase(dataDir);
     const fileColumns = db.prepare('PRAGMA table_info(code_files)').all().map((row: { name: string }) => row.name);
     const migration = db.prepare('SELECT id FROM schema_migrations WHERE id = ?').get('1.2-code-state-snapshots');
+    const manifestMigration = db.prepare('SELECT id FROM schema_migrations WHERE id = ?').get('1.4-codegraph-snapshot-manifest');
     expect(fileColumns).toEqual(expect.arrayContaining(['snapshotId', 'sourceEpoch']));
     expect(migration).toEqual(expect.objectContaining({ id: '1.2-code-state-snapshots' }));
+    expect(manifestMigration).toEqual(expect.objectContaining({ id: '1.4-codegraph-snapshot-manifest' }));
 
     const store = new CodeGraphStore();
     await store.init(dataDir);
@@ -174,6 +176,90 @@ describe('CodeStateSnapshot', () => {
     expect(store.listObservationRefs('org/repo', 1)[0]).toMatchObject({ snapshotId: second.id });
     expect(store.status('org/repo').latestSnapshot).toMatchObject({ id: second.id, sourceEpoch: 2 });
     expect(store.listSnapshots('org/repo')).toHaveLength(2);
+    expect(store.listSnapshotFiles(second.id)).toEqual([
+      expect.objectContaining({ snapshotId: second.id, path: 'src/auth.ts', contentHash: 'file-hash' }),
+    ]);
+  });
+
+  it('compares hash-only snapshot manifests and returns a bounded structural impact slice', async () => {
+    const dataDir = tempRoot();
+    const store = new CodeGraphStore();
+    await store.init(dataDir);
+    store.upsertFiles([
+      { id: 'file:auth', projectId: 'org/repo', path: 'src/auth.ts', contentHash: 'auth-v1', indexedAt: '2026-07-17T00:00:00.000Z' },
+      { id: 'file:api', projectId: 'org/repo', path: 'src/api.ts', contentHash: 'api-v1', indexedAt: '2026-07-17T00:00:00.000Z' },
+    ]);
+    store.upsertEdges([{
+      id: 'edge:api-auth', projectId: 'org/repo', fromFileId: 'file:api', toFileId: 'file:auth',
+      type: 'imports', confidence: 1, indexedAt: '2026-07-17T00:00:00.000Z',
+    }, {
+      id: 'edge:symbol-api-auth', projectId: 'org/repo', fromSymbolId: 'symbol:api', toSymbolId: 'symbol:auth',
+      type: 'calls', confidence: 1, indexedAt: '2026-07-17T00:00:00.000Z',
+    }]);
+    store.upsertSymbols([
+      { id: 'symbol:api', projectId: 'org/repo', fileId: 'file:api', path: 'src/api.ts', name: 'api', qualifiedName: 'api', kind: 'function', indexedAt: '2026-07-17T00:00:00.000Z' },
+      { id: 'symbol:auth', projectId: 'org/repo', fileId: 'file:auth', path: 'src/auth.ts', name: 'auth', qualifiedName: 'auth', kind: 'function', indexedAt: '2026-07-17T00:00:00.000Z' },
+    ]);
+    const first = store.recordCodeStateSnapshot(snapshotInput('org/repo', '2026-07-17T00:00:00.000Z'));
+    store.upsertFiles([
+      { id: 'file:auth', projectId: 'org/repo', path: 'src/auth.ts', contentHash: 'auth-v2', indexedAt: '2026-07-17T00:01:00.000Z' },
+      { id: 'file:new', projectId: 'org/repo', path: 'src/new.ts', contentHash: 'new-v1', indexedAt: '2026-07-17T00:01:00.000Z' },
+    ]);
+    const second = store.recordCodeStateSnapshot(snapshotInput('org/repo', '2026-07-17T00:01:00.000Z'));
+
+    expect(store.diffSnapshots('org/repo', first.id, second.id)).toMatchObject({
+      available: true,
+      changes: expect.arrayContaining([
+        expect.objectContaining({ path: 'src/auth.ts', kind: 'modified', beforeHash: 'auth-v1', afterHash: 'auth-v2' }),
+        expect.objectContaining({ path: 'src/new.ts', kind: 'added', afterHash: 'new-v1' }),
+      ]),
+    });
+    expect(store.impactSlice('org/repo', ['src/auth.ts'])).toMatchObject({
+      changedPaths: ['src/auth.ts'],
+      directlyConnectedPaths: ['src/api.ts'],
+      relationCount: 2,
+      truncated: false,
+    });
+  });
+
+  it('counts only stale memory links bound to explicitly changed snapshot files', async () => {
+    const dataDir = tempRoot();
+    const store = new CodeGraphStore();
+    await store.init(dataDir);
+    store.upsertFiles([{
+      id: 'file:auth', projectId: 'org/repo', path: 'src/auth.ts', contentHash: 'auth-v1', indexedAt: '2026-07-17T00:00:00.000Z',
+    }, {
+      id: 'file:other', projectId: 'org/repo', path: 'src/other.ts', contentHash: 'other-v1', indexedAt: '2026-07-17T00:00:00.000Z',
+    }]);
+    store.upsertObservationRefs([{
+      id: 'ref:auth', projectId: 'org/repo', observationId: 1, fileId: 'file:auth', status: 'stale', createdAt: '2026-07-17T00:00:00.000Z',
+    }, {
+      id: 'ref:other', projectId: 'org/repo', observationId: 2, fileId: 'file:other', status: 'stale', createdAt: '2026-07-17T00:00:00.000Z',
+    }]);
+
+    expect(store.countStaleObservationRefsForFiles('org/repo', ['file:auth'])).toBe(1);
+  });
+
+  it('does not present an incomplete scan as an exact snapshot diff', async () => {
+    const dataDir = tempRoot();
+    const store = new CodeGraphStore();
+    await store.init(dataDir);
+    store.upsertFiles([{
+      id: 'file:auth', projectId: 'org/repo', path: 'src/auth.ts', contentHash: 'auth-v1', indexedAt: '2026-07-17T00:00:00.000Z',
+    }]);
+    const first = store.recordCodeStateSnapshot(snapshotInput('org/repo', '2026-07-17T00:00:00.000Z'));
+    store.upsertFiles([{
+      id: 'file:auth', projectId: 'org/repo', path: 'src/auth.ts', contentHash: 'auth-v2', indexedAt: '2026-07-17T00:01:00.000Z',
+    }]);
+    const incomplete = snapshotInput('org/repo', '2026-07-17T00:01:00.000Z');
+    incomplete.completeness.skippedOversizedFiles = 1;
+    const second = store.recordCodeStateSnapshot(incomplete);
+
+    expect(store.diffSnapshots('org/repo', first.id, second.id)).toEqual(expect.objectContaining({
+      available: false,
+      reason: 'incomplete-snapshot',
+      changes: [],
+    }));
   });
 
   it('upgrades a legacy CodeGraph database without replacing its existing rows', () => {

--- a/tests/codegraph/lite-provider.test.ts
+++ b/tests/codegraph/lite-provider.test.ts
@@ -66,6 +66,36 @@ describe('CodeGraph Lite provider', () => {
     expect(result.edges.some((e) => e.type === 'imports' && e.evidence?.includes('./jwt'))).toBe(true);
   });
 
+  it('rebinds a local import when its target disappears and later returns', async () => {
+    const dir = makeRoot();
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    const authPath = join(dir, 'src', 'auth.ts');
+    const jwtPath = join(dir, 'src', 'jwt.ts');
+    writeFileSync(authPath, "import { verifyJwt } from './jwt.js';\nexport const auth = verifyJwt;\n");
+    writeFileSync(jwtPath, 'export const verifyJwt = () => true;\n');
+
+    const store = new CodeGraphStore();
+    await store.init(dir);
+    await refreshProjectLite(store, { projectId: 'org/repo', projectRoot: dir });
+    const jwtId = store.getFile('org/repo', 'src/jwt.ts')?.id;
+    expect(store.listEdges('org/repo')).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: 'imports', toFileId: jwtId }),
+    ]));
+
+    rmSync(jwtPath);
+    await refreshProjectLite(store, { projectId: 'org/repo', projectRoot: dir });
+    expect(store.listEdges('org/repo')).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: 'imports', evidence: './jwt.js' }),
+    ]));
+    expect(store.listEdges('org/repo')[0]?.toFileId).toBeUndefined();
+
+    writeFileSync(jwtPath, 'export const verifyJwt = () => false;\n');
+    await refreshProjectLite(store, { projectId: 'org/repo', projectRoot: dir });
+    expect(store.listEdges('org/repo')).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: 'imports', toFileId: store.getFile('org/repo', 'src/jwt.ts')?.id }),
+    ]));
+  });
+
   it('indexes common non-TS languages with file-level nodes and top-level symbols', async () => {
     const dir = makeRoot();
     mkdirSync(join(dir, 'src'), { recursive: true });

--- a/tests/knowledge/governor.test.ts
+++ b/tests/knowledge/governor.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+import { governContextCandidates } from '../../src/knowledge/governor.js';
+
+describe('context evidence governor', () => {
+  it('keeps current source-backed evidence and refuses out-of-scope, conflicting, or blocked candidates', () => {
+    const plan = governContextCandidates([
+      {
+        kind: 'claim', id: 'claim:release', estimatedTokens: 12, relevance: 0.9,
+        scopeAllowed: true, freshness: 'current', trust: 'source-backed', quality: 'verified', evidenceCount: 2,
+      },
+      {
+        kind: 'memory', id: 'memory:other-project', estimatedTokens: 10, relevance: 1,
+        scopeAllowed: false, freshness: 'current', trust: 'source-backed', quality: 'verified',
+      },
+      {
+        kind: 'workflow', id: 'workflow:conflict', estimatedTokens: 10, relevance: 0.8,
+        scopeAllowed: true, conflict: 'confirmed', quality: 'verified',
+      },
+      {
+        kind: 'knowledge-page', id: 'page:blocked', estimatedTokens: 10, relevance: 0.8,
+        scopeAllowed: true, quality: 'blocked',
+      },
+    ], 40);
+
+    expect(plan.mode).toBe('workset');
+    expect(plan.budget.usedTokens).toBe(12);
+    expect(plan.decisions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ candidate: expect.objectContaining({ id: 'claim:release' }), disposition: 'include', reasons: ['current-source-backed-evidence'] }),
+      expect.objectContaining({ candidate: expect.objectContaining({ id: 'memory:other-project' }), disposition: 'exclude', reasons: ['scope-forbidden'] }),
+      expect.objectContaining({ candidate: expect.objectContaining({ id: 'workflow:conflict' }), disposition: 'exclude', reasons: ['confirmed-conflict'] }),
+      expect.objectContaining({ candidate: expect.objectContaining({ id: 'page:blocked' }), disposition: 'exclude', reasons: ['blocked-quality'] }),
+    ]));
+  });
+
+  it('downgrades uncertain evidence to a compact card and keeps stale evidence out of the prompt', () => {
+    const plan = governContextCandidates([
+      {
+        kind: 'memory', id: 'memory:unknown', estimatedTokens: 8, relevance: 0.8,
+        scopeAllowed: true, freshness: 'unknown', trust: 'historical', quality: 'probationary',
+      },
+      {
+        kind: 'code-state', id: 'snapshot:old', estimatedTokens: 8, relevance: 1,
+        scopeAllowed: true, freshness: 'stale', trust: 'source-backed', quality: 'verified',
+      },
+    ], 24);
+
+    expect(plan.mode).toBe('card');
+    expect(plan.decisions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ candidate: expect.objectContaining({ id: 'memory:unknown' }), disposition: 'compact', reasons: expect.arrayContaining(['unknown-freshness', 'probationary-evidence']) }),
+      expect.objectContaining({ candidate: expect.objectContaining({ id: 'snapshot:old' }), disposition: 'defer', reasons: ['stale-evidence'] }),
+    ]));
+    expect(plan.cautions).toEqual(expect.arrayContaining(['unknown-freshness', 'stale-evidence']));
+  });
+
+  it('degrades lower-priority candidates when the token budget is exhausted instead of cutting them', () => {
+    const plan = governContextCandidates([
+      {
+        kind: 'claim', id: 'claim:high', estimatedTokens: 9, relevance: 1,
+        scopeAllowed: true, freshness: 'current', trust: 'source-backed', quality: 'verified',
+      },
+      {
+        kind: 'durable-memory', id: 'durable:low', estimatedTokens: 9, relevance: 0.1,
+        scopeAllowed: true, freshness: 'current', trust: 'source-backed', quality: 'verified',
+      },
+    ], 10);
+
+    expect(plan.mode).toBe('workset');
+    expect(plan.budget).toEqual({ maxTokens: 10, usedTokens: 9 });
+    expect(plan.decisions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ candidate: expect.objectContaining({ id: 'claim:high' }), disposition: 'include' }),
+      expect.objectContaining({ candidate: expect.objectContaining({ id: 'durable:low' }), disposition: 'defer', reasons: expect.arrayContaining(['token-budget']) }),
+    ]));
+  });
+
+  it('abstains when no candidate is safe to deliver', () => {
+    const plan = governContextCandidates([{
+      kind: 'memory', estimatedTokens: 5, relevance: 1, scopeAllowed: false,
+    }], 20);
+
+    expect(plan.mode).toBe('abstain');
+    expect(plan.budget.usedTokens).toBe(0);
+    expect(plan.cautions).toContain('scope-forbidden');
+  });
+});

--- a/tests/knowledge/outcomes.test.ts
+++ b/tests/knowledge/outcomes.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { OutcomeStore } from '../../src/knowledge/outcome-store.js';
+import { qualityFromOutcome } from '../../src/knowledge/outcome-types.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+
+let dir: string | undefined;
+
+function dataDir(): string {
+  dir = mkdtempSync(path.join(tmpdir(), 'memorix-outcomes-'));
+  return dir;
+}
+
+afterEach(() => {
+  closeAllDatabases();
+  if (dir) rmSync(dir, { recursive: true, force: true });
+  dir = undefined;
+});
+
+describe('memory outcome signals', () => {
+  it('keeps an append-only latest outcome per scoped candidate', async () => {
+    const store = new OutcomeStore();
+    await store.init(dataDir());
+    store.record({
+      projectId: 'org/repo',
+      candidateKind: 'durable-memory',
+      candidateId: 'memory-a',
+      kind: 'verification-passed',
+      sourceRef: 'workflow-run:one',
+      observedAt: '2026-08-01T00:00:00.000Z',
+    });
+    store.record({
+      projectId: 'org/repo',
+      candidateKind: 'durable-memory',
+      candidateId: 'memory-a',
+      kind: 'verification-failed',
+      sourceRef: 'workflow-run:two',
+      observedAt: '2026-08-02T00:00:00.000Z',
+    });
+
+    const latest = store.latestForCandidates('org/repo', 'durable-memory', ['memory-a']);
+    expect(latest.get('memory-a')).toMatchObject({ kind: 'verification-failed' });
+    expect(qualityFromOutcome(latest.get('memory-a'))).toBe('degraded');
+  });
+
+  it('sanitizes stored outcome detail without mutating the referenced artifact', async () => {
+    const store = new OutcomeStore();
+    await store.init(dataDir());
+    const signal = store.record({
+      projectId: 'org/repo',
+      candidateKind: 'claim',
+      candidateId: 'claim-a',
+      kind: 'user-correction',
+      sourceRef: 'review:one',
+      detail: 'api_key=super-secret-value must not be retained.',
+    });
+    expect(signal.detail).toContain('api_key=[REDACTED]');
+    expect(qualityFromOutcome(signal)).toBe('degraded');
+  });
+});

--- a/tests/knowledge/workflows.test.ts
+++ b/tests/knowledge/workflows.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../../src/knowledge/workflows.js';
 import type { WorkflowSpec } from '../../src/knowledge/workflow-types.js';
 import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+import { OutcomeStore } from '../../src/knowledge/outcome-store.js';
 
 let root: string | null = null;
 
@@ -254,6 +255,37 @@ describe('Workflow Inheritance', () => {
       task: 'What is the capital of France?',
     });
     expect(unrelated.selections).toHaveLength(0);
+  });
+
+  it('records workflow verification as append-only evidence for selected context artifacts', async () => {
+    const sandbox = tempRoot();
+    const dataDir = path.join(sandbox, 'data');
+    const workspace = await initializeKnowledgeWorkspace({ projectId: 'org/repo', dataDir, mode: 'local' });
+    const release = await writeCanonicalWorkflow({
+      workspace,
+      workflow: workflow(workspace.id, 'workflow:release', 'Release', ['release'], '## Verify\n\nRun the package smoke.'),
+    });
+    const run = await recordWorkflowRun({
+      workspace,
+      run: {
+        workflowId: release.id,
+        projectId: 'org/repo',
+        task: 'Publish the release.',
+        outcome: 'failed',
+        verificationVerdict: 'failed',
+        failureReason: 'Package smoke failed.',
+        selectedEvidence: ['claim:claim-a', 'durable:memory-a'],
+      },
+    });
+    const outcomes = new OutcomeStore();
+    await outcomes.init(dataDir);
+    expect(outcomes.latestForCandidates('org/repo', 'claim', ['claim-a']).get('claim-a')).toMatchObject({
+      kind: 'verification-failed',
+      sourceRef: 'workflow-run:' + run.id,
+    });
+    expect(outcomes.latestForCandidates('org/repo', 'durable-memory', ['memory-a']).get('memory-a')).toMatchObject({
+      kind: 'verification-failed',
+    });
   });
 
   it('previews and applies only Memorix-owned adapters, preserving user project files', async () => {

--- a/tests/knowledge/workset.test.ts
+++ b/tests/knowledge/workset.test.ts
@@ -9,6 +9,7 @@ import { initializeKnowledgeWorkspace } from '../../src/knowledge/workspace.js';
 import { buildTaskWorkset } from '../../src/knowledge/workset.js';
 import { createManualLongTermMemory, qualifyLongTermMemory } from '../../src/memory/long-term.js';
 import { recordWorkflowRun, writeCanonicalWorkflow } from '../../src/knowledge/workflows.js';
+import { OutcomeStore } from '../../src/knowledge/outcome-store.js';
 import { closeAllDatabases } from '../../src/store/sqlite-db.js';
 
 let dataDir: string | null = null;
@@ -191,6 +192,67 @@ describe('Task Workset', () => {
     expect(workset.prompt).not.toContain('Project workflow');
   });
 
+  it('keeps degraded optional memory out of the brief while retaining its qualification receipt', async () => {
+    const root = tempDir();
+    const workset = await buildTaskWorkset({
+      projectId: 'org/repo',
+      dataDir: root,
+      task: 'Continue the authentication work.',
+      lens: 'feature',
+      currentFacts: ['Git: clean worktree'],
+      startHere: ['src/auth.ts'],
+      reliableMemory: [{
+        id: 42,
+        title: 'Old auth strategy that must not guide new edits',
+        type: 'decision',
+        status: 'stale',
+        path: 'src/auth.ts',
+      }],
+      cautionMemory: [],
+      verificationHints: ['Run the focused auth test.'],
+      worktreeDirty: false,
+      freshness: { suspect: 0, stale: 1 },
+    });
+
+    expect(workset.prompt).not.toContain('Old auth strategy');
+    expect(workset.receipt.governance?.scope).toBe('optional-evidence');
+    expect(workset.receipt.governance?.decisions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'memory:42', disposition: 'defer', reasons: ['degraded-quality'] }),
+    ]));
+  });
+
+  it('renders exact prior-scan file changes only as a bounded continuation aid', async () => {
+    const root = tempDir();
+    const workset = await buildTaskWorkset({
+      projectId: 'org/repo',
+      dataDir: root,
+      task: 'Continue the authentication work.',
+      lens: 'feature',
+      currentFacts: ['Git: dirty worktree'],
+      codeState: 'Code state: dirty worktree.',
+      codeEvolution: {
+        fromSnapshotId: 'snapshot:1',
+        toSnapshotId: 'snapshot:2',
+        changes: [{ path: 'src/auth.ts', kind: 'modified' }],
+        directlyConnectedPaths: ['src/api.ts'],
+        truncated: false,
+      },
+      startHere: ['src/auth.ts'],
+      reliableMemory: [],
+      cautionMemory: [],
+      verificationHints: ['Run the focused auth test.'],
+      worktreeDirty: true,
+      freshness: { suspect: 0, stale: 0 },
+    });
+
+    expect(workset.prompt).toContain('Code changes since prior scan');
+    expect(workset.prompt).toContain('modified: src/auth.ts');
+    expect(workset.prompt).toContain('connected now: src/api.ts');
+    expect(workset.receipt.selected).toEqual(expect.arrayContaining([
+      expect.objectContaining({ kind: 'code-state', id: 'snapshot:snapshot:2' }),
+    ]));
+  });
+
   it('adds only qualified task-matching durable memory within the Workset budget', async () => {
     const root = tempDir();
     const durable = await createManualLongTermMemory({
@@ -235,6 +297,55 @@ describe('Task Workset', () => {
       expect.objectContaining({ kind: 'durable-memory', id: 'durable:' + durable.memory.id }),
     ]));
     expect(workset.budget.tokenCount).toBeLessThanOrEqual(workset.budget.maxTokens);
+  });
+
+  it('does not inject durable memory after its latest verified workflow outcome failed', async () => {
+    const root = tempDir();
+    const durable = await createManualLongTermMemory({
+      dataDir: root,
+      projectId: 'org/project-a',
+      scope: 'user',
+      kind: 'procedural',
+      portability: 'portable',
+      title: 'Package publishing procedure',
+      content: 'Run the package smoke before publishing an npm release.',
+      tags: ['release', 'package'],
+    });
+    await qualifyLongTermMemory({
+      dataDir: root,
+      id: durable.memory.id,
+      reason: 'Previously checked against a package release.',
+    });
+    const outcomes = new OutcomeStore();
+    await outcomes.init(root);
+    outcomes.record({
+      projectId: 'org/project-b',
+      candidateKind: 'durable-memory',
+      candidateId: durable.memory.id,
+      kind: 'verification-failed',
+      sourceRef: 'workflow-run:failed-release',
+    });
+
+    const workset = await buildTaskWorkset({
+      projectId: 'org/project-b',
+      dataDir: root,
+      task: 'Prepare the npm release and verify the package.',
+      lens: 'release',
+      currentFacts: ['Git: clean worktree'],
+      startHere: ['package.json'],
+      reliableMemory: [],
+      cautionMemory: [],
+      verificationHints: ['Run the package smoke.'],
+      worktreeDirty: false,
+      freshness: { suspect: 0, stale: 0 },
+    });
+
+    expect(workset.durableMemory).toHaveLength(0);
+    expect(workset.prompt).not.toContain('Package publishing procedure');
+    expect(workset.evidenceIds).not.toContain('durable:' + durable.memory.id);
+    expect(workset.receipt.governance?.decisions).toEqual(expect.arrayContaining([
+      expect.objectContaining({ id: 'durable:' + durable.memory.id, disposition: 'defer', reasons: ['degraded-quality'] }),
+    ]));
   });
 
   it('puts a bounded continuation projection ahead of optional project detail', async () => {


### PR DESCRIPTION
## Summary
- qualify optional memory and knowledge before context delivery, with auditable outcome signals
- add exact hash-only CodeGraph snapshot diffs and bounded current impact slices
- expose CLI-only CodeGraph diff and impact inspection without adding default MCP tools
- preserve and rebind local import evidence across target file changes

## Verification
- focused CodeGraph/knowledge suite: 21 files, 141 tests passed
- real CLI smoke indexed 3,250 files and returned bounded impact results
- 
pm run lint is pending clean CI because this isolated worktree resolves a stale parent workspace declaration; packages/ai typecheck passes

## Scope
- Draft until clean CI passes. No release changes included.