### PR TITLE
fix(cli): coerce repeated citty args instead of throwing on arrays (#194)

### DIFF
--- a/ACTIVE_WORK.md
+++ b/ACTIVE_WORK.md
@@ -24,6 +24,11 @@
 ## Completed Contribution Decisions
 
 - #153: accepted and merged with focused MiniMax M3 video-input tests.
+- #178: accepted and merged (squash) with author and co-author credit preserved
+  on the merge commit. Adds MiniMax image-to-image via `subject_reference`
+  across the provider layer, the media CLI, and the gated `memorix_media` MCP
+  tool. Changelog credit for @octo-patch lands with the next release, following
+  the #153 precedent.
 - #140: accepted and merged after replacing its stale release timeline with a
   maintained boundary-and-roadmap document.
 - #33, #31, #30: not merged into the superseding media/retrieval architecture.
@@ -49,8 +54,8 @@ The #174 controlled audio derivations, #175 governed one-hop graph evidence,
 #185 CodeBuddy integration, and #184 Star History CI verification are merged
 and included in the published 1.4.3 release. The local machine does not have
 the CodeBuddy CLI installed, so a native CodeBuddy-host smoke remains a
-documented follow-up rather than claimed release evidence. Open contributor
-work #178 and legacy requests #49/#3 remain independent of the 1.4.3 release.
+documented follow-up rather than claimed release evidence. Legacy requests
+#49/#3 remain independent of the 1.4.3 release.
 
 - #194 (reported 2026-08-12): `memorix memory store --text` crash on long
   text — root-caused to repeated-flag arrays from citty combined with
@@ -58,3 +63,8 @@ work #178 and legacy requests #49/#3 remain independent of the 1.4.3 release.
   `fix/194-cli-args-coercion` and open as PR #195 with regression tests.
 - PR #195 needs CI verification and merge review before the fix ships in the
   next release line.
+- Branch protection on `main` was synced with the current CI matrix
+  (2026-08-14): the required status contexts referenced removed Node 20 test
+  jobs, which blocked every PR from merging. Required contexts are now the
+  live `test (ubuntu-latest, 22)`, `test (windows-latest, 22)`, and
+  `typecheck`; the one-approval review requirement is unchanged.

--- a/ACTIVE_WORK.md
+++ b/ACTIVE_WORK.md
@@ -51,3 +51,10 @@ and included in the published 1.4.3 release. The local machine does not have
 the CodeBuddy CLI installed, so a native CodeBuddy-host smoke remains a
 documented follow-up rather than claimed release evidence. Open contributor
 work #178 and legacy requests #49/#3 remain independent of the 1.4.3 release.
+
+- #194 (reported 2026-08-12): `memorix memory store --text` crash on long
+  text — root-caused to repeated-flag arrays from citty combined with
+  Windows PowerShell 5.1 argument splitting; fix committed on
+  `fix/194-cli-args-coercion` and open as PR #195 with regression tests.
+- PR #195 needs CI verification and merge review before the fix ships in the
+  next release line.

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -5,6 +5,7 @@ import { getAllObservations, getObservation, getProjectObservations, resolveObse
 import { buildGraphContextPacket, formatGraphContextPrompt } from '../../memory/graph-context.js';
 import { canManageObservation, filterReadableObservations, resolveObservationVisibility } from '../../memory/visibility.js';
 import {
+  asStringArg,
   coerceObservationStatus,
   coerceObservationType,
   coerceRetrievalQuality,
@@ -12,6 +13,7 @@ import {
   emitResult,
   getCliReadContext,
   getCliProjectContext,
+  lastStringArg,
   parseCsvList,
   parsePositiveInt,
   resolveCliWriteScope,
@@ -66,7 +68,7 @@ export default defineCommand({
     const action = (args._ as string[])?.[0] || '';
     const positional = ((args._ as string[]) ?? []).slice(1);
     const longTermAction = action === 'long-term'
-      ? (positional[0] || (args.action as string | undefined) || 'list').trim().toLowerCase()
+      ? (positional[0] || asStringArg(args.action) || 'list').trim().toLowerCase()
       : undefined;
     const asJson = !!args.json;
 
@@ -107,7 +109,7 @@ export default defineCommand({
             query,
             limit: parsePositiveInt(args.graphLimit as string | undefined, 5),
           });
-          const format = (args.format as string | undefined)?.trim().toLowerCase();
+          const format = asStringArg(args.format)?.toLowerCase();
           const formatted = format === 'prompt'
             ? formatGraphContextPrompt(packet)
             : [
@@ -146,10 +148,10 @@ export default defineCommand({
             emitError('text is required for "memorix memory store"', asJson);
             return;
           }
-          const title = (args.title as string | undefined)?.trim() || narrative.slice(0, 80);
+          const title = asStringArg(args.title) || narrative.slice(0, 80);
           const type = coerceObservationType(args.type as string | undefined);
           const topicKey =
-            (args.topicKey as string | undefined)?.trim() ||
+            asStringArg(args.topicKey) ||
             suggestTopicKey(type, title) ||
             undefined;
           const writeScope = resolveCliWriteScope(
@@ -157,7 +159,7 @@ export default defineCommand({
             args.visibility as string | undefined,
           );
           const result = await storeObservation({
-            entityName: (args.entity as string | undefined)?.trim() || 'general',
+            entityName: asStringArg(args.entity) || 'general',
             type,
             title,
             narrative,
@@ -179,7 +181,7 @@ export default defineCommand({
 
         case 'suggest-topic-key': {
           const type = coerceObservationType(args.type as string | undefined);
-          const title = (args.title as string | undefined)?.trim();
+          const title = asStringArg(args.title);
           if (!title) {
             emitError('title is required for "memorix memory suggest-topic-key"', asJson);
             return;
@@ -274,7 +276,7 @@ export default defineCommand({
         }
 
         case 'deduplicate': {
-          const query = (args.query as string | undefined)?.trim();
+          const query = asStringArg(args.query);
           const dryRun = !!args.dryRun || !!args['dry-run'];
           const { isLLMEnabled } = await import('../../llm/provider.js');
           if (!isLLMEnabled()) {
@@ -479,8 +481,8 @@ export default defineCommand({
           };
 
           const memoryId = (): string => {
-            const id = (args.id as string | undefined)?.trim()
-              || (args.fromObservation as string | undefined)?.trim()
+            const id = asStringArg(args.id)
+              || asStringArg(args.fromObservation)
               || longTermPositional[0]?.trim();
             if (!id) throw new Error('long-term memory id is required.');
             return id;
@@ -535,11 +537,11 @@ export default defineCommand({
                 projectId: project.id,
                 scope: scope(),
                 kind: kind(),
-                title: (args.title as string | undefined)?.trim() || content.slice(0, 100),
+                title: asStringArg(args.title) || content.slice(0, 100),
                 content,
                 facts: parseCsvList(args.facts as string | undefined),
                 tags: parseCsvList(args.tags as string | undefined),
-                applicability: (args.applicability as string | undefined)?.trim(),
+                applicability: asStringArg(args.applicability),
                 portability: portability(),
                 reader: longTermReader,
               });
@@ -552,8 +554,8 @@ export default defineCommand({
             }
 
             case 'promote': {
-              const rawId = (args.fromObservation as string | undefined)?.trim()
-                || (args.id as string | undefined)?.trim()
+              const rawId = asStringArg(args.fromObservation)
+                || asStringArg(args.id)
                 || longTermPositional[0]?.trim();
               const observationId = Number.parseInt(rawId || '', 10);
               if (!Number.isFinite(observationId)) {
@@ -571,7 +573,7 @@ export default defineCommand({
                 scope: scope(),
                 kind: kind(),
                 tags: parseCsvList(args.tags as string | undefined),
-                applicability: (args.applicability as string | undefined)?.trim(),
+                applicability: asStringArg(args.applicability),
                 reader: longTermReader,
               });
               emitResult(
@@ -604,8 +606,8 @@ export default defineCommand({
             }
 
             case 'supersede': {
-              const supersededBy = (args.supersededBy as string | undefined)?.trim()
-                || (args['superseded-by'] as string | undefined)?.trim();
+              const supersededBy = asStringArg(args.supersededBy)
+                || asStringArg(args['superseded-by']);
               if (!supersededBy) {
                 emitError('supersededBy is required for "memorix memory long-term supersede"', asJson);
                 return;
@@ -642,31 +644,39 @@ export default defineCommand({
   },
 });
 
-function getStringArg(named: string | undefined, positional: string[]): string | undefined {
-  const value = named?.trim() || positional.join(' ').trim();
+/**
+ * Read a free-text citty named argument with positional fallback.
+ *
+ * Named values may be arrays: citty accumulates repeated flags and Windows
+ * shells can split one long quoted argument into argv fragments that
+ * re-introduce the flag mid-value (issue #194). Joining array fragments
+ * preserves the original text instead of throwing on `.trim()`.
+ */
+function getStringArg(named: unknown, positional: string[]): string | undefined {
+  const value = asStringArg(named) || positional.join(' ').trim();
   return value || undefined;
 }
 
 function getIdArg(args: Record<string, unknown>, positional: string[]): string {
   return (
-    (args.ids as string | undefined) ||
-    (args.id as string | undefined) ||
+    lastStringArg(args.ids) ||
+    lastStringArg(args.id) ||
     positional.join(',')
   );
 }
 
-function parseObservationId(value: string): number {
-  const normalized = value.trim();
+function parseObservationId(value: unknown): number {
+  const normalized = (asStringArg(value) ?? '').trim();
   if (!/^[1-9]\d*$/.test(normalized)) {
-    throw new Error(`Invalid observation ID: ${value}`);
+    throw new Error(`Invalid observation ID: ${String(value ?? '')}`);
   }
   const id = Number(normalized);
-  if (!Number.isSafeInteger(id)) throw new Error(`Invalid observation ID: ${value}`);
+  if (!Number.isSafeInteger(id)) throw new Error(`Invalid observation ID: ${String(value ?? '')}`);
   return id;
 }
 
-function parseObservationIds(value: string): number[] {
-  const values = parseCsvList(value);
+function parseObservationIds(value: unknown): number[] {
+  const values = parseCsvList(typeof value === 'string' || Array.isArray(value) ? value : undefined);
   if (values.length === 0) return [];
   return values.map(parseObservationId);
 }
@@ -695,26 +705,26 @@ function printMemoryUsage(): void {
   console.log('  memorix memory long-term supersede --id <old-id> --superseded-by <qualified-id> --reason "replaced"');
 }
 
-function longTermKind(value: string | undefined): 'episodic' | 'semantic' | 'procedural' {
-  const normalized = (value ?? 'semantic').trim().toLowerCase();
+function longTermKind(value: unknown): 'episodic' | 'semantic' | 'procedural' {
+  const normalized = (asStringArg(value) ?? 'semantic').toLowerCase();
   if (normalized === 'episodic' || normalized === 'semantic' || normalized === 'procedural') return normalized;
   throw new Error('long-term kind must be episodic, semantic, or procedural.');
 }
 
-function longTermScope(value: string | undefined): 'project' | 'user' | 'team' {
-  const normalized = (value ?? 'project').trim().toLowerCase();
+function longTermScope(value: unknown): 'project' | 'user' | 'team' {
+  const normalized = (asStringArg(value) ?? 'project').toLowerCase();
   if (normalized === 'project' || normalized === 'user' || normalized === 'team') return normalized;
   throw new Error('long-term scope must be project, user, or team.');
 }
 
-function longTermPortability(value: string | undefined): 'project-bound' | 'portable' {
-  const normalized = (value ?? 'project-bound').trim().toLowerCase();
+function longTermPortability(value: unknown): 'project-bound' | 'portable' {
+  const normalized = (asStringArg(value) ?? 'project-bound').toLowerCase();
   if (normalized === 'project-bound' || normalized === 'portable') return normalized;
   throw new Error('long-term portability must be project-bound or portable.');
 }
 
-function requiredLongTermReason(value: string | undefined): string {
-  const reason = value?.trim();
+function requiredLongTermReason(value: unknown): string {
+  const reason = asStringArg(value);
   if (!reason) throw new Error('reason is required for this long-term memory transition.');
   return reason;
 }

--- a/src/cli/commands/operator-shared.ts
+++ b/src/cli/commands/operator-shared.ts
@@ -147,9 +147,52 @@ export function emitError(message: string, asJson?: boolean): void {
   process.exitCode = 1;
 }
 
-export function parseCsvList(input?: string | null): string[] {
+/**
+ * Coerce a citty named argument into a trimmed string.
+ *
+ * Citty accumulates repeated string flags into an array (`--text a --text b`
+ * becomes `["a", "b"]`), and Windows shells can split one long quoted
+ * argument into several argv elements that re-introduce the flag mid-value
+ * (issue #194). Joining the fragments preserves as much of the original text
+ * as possible and prevents `TypeError: named?.trim is not a function`.
+ */
+export function asStringArg(value: unknown): string | undefined {
+  if (value == null) return undefined;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  if (Array.isArray(value)) {
+    const joined = value
+      .filter((item): item is string => typeof item === 'string')
+      .map((item) => item.trim())
+      .filter(Boolean)
+      .join(' ');
+    return joined.length > 0 ? joined : undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Coerce a repeated scalar flag to its last value (last-wins convention for
+ * enums, IDs, and numeric limits). Repeated flags are otherwise accumulated
+ * into arrays by citty and would reach `.trim()` as non-strings.
+ */
+export function lastStringArg(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) {
+    const strings = value.filter((item): item is string => typeof item === 'string');
+    return strings[strings.length - 1];
+  }
+  return undefined;
+}
+
+export function parseCsvList(input?: string | string[] | null): string[] {
   if (!input) return [];
-  return input
+  const source = Array.isArray(input)
+    ? input.filter((item): item is string => typeof item === 'string').join(',')
+    : input;
+  return source
     .split(',')
     .map((item) => item.trim())
     .filter(Boolean);
@@ -174,14 +217,15 @@ export function shortId(id?: string | null): string {
   return id ? `${id.slice(0, 8)}…` : '-';
 }
 
-export function parsePositiveInt(input: string | undefined, fallback: number): number {
-  if (input == null || input.trim() === '') return fallback;
-  if (!/^\d+$/.test(input.trim())) {
-    throw new Error(`Expected a positive integer, received "${input}".`);
+export function parsePositiveInt(input: string | string[] | undefined, fallback: number): number {
+  const value = lastStringArg(input);
+  if (value == null || value.trim() === '') return fallback;
+  if (!/^\d+$/.test(value.trim())) {
+    throw new Error(`Expected a positive integer, received "${value}".`);
   }
-  const parsed = Number(input);
+  const parsed = Number(value);
   if (!Number.isSafeInteger(parsed) || parsed <= 0) {
-    throw new Error(`Expected a positive integer, received "${input}".`);
+    throw new Error(`Expected a positive integer, received "${value}".`);
   }
   return parsed;
 }
@@ -203,36 +247,36 @@ const OBSERVATION_TYPES: ObservationType[] = [
 const OBSERVATION_STATUSES: ObservationStatus[] = ['active', 'resolved', 'archived'];
 const RETRIEVAL_QUALITIES: RetrievalQuality[] = ['fast', 'balanced', 'thorough'];
 
-export function coerceObservationType(input?: string): ObservationType {
-  const normalized = (input ?? 'discovery') as ObservationType;
+export function coerceObservationType(input?: unknown): ObservationType {
+  const normalized = (lastStringArg(input) ?? 'discovery') as ObservationType;
   if (!OBSERVATION_TYPES.includes(normalized)) {
     throw new Error(
-      `Unknown observation type "${input}". Valid types: ${OBSERVATION_TYPES.join(', ')}`,
+      `Unknown observation type "${String(input ?? '')}". Valid types: ${OBSERVATION_TYPES.join(', ')}`,
     );
   }
   return normalized;
 }
 
-export function coerceObservationStatus(input?: string): ObservationStatus {
-  const normalized = (input ?? 'resolved') as ObservationStatus;
+export function coerceObservationStatus(input?: unknown): ObservationStatus {
+  const normalized = (lastStringArg(input) ?? 'resolved') as ObservationStatus;
   if (!OBSERVATION_STATUSES.includes(normalized)) {
     throw new Error(
-      `Unknown observation status "${input}". Valid statuses: ${OBSERVATION_STATUSES.join(', ')}`,
+      `Unknown observation status "${String(input ?? '')}". Valid statuses: ${OBSERVATION_STATUSES.join(', ')}`,
     );
   }
   return normalized;
 }
 
-export function coerceRetrievalQuality(input?: string): RetrievalQuality {
-  const normalized = (input ?? 'balanced').trim().toLowerCase() as RetrievalQuality;
+export function coerceRetrievalQuality(input?: unknown): RetrievalQuality {
+  const normalized = (lastStringArg(input) ?? 'balanced').trim().toLowerCase() as RetrievalQuality;
   if (!RETRIEVAL_QUALITIES.includes(normalized)) {
     throw new Error('quality must be fast, balanced, or thorough');
   }
   return normalized;
 }
 
-export function coerceObservationVisibility(input?: string): ObservationVisibility {
-  const normalized = (input ?? 'project').trim().toLowerCase();
+export function coerceObservationVisibility(input?: unknown): ObservationVisibility {
+  const normalized = (lastStringArg(input) ?? 'project').trim().toLowerCase();
   if (normalized === 'personal' || normalized === 'project' || normalized === 'team') {
     return normalized;
   }

--- a/tests/cli/memory-command.test.ts
+++ b/tests/cli/memory-command.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execSync } from 'node:child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import memoryCommand from '../../src/cli/commands/memory.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+import { resetObservationStore } from '../../src/store/obs-store.js';
+import { resetSessionStore } from '../../src/store/session-store.js';
+import { resetTeamStore } from '../../src/team/team-store.js';
+import { resetDb } from '../../src/store/orama-store.js';
+
+async function runCommand(command: any, args: Record<string, unknown>) {
+  const logs: string[] = [];
+  const errors: string[] = [];
+  const logSpy = vi.spyOn(console, 'log').mockImplementation((...parts) => logs.push(parts.map(String).join(' ')));
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation((...parts) => errors.push(parts.map(String).join(' ')));
+  const previousExitCode = process.exitCode;
+  process.exitCode = undefined;
+  try {
+    await command.run?.({ args, rawArgs: [], cmd: command } as any);
+    return { stdout: logs.join('\n'), stderr: errors.join('\n'), exitCode: process.exitCode ?? 0 };
+  } finally {
+    process.exitCode = previousExitCode;
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  }
+}
+
+describe('memory store CLI argument coercion', () => {
+  const originalCwd = process.cwd();
+  const originalDataDir = process.env.MEMORIX_DATA_DIR;
+  const originalEmbedding = process.env.MEMORIX_EMBEDDING;
+  let root = '';
+  let project = '';
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), 'memorix-memory-cli-'));
+    project = path.join(root, 'project');
+    mkdirSync(project, { recursive: true });
+    writeFileSync(path.join(project, 'README.md'), '# test\n', 'utf8');
+    execSync('git init', { cwd: project, stdio: 'ignore' });
+    execSync('git config user.email test@example.com', { cwd: project, stdio: 'ignore' });
+    execSync('git config user.name "Memorix Test"', { cwd: project, stdio: 'ignore' });
+    process.chdir(project);
+    process.env.MEMORIX_DATA_DIR = path.join(root, 'data');
+    process.env.MEMORIX_EMBEDDING = 'off';
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    if (originalDataDir === undefined) delete process.env.MEMORIX_DATA_DIR;
+    else process.env.MEMORIX_DATA_DIR = originalDataDir;
+    if (originalEmbedding === undefined) delete process.env.MEMORIX_EMBEDDING;
+    else process.env.MEMORIX_EMBEDDING = originalEmbedding;
+    resetObservationStore();
+    resetSessionStore();
+    resetTeamStore();
+    await resetDb();
+    closeAllDatabases();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('stores a joined narrative when --text arrives as a repeated-flag array', async () => {
+    // Citty accumulates repeated string flags into an array, and Windows
+    // PowerShell 5.1 can split one long quoted argument into argv fragments
+    // that re-introduce the flag mid-value. See issue #194.
+    const result = await runCommand(memoryCommand, {
+      _: ['store'],
+      text: ['opencode upgrade: run', 'upgrade note after the quoted section'],
+      json: true,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).not.toContain('named?.trim');
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.observation.narrative).toBe(
+      'opencode upgrade: run upgrade note after the quoted section',
+    );
+  });
+
+  it('coerces repeated scalar flags on the store path instead of throwing a TypeError', async () => {
+    const result = await runCommand(memoryCommand, {
+      _: ['store'],
+      text: ['fragment one', 'fragment two'],
+      title: ['Upgrade', 'note'],
+      topicKey: ['upgrade', 'note'],
+      entity: ['cli', 'memory'],
+      facts: ['a,b', 'c'],
+      json: true,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    const parsed = JSON.parse(result.stdout);
+    expect(parsed.observation.narrative).toBe('fragment one fragment two');
+    expect(parsed.observation.title).toBe('Upgrade note');
+    expect(parsed.observation.topicKey).toBe('upgrade note');
+    expect(parsed.observation.entityName).toBe('cli memory');
+    expect(parsed.observation.facts).toEqual(['a', 'b', 'c']);
+  });
+});


### PR DESCRIPTION
Fixes #194.

## What was happening

`memorix memory store --text "<long text>"` could crash with
`Error: named?.trim is not a function`. The chain:

1. Windows PowerShell 5.1's legacy native-argument passing doesn't escape
   embedded double quotes, so one quoted argument gets re-split at each `"`.
2. When the text itself contains a `--text` token (e.g. a note documenting
   this very command), the split fragments re-introduce the flag.
3. Citty accumulates a repeated string flag into an array.
4. `getStringArg` in `src/cli/commands/memory.ts` called `.trim()` on that
   array → TypeError.

Even without a second flag token, the same PS 5.1 splitting silently truncated
the stored narrative to the first argv fragment (the "title-only" symptom in
the issue).

## What changed

- Added `asStringArg` (joins fragments) and `lastStringArg` (last-wins for
  scalar/enum flags) coercion helpers in `src/cli/commands/operator-shared.ts`.
- `parseCsvList`, `parsePositiveInt`, and the enum coercers
  (`coerceObservationType`, `coerceObservationStatus`,
  `coerceRetrievalQuality`, `coerceObservationVisibility`) now tolerate array
  values.
- Converted every `args.*.trim()` site in `src/cli/commands/memory.ts`
  (store, long-term add/promote/supersede, suggest-topic-key, deduplicate,
  graph-context, ID parsing) to the new helpers.
- Regression tests in `tests/cli/memory-command.test.ts` cover repeated
  `--text` and repeated scalar flags on the store path.

## Verified

- New tests fail before the fix (reproduce the exact `named?.trim is not a
  function` error) and pass after.
- `npm run lint` clean.
- Full `npm test`: 2869 passed, 1 skipped (the one full-suite rerun flake in
  `uninstall.test.ts` is unrelated and passes in isolation and on rerun).
- End-to-end PS 5.1 repro with the rebuilt CLI: same split-argv input now
  stores successfully with the recoverable fragments joined.
