### PR TITLE
chore: ignore local inspection artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,10 @@ packages/*/.tsbuildinfo
 # CodeGraph
 .codegraph/
 
+# Local inspection and agent goal artifacts
+.demokiller/
+.opencode/
+
 # Session files
 *.jsonl
 


### PR DESCRIPTION
Ignore local demokiller inspection output and OpenCode goal artifacts so machine-local files cannot leak into the repository.