### PR TITLE
feat(media): add controlled audio transcript derivations

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,13 @@
 # MINIMAX_IMAGE_BASE_URL=https://api.minimax.io
 # MINIMAX_VIDEO_MODEL=MiniMax-H3
 # MINIMAX_VIDEO_BASE_URL=https://api.minimax.io
+# Explicit, opt-in audio transcription. Supported providers: openai, groq.
+# MEMORIX_TRANSCRIPTION_PROVIDER=openai
+# MEMORIX_TRANSCRIPTION_MODEL=gpt-4o-transcribe
+# OPENAI_API_KEY=...
+# GROQ_API_KEY=...
+# Set only after reviewing provider billing before allowing MCP-originated jobs.
+# MEMORIX_MCP_MEDIA_TRANSCRIPTION=1
 #
 # MCP generation is disabled by default because it can incur provider charges.
 # Set only after deliberately authorizing agent-initiated generation:

--- a/ACTIVE_WORK.md
+++ b/ACTIVE_WORK.md
@@ -16,8 +16,9 @@
 
 1. Keep the public repository free of operator state, local paths, credentials,
    raw session captures, and one-off development artifacts.
-2. Deliver #173 as an explicit, bounded PDF-to-text derivation path over the
-   existing controlled media asset store.
+2. Deliver the controlled media follow-through: #174 audio transcript
+   derivations, #175 evidence-bounded graph retrieval, #185 CodeBuddy support,
+   and #184 automated Star History verification.
 
 ## Completed Contribution Decisions
 
@@ -43,7 +44,7 @@
 
 ## Immediate Next Step
 
-Complete #173 with a shared derivation metadata contract, explicit CLI and
-bounded MCP operation, page-aware text projections, and corrupt/oversized/
-multipage regression coverage. #174 must reuse this contract rather than add
-its own storage path.
+Complete #174 on the shared derivation contract. It must use provider-specific
+credentials, explicit CLI-first consent, bounded asynchronous jobs, and source
+asset lifecycle cancellation; #175 must then reuse the existing evidence
+governor rather than add unbounded graph traversal.

--- a/docs/1.4.3-CONTROLLED-AUDIO-TRANSCRIPTS.md
+++ b/docs/1.4.3-CONTROLLED-AUDIO-TRANSCRIPTS.md
@@ -1,0 +1,62 @@
+# Controlled Audio Transcript Derivations
+
+## Purpose
+
+Issue #174 turns an already controlled local audio asset into an explicit text
+derivative. It evolves the original audio-ingestion proposal in #31 without
+reintroducing an untracked file-to-MCP write path.
+
+```text
+local audio -> controlled asset -> explicit derive-audio -> durable transcript
+                                           -> optional --attach -> memory projection
+```
+
+## Provider Contract
+
+Only two documented providers are accepted:
+
+| Provider | Credential read | Endpoint | Default model |
+| --- | --- | --- | --- |
+| `openai` | `OPENAI_API_KEY` | OpenAI Audio Transcriptions | `gpt-4o-transcribe` |
+| `groq` | `GROQ_API_KEY` | Groq OpenAI-compatible Audio Transcriptions | `whisper-large-v3-turbo` |
+
+`MEMORIX_TRANSCRIPTION_PROVIDER` and `MEMORIX_TRANSCRIPTION_MODEL` select
+defaults for an explicit request. They never borrow the generic Memorix LLM
+credential, and credentials are never saved in a media job or derivation.
+
+The request uses provider-documented multipart `file`, `model`, and
+`response_format=verbose_json`. Audio input is capped at 25 MiB, which is the
+conservative common limit. A provider response may report duration or token
+usage; Memorix records those units as audit metadata but does not invent a
+currency price from a moving provider price sheet.
+
+## User Surface
+
+```powershell
+memorix media import --path .\meeting.wav --json
+memorix media derive-audio --asset <asset-id> --provider groq --json
+memorix media derive-audio --asset <asset-id> --provider openai --language en --attach --json
+memorix media status --job <media-job-id> --json
+memorix media cancel --job <media-job-id> --json
+```
+
+The CLI is complete: it queues, starts a bounded local worker, shows status,
+and cancels. The matching `memorix_media` MCP action is intentionally disabled
+unless `MEMORIX_MCP_MEDIA_TRANSCRIPTION=1` is set, because each transcription
+can incur provider charges. Retrieval never triggers transcription.
+
+## Failure and Lifecycle Rules
+
+- Missing or unsupported providers fail before a durable job is created.
+- Network outcomes that might already be billable fail closed, rather than
+  replaying the request. Explicit 408, 429, and 5xx provider responses receive
+  bounded retries with the error recorded on the job.
+- A cancellation wins over an in-flight worker. Removing the source asset also
+  cancels unfinished transcript jobs and deletes the derivative with the asset.
+- Re-running `derive-audio` after deletion is the explicit reindex path; a
+  ready derivative is reused without another provider call.
+
+## Sources
+
+- [OpenAI Audio Transcriptions API](https://developers.openai.com/api/docs/api-reference/audio/createTranscription)
+- [Groq Speech to Text API](https://console.groq.com/docs/speech-to-text)

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -754,6 +754,7 @@ durable job, so it survives process restarts and can be inspected or cancelled.
 ```bash
 memorix media generate image --prompt "..." --json
 memorix media generate video --prompt "..." --json
+memorix media derive-audio --asset <asset-id> --provider groq --attach --json
 memorix media status --job <media-job-id> --json
 memorix media cancel --job <media-job-id> --json
 ```
@@ -764,6 +765,12 @@ and `full` profiles. Its import/attach/list/show/status actions are available
 normally; generation requires `MEMORIX_MCP_MEDIA_GENERATION=1` because it can
 incur provider charges. Text-only embedding providers never produce a pretend
 image, audio, video, or document vector.
+
+Audio transcription is also explicit. `derive-audio` consumes an existing
+controlled audio asset and queues a durable transcript derivative. It supports
+`openai` (`OPENAI_API_KEY`) and `groq` (`GROQ_API_KEY`) with no credential
+fallback between them. MCP transcription is disabled until
+`MEMORIX_MCP_MEDIA_TRANSCRIPTION=1` is deliberately set.
 
 ### `memorix_ingest_image`
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -201,6 +201,19 @@ Controlled assets default to a 100 MiB import limit. Vision analysis has a
 separate 20 MiB cap so a large local file can remain a usable asset without
 creating an oversized chat-completions request.
 
+### Controlled audio transcription
+
+Audio-to-text is a separate, opt-in derivative lane. Set the matching provider
+credential outside Git:
+
+- `OPENAI_API_KEY` with `MEMORIX_TRANSCRIPTION_PROVIDER=openai`
+- `GROQ_API_KEY` with `MEMORIX_TRANSCRIPTION_PROVIDER=groq`
+- optional `MEMORIX_TRANSCRIPTION_MODEL=<provider model>`
+
+The conservative source limit is 25 MiB. The CLI is enabled when a credential
+is present; MCP-originated transcription remains disabled unless
+`MEMORIX_MCP_MEDIA_TRANSCRIPTION=1` is set after reviewing provider billing.
+
 ### `[memory]`
 
 Runtime memory behavior.

--- a/src/cli/commands/media.ts
+++ b/src/cli/commands/media.ts
@@ -16,6 +16,7 @@ import {
   type MiniMaxVideoGenerationRequest,
 } from '../../media/minimax.js';
 import { launchMediaVideoRunner, queueMiniMaxVideoGeneration } from '../../media/video-jobs.js';
+import { launchMediaAudioRunner, queueAudioTranscription } from '../../media/audio-jobs.js';
 import type { MediaKind } from '../../media/types.js';
 import {
   emitError,
@@ -113,6 +114,7 @@ function help(): string {
     '  memorix media list [--kind image]',
     '  memorix media show --asset <asset-id>',
     '  memorix media derive-pdf --asset <asset-id> [--attach] [--maxPages 100] [--maxChars 120000]',
+    '  memorix media derive-audio --asset <asset-id> [--provider openai|groq] [--model ...] [--attach]',
     '  memorix media attach --asset <asset-id> [--title "Architecture"] [--text "..."]',
     '  memorix media embed --asset <asset-id>',
     '  memorix media similar --asset <asset-id> [--limit 10]',
@@ -144,6 +146,8 @@ export default defineCommand({
     visibility: { type: 'string', description: 'Observation visibility when attaching' },
     prompt: { type: 'string', description: 'Generation prompt' },
     model: { type: 'string', description: 'Provider model' },
+    provider: { type: 'string', description: 'Audio transcription provider: openai or groq' },
+    language: { type: 'string', description: 'Optional ISO-639-1 hint for audio transcription' },
     region: { type: 'string', description: 'MiniMax region: global or cn' },
     n: { type: 'string', description: 'Generated image count (1-4)' },
     ratio: { type: 'string', description: 'Image or video aspect ratio' },
@@ -259,12 +263,19 @@ export default defineCommand({
           if (!job) throw new Error(`Media job not found: ${jobId}`);
           const runner = job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled'
             ? undefined
-            : launchMediaVideoRunner({
+            : job.kind === 'audio-transcription'
+              ? launchMediaAudioRunner({
+                projectId: project.id,
+                projectRoot: project.rootPath,
+                dataDir,
+                mediaJobId: job.id,
+              })
+              : launchMediaVideoRunner({
               projectId: project.id,
               projectRoot: project.rootPath,
               dataDir,
               mediaJobId: job.id,
-            });
+              });
           emitResult(
             { project, job, ...(runner ? { runner } : {}) },
             `${job.kind} ${job.id}: ${job.status}${job.assetId ? ` (${job.assetId})` : ''}`,
@@ -332,6 +343,43 @@ export default defineCommand({
           emitResult(
             { project, ...derived, observations },
             `Derived ${derived.chunks.length} PDF text chunk(s) from ${assetId}${observations.length ? ` and attached ${observations.length} retrieval projection(s)` : ''}.`,
+            asJson,
+          );
+          return;
+        }
+        case 'derive-audio':
+        case 'transcribe': {
+          const assetId = getValue(args.asset, positional);
+          if (!assetId) throw new Error(`asset is required for "memorix media ${action}"`);
+          const { project, dataDir } = await getCliProjectContext();
+          loadDotenv(project.rootPath);
+          const provider = args.provider === undefined ? undefined : String(args.provider).trim().toLowerCase();
+          if (provider !== undefined && provider !== 'openai' && provider !== 'groq') {
+            throw new Error('provider must be openai or groq');
+          }
+          const queued = queueAudioTranscription({
+            dataDir,
+            projectId: project.id,
+            assetId,
+            ...(provider ? { provider } : {}),
+            model: (args.model as string | undefined)?.trim(),
+            language: (args.language as string | undefined)?.trim(),
+            prompt: (args.prompt as string | undefined)?.trim(),
+            maxBytes: parseOptionalInteger(args.maxBytes ?? args['max-bytes'], 'maxBytes', 1, 25 * 1024 * 1024),
+            attachOnComplete: args.attach === true,
+            observationTitle: (args.title as string | undefined)?.trim(),
+          });
+          const runner = launchMediaAudioRunner({
+            projectId: project.id,
+            projectRoot: project.rootPath,
+            dataDir,
+            mediaJobId: queued.mediaJob.id,
+          });
+          emitResult(
+            { project, ...queued, runner },
+            runner.launched
+              ? `Queued audio transcription job ${queued.mediaJob.id}; transcription continues in the background.`
+              : `Queued audio transcription job ${queued.mediaJob.id}. ${runner.reason ?? 'Run a Memorix server or invoke media status after building to resume it.'}`,
             asJson,
           );
           return;

--- a/src/media/audio-jobs.ts
+++ b/src/media/audio-jobs.ts
@@ -1,0 +1,405 @@
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { sanitizeCredentials } from '../memory/secret-filter.js';
+import {
+  MaintenanceJobStore,
+  type MaintenanceJob,
+  type MaintenanceJobRunResult,
+} from '../runtime/maintenance-jobs.js';
+import { attachMediaAssetToObservation } from './attachment.js';
+import { readMediaAsset } from './asset-store.js';
+import { MediaStore } from './media-store.js';
+import type { MediaAsset, MediaDerivation, MediaJob } from './types.js';
+
+export const MEDIA_AUDIO_MAINTENANCE_KIND = 'media-audio-transcription' as const;
+export const DEFAULT_TRANSCRIPTION_MAX_BYTES = 25 * 1024 * 1024;
+const MAX_AUDIO_TRANSCRIPTION_ATTEMPTS = 3;
+
+export type AudioTranscriptionProvider = 'openai' | 'groq';
+
+interface StoredAudioRequest {
+  provider: AudioTranscriptionProvider;
+  model: string;
+  language?: string;
+  prompt?: string;
+  maxBytes: number;
+}
+
+interface TranscriptionUsage {
+  seconds?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+  totalTokens?: number;
+}
+
+export interface AudioTranscriptionResponse {
+  text: string;
+  durationSeconds?: number;
+  usage?: TranscriptionUsage;
+}
+
+export interface QueueAudioTranscriptionInput {
+  dataDir: string;
+  projectId: string;
+  assetId: string;
+  provider?: AudioTranscriptionProvider;
+  model?: string;
+  language?: string;
+  prompt?: string;
+  maxBytes?: number;
+  attachOnComplete?: boolean;
+  observationTitle?: string;
+}
+
+export interface QueuedAudioTranscription {
+  mediaJob: MediaJob;
+  maintenanceJob: MaintenanceJob;
+}
+
+export interface AudioTranscriptionDependencies {
+  transcribe?: (input: {
+    provider: AudioTranscriptionProvider;
+    model: string;
+    language?: string;
+    prompt?: string;
+    asset: MediaAsset;
+    bytes: Buffer;
+  }) => Promise<AudioTranscriptionResponse>;
+  attach?: typeof attachMediaAssetToObservation;
+}
+
+export interface MediaAudioRunnerRequest {
+  projectId: string;
+  projectRoot: string;
+  dataDir: string;
+  mediaJobId: string;
+}
+
+class RetryableAudioProviderError extends Error {}
+
+function safeError(error: unknown): string {
+  return sanitizeCredentials(error instanceof Error ? error.message : String(error)).slice(0, 1_000);
+}
+
+function parseProvider(value: unknown): AudioTranscriptionProvider {
+  if (value === 'openai' || value === 'groq') return value;
+  throw new Error('Transcription provider must be openai or groq');
+}
+
+function parseMaxBytes(value: number | undefined): number {
+  const maxBytes = value ?? DEFAULT_TRANSCRIPTION_MAX_BYTES;
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 1 || maxBytes > DEFAULT_TRANSCRIPTION_MAX_BYTES) {
+    throw new Error(`Audio transcription maxBytes must be between 1 and ${DEFAULT_TRANSCRIPTION_MAX_BYTES}`);
+  }
+  return maxBytes;
+}
+
+function trimOptional(value: string | undefined, label: string, maximum: number): string | undefined {
+  if (value === undefined) return undefined;
+  const normalized = value.trim();
+  if (!normalized) return undefined;
+  if (normalized.length > maximum) throw new Error(`${label} is too long (limit ${maximum} characters)`);
+  return normalized;
+}
+
+function defaultModel(provider: AudioTranscriptionProvider): string {
+  return provider === 'groq' ? 'whisper-large-v3-turbo' : 'gpt-4o-transcribe';
+}
+
+function providerConfig(provider: AudioTranscriptionProvider): { apiKey: string; endpoint: string } {
+  if (provider === 'openai') {
+    const apiKey = process.env.OPENAI_API_KEY?.trim();
+    if (!apiKey) throw new Error('OPENAI_API_KEY is required for transcription provider openai');
+    return { apiKey, endpoint: 'https://api.openai.com/v1/audio/transcriptions' };
+  }
+  const apiKey = process.env.GROQ_API_KEY?.trim();
+  if (!apiKey) throw new Error('GROQ_API_KEY is required for transcription provider groq');
+  return { apiKey, endpoint: 'https://api.groq.com/openai/v1/audio/transcriptions' };
+}
+
+function parseStoredRequest(value: Record<string, unknown>): StoredAudioRequest {
+  const provider = parseProvider(value.provider);
+  const model = typeof value.model === 'string' && value.model.trim();
+  const language = typeof value.language === 'string' ? value.language.trim() || undefined : undefined;
+  const prompt = typeof value.prompt === 'string' ? value.prompt.trim() || undefined : undefined;
+  const maxBytes = value.maxBytes;
+  if (!model || typeof maxBytes !== 'number' || !Number.isSafeInteger(maxBytes)
+    || maxBytes < 1 || maxBytes > DEFAULT_TRANSCRIPTION_MAX_BYTES) {
+    throw new Error('Audio transcription job has an invalid request payload');
+  }
+  return { provider, model, ...(language ? { language } : {}), ...(prompt ? { prompt } : {}), maxBytes };
+}
+
+function mediaJobIdFromMaintenance(job: MaintenanceJob): string {
+  const mediaJobId = job.payload.mediaJobId;
+  if (typeof mediaJobId !== 'string' || !mediaJobId.trim()) {
+    throw new Error('Audio transcription maintenance job is missing mediaJobId');
+  }
+  return mediaJobId;
+}
+
+function terminal(job: MediaJob): boolean {
+  return job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled';
+}
+
+function sourceFilename(asset: MediaAsset): string {
+  const label = asset.sourceLabel?.replace(/[^A-Za-z0-9._-]/g, '_') || `${asset.id}.audio`;
+  return label.includes('.') ? label : `${label}.audio`;
+}
+
+function asFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+function parseProviderResponse(payload: unknown): AudioTranscriptionResponse {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) throw new Error('Transcription provider returned an invalid response');
+  const record = payload as Record<string, unknown>;
+  const text = typeof record.text === 'string' ? record.text.trim() : '';
+  if (!text) throw new Error('Transcription provider returned no transcript text');
+  const usageRecord = record.usage && typeof record.usage === 'object' && !Array.isArray(record.usage)
+    ? record.usage as Record<string, unknown>
+    : undefined;
+  const inputTokenDetails = usageRecord?.input_token_details && typeof usageRecord.input_token_details === 'object'
+    ? usageRecord.input_token_details as Record<string, unknown>
+    : undefined;
+  return {
+    text,
+    ...(asFiniteNumber(record.duration) !== undefined ? { durationSeconds: asFiniteNumber(record.duration) } : {}),
+    ...(usageRecord ? {
+      usage: {
+        ...(asFiniteNumber(usageRecord.seconds) !== undefined ? { seconds: asFiniteNumber(usageRecord.seconds) } : {}),
+        ...(asFiniteNumber(inputTokenDetails?.audio_tokens) !== undefined ? { inputTokens: asFiniteNumber(inputTokenDetails?.audio_tokens) } : {}),
+        ...(asFiniteNumber(usageRecord.output_tokens) !== undefined ? { outputTokens: asFiniteNumber(usageRecord.output_tokens) } : {}),
+        ...(asFiniteNumber(usageRecord.total_tokens) !== undefined ? { totalTokens: asFiniteNumber(usageRecord.total_tokens) } : {}),
+      },
+    } : {}),
+  };
+}
+
+/** Execute only the documented OpenAI-compatible multipart contract. */
+export async function transcribeAudio(input: {
+  provider: AudioTranscriptionProvider;
+  model: string;
+  language?: string;
+  prompt?: string;
+  asset: MediaAsset;
+  bytes: Buffer;
+}): Promise<AudioTranscriptionResponse> {
+  const { apiKey, endpoint } = providerConfig(input.provider);
+  const form = new FormData();
+  form.set('file', new Blob([input.bytes], { type: input.asset.mimeType }), sourceFilename(input.asset));
+  form.set('model', input.model);
+  form.set('response_format', 'verbose_json');
+  if (input.language) form.set('language', input.language);
+  if (input.prompt) form.set('prompt', input.prompt);
+
+  let response: Response;
+  try {
+    response = await fetch(endpoint, { method: 'POST', headers: { Authorization: `Bearer ${apiKey}` }, body: form });
+  } catch (error) {
+    // An interrupted request may already have reached the provider. Failing
+    // closed avoids a blind retry and a possible duplicate billed request.
+    throw new Error(`Transcription request outcome is unknown: ${safeError(error)}`);
+  }
+  const body = await response.text();
+  if (!response.ok) {
+    const message = body.slice(0, 1_000) || `${response.status} ${response.statusText}`;
+    if (response.status === 408 || response.status === 429 || response.status >= 500) {
+      throw new RetryableAudioProviderError(`Transcription provider returned ${response.status}: ${message}`);
+    }
+    throw new Error(`Transcription provider returned ${response.status}: ${message}`);
+  }
+  let payload: unknown;
+  try {
+    payload = JSON.parse(body);
+  } catch (error) {
+    throw new Error(`Transcription provider returned invalid JSON: ${safeError(error)}`);
+  }
+  return parseProviderResponse(payload);
+}
+
+function toDerivation(input: {
+  asset: MediaAsset;
+  projectId: string;
+  request: StoredAudioRequest;
+  transcript: AudioTranscriptionResponse;
+}): Omit<MediaDerivation, 'id' | 'createdAt' | 'updatedAt'> {
+  const { asset, projectId, request, transcript } = input;
+  const usage = transcript.usage;
+  return {
+    assetId: asset.id,
+    projectId,
+    kind: 'audio-transcript',
+    content: transcript.text,
+    status: 'ready',
+    metadata: {
+      extractor: 'audio-transcription',
+      sourceAssetId: asset.id,
+      provider: request.provider,
+      model: request.model,
+      responseFormat: 'verbose_json',
+      ...(transcript.durationSeconds !== undefined ? { durationSeconds: transcript.durationSeconds } : {}),
+      billing: {
+        costStatus: 'not-reported',
+        ...(usage?.seconds !== undefined ? { inputAudioSeconds: usage.seconds } : {}),
+        ...(usage?.inputTokens !== undefined ? { inputTokens: usage.inputTokens } : {}),
+        ...(usage?.outputTokens !== undefined ? { outputTokens: usage.outputTokens } : {}),
+        ...(usage?.totalTokens !== undefined ? { totalTokens: usage.totalTokens } : {}),
+      },
+    },
+  };
+}
+
+function retryAfterProviderError(
+  store: MediaStore,
+  projectId: string,
+  mediaJob: MediaJob,
+  maintenanceJob: MaintenanceJob,
+  error: unknown,
+): MaintenanceJobRunResult {
+  const message = safeError(error);
+  if (!(error instanceof RetryableAudioProviderError) || maintenanceJob.attempts >= maintenanceJob.maxAttempts) {
+    store.updateJobIfNotCancelled(projectId, mediaJob.id, { status: 'failed', lastError: message, incrementAttempts: true });
+    return { action: 'complete' };
+  }
+  if (!store.updateJobIfNotCancelled(projectId, mediaJob.id, { status: 'retry', lastError: message, incrementAttempts: true })) {
+    return { action: 'complete' };
+  }
+  return { action: 'reschedule', delayMs: 5_000, status: 'retry', lastError: message };
+}
+
+/** Queue an explicit, opt-in audio derivative. Credentials never enter SQLite. */
+export function queueAudioTranscription(input: QueueAudioTranscriptionInput): QueuedAudioTranscription {
+  const provider = parseProvider(input.provider ?? (process.env.MEMORIX_TRANSCRIPTION_PROVIDER?.trim() || 'openai'));
+  providerConfig(provider);
+  const request: StoredAudioRequest = {
+    provider,
+    model: trimOptional(input.model ?? process.env.MEMORIX_TRANSCRIPTION_MODEL, 'model', 160) ?? defaultModel(provider),
+    ...(trimOptional(input.language, 'language', 32) ? { language: trimOptional(input.language, 'language', 32) } : {}),
+    ...(trimOptional(input.prompt, 'prompt', 1_000) ? { prompt: trimOptional(input.prompt, 'prompt', 1_000) } : {}),
+    maxBytes: parseMaxBytes(input.maxBytes),
+  };
+  const store = new MediaStore(input.dataDir);
+  const asset = store.getAsset(input.projectId, input.assetId);
+  if (!asset) throw new Error(`Media asset not found: ${input.assetId}`);
+  if (asset.kind !== 'audio') throw new Error(`Media asset ${input.assetId} is ${asset.kind}, not audio`);
+  if (asset.byteSize > request.maxBytes) throw new Error(`Audio asset exceeds transcription limit (${asset.byteSize} bytes; limit ${request.maxBytes})`);
+  const mediaJob = store.createJob({
+    projectId: input.projectId,
+    kind: 'audio-transcription',
+    request: { ...request },
+    sourceAssetId: asset.id,
+    attachOnComplete: input.attachOnComplete,
+    observationTitle: input.observationTitle,
+  });
+  const maintenanceJob = new MaintenanceJobStore(input.dataDir).enqueue({
+    projectId: input.projectId,
+    kind: MEDIA_AUDIO_MAINTENANCE_KIND,
+    dedupeKey: `media-audio:${mediaJob.id}`,
+    payload: { mediaJobId: mediaJob.id },
+    maxAttempts: MAX_AUDIO_TRANSCRIPTION_ATTEMPTS,
+  });
+  return { mediaJob, maintenanceJob };
+}
+
+export async function runAudioTranscriptionJob(
+  maintenanceJob: MaintenanceJob,
+  context: { dataDir: string; projectId: string },
+  dependencies: AudioTranscriptionDependencies = {},
+): Promise<MaintenanceJobRunResult> {
+  const mediaJobId = mediaJobIdFromMaintenance(maintenanceJob);
+  const store = new MediaStore(context.dataDir);
+  const mediaJob = store.getJob(context.projectId, mediaJobId);
+  if (!mediaJob || terminal(mediaJob)) return { action: 'complete' };
+  if (mediaJob.kind !== 'audio-transcription') throw new Error(`Unsupported media job kind: ${mediaJob.kind}`);
+  if (!mediaJob.sourceAssetId) {
+    store.updateJobIfNotCancelled(context.projectId, mediaJob.id, { status: 'cancelled', lastError: 'Audio source asset is unavailable' });
+    return { action: 'complete' };
+  }
+  const request = parseStoredRequest(mediaJob.request);
+  const asset = store.getAsset(context.projectId, mediaJob.sourceAssetId);
+  if (!asset || asset.kind !== 'audio') {
+    store.updateJobIfNotCancelled(context.projectId, mediaJob.id, { status: 'cancelled', lastError: 'Audio source asset is unavailable' });
+    return { action: 'complete' };
+  }
+
+  const existing = store.listDerivations(context.projectId, asset.id)
+    .find((derivation) => derivation.kind === 'audio-transcript' && derivation.status === 'ready');
+  let derivation = existing;
+  if (!derivation) {
+    if (!store.updateJobIfNotCancelled(context.projectId, mediaJob.id, { status: 'submitting', incrementAttempts: true })) {
+      return { action: 'complete' };
+    }
+    try {
+      const transcript = await (dependencies.transcribe ?? transcribeAudio)({
+        provider: request.provider,
+        model: request.model,
+        ...(request.language ? { language: request.language } : {}),
+        ...(request.prompt ? { prompt: request.prompt } : {}),
+        asset,
+        bytes: await readMediaAsset(context.dataDir, asset, request.maxBytes),
+      });
+      derivation = store.addDerivation(toDerivation({ asset, projectId: context.projectId, request, transcript }));
+    } catch (error) {
+      return retryAfterProviderError(store, context.projectId, mediaJob, maintenanceJob, error);
+    }
+  }
+
+  const activeJob = store.getJob(context.projectId, mediaJob.id);
+  if (!activeJob || terminal(activeJob)) return { action: 'complete' };
+  if (activeJob.attachOnComplete) {
+    const hasAttachment = store.listLinks(context.projectId, asset.id)
+      .some((link) => link.role === 'attachment' && link.observationId !== undefined);
+    if (!hasAttachment) {
+      await (dependencies.attach ?? attachMediaAssetToObservation)({
+        dataDir: context.dataDir,
+        projectId: context.projectId,
+        asset,
+        title: activeJob.observationTitle ?? `Audio transcript: ${asset.sourceLabel ?? asset.id}`,
+        narrative: derivation.content,
+        facts: [
+          'Derived with explicit audio transcription.',
+          `Transcription provider: ${request.provider}`,
+          `Transcription model: ${request.model}`,
+        ],
+        concepts: ['audio', 'audio-transcript', 'media-derivation', request.provider, request.model],
+      });
+    }
+  }
+  store.updateJobIfNotCancelled(context.projectId, mediaJob.id, { status: 'completed' });
+  return { action: 'complete' };
+}
+
+export function resolveMediaAudioRunnerPath(moduleUrl = import.meta.url): string {
+  const moduleDir = path.dirname(fileURLToPath(moduleUrl));
+  const parentDir = path.dirname(moduleDir);
+  const distDir = path.basename(moduleDir) === 'cli'
+    ? parentDir
+    : path.basename(moduleDir) === 'media' && path.basename(parentDir) === 'src'
+      ? path.join(path.dirname(parentDir), 'dist')
+      : moduleDir;
+  return path.join(distDir, 'media-audio-runner.js');
+}
+
+/** Kick a short-lived worker for CLI users without opening a Windows console. */
+export function launchMediaAudioRunner(
+  request: MediaAudioRunnerRequest,
+  options: { runnerPath?: string } = {},
+): { launched: boolean; reason?: string } {
+  const runnerPath = options.runnerPath ?? resolveMediaAudioRunnerPath();
+  if (!existsSync(runnerPath)) return { launched: false, reason: 'Audio runner is unavailable until Memorix is built or reinstalled.' };
+  try {
+    const child = spawn(process.execPath, [runnerPath, JSON.stringify(request)], {
+      cwd: request.projectRoot,
+      stdio: 'ignore',
+      windowsHide: true,
+    });
+    child.unref();
+    return { launched: true };
+  } catch (error) {
+    return { launched: false, reason: safeError(error) };
+  }
+}

--- a/src/media/media-store.ts
+++ b/src/media/media-store.ts
@@ -124,6 +124,7 @@ function rowToJob(row: any): MediaJob {
     kind: row.kind as MediaJobKind,
     status: row.status as MediaJobStatus,
     request: parseRequest(row.request_json),
+    ...(asOptionalText(row.source_asset_id) ? { sourceAssetId: row.source_asset_id } : {}),
     ...(asOptionalText(row.provider_task_id) ? { providerTaskId: row.provider_task_id } : {}),
     ...(asOptionalText(row.asset_id) ? { assetId: row.asset_id } : {}),
     ...(asOptionalText(row.last_error) ? { lastError: row.last_error } : {}),
@@ -263,6 +264,17 @@ export class MediaStore {
       this.db.prepare(`
         UPDATE media_jobs SET asset_id = NULL, updated_at = ?
         WHERE project_id = ? AND asset_id = ?
+      `).run(Date.now(), projectId, assetId);
+      // A pending derivative cannot safely run after its source disappears.
+      // Mark it terminal instead of letting a later worker rediscover a stale
+      // JSON request and make a paid provider call.
+      this.db.prepare(`
+        UPDATE media_jobs
+        SET source_asset_id = NULL,
+            status = CASE WHEN status IN ('completed', 'failed', 'cancelled') THEN status ELSE 'cancelled' END,
+            last_error = CASE WHEN status IN ('completed', 'failed', 'cancelled') THEN last_error ELSE 'Source asset was removed' END,
+            updated_at = ?
+        WHERE project_id = ? AND source_asset_id = ?
       `).run(Date.now(), projectId, assetId);
       const result = this.db.prepare(`
         UPDATE media_assets SET deleted_at = ?, updated_at = ?
@@ -415,6 +427,7 @@ export class MediaStore {
     projectId: string;
     kind: MediaJobKind;
     request: Record<string, unknown>;
+    sourceAssetId?: string;
     attachOnComplete?: boolean;
     observationTitle?: string;
   }): MediaJob {
@@ -425,6 +438,7 @@ export class MediaStore {
       kind: input.kind,
       status: 'queued',
       request: sanitizeRequest(input.request),
+      ...(input.sourceAssetId ? { sourceAssetId: input.sourceAssetId } : {}),
       attempts: 0,
       attachOnComplete: input.attachOnComplete === true,
       ...(input.observationTitle ? { observationTitle: sanitizeCredentials(input.observationTitle) } : {}),
@@ -433,11 +447,11 @@ export class MediaStore {
     };
     this.db.prepare(`
       INSERT INTO media_jobs (
-        id, project_id, kind, status, request_json, attempts, attach_on_complete,
+        id, project_id, kind, status, request_json, source_asset_id, attempts, attach_on_complete,
         observation_title, created_at, updated_at
-      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
-      job.id, job.projectId, job.kind, job.status, JSON.stringify(job.request), job.attempts,
+      job.id, job.projectId, job.kind, job.status, JSON.stringify(job.request), job.sourceAssetId ?? null, job.attempts,
       job.attachOnComplete ? 1 : 0, job.observationTitle ?? null, now, now,
     );
     return job;

--- a/src/media/types.ts
+++ b/src/media/types.ts
@@ -7,10 +7,23 @@ export type MediaSourceKind =
 
 export type MediaLinkRole = 'source' | 'generated' | 'attachment';
 
-export type MediaDerivationKind = 'description' | 'ocr' | 'embedding' | 'pdf-text';
+export type MediaDerivationKind = 'description' | 'ocr' | 'embedding' | 'pdf-text' | 'audio-transcript';
 
 export interface MediaDerivationMetadata {
   extractor?: string;
+  provider?: string;
+  model?: string;
+  sourceAssetId?: string;
+  responseFormat?: string;
+  durationSeconds?: number;
+  billing?: {
+    /** Providers may report usage but not a stable monetary amount. */
+    costStatus: 'not-reported';
+    inputAudioSeconds?: number;
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+  };
   pageCount?: number;
   processedPages?: number;
   chunkCount?: number;
@@ -19,7 +32,7 @@ export interface MediaDerivationMetadata {
   maxChars?: number;
 }
 
-export type MediaJobKind = 'minimax-video-generation';
+export type MediaJobKind = 'minimax-video-generation' | 'audio-transcription';
 
 export type MediaJobStatus =
   | 'queued'
@@ -100,6 +113,8 @@ export interface MediaJob {
   kind: MediaJobKind;
   status: MediaJobStatus;
   request: Record<string, unknown>;
+  /** The controlled local asset consumed by this job, if any. */
+  sourceAssetId?: string;
   providerTaskId?: string;
   assetId?: string;
   lastError?: string;

--- a/src/runtime/control-plane-maintenance.ts
+++ b/src/runtime/control-plane-maintenance.ts
@@ -9,6 +9,7 @@ import { MaintenanceTargetStore } from './maintenance-targets.js';
 
 export const CONTROL_PLANE_MAINTENANCE_KINDS: readonly MaintenanceJobKind[] = [
   'media-video-generation',
+  'media-audio-transcription',
   'retention-archive',
   'consolidation',
   'codegraph-refresh',

--- a/src/runtime/isolated-maintenance.ts
+++ b/src/runtime/isolated-maintenance.ts
@@ -10,6 +10,7 @@ export const MAINTENANCE_RESULT_PREFIX = '__MEMORIX_MAINTENANCE_RESULT__';
 
 export const ISOLATED_MAINTENANCE_JOB_KINDS: readonly MaintenanceJobKind[] = [
   'media-video-generation',
+  'media-audio-transcription',
   'retention-archive',
   'consolidation',
   'codegraph-refresh',

--- a/src/runtime/maintenance-jobs.ts
+++ b/src/runtime/maintenance-jobs.ts
@@ -6,6 +6,7 @@ import { sanitizeCredentials } from '../memory/secret-filter.js';
 export const MAINTENANCE_JOB_KINDS = [
   'vector-backfill',
   'media-video-generation',
+  'media-audio-transcription',
   'retention-archive',
   'consolidation',
   'codegraph-refresh',

--- a/src/runtime/media-audio-runner.ts
+++ b/src/runtime/media-audio-runner.ts
@@ -1,0 +1,99 @@
+import path from 'node:path';
+
+import { loadDotenv } from '../config/dotenv-loader.js';
+import { initProjectRoot } from '../config/yaml-loader.js';
+import { MediaStore } from '../media/media-store.js';
+import { MEDIA_AUDIO_MAINTENANCE_KIND, type MediaAudioRunnerRequest } from '../media/audio-jobs.js';
+import { initObservations } from '../memory/observations.js';
+import { closeAllDatabases } from '../store/sqlite-db.js';
+import { MaintenanceJobStore, MaintenanceJobWorker } from './maintenance-jobs.js';
+import { createProjectMaintenanceHandler } from './project-maintenance.js';
+
+const POLL_DELAY_MS = 1_000;
+const MAX_RUNNER_LIFETIME_MS = 10 * 60_000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function terminal(status: string): status is 'completed' | 'failed' | 'cancelled' {
+  return status === 'completed' || status === 'failed' || status === 'cancelled';
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function parseMediaAudioRunnerRequest(raw: string): MediaAudioRunnerRequest {
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new Error('Media audio runner received invalid JSON input');
+  }
+  if (!isRecord(value)
+    || typeof value.projectId !== 'string' || !value.projectId
+    || typeof value.projectRoot !== 'string' || !path.isAbsolute(value.projectRoot)
+    || typeof value.dataDir !== 'string' || !path.isAbsolute(value.dataDir)
+    || typeof value.mediaJobId !== 'string' || !value.mediaJobId) {
+    throw new Error('Media audio runner received an invalid request');
+  }
+  return {
+    projectId: value.projectId,
+    projectRoot: value.projectRoot,
+    dataDir: value.dataDir,
+    mediaJobId: value.mediaJobId,
+  };
+}
+
+/** A bounded CLI nudge; durable work remains resumable from the queue. */
+export async function executeMediaAudioRunner(
+  request: MediaAudioRunnerRequest,
+  options: { maxLifetimeMs?: number; pollDelayMs?: number } = {},
+): Promise<'completed' | 'failed' | 'cancelled' | 'missing' | 'timed-out'> {
+  initProjectRoot(request.projectRoot);
+  loadDotenv(request.projectRoot);
+  await initObservations(request.dataDir, { embeddingWriteMode: 'deferred', projectRoot: request.projectRoot });
+  const mediaStore = new MediaStore(request.dataDir);
+  const queue = new MaintenanceJobStore(request.dataDir);
+  const worker = new MaintenanceJobWorker(
+    queue,
+    createProjectMaintenanceHandler(request.projectId, request.dataDir, request.projectRoot),
+    { projectId: request.projectId, kinds: [MEDIA_AUDIO_MAINTENANCE_KIND], pollIntervalMs: POLL_DELAY_MS },
+  );
+  const maxLifetimeMs = Number.isSafeInteger(options.maxLifetimeMs)
+    ? Math.max(POLL_DELAY_MS, options.maxLifetimeMs!)
+    : MAX_RUNNER_LIFETIME_MS;
+  const pollDelayMs = Number.isSafeInteger(options.pollDelayMs)
+    ? Math.max(25, options.pollDelayMs!)
+    : POLL_DELAY_MS;
+  const deadline = Date.now() + maxLifetimeMs;
+  while (Date.now() < deadline) {
+    const before = mediaStore.getJob(request.projectId, request.mediaJobId);
+    if (!before) return 'missing';
+    if (terminal(before.status)) return before.status;
+    await worker.runOnce();
+    const after = mediaStore.getJob(request.projectId, request.mediaJobId);
+    if (!after) return 'missing';
+    if (terminal(after.status)) return after.status;
+    await sleep(pollDelayMs);
+  }
+  return 'timed-out';
+}
+
+export async function main(): Promise<void> {
+  try {
+    const raw = process.argv[2];
+    if (!raw) throw new Error('Media audio runner requires a request payload');
+    await executeMediaAudioRunner(parseMediaAudioRunnerRequest(raw));
+  } catch (error) {
+    process.stderr.write(`[memorix] media audio runner failed: ${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  } finally {
+    closeAllDatabases();
+  }
+}
+
+if (process.argv[1] && process.argv[1].endsWith('media-audio-runner.js')) {
+  void main();
+}

--- a/src/runtime/project-maintenance.ts
+++ b/src/runtime/project-maintenance.ts
@@ -239,6 +239,11 @@ export function createProjectMaintenanceHandler(
       return runMiniMaxVideoGenerationJob(job, { dataDir: projectDir, projectId });
     }
 
+    if (job.kind === 'media-audio-transcription') {
+      const { runAudioTranscriptionJob } = await import('../media/audio-jobs.js');
+      return runAudioTranscriptionJob(job, { dataDir: projectDir, projectId });
+    }
+
     if (job.kind === 'retention-archive') {
       const { archiveExpiredBatch } = await import('../memory/retention.js');
       const limit = retentionBatchSize(job.payload);

--- a/src/server.ts
+++ b/src/server.ts
@@ -4996,7 +4996,7 @@ export async function createMemorixServer(
         'Use the CLI for destructive removal, quota cleanup, and direct generation. ' +
         'MCP generation is disabled by default and requires MEMORIX_MCP_MEDIA_GENERATION=1 after the operator reviews provider billing.',
       inputSchema: {
-        action: z.enum(['import', 'attach', 'list', 'show', 'derive-pdf', 'generate-image', 'generate-video', 'status', 'cancel']),
+        action: z.enum(['import', 'attach', 'list', 'show', 'derive-pdf', 'derive-audio', 'generate-image', 'generate-video', 'status', 'cancel']),
         path: z.string().optional().describe('Explicit local image/audio/video/PDF path for import.'),
         assetId: z.string().optional().describe('Controlled MediaAsset ID for attach/show.'),
         jobId: z.string().optional().describe('Durable media job ID for status.'),
@@ -5005,7 +5005,9 @@ export async function createMemorixServer(
         title: z.string().optional().describe('Observation title when attaching generated/imported output.'),
         narrative: z.string().optional().describe('Short retrieval text when attaching an asset.'),
         prompt: z.string().optional().describe('Explicit MiniMax generation prompt.'),
-        model: z.enum(['image-01', 'image-01-live', 'MiniMax-H3']).optional().describe('MiniMax image or video model.'),
+        model: z.string().max(160).optional().describe('Provider model for the selected media action.'),
+        provider: z.enum(['openai', 'groq']).optional().describe('Explicit audio transcription provider.'),
+        language: z.string().max(32).optional().describe('Optional ISO-639-1 hint for audio transcription.'),
         region: z.enum(['global', 'cn']).optional().describe('MiniMax deployment region.'),
         n: z.number().int().min(1).max(4).optional().describe('Image output count.'),
         ratio: z.enum(['adaptive', '1:1', '16:9', '4:3', '3:2', '2:3', '3:4', '9:16', '21:9']).optional().describe('Image or video aspect ratio.'),
@@ -5017,7 +5019,7 @@ export async function createMemorixServer(
         attach: z.boolean().optional().describe('Attach generated/imported output to normal project memory explicitly.'),
       },
     },
-    async ({ action, path: assetPath, assetId, jobId, kind, limit, title, narrative, prompt, model, region, n, ratio, width, height, duration, maxPages, maxChars, attach }) => {
+    async ({ action, path: assetPath, assetId, jobId, kind, limit, title, narrative, prompt, model, provider, language, region, n, ratio, width, height, duration, maxPages, maxChars, attach }) => {
       const unresolved = requireResolvedProject('manage controlled media');
       if (unresolved) return unresolved;
       const safeError = (error: unknown) => sanitizeCredentials(
@@ -5042,6 +5044,7 @@ export async function createMemorixServer(
         content: [{ type: 'text' as const, text: JSON.stringify(value) }],
       });
       const mcpGenerationEnabled = process.env.MEMORIX_MCP_MEDIA_GENERATION === '1';
+      const mcpTranscriptionEnabled = process.env.MEMORIX_MCP_MEDIA_TRANSCRIPTION === '1';
 
       try {
         const { MediaStore } = await import('./media/media-store.js');
@@ -5120,6 +5123,25 @@ export async function createMemorixServer(
             }
           }
           return result({ action, projectId: project.id, ...derived, observations });
+        }
+        if (action === 'derive-audio') {
+          if (!mcpTranscriptionEnabled) {
+            throw new Error('MCP audio transcription is disabled. Use the CLI, or set MEMORIX_MCP_MEDIA_TRANSCRIPTION=1 after reviewing provider billing.');
+          }
+          if (!assetId?.trim()) throw new Error('assetId is required for audio transcription');
+          const { queueAudioTranscription } = await import('./media/audio-jobs.js');
+          const queued = queueAudioTranscription({
+            dataDir: projectDir,
+            projectId: project.id,
+            assetId,
+            ...(provider ? { provider } : {}),
+            ...(model?.trim() ? { model } : {}),
+            ...(language?.trim() ? { language } : {}),
+            ...(prompt?.trim() ? { prompt } : {}),
+            attachOnComplete: attach === true,
+            observationTitle: title,
+          });
+          return result({ action, projectId: project.id, ...queued });
         }
         if (action === 'generate-image') {
           if (!mcpGenerationEnabled) {

--- a/src/store/sqlite-db.ts
+++ b/src/store/sqlite-db.ts
@@ -667,6 +667,7 @@ CREATE TABLE IF NOT EXISTS media_jobs (
   kind                 TEXT NOT NULL,
   status               TEXT NOT NULL,
   request_json         TEXT NOT NULL DEFAULT '{}',
+  source_asset_id      TEXT,
   provider_task_id     TEXT,
   asset_id             TEXT,
   last_error           TEXT,
@@ -676,7 +677,8 @@ CREATE TABLE IF NOT EXISTS media_jobs (
   created_at           INTEGER NOT NULL,
   updated_at           INTEGER NOT NULL,
   completed_at         INTEGER,
-  FOREIGN KEY (asset_id) REFERENCES media_assets(id) ON DELETE SET NULL
+  FOREIGN KEY (asset_id) REFERENCES media_assets(id) ON DELETE SET NULL,
+  FOREIGN KEY (source_asset_id) REFERENCES media_assets(id) ON DELETE SET NULL
 );
 `;
 
@@ -955,6 +957,13 @@ const SCHEMA_MIGRATIONS: SchemaMigration[] = [
     id: '1.4.3-media-derivation-metadata',
     apply: (db) => {
       try { db.exec('ALTER TABLE media_derivations ADD COLUMN metadata_json TEXT'); } catch { /* already exists */ }
+    },
+  },
+  {
+    id: '1.4.3-media-job-source-asset',
+    apply: (db) => {
+      try { db.exec('ALTER TABLE media_jobs ADD COLUMN source_asset_id TEXT'); } catch { /* already exists */ }
+      db.exec('CREATE INDEX IF NOT EXISTS idx_media_jobs_source_asset ON media_jobs(project_id, source_asset_id, status)');
     },
   },
 ];

--- a/tests/integration/media-mcp.test.ts
+++ b/tests/integration/media-mcp.test.ts
@@ -27,6 +27,11 @@ const PNG_BYTES = Buffer.from(
   'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+XWZ0AAAAASUVORK5CYII=',
   'base64',
 );
+const WAV_BYTES = Buffer.concat([
+  Buffer.from('RIFF'), Buffer.from([36, 0, 0, 0]), Buffer.from('WAVEfmt '),
+  Buffer.from([16, 0, 0, 0, 1, 0, 1, 0, 0x40, 0x1f, 0, 0, 0x80, 0x3e, 0, 0, 2, 0, 16, 0]),
+  Buffer.from('data'), Buffer.from([0, 0, 0, 0]),
+]);
 
 function buildPdf(text: string): Buffer {
   const stream = `BT\n/F1 12 Tf\n72 720 Td\n(${text.replace(/[\\()]/g, '\\$&')}) Tj\nET`;
@@ -66,6 +71,8 @@ describe('controlled media through MCP', () => {
   const priorDataDir = process.env.MEMORIX_DATA_DIR;
   const priorApiKey = process.env.MINIMAX_API_KEY;
   const priorMcpMediaGeneration = process.env.MEMORIX_MCP_MEDIA_GENERATION;
+  const priorMcpMediaTranscription = process.env.MEMORIX_MCP_MEDIA_TRANSCRIPTION;
+  const priorGroqApiKey = process.env.GROQ_API_KEY;
   let root = '';
   let projectRoot = '';
   let dataDir = '';
@@ -77,9 +84,12 @@ describe('controlled media through MCP', () => {
     await fs.mkdir(path.join(projectRoot, '.git'), { recursive: true });
     await fs.writeFile(path.join(projectRoot, 'diagram.png'), PNG_BYTES);
     await fs.writeFile(path.join(projectRoot, 'design.pdf'), buildPdf('MCP PDF evidence'));
+    await fs.writeFile(path.join(projectRoot, 'meeting.wav'), WAV_BYTES);
     process.env.MEMORIX_DATA_DIR = dataDir;
     process.env.MINIMAX_API_KEY = 'mcp-test-key';
     delete process.env.MEMORIX_MCP_MEDIA_GENERATION;
+    delete process.env.MEMORIX_MCP_MEDIA_TRANSCRIPTION;
+    process.env.GROQ_API_KEY = 'mcp-groq-key';
     resetDotenv();
     resetObservationStore();
     await resetDb();
@@ -92,6 +102,10 @@ describe('controlled media through MCP', () => {
     else process.env.MINIMAX_API_KEY = priorApiKey;
     if (priorMcpMediaGeneration === undefined) delete process.env.MEMORIX_MCP_MEDIA_GENERATION;
     else process.env.MEMORIX_MCP_MEDIA_GENERATION = priorMcpMediaGeneration;
+    if (priorMcpMediaTranscription === undefined) delete process.env.MEMORIX_MCP_MEDIA_TRANSCRIPTION;
+    else process.env.MEMORIX_MCP_MEDIA_TRANSCRIPTION = priorMcpMediaTranscription;
+    if (priorGroqApiKey === undefined) delete process.env.GROQ_API_KEY;
+    else process.env.GROQ_API_KEY = priorGroqApiKey;
     resetDotenv();
     resetObservationStore();
     await resetDb();
@@ -211,6 +225,25 @@ describe('controlled media through MCP', () => {
     });
     expect(derived.observations).toHaveLength(1);
     expect(derived.derivation.content).toContain('MCP PDF evidence');
+  });
+
+  it('keeps MCP audio transcription opt-in and provider credentials out of its durable response', async () => {
+    const { server } = await createMemorixServer(projectRoot, undefined, undefined, { toolProfile: 'lite' });
+    const media = getHandler(server as any, 'memorix_media');
+    const imported = readJson(await media({ action: 'import', path: path.join(projectRoot, 'meeting.wav') }));
+
+    const disabled = await media({ action: 'derive-audio', assetId: imported.asset.id, provider: 'groq' });
+    expect(disabled.isError).toBe(true);
+    expect(disabled.content?.[0]?.text).toContain('MCP audio transcription is disabled');
+
+    process.env.MEMORIX_MCP_MEDIA_TRANSCRIPTION = '1';
+    const queued = readJson(await media({ action: 'derive-audio', assetId: imported.asset.id, provider: 'groq' }));
+    expect(queued).toMatchObject({
+      action: 'derive-audio',
+      mediaJob: { kind: 'audio-transcription', sourceAssetId: imported.asset.id, status: 'queued' },
+      maintenanceJob: { kind: 'media-audio-transcription' },
+    });
+    expect(JSON.stringify(queued)).not.toContain('mcp-groq-key');
   });
 
   it('rejects invalid legacy base64 before it can become a controlled asset', async () => {

--- a/tests/media/audio-jobs.test.ts
+++ b/tests/media/audio-jobs.test.ts
@@ -1,0 +1,116 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { importMediaBuffer, removeMediaAsset } from '../../src/media/asset-store.js';
+import { MediaStore } from '../../src/media/media-store.js';
+import { queueAudioTranscription, runAudioTranscriptionJob } from '../../src/media/audio-jobs.js';
+import { closeDatabase } from '../../src/store/sqlite-db.js';
+
+const roots: Array<{ root: string; dataDir: string }> = [];
+const originalOpenAiKey = process.env.OPENAI_API_KEY;
+const originalGroqKey = process.env.GROQ_API_KEY;
+const originalProvider = process.env.MEMORIX_TRANSCRIPTION_PROVIDER;
+const WAV_BYTES = Buffer.concat([
+  Buffer.from('RIFF'), Buffer.from([36, 0, 0, 0]), Buffer.from('WAVEfmt '),
+  Buffer.from([16, 0, 0, 0, 1, 0, 1, 0, 0x40, 0x1f, 0, 0, 0x80, 0x3e, 0, 0, 2, 0, 16, 0]),
+  Buffer.from('data'), Buffer.from([0, 0, 0, 0]),
+]);
+
+async function fixture(): Promise<{ root: string; dataDir: string; projectId: string; assetId: string }> {
+  const root = await mkdtemp(path.join(tmpdir(), 'memorix-audio-job-'));
+  const dataDir = path.join(root, 'data');
+  roots.push({ root, dataDir });
+  const projectId = 'test/audio-job-project';
+  const asset = await importMediaBuffer({ dataDir, projectId, bytes: WAV_BYTES, filename: 'meeting.wav', sourceKind: 'import' });
+  return { root, dataDir, projectId, assetId: asset.asset.id };
+}
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  if (originalOpenAiKey === undefined) delete process.env.OPENAI_API_KEY;
+  else process.env.OPENAI_API_KEY = originalOpenAiKey;
+  if (originalGroqKey === undefined) delete process.env.GROQ_API_KEY;
+  else process.env.GROQ_API_KEY = originalGroqKey;
+  if (originalProvider === undefined) delete process.env.MEMORIX_TRANSCRIPTION_PROVIDER;
+  else process.env.MEMORIX_TRANSCRIPTION_PROVIDER = originalProvider;
+  for (const item of roots.splice(0)) {
+    closeDatabase(item.dataDir);
+    await rm(item.root, { recursive: true, force: true });
+  }
+});
+
+describe('controlled audio transcript derivations', () => {
+  it('queues a provider-specific request and stores a transcript derivative without credentials', async () => {
+    const input = await fixture();
+    process.env.GROQ_API_KEY = 'groq-secret-for-test';
+    const queued = queueAudioTranscription({
+      ...input,
+      assetId: input.assetId,
+      provider: 'groq',
+      model: 'whisper-large-v3-turbo',
+      language: 'en',
+    });
+
+    expect(queued.mediaJob).toMatchObject({ kind: 'audio-transcription', status: 'queued', sourceAssetId: input.assetId });
+    expect(queued.maintenanceJob).toMatchObject({ kind: 'media-audio-transcription' });
+    expect(JSON.stringify(queued.mediaJob)).not.toContain('groq-secret-for-test');
+
+    await expect(runAudioTranscriptionJob(queued.maintenanceJob, input, {
+      transcribe: async () => ({ text: 'A durable decision was recorded.', durationSeconds: 3.2, usage: { seconds: 4 } }),
+    })).resolves.toEqual({ action: 'complete' });
+
+    const store = new MediaStore(input.dataDir);
+    expect(store.getJob(input.projectId, queued.mediaJob.id)).toMatchObject({ status: 'completed', sourceAssetId: input.assetId });
+    expect(store.listDerivations(input.projectId, input.assetId)).toMatchObject([{
+      kind: 'audio-transcript',
+      status: 'ready',
+      content: 'A durable decision was recorded.',
+      metadata: {
+        extractor: 'audio-transcription', provider: 'groq', model: 'whisper-large-v3-turbo',
+        billing: { costStatus: 'not-reported', inputAudioSeconds: 4 },
+      },
+    }]);
+  });
+
+  it('fails closed for an unavailable provider before creating a job', async () => {
+    const input = await fixture();
+    delete process.env.OPENAI_API_KEY;
+    await expect(Promise.resolve().then(() => queueAudioTranscription({ ...input, assetId: input.assetId, provider: 'openai' })))
+      .rejects.toThrow('OPENAI_API_KEY is required');
+    expect(new MediaStore(input.dataDir).listAssets(input.projectId)).toHaveLength(1);
+  });
+
+  it('does not call a provider after cancellation or source deletion', async () => {
+    const input = await fixture();
+    process.env.OPENAI_API_KEY = 'openai-secret-for-test';
+    const queued = queueAudioTranscription({ ...input, assetId: input.assetId });
+    new MediaStore(input.dataDir).cancelJob(input.projectId, queued.mediaJob.id);
+    const transcribe = vi.fn(async () => ({ text: 'must not run' }));
+    await runAudioTranscriptionJob(queued.maintenanceJob, input, { transcribe });
+    expect(transcribe).not.toHaveBeenCalled();
+
+    const second = queueAudioTranscription({ ...input, assetId: input.assetId });
+    await removeMediaAsset({ ...input, assetId: input.assetId });
+    await runAudioTranscriptionJob(second.maintenanceJob, input, { transcribe });
+    expect(transcribe).not.toHaveBeenCalled();
+    expect(new MediaStore(input.dataDir).getJob(input.projectId, second.mediaJob.id)).toMatchObject({ status: 'cancelled' });
+  });
+
+  it('retries an explicit provider 429 and uses the Groq-specific endpoint and credential', async () => {
+    const input = await fixture();
+    process.env.GROQ_API_KEY = 'groq-key-only';
+    const queued = queueAudioTranscription({ ...input, assetId: input.assetId, provider: 'groq' });
+    const fetchMock = vi.fn(async (url: string, init: RequestInit) => {
+      expect(url).toBe('https://api.groq.com/openai/v1/audio/transcriptions');
+      expect(init.headers).toEqual({ Authorization: 'Bearer groq-key-only' });
+      return new Response('slow down', { status: 429 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(runAudioTranscriptionJob(queued.maintenanceJob, input)).resolves.toMatchObject({ action: 'reschedule', status: 'retry' });
+    expect(new MediaStore(input.dataDir).getJob(input.projectId, queued.mediaJob.id)).toMatchObject({ status: 'retry', attempts: 2 });
+  });
+});

--- a/tests/runtime/media-audio-runner.test.ts
+++ b/tests/runtime/media-audio-runner.test.ts
@@ -1,0 +1,20 @@
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { parseMediaAudioRunnerRequest } from '../../src/runtime/media-audio-runner.js';
+
+describe('media audio runner request', () => {
+  it('accepts a fully bound local project request', () => {
+    expect(parseMediaAudioRunnerRequest(JSON.stringify({
+      projectId: 'test/project', projectRoot: path.resolve('project'), dataDir: path.resolve('data'), mediaJobId: 'job-1',
+    }))).toMatchObject({ projectId: 'test/project', mediaJobId: 'job-1' });
+  });
+
+  it('rejects relative paths and malformed payloads', () => {
+    expect(() => parseMediaAudioRunnerRequest('{}')).toThrow('invalid request');
+    expect(() => parseMediaAudioRunnerRequest(JSON.stringify({
+      projectId: 'test/project', projectRoot: 'relative', dataDir: 'relative', mediaJobId: 'job-1',
+    }))).toThrow('invalid request');
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -22,6 +22,8 @@ export default defineConfig([
       // Durable MiniMax video generation is polled outside the CLI process.
       // This runner intentionally has no detached Windows console.
       'media-video-runner': 'src/runtime/media-video-runner.ts',
+      // Explicit audio transcription follows the same durable queue contract.
+      'media-audio-runner': 'src/runtime/media-audio-runner.ts',
     },
     format: ['esm'],
     target: 'node20',


### PR DESCRIPTION
## Summary
- add explicit OpenAI/Groq audio transcript derivatives over controlled assets
- preserve provider-specific credentials, durable queue/cancellation/retry provenance, and CLI/MCP opt-in boundaries
- add focused lifecycle, MCP, and runner tests

Closes #174

Credits #31 / @RaviTharuma as the original audio ingestion proposal.