### PR TITLE
ci: verify automated star history pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   test:

--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -6,6 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -51,5 +52,12 @@ jobs:
               --title "docs: update star history chart" \
               --body "Automated refresh of the self-hosted star history assets."
           fi
+
+          # A push made with github.token intentionally does not emit a normal
+          # pull_request workflow event. Dispatch CI explicitly for the exact
+          # generated head ref so this automated PR carries real checks.
+          gh workflow run ci.yml \
+            --repo "${GITHUB_REPOSITORY}" \
+            --ref automation/star-history
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- allow CI to be explicitly dispatched for automation-owned branches
- dispatch CI after Star History creates or updates its pull request
- grant only the action-dispatch permission needed for that verification

Refs #184