### PR TITLE
chore(release): prepare memorix 1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.2] - 2026-08-06
+
+### Added
+- **Evidence-governed memory** -- A deterministic governor now decides whether
+  project knowledge should be included, compacted, deferred, or excluded based
+  on source backing, freshness, conflicts, quality, scope, and token budget.
+- **Outcome-aware memory** -- Workflow verification results are recorded as
+  append-only outcome signals so failed evidence is less likely to be reused
+  as trusted project knowledge.
+- **CodeGraph evolution views** -- Lite CodeGraph now keeps hash-only snapshot
+  manifests, reports exact file-level diffs, and exposes bounded one-hop impact
+  slices through the CLI. Continuation worksets include code evolution and
+  stale-memory binding counts.
+
+### Fixed
+- **Star History automation** -- The chart workflow now updates a dedicated
+  branch and opens or refreshes a pull request instead of trying to push
+  directly to protected `main`, which caused every scheduled refresh to fail.
+
 ## [1.4.1] - 2026-08-03
 
 ### Added

--- a/docs/1.4.2-EVIDENCE-GOVERNED-MEMORY-SPEC.md
+++ b/docs/1.4.2-EVIDENCE-GOVERNED-MEMORY-SPEC.md
@@ -1,6 +1,6 @@
 # Memorix 1.4.2: Evidence-Governed Memory and CodeGraph
 
-Status: implementation complete on this branch; clean-package verification pending
+Status: implementation complete; release verification recorded in v1.4.2
 Branch: `codex/1.4.2-evidence-governor`
 Baseline: `v1.4.1`
 Updated: 2026-08-06

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memorix",
   "mcpName": "io.github.AVIDS2/memorix",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AVIDS2/memorix",
     "source": "github"
   },
-  "version": "1.4.1",
+  "version": "1.4.2",
   "websiteUrl": "https://github.com/AVIDS2/memorix#readme",
   "icons": [
     {
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "memorix",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "runtimeHint": "npx",
       "packageArguments": [
         {

--- a/tests/memory/freshness.test.ts
+++ b/tests/memory/freshness.test.ts
@@ -179,5 +179,5 @@ describe('reindexMiniSkills deterministic cleanup (Fix 4)', () => {
       const { closeAllDatabases } = await import('../../src/store/sqlite-db.js');
       closeAllDatabases();
     }
-  });
+  }, 15_000);
 });


### PR DESCRIPTION
Release preparation for Memorix 1.4.2.\n\n- Bump the public package and MCP Registry manifest to 1.4.2.\n- Sync all plugin release metadata.\n- Document evidence-governed memory and CodeGraph evolution.\n- Record the Star History protected-branch workflow fix.\n\nLocal verification: npm ci, npm run build, npm run lint, npm test, manifest checks, and npm pack --dry-run passed.