### PR TITLE
feat(media): add controlled PDF text derivations

### DIFF
--- a/ACTIVE_WORK.md
+++ b/ACTIVE_WORK.md
@@ -4,24 +4,20 @@
 > before resuming substantial work, update it after a material decision or
 > milestone, and do not create parallel progress logs.
 
-**Last updated:** 2026-08-03
+**Last updated:** 2026-08-10
 
 ## Current Product State
 
-- `1.4.1` is the current published release.
-- It includes the accepted MiniMax M3 video-input contribution (#153), the
-  maintained public-roadmap contribution (#140), deterministic provider-test
-  boundaries, and synchronized plugin/MCP Registry release metadata.
-- Release evidence is complete: full local checks, a fresh-package CLI/MCP
-  smoke, Ubuntu and Windows CI, npm provenance, the official MCP Registry, and
-  the GitHub Release `v1.4.1`.
+- `1.4.2` is the current published release.
+- It adds evidence-governed memory retrieval and maintains the controlled media
+  boundary introduced in 1.3.x.
 
 ## Active Objectives
 
 1. Keep the public repository free of operator state, local paths, credentials,
    raw session captures, and one-off development artifacts.
-2. Turn MemorixBench from a local harness into a reproducible study with public
-   permissive-license task sources, isolated trials, and provenance receipts.
+2. Deliver #173 as an explicit, bounded PDF-to-text derivation path over the
+   existing controlled media asset store.
 
 ## Completed Contribution Decisions
 
@@ -31,14 +27,8 @@
 - #33, #31, #30: not merged into the superseding media/retrieval architecture.
   Their original authorship is preserved through #173 (PDF derivations), #174
   (audio derivatives), and #175 (graph-assisted evidence expansion).
-- #136 and #151: research-only work. Keep it outside npm releases until the
-  experimental protocol and evidence are independently complete.
-
-## Research Boundary
-
-The current benchmark harness is a pilot, not a paper result. Confirmatory
-claims require public task provenance, isolated execution, frozen routes and
-models, blinded grading where applicable, and reported failures as well as wins.
+- #136, #151, #179, #147, and #152: withdrawn research work. Do not use them
+  as product or release evidence.
 
 ## Operating Rules
 
@@ -53,7 +43,7 @@ models, blinded grading where applicable, and reported failures as well as wins.
 
 ## Immediate Next Step
 
-Advance MemorixBench from a pilot harness to a reproducible study with public
-task sources, isolated trials, frozen model routes, and reviewable provenance.
-Keep research work separate from npm release claims until the experimental
-protocol and evidence are independently complete.
+Complete #173 with a shared derivation metadata contract, explicit CLI and
+bounded MCP operation, page-aware text projections, and corrupt/oversized/
+multipage regression coverage. #174 must reuse this contract rather than add
+its own storage path.

--- a/docs/1.4.3-CONTROLLED-PDF-DERIVATIONS.md
+++ b/docs/1.4.3-CONTROLLED-PDF-DERIVATIONS.md
@@ -1,0 +1,55 @@
+# Controlled PDF Text Derivations
+
+## Purpose
+
+Issue #173 adds an explicit way to turn a controlled local PDF asset into
+page-aware text evidence. It is not automatic ingestion: importing a PDF only
+stores its verified local copy. `derive-pdf` is a separate operator action, and
+`--attach` is a second opt-in that creates searchable memory projections.
+
+## Contract
+
+```text
+local PDF -> controlled asset -> explicit derive-pdf -> stored page chunks
+                                      -> optional --attach -> observations
+```
+
+- The asset hash, MIME type, and stored bytes remain the source of truth.
+- The derivation records extractor name, page count, processed pages, chunk
+  count, and the limits used. This metadata is generic so audio transcription
+  can use the same record model in #174.
+- PDF bytes are bounded before reading. Page count and total text characters
+  are bounded before a retrieval projection is created.
+- Parsing uses `unpdf`'s bundled PDF.js build with system fonts disabled and a
+  finite image size. Parsed documents are destroyed in `finally`.
+- Corrupt, encrypted, malformed, oversize, or over-budget PDFs produce a
+  failed derivation audit record and no searchable text projection.
+
+## User Surface
+
+```powershell
+memorix media import --path .\architecture.pdf --json
+memorix media derive-pdf --asset <asset-id> --json
+memorix media derive-pdf --asset <asset-id> --attach --maxPages 100 --maxChars 120000 --json
+```
+
+The CLI is the full management surface. MCP exposes the same operation as
+`memorix_media` with `action: "derive-pdf"`, but limits it to 100 pages and
+60,000 characters. It cannot remove assets or bypass the explicit attachment
+choice.
+
+## Non-goals
+
+- No OCR for scans, document rendering, table reconstruction, remote URL
+  import, password submission, or background extraction from retrieval.
+- No claim that a PDF image or visual embedding exists merely because PDF text
+  was extracted.
+- No automatic attachment of every imported document to project memory.
+
+## Verification
+
+- Real one- and two-page PDFs prove page labels, chunking, metadata, and
+  resource cleanup.
+- Malformed PDFs and over-page-budget PDFs persist a failed derivation only.
+- MCP tests exercise import, bounded derivation, and explicit searchable
+  attachment through the same project binding as CLI.

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "react": "19.2.7",
         "remark": "^15.0.1",
         "remark-stringify": "^11.0.0",
+        "unpdf": "^1.8.0",
         "zod": "^3.24.0"
       },
       "bin": {
@@ -8998,6 +8999,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unpdf": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.8.0.tgz",
+      "integrity": "sha512-jQlkckbe5nKxRHQdbvo9IKHlU6Cjq00UlxxB8lrCIxvS2o5IbAL1wM+4a1Yc3+BIohg9p5AsoaftwO+G4Aq/qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "@napi-rs/canvas": "^0.1.69 || ^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@napi-rs/canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/unpipe": {

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "react": "19.2.7",
     "remark": "^15.0.1",
     "remark-stringify": "^11.0.0",
+    "unpdf": "^1.8.0",
     "zod": "^3.24.0"
   },
   "optionalDependencies": {

--- a/src/cli/commands/media.ts
+++ b/src/cli/commands/media.ts
@@ -9,6 +9,7 @@ import {
   removeMediaAsset,
 } from '../../media/asset-store.js';
 import { MediaStore } from '../../media/media-store.js';
+import { derivePdfText } from '../../media/pdf.js';
 import {
   generateMiniMaxImages,
   type MiniMaxImageGenerationInput,
@@ -111,6 +112,7 @@ function help(): string {
     '  memorix media import --path ./diagram.png',
     '  memorix media list [--kind image]',
     '  memorix media show --asset <asset-id>',
+    '  memorix media derive-pdf --asset <asset-id> [--attach] [--maxPages 100] [--maxChars 120000]',
     '  memorix media attach --asset <asset-id> [--title "Architecture"] [--text "..."]',
     '  memorix media embed --asset <asset-id>',
     '  memorix media similar --asset <asset-id> [--limit 10]',
@@ -157,6 +159,12 @@ export default defineCommand({
     limit: { type: 'string', description: 'List limit' },
     maxBytes: { type: 'string', description: 'Import or cleanup byte limit' },
     'max-bytes': { type: 'string', description: 'Kebab-case alias for --maxBytes' },
+    maxPages: { type: 'string', description: 'Maximum PDF pages to derive (1-1000)' },
+    'max-pages': { type: 'string', description: 'Kebab-case alias for --maxPages' },
+    maxChars: { type: 'string', description: 'Maximum total PDF text characters (1-1000000)' },
+    'max-chars': { type: 'string', description: 'Kebab-case alias for --maxChars' },
+    chunkChars: { type: 'string', description: 'Maximum PDF retrieval chunk characters (1-120000)' },
+    'chunk-chars': { type: 'string', description: 'Kebab-case alias for --chunkChars' },
     force: { type: 'boolean', description: 'Detach linked observations before removal' },
     json: { type: 'boolean', description: 'Emit machine-readable JSON output' },
   },
@@ -285,6 +293,45 @@ export default defineCommand({
           emitResult(
             { project, ...result },
             `${result.deduplicated ? 'Reused' : 'Imported'} ${result.asset.kind} asset ${result.asset.id}`,
+            asJson,
+          );
+          return;
+        }
+        case 'derive-pdf': {
+          const assetId = getValue(args.asset, positional);
+          if (!assetId) throw new Error('asset is required for "memorix media derive-pdf"');
+          const { project, dataDir, reader, identity } = await getCliProjectContext();
+          const maxChars = parseOptionalInteger(args.maxChars ?? args['max-chars'], 'maxChars', 1, 1_000_000);
+          const requestedChunkChars = parseOptionalInteger(args.chunkChars ?? args['chunk-chars'], 'chunkChars', 1, 120_000);
+          const derived = await derivePdfText({
+            dataDir,
+            projectId: project.id,
+            assetId,
+            maxBytes: parseOptionalInteger(args.maxBytes ?? args['max-bytes'], 'maxBytes', 1, 100 * 1024 * 1024),
+            maxPages: parseOptionalInteger(args.maxPages ?? args['max-pages'], 'maxPages', 1, 1_000),
+            maxChars,
+            chunkChars: requestedChunkChars === undefined || maxChars === undefined
+              ? requestedChunkChars
+              : Math.min(requestedChunkChars, maxChars),
+          });
+          const observations = [];
+          if (args.attach === true) {
+            for (const chunk of derived.chunks) {
+              observations.push(await attachMediaAssetToObservation({
+                dataDir,
+                projectId: project.id,
+                asset: derived.asset,
+                title: `PDF: ${derived.asset.sourceLabel ?? derived.asset.id} (pages ${chunk.pageStart}-${chunk.pageEnd})`,
+                narrative: chunk.text,
+                facts: [`PDF pages: ${chunk.pageStart}-${chunk.pageEnd}`, 'Derived with explicit PDF text extraction.'],
+                concepts: ['pdf', 'pdf-text', 'media-derivation'],
+                ...resolveCliWriteScope({ reader, identity }, args.visibility as string | undefined),
+              }));
+            }
+          }
+          emitResult(
+            { project, ...derived, observations },
+            `Derived ${derived.chunks.length} PDF text chunk(s) from ${assetId}${observations.length ? ` and attached ${observations.length} retrieval projection(s)` : ''}.`,
             asJson,
           );
           return;

--- a/src/media/media-store.ts
+++ b/src/media/media-store.ts
@@ -6,6 +6,7 @@ import type {
   MediaAsset,
   MediaAssetLink,
   MediaDerivation,
+  MediaDerivationMetadata,
   MediaEmbedding,
   MediaEmbeddingProfile,
   MediaJob,
@@ -57,6 +58,18 @@ function parseVector(value: unknown): number[] | undefined {
   }
 }
 
+function parseDerivationMetadata(value: unknown): MediaDerivationMetadata | undefined {
+  if (typeof value !== 'string' || !value) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed as MediaDerivationMetadata
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function rowToAsset(row: any): MediaAsset {
   return {
     id: row.id,
@@ -88,6 +101,7 @@ function rowToLink(row: any): MediaAssetLink {
 }
 
 function rowToDerivation(row: any): MediaDerivation {
+  const metadata = parseDerivationMetadata(row.metadata_json);
   return {
     id: row.id,
     assetId: row.asset_id,
@@ -95,6 +109,7 @@ function rowToDerivation(row: any): MediaDerivation {
     kind: row.kind,
     ...(asOptionalText(row.profile_key) ? { profileKey: row.profile_key } : {}),
     content: row.content,
+    ...(metadata ? { metadata } : {}),
     status: row.status,
     ...(asOptionalText(row.error) ? { error: row.error } : {}),
     createdAt: Number(row.created_at),
@@ -295,14 +310,15 @@ export class MediaStore {
     const now = Date.now();
     const content = sanitizeCredentials(input.content);
     const error = input.error ? sanitizeCredentials(input.error).slice(0, 1_000) : undefined;
+    const metadataJson = input.metadata ? JSON.stringify(input.metadata) : null;
     const existing = this.db.prepare(`
       SELECT * FROM media_derivations
       WHERE asset_id = ? AND kind = ? AND profile_key IS ? LIMIT 1
     `).get(input.assetId, input.kind, input.profileKey ?? null);
     if (existing) {
       this.db.prepare(`
-        UPDATE media_derivations SET content = ?, status = ?, error = ?, updated_at = ? WHERE id = ?
-      `).run(content, input.status, error ?? null, now, existing.id);
+        UPDATE media_derivations SET content = ?, metadata_json = ?, status = ?, error = ?, updated_at = ? WHERE id = ?
+      `).run(content, metadataJson, input.status, error ?? null, now, existing.id);
       return rowToDerivation(this.db.prepare('SELECT * FROM media_derivations WHERE id = ?').get(existing.id));
     }
     const derivation: MediaDerivation = {
@@ -314,8 +330,8 @@ export class MediaStore {
       updatedAt: now,
     };
     this.db.prepare(`
-      INSERT INTO media_derivations (id, asset_id, project_id, kind, profile_key, content, status, error, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO media_derivations (id, asset_id, project_id, kind, profile_key, content, metadata_json, status, error, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       derivation.id,
       derivation.assetId,
@@ -323,6 +339,7 @@ export class MediaStore {
       derivation.kind,
       derivation.profileKey ?? null,
       derivation.content,
+      metadataJson,
       derivation.status,
       error ?? null,
       now,

--- a/src/media/pdf.ts
+++ b/src/media/pdf.ts
@@ -1,0 +1,139 @@
+import { getDocumentProxy } from 'unpdf';
+
+import { sanitizeCredentials } from '../memory/secret-filter.js';
+import { readMediaAsset } from './asset-store.js';
+import { MediaStore } from './media-store.js';
+import type { MediaAsset, MediaDerivation } from './types.js';
+
+export const DEFAULT_PDF_MAX_BYTES = 20 * 1024 * 1024;
+export const DEFAULT_PDF_MAX_PAGES = 100;
+export const DEFAULT_PDF_MAX_CHARS = 120_000;
+export const DEFAULT_PDF_CHUNK_CHARS = 8_000;
+
+export interface PdfDerivationInput {
+  dataDir: string;
+  projectId: string;
+  assetId: string;
+  maxBytes?: number;
+  maxPages?: number;
+  maxChars?: number;
+  chunkChars?: number;
+}
+
+export interface PdfTextChunk {
+  pageStart: number;
+  pageEnd: number;
+  text: string;
+}
+
+export interface PdfDerivationResult {
+  asset: MediaAsset;
+  derivation: MediaDerivation;
+  chunks: PdfTextChunk[];
+}
+
+function positiveLimit(value: number | undefined, fallback: number, label: string): number {
+  const resolved = value ?? fallback;
+  if (!Number.isSafeInteger(resolved) || resolved <= 0) throw new Error(`${label} must be a positive whole number`);
+  return resolved;
+}
+
+function pageText(content: { items: Array<unknown> }): string {
+  return content.items
+    .map((item) => item && typeof item === 'object' && 'str' in item && typeof item.str === 'string' ? item.str.trim() : '')
+    .filter(Boolean)
+    .join(' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function chunkPages(pages: Array<{ page: number; text: string }>, maxChars: number, chunkChars: number): PdfTextChunk[] {
+  const chunks: PdfTextChunk[] = [];
+  let current = '';
+  let pageStart = 0;
+  let pageEnd = 0;
+  for (const page of pages) {
+    const section = `Page ${page.page}\n${page.text || '[No extractable text on this page.]'}`;
+    if (section.length > maxChars) throw new Error(`PDF page ${page.page} exceeds the configured text limit`);
+    if (current && current.length + section.length + 2 > chunkChars) {
+      chunks.push({ pageStart, pageEnd, text: current });
+      current = '';
+    }
+    if (!current) pageStart = page.page;
+    current = current ? `${current}\n\n${section}` : section;
+    pageEnd = page.page;
+    if (current.length > maxChars) throw new Error(`PDF text exceeds the configured limit of ${maxChars} characters`);
+  }
+  if (current) chunks.push({ pageStart, pageEnd, text: current });
+  return chunks;
+}
+
+export async function derivePdfText(input: PdfDerivationInput): Promise<PdfDerivationResult> {
+  const maxBytes = positiveLimit(input.maxBytes, DEFAULT_PDF_MAX_BYTES, 'maxBytes');
+  const maxPages = positiveLimit(input.maxPages, DEFAULT_PDF_MAX_PAGES, 'maxPages');
+  const maxChars = positiveLimit(input.maxChars, DEFAULT_PDF_MAX_CHARS, 'maxChars');
+  const chunkChars = positiveLimit(input.chunkChars, DEFAULT_PDF_CHUNK_CHARS, 'chunkChars');
+  if (chunkChars > maxChars) throw new Error('chunkChars cannot exceed maxChars');
+
+  const store = new MediaStore(input.dataDir);
+  const asset = store.getAsset(input.projectId, input.assetId);
+  if (!asset) throw new Error(`Media asset not found: ${input.assetId}`);
+  if (asset.kind !== 'document' || asset.mimeType !== 'application/pdf') {
+    throw new Error(`Asset ${asset.id} is not a PDF document`);
+  }
+
+  try {
+    const bytes = await readMediaAsset(input.dataDir, asset, maxBytes);
+    const pdf = await getDocumentProxy(new Uint8Array(bytes), {
+      useSystemFonts: true,
+      maxImageSize: 16_777_216,
+      stopAtErrors: true,
+      verbosity: 0,
+    });
+    try {
+      if (pdf.numPages > maxPages) throw new Error(`PDF has ${pdf.numPages} pages; limit is ${maxPages}`);
+      const pages: Array<{ page: number; text: string }> = [];
+      let totalChars = 0;
+      for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber += 1) {
+        const page = await pdf.getPage(pageNumber);
+        const text = pageText(await page.getTextContent());
+        totalChars += text.length;
+        if (totalChars > maxChars) throw new Error(`PDF text exceeds the configured limit of ${maxChars} characters`);
+        pages.push({ page: pageNumber, text });
+      }
+      const chunks = chunkPages(pages, maxChars, chunkChars);
+      const content = chunks.map((chunk) => `[Pages ${chunk.pageStart}-${chunk.pageEnd}]\n${chunk.text}`).join('\n\n');
+      const derivation = store.addDerivation({
+        projectId: input.projectId,
+        assetId: asset.id,
+        kind: 'pdf-text',
+        content,
+        metadata: {
+          extractor: 'unpdf',
+          pageCount: pdf.numPages,
+          processedPages: pages.length,
+          chunkCount: chunks.length,
+          truncated: false,
+          maxPages,
+          maxChars,
+        },
+        status: 'ready',
+      });
+      return { asset, derivation, chunks };
+    } finally {
+      await pdf.loadingTask.destroy();
+    }
+  } catch (error) {
+    const message = sanitizeCredentials(error instanceof Error ? error.message : String(error)).slice(0, 1_000);
+    store.addDerivation({
+      projectId: input.projectId,
+      assetId: asset.id,
+      kind: 'pdf-text',
+      content: '',
+      metadata: { extractor: 'unpdf', maxPages, maxChars },
+      status: 'failed',
+      error: message,
+    });
+    throw new Error(`PDF text extraction failed: ${message}`);
+  }
+}

--- a/src/media/types.ts
+++ b/src/media/types.ts
@@ -7,7 +7,17 @@ export type MediaSourceKind =
 
 export type MediaLinkRole = 'source' | 'generated' | 'attachment';
 
-export type MediaDerivationKind = 'description' | 'ocr' | 'embedding';
+export type MediaDerivationKind = 'description' | 'ocr' | 'embedding' | 'pdf-text';
+
+export interface MediaDerivationMetadata {
+  extractor?: string;
+  pageCount?: number;
+  processedPages?: number;
+  chunkCount?: number;
+  truncated?: boolean;
+  maxPages?: number;
+  maxChars?: number;
+}
 
 export type MediaJobKind = 'minimax-video-generation';
 
@@ -57,6 +67,7 @@ export interface MediaDerivation {
   /** Embedding profile key for vector derivations; absent for textual data. */
   profileKey?: string;
   content: string;
+  metadata?: MediaDerivationMetadata;
   status: 'ready' | 'failed';
   error?: string;
   createdAt: number;

--- a/src/server.ts
+++ b/src/server.ts
@@ -4996,7 +4996,7 @@ export async function createMemorixServer(
         'Use the CLI for destructive removal, quota cleanup, and direct generation. ' +
         'MCP generation is disabled by default and requires MEMORIX_MCP_MEDIA_GENERATION=1 after the operator reviews provider billing.',
       inputSchema: {
-        action: z.enum(['import', 'attach', 'list', 'show', 'generate-image', 'generate-video', 'status', 'cancel']),
+        action: z.enum(['import', 'attach', 'list', 'show', 'derive-pdf', 'generate-image', 'generate-video', 'status', 'cancel']),
         path: z.string().optional().describe('Explicit local image/audio/video/PDF path for import.'),
         assetId: z.string().optional().describe('Controlled MediaAsset ID for attach/show.'),
         jobId: z.string().optional().describe('Durable media job ID for status.'),
@@ -5012,10 +5012,12 @@ export async function createMemorixServer(
         width: z.number().int().min(1).max(8192).optional().describe('Requested image width.'),
         height: z.number().int().min(1).max(8192).optional().describe('Requested image height.'),
         duration: z.union([z.literal(5), z.literal(10)]).optional().describe('MiniMax video duration in seconds.'),
+        maxPages: z.number().int().min(1).max(100).optional().describe('Bounded PDF extraction page limit.'),
+        maxChars: z.number().int().min(1).max(60_000).optional().describe('Bounded PDF extraction character limit.'),
         attach: z.boolean().optional().describe('Attach generated/imported output to normal project memory explicitly.'),
       },
     },
-    async ({ action, path: assetPath, assetId, jobId, kind, limit, title, narrative, prompt, model, region, n, ratio, width, height, duration, attach }) => {
+    async ({ action, path: assetPath, assetId, jobId, kind, limit, title, narrative, prompt, model, region, n, ratio, width, height, duration, maxPages, maxChars, attach }) => {
       const unresolved = requireResolvedProject('manage controlled media');
       if (unresolved) return unresolved;
       const safeError = (error: unknown) => sanitizeCredentials(
@@ -5094,6 +5096,30 @@ export async function createMemorixServer(
             ? await attachAsset(imported.asset, title, narrative)
             : undefined;
           return result({ action, projectId: project.id, ...imported, ...(observation ? { observation } : {}) });
+        }
+        if (action === 'derive-pdf') {
+          if (!assetId?.trim()) throw new Error('assetId is required for PDF text derivation');
+          const { derivePdfText } = await import('./media/pdf.js');
+          const boundedChars = maxChars ?? 60_000;
+          const derived = await derivePdfText({
+            dataDir: projectDir,
+            projectId: project.id,
+            assetId,
+            maxPages: maxPages ?? 50,
+            maxChars: boundedChars,
+            chunkChars: Math.min(6_000, boundedChars),
+          });
+          const observations = [];
+          if (attach === true) {
+            for (const chunk of derived.chunks) {
+              observations.push(await attachAsset(
+                derived.asset,
+                `${title?.trim() || `PDF: ${derived.asset.sourceLabel ?? derived.asset.id}`} (pages ${chunk.pageStart}-${chunk.pageEnd})`,
+                chunk.text,
+              ));
+            }
+          }
+          return result({ action, projectId: project.id, ...derived, observations });
         }
         if (action === 'generate-image') {
           if (!mcpGenerationEnabled) {

--- a/src/store/sqlite-db.ts
+++ b/src/store/sqlite-db.ts
@@ -624,6 +624,7 @@ CREATE TABLE IF NOT EXISTS media_derivations (
   kind        TEXT NOT NULL,
   profile_key TEXT,
   content     TEXT NOT NULL DEFAULT '',
+  metadata_json TEXT,
   status      TEXT NOT NULL DEFAULT 'ready',
   error       TEXT,
   created_at  INTEGER NOT NULL,
@@ -948,6 +949,12 @@ const SCHEMA_MIGRATIONS: SchemaMigration[] = [
       db.exec('CREATE INDEX IF NOT EXISTS idx_media_derivations_asset ON media_derivations(project_id, asset_id, kind)');
       db.exec('CREATE INDEX IF NOT EXISTS idx_media_embeddings_profile ON media_embeddings(project_id, profile_key, asset_id)');
       db.exec('CREATE INDEX IF NOT EXISTS idx_media_jobs_project_status ON media_jobs(project_id, status, updated_at DESC)');
+    },
+  },
+  {
+    id: '1.4.3-media-derivation-metadata',
+    apply: (db) => {
+      try { db.exec('ALTER TABLE media_derivations ADD COLUMN metadata_json TEXT'); } catch { /* already exists */ }
     },
   },
 ];

--- a/tests/integration/media-mcp.test.ts
+++ b/tests/integration/media-mcp.test.ts
@@ -28,6 +28,27 @@ const PNG_BYTES = Buffer.from(
   'base64',
 );
 
+function buildPdf(text: string): Buffer {
+  const stream = `BT\n/F1 12 Tf\n72 720 Td\n(${text.replace(/[\\()]/g, '\\$&')}) Tj\nET`;
+  const objects = [
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [3 0 R] /Count 1 >>',
+    '<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 5 0 R >> >> /MediaBox [0 0 612 792] /Contents 4 0 R >>',
+    `<< /Length ${Buffer.byteLength(stream)} >>\nstream\n${stream}\nendstream`,
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+  ];
+  let document = '%PDF-1.4\n';
+  const offsets = [0];
+  objects.forEach((object, index) => {
+    offsets.push(Buffer.byteLength(document));
+    document += `${index + 1} 0 obj\n${object}\nendobj\n`;
+  });
+  const xrefOffset = Buffer.byteLength(document);
+  document += 'xref\n0 6\n0000000000 65535 f \n';
+  offsets.slice(1).forEach((offset) => { document += `${String(offset).padStart(10, '0')} 00000 n \n`; });
+  return Buffer.from(`${document}trailer\n<< /Size 6 /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`);
+}
+
 function getHandler(server: any, name: string): (args: Record<string, unknown>) => Promise<any> {
   const handler = server._registeredTools?.[name]?.handler;
   expect(handler).toBeTypeOf('function');
@@ -55,6 +76,7 @@ describe('controlled media through MCP', () => {
     dataDir = path.join(root, 'data');
     await fs.mkdir(path.join(projectRoot, '.git'), { recursive: true });
     await fs.writeFile(path.join(projectRoot, 'diagram.png'), PNG_BYTES);
+    await fs.writeFile(path.join(projectRoot, 'design.pdf'), buildPdf('MCP PDF evidence'));
     process.env.MEMORIX_DATA_DIR = dataDir;
     process.env.MINIMAX_API_KEY = 'mcp-test-key';
     delete process.env.MEMORIX_MCP_MEDIA_GENERATION;
@@ -167,6 +189,28 @@ describe('controlled media through MCP', () => {
     const shown = readJson(await media({ action: 'show', assetId: listed.assets[0].id }));
     expect(shown.links).toHaveLength(1);
     expect(shown.derivations).toMatchObject([{ kind: 'description', status: 'ready' }]);
+  });
+
+  it('derives bounded PDF text through the same controlled MCP lifecycle', async () => {
+    const { server } = await createMemorixServer(projectRoot, undefined, undefined, { toolProfile: 'lite' });
+    const media = getHandler(server as any, 'memorix_media');
+    const imported = readJson(await media({ action: 'import', path: path.join(projectRoot, 'design.pdf') }));
+
+    const rawDerived = await media({
+      action: 'derive-pdf',
+      assetId: imported.asset.id,
+      maxPages: 10,
+      maxChars: 1_000,
+      attach: true,
+    });
+    const derived = readJson(rawDerived);
+
+    expect(derived).toMatchObject({
+      action: 'derive-pdf',
+      derivation: { kind: 'pdf-text', status: 'ready', metadata: { pageCount: 1 } },
+    });
+    expect(derived.observations).toHaveLength(1);
+    expect(derived.derivation.content).toContain('MCP PDF evidence');
   });
 
   it('rejects invalid legacy base64 before it can become a controlled asset', async () => {

--- a/tests/media/pdf.test.ts
+++ b/tests/media/pdf.test.ts
@@ -1,0 +1,112 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { importMediaBuffer } from '../../src/media/asset-store.js';
+import { MediaStore } from '../../src/media/media-store.js';
+import { derivePdfText } from '../../src/media/pdf.js';
+import { closeDatabase } from '../../src/store/sqlite-db.js';
+
+const roots: string[] = [];
+
+function buildPdf(pages: string[]): Buffer {
+  const pageObjectIds = pages.map((_, index) => 3 + index * 2);
+  const fontObjectId = 3 + pages.length * 2;
+  const objects = new Map<number, string>();
+  objects.set(1, '<< /Type /Catalog /Pages 2 0 R >>');
+  objects.set(2, `<< /Type /Pages /Kids [${pageObjectIds.map((id) => `${id} 0 R`).join(' ')}] /Count ${pages.length} >>`);
+  pages.forEach((text, index) => {
+    const pageId = pageObjectIds[index];
+    const contentId = pageId + 1;
+    const stream = `BT\n/F1 12 Tf\n72 720 Td\n(${text.replace(/[\\()]/g, '\\$&')}) Tj\nET`;
+    objects.set(pageId, `<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 ${fontObjectId} 0 R >> >> /MediaBox [0 0 612 792] /Contents ${contentId} 0 R >>`);
+    objects.set(contentId, `<< /Length ${Buffer.byteLength(stream)} >>\nstream\n${stream}\nendstream`);
+  });
+  objects.set(fontObjectId, '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>');
+
+  let document = '%PDF-1.4\n';
+  const offsets = [0];
+  for (let id = 1; id <= fontObjectId; id += 1) {
+    offsets[id] = Buffer.byteLength(document);
+    document += `${id} 0 obj\n${objects.get(id)}\nendobj\n`;
+  }
+  const xrefOffset = Buffer.byteLength(document);
+  document += `xref\n0 ${fontObjectId + 1}\n0000000000 65535 f \n`;
+  for (let id = 1; id <= fontObjectId; id += 1) {
+    document += `${String(offsets[id]).padStart(10, '0')} 00000 n \n`;
+  }
+  document += `trailer\n<< /Size ${fontObjectId + 1} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+  return Buffer.from(document, 'utf8');
+}
+
+async function fixture() {
+  const root = await mkdtemp(path.join(tmpdir(), 'memorix-pdf-'));
+  roots.push(root);
+  return { dataDir: path.join(root, 'data'), projectId: 'test/pdf-project' };
+}
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) {
+    closeDatabase(path.join(root, 'data'));
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+describe('controlled PDF text derivations', () => {
+  it('extracts page-labelled chunks and durable provenance from an explicit PDF asset', async () => {
+    const input = await fixture();
+    const imported = await importMediaBuffer({
+      ...input,
+      bytes: buildPdf(['Architecture decision', 'Retry behavior']),
+      filename: 'design.pdf',
+      sourceKind: 'import',
+    });
+
+    const derived = await derivePdfText({ ...input, assetId: imported.asset.id, chunkChars: 30 });
+
+    expect(imported.asset).toMatchObject({ kind: 'document', mimeType: 'application/pdf' });
+    expect(derived.chunks).toHaveLength(2);
+    expect(derived.derivation).toMatchObject({
+      kind: 'pdf-text',
+      status: 'ready',
+      metadata: { extractor: 'unpdf', pageCount: 2, processedPages: 2, chunkCount: 2 },
+    });
+    expect(derived.derivation.content).toContain('Page 1');
+    expect(derived.derivation.content).toContain('Architecture decision');
+    expect(derived.derivation.content).toContain('Retry behavior');
+  });
+
+  it('records a failed derivation for malformed input without creating a text projection', async () => {
+    const input = await fixture();
+    const imported = await importMediaBuffer({
+      ...input,
+      bytes: Buffer.from('%PDF-not-a-real-document'),
+      filename: 'broken.pdf',
+      sourceKind: 'import',
+    });
+
+    await expect(derivePdfText({ ...input, assetId: imported.asset.id })).rejects.toThrow(/PDF text extraction failed/i);
+    expect(new MediaStore(input.dataDir).listDerivations(input.projectId, imported.asset.id)).toMatchObject([
+      { kind: 'pdf-text', status: 'failed', content: '' },
+    ]);
+  });
+
+  it('fails closed before indexing when the PDF exceeds the caller page budget', async () => {
+    const input = await fixture();
+    const imported = await importMediaBuffer({
+      ...input,
+      bytes: buildPdf(['One', 'Two']),
+      filename: 'two-pages.pdf',
+      sourceKind: 'import',
+    });
+
+    await expect(derivePdfText({ ...input, assetId: imported.asset.id, maxPages: 1 })).rejects.toThrow(/2 pages; limit is 1/i);
+    expect(new MediaStore(input.dataDir).listDerivations(input.projectId, imported.asset.id)[0]).toMatchObject({
+      kind: 'pdf-text',
+      status: 'failed',
+      metadata: { maxPages: 1 },
+    });
+  });
+});


### PR DESCRIPTION
## Summary\n\nImplements the first production slice of #173 without changing implicit memory capture.\n\n- Adds the shared derivation metadata field and idempotent SQLite migration.\n- Adds bounded explicit PDF extraction with unpdf, page labels, chunk metadata, cleanup, and failed-derivation audit records.\n- Adds CLI memorix media derive-pdf and bounded MCP memorix_media action derive-pdf.\n- --attach is explicit and creates page-range retrieval projections; import alone never indexes PDF text.\n- Adds real PDF unit tests, MCP integration coverage, docs, and updates ACTIVE_WORK.\n\n## Verification\n\n- 
pm run build\n- 
pm run lint\n- 
pm test (all tests passed)\n- Real Windows CLI import/derive/attach smoke with a public one-page PDF\n- 
pm pack --dry-run\n\nContributor media work remains credited in #173; this PR does not copy or erase prior contributions.