### PR TITLE
feat(setup): add DeepSeek Harness (DSH) integration

### DIFF
--- a/ACTIVE_WORK.md
+++ b/ACTIVE_WORK.md
@@ -61,6 +61,12 @@ documented follow-up rather than claimed release evidence. Legacy requests
 
 - 1.4.4 published (2026-08-14) through the GitHub publish workflow; the #194
   reporter has been notified with the shipped version.
+- DeepSeek Harness support implemented (2026-08-14): `memorix setup --agent
+  dsh` installs the `@deepseek-ai/dsh-mcp-client` row into
+  `$DSH_HOME/cordis.patch.yml`, AGENTS.md guidance, and skills. Native
+  validation composed the generated patch with the real
+  `@deepseek-ai/dsh@0.1.0-rc.6` launcher. Awaiting PR review before it
+  ships in the next release line.
 - Branch protection on `main` was synced with the current CI matrix
   (2026-08-14): the required status contexts referenced removed Node 20 test
   jobs, which blocked every PR from merging. Required contexts are now the

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <strong>Local-first shared memory layer for AI coding agents.</strong><br>
-  One project memory system for Claude Code, Codex, CodeBuddy Code, Cursor, Windsurf, Copilot, Gemini CLI, OpenCode, OpenClaw, Hermes Agent, Oh-my-Pi, Pi, Kiro, Antigravity, Trae, and any MCP-capable agent.
+  One project memory system for Claude Code, Codex, CodeBuddy Code, Cursor, Windsurf, Copilot, Gemini CLI, OpenCode, OpenClaw, Hermes Agent, Oh-my-Pi, Pi, Kiro, Antigravity, Trae, DeepSeek Harness, and any MCP-capable agent.
 </p>
 
 <p align="center">
@@ -171,6 +171,11 @@ Memorix connects through the interfaces each agent already supports: plugin pack
 <sub>package + MCP + hooks + skills</sub>
 </td>
 <td align="center" width="12.5%">
+<a href="https://github.com/deepseek-ai/deepseek-harness"><img src="https://github.com/deepseek-ai.png?size=120" alt="DeepSeek Harness" width="48" height="48"></a><br>
+<strong>DeepSeek Harness</strong><br>
+<sub>MCP patch + AGENTS.md + skills</sub>
+</td>
+<td align="center" width="12.5%">
 <a href="https://modelcontextprotocol.io"><img src="https://github.com/modelcontextprotocol.png?size=120" alt="Any MCP Client" width="48" height="48"></a><br>
 <strong>Any MCP Client</strong><br>
 <sub>stdio or HTTP MCP</sub>
@@ -193,7 +198,7 @@ Integration surfaces:
 | Plugin or bundle package | Installs plugin, compatible-bundle, or package files where the agent supports them | Claude Code, Codex, CodeBuddy Code, GitHub Copilot CLI, Antigravity, OpenClaw, Hermes Agent, Oh-my-Pi, Pi |
 | Extension | Installs extension files where the agent supports them | Gemini CLI |
 | Local plugin | Installs local plugin files where the agent loads them directly | OpenCode |
-| MCP/rules config | Writes MCP, rules, steering, guidance, or hook config for IDEs and agents that expose those surfaces | Cursor, Windsurf, Kiro, Trae |
+| MCP/rules config | Writes MCP, rules, steering, guidance, or hook config for IDEs and agents that expose those surfaces | Cursor, Windsurf, Kiro, Trae, DeepSeek Harness |
 | Skills | Turns durable project knowledge into reusable task guidance | `memorix skills` and `memorix_promote` |
 | memcode | Opens the bundled terminal agent that already uses Memorix memory | `memorix` or `memcode` |
 
@@ -254,6 +259,7 @@ memorix setup --agent openclaw --global
 memorix setup --agent hermes --global
 memorix setup --agent codebuddy --global
 memorix setup --agent omp --global
+memorix setup --agent dsh --global
 ```
 
 What it installs depends on the target agent, but the goal is the same: make Memorix available wherever you open that agent without asking you to wire every repo by hand.
@@ -271,6 +277,7 @@ What it installs depends on the target agent, but the goal is the same: make Mem
 - Hermes Agent: installs into Hermes home (`%LOCALAPPDATA%\hermes` on native Windows, `~/.hermes` elsewhere, or `HERMES_HOME`), enables the plugin in `config.yaml`, registers plugin hooks, slash/CLI commands, skills, and writes MCP config.
 - CodeBuddy Code: installs a user-scope local marketplace plugin under `~/.codebuddy/memorix-local` with MCP, skills, and hooks. It does not change existing CodeBuddy model, permission, or settings files; CodeBuddy keeps third-party hook approval in its own `/hooks` flow.
 - Oh-my-Pi: installs an `omp.extensions` package with extension hook events, a `memorix` command, official skills, and writes MCP config.
+- DeepSeek Harness: writes a Memorix `@deepseek-ai/dsh-mcp-client` row into `$DSH_HOME/cordis.patch.yml` (default `~/.dsh/cordis.patch.yml`), appends guidance to the harness `AGENTS.md`, and installs official skills under `$DSH_HOME/skills`. The row follows DSH's own shipped Memorix reference, so tools appear as `mcp__memorix__*`.
 
 Need a quieter install? Add `--noHooks` for targets where setup can control hook capture separately from the host's official package entry. It keeps MCP and guidance, but skips Memorix hook capture.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <strong>面向 AI Coding Agent 的本地优先共享记忆层。</strong><br>
-  让 Claude Code、Codex、CodeBuddy Code、Cursor、Windsurf、Copilot、Gemini CLI、OpenCode、OpenClaw、Hermes Agent、Oh-my-Pi、Pi、Kiro、Antigravity、Trae 和任何 MCP Agent 共用同一套项目记忆。
+  让 Claude Code、Codex、CodeBuddy Code、Cursor、Windsurf、Copilot、Gemini CLI、OpenCode、OpenClaw、Hermes Agent、Oh-my-Pi、Pi、Kiro、Antigravity、Trae、DeepSeek Harness 和任何 MCP Agent 共用同一套项目记忆。
 </p>
 
 <p align="center">
@@ -170,6 +170,11 @@ Memorix 通过目标 Agent 已有的接口接入：插件包、MCP、项目规�
 <sub>package + MCP + hooks + skills</sub>
 </td>
 <td align="center" width="12.5%">
+<a href="https://github.com/deepseek-ai/deepseek-harness"><img src="https://github.com/deepseek-ai.png?size=120" alt="DeepSeek Harness" width="48" height="48"></a><br>
+<strong>DeepSeek Harness</strong><br>
+<sub>MCP patch + AGENTS.md + skills</sub>
+</td>
+<td align="center" width="12.5%">
 <a href="https://modelcontextprotocol.io"><img src="https://github.com/modelcontextprotocol.png?size=120" alt="Any MCP Client" width="48" height="48"></a><br>
 <strong>Any MCP Client</strong><br>
 <sub>stdio or HTTP MCP</sub>
@@ -192,7 +197,7 @@ Memorix 通过目标 Agent 已有的接口接入：插件包、MCP、项目规�
 | 插件 / Bundle / Package | 给支持插件、兼容 bundle 或 package 的 Agent 安装对应文件 | Claude Code、Codex、CodeBuddy Code、GitHub Copilot CLI、Antigravity、OpenClaw、Hermes Agent、Oh-my-Pi、Pi |
 | Extension | 给支持 extension 的 Agent 安装对应文件 | Gemini CLI |
 | 本地插件 | 给直接加载本地插件文件的 Agent 安装插件 | OpenCode |
-| MCP / rules 配置 | 给支持 MCP、rules、steering、guidance 或 hooks 的 IDE 和 Agent 写入配置 | Cursor、Windsurf、Kiro、Trae |
+| MCP / rules 配置 | 给支持 MCP、rules、steering、guidance 或 hooks 的 IDE 和 Agent 写入配置 | Cursor、Windsurf、Kiro、Trae、DeepSeek Harness |
 | Skills | 把沉淀下来的项目知识提升成可复用任务指导 | `memorix skills` 和 `memorix_promote` |
 | memcode | 打开已经接好 Memorix 记忆的内置终端 Agent | `memorix` 或 `memcode` |
 
@@ -253,6 +258,7 @@ memorix setup --agent openclaw --global
 memorix setup --agent hermes --global
 memorix setup --agent codebuddy --global
 memorix setup --agent omp --global
+memorix setup --agent dsh --global
 ```
 
 它会做的事情取决于目标 Agent，但目标是一致的：你以后在哪里打开这个 Agent，Memorix 就可以在哪里被使用，而不是让你一个仓库一个仓库重复配置。
@@ -270,6 +276,7 @@ memorix setup --agent omp --global
 - Hermes Agent：安装到 Hermes home（Windows native 默认为 `%LOCALAPPDATA%\hermes`，其他平台默认为 `~/.hermes`，也支持 `HERMES_HOME`），在 `config.yaml` 启用插件，注册 plugin hooks、slash/CLI commands、skills，并写入 MCP 配置。
 - CodeBuddy Code：安装用户级本地市场插件到 `~/.codebuddy/memorix-local`，包含 MCP、skills 和 hooks。它不会修改既有的 CodeBuddy 模型、权限或 settings 文件；第三方 hook 仍由 CodeBuddy 自己的 `/hooks` 流程确认。
 - Oh-my-Pi：安装 `omp.extensions` package，包含 extension hook 事件、`memorix` command、官方 skills，并写入 MCP 配置。
+- DeepSeek Harness：向 `$DSH_HOME/cordis.patch.yml`（默认 `~/.dsh/cordis.patch.yml`）写入一行 Memorix `@deepseek-ai/dsh-mcp-client`，向 harness 的 `AGENTS.md` 追加使用规范，并把官方 skills 安装到 `$DSH_HOME/skills`。这一行遵循 DSH 自带的 Memorix 参考配置，因此工具以 `mcp__memorix__*` 形式出现。
 
 如果你想要更安静一点的安装，可以对那些 setup 能独立控制 hook capture 的 target 加 `--noHooks`。它会保留 MCP 和使用规范，只跳过 Memorix 的 hook 自动捕获。
 

--- a/docs/AGENT_OPERATOR_PLAYBOOK.md
+++ b/docs/AGENT_OPERATOR_PLAYBOOK.md
@@ -23,7 +23,7 @@ It supports:
 - HTTP MCP service + dashboard (`memorix background start` or `memorix serve-http --port 3211`)
 - bundled terminal agent (`memorix` or `memcode`) that uses the same shared memory pool
 - local-first project-scoped memory
-- cross-agent recall across Cursor, Claude Code, Codex, CodeBuddy Code, Windsurf, Gemini CLI, GitHub Copilot, OpenCode, OpenClaw, Hermes Agent, Oh-my-Pi, Pi, Kiro, Antigravity, and Trae
+- cross-agent recall across Cursor, Claude Code, Codex, CodeBuddy Code, Windsurf, Gemini CLI, GitHub Copilot, OpenCode, OpenClaw, Hermes Agent, Oh-my-Pi, Pi, Kiro, Antigravity, Trae, and DeepSeek Harness
 
 ### Current 1.4 Baseline
 
@@ -41,7 +41,7 @@ For the 1.4 release line, the visible product shape is:
 - `memorix_project_context` / `memorix context "..."` is the normal black-box entry for non-trivial coding work: it assembles a bounded task Workset instead of injecting a generic memory dump; `memorix resume "..."` is the explicit CLI continuation projection
 - Code State keeps local snapshots and freshness links; a healthy pre-existing local CodeGraph index can add a bounded semantic outline, but Memorix never initializes or synchronizes that external index itself
 - `memorix knowledge` is an explicit review path for source-backed Markdown knowledge and canonical workflows. Do not initialize a versioned workspace or apply a proposal unless the user asks for that managed artifact
-- integration surfaces are agent-specific: Claude Code, Codex, GitHub Copilot CLI, Antigravity, and Hermes receive plugin packages; OpenClaw receives a compatible bundle; Pi and Oh-my-Pi receive package entries; Gemini CLI receives an extension package; OpenCode receives a plugin file and skill; Cursor and other agents receive MCP/rules/hooks where supported
+- integration surfaces are agent-specific: Claude Code, Codex, GitHub Copilot CLI, Antigravity, and Hermes receive plugin packages; OpenClaw receives a compatible bundle; Pi and Oh-my-Pi receive package entries; Gemini CLI receives an extension package; OpenCode receives a plugin file and skill; DeepSeek Harness receives an MCP patch row, AGENTS.md guidance, and skills; Cursor and other agents receive MCP/rules/hooks where supported
 - privacy-safe diagnostics and receipts avoid raw chat, memory text, query text, tool payloads, and local file paths
 
 ---
@@ -256,6 +256,7 @@ What this installs depends on the target agent:
 - Hermes Agent: Hermes plugin under Hermes home (`%LOCALAPPDATA%\hermes` on native Windows, `~/.hermes` elsewhere, or `HERMES_HOME`), enabled in `config.yaml`, with plugin hooks, slash command, CLI command, skills, and MCP config.
 - Oh-my-Pi: `omp.extensions` package linked through `omp plugin link <path>` when available, with extension hook events, a `memorix` command, skills, and MCP config.
 - Windsurf, Kiro, Trae: MCP config plus rules/hooks where supported.
+- DeepSeek Harness: a Memorix `@deepseek-ai/dsh-mcp-client` row in `$DSH_HOME/cordis.patch.yml` (default `~/.dsh/cordis.patch.yml`), harness `AGENTS.md` guidance, and official skills under `$DSH_HOME/skills`. Tools appear as `mcp__memorix__*`; there is no hooks surface. Project-local setup writes project `AGENTS.md` guidance and `.dsh/skills`, while the MCP row stays in the harness-level patch file.
 
 Run the same setup command without `--global` only when you intentionally want repo-local guidance, rules, or hooks for a single Git project.
 

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -20,7 +20,7 @@ That command installs the recommended Memorix package or config for the target a
 | Package or extension | Bundles Memorix for agents that use package or extension systems | `memorix setup --agent pi --global`, `omp --global`, or `gemini-cli --global` |
 | Local plugin | Installs a local plugin file where the agent loads plugins directly | `memorix setup --agent opencode --global` |
 | MCP server | Gives an agent live tools for search, recall, storage, reasoning, and coordination | bundled by setup, host MCP config, or `memorix serve` |
-| Usage guidance | Tells the agent when and how to use memory | `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, Cursor/Windsurf/Kiro/Trae rules |
+| Usage guidance | Tells the agent when and how to use memory | `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, Cursor/Windsurf/Kiro/Trae rules, DeepSeek Harness AGENTS.md |
 | Hooks | Captures useful session events when the agent exposes hook events | bundled by plugin packages or generated hook files |
 | Skills | Turns durable project knowledge into reusable task guidance | plugin skills, `memorix skills`, `memorix_promote` |
 | memcode | Opens a terminal coding agent that already uses Memorix memory | `memorix`, `memcode` |
@@ -36,7 +36,7 @@ CLI, MCP, and HTTP have separate jobs:
 
 Generated guidance also has scope:
 
-- Project guidance (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, Cursor/Windsurf/Kiro/Trae rules) may say the repository is configured for Memorix.
+- Project guidance (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, Cursor/Windsurf/Kiro/Trae rules, DeepSeek Harness AGENTS.md) may say the repository is configured for Memorix.
 - Plugin or skill package guidance is workspace-safe. It says to use Memorix when the active workspace has Memorix tools available.
 - `--global` writes user-level plugin, config, and hook surfaces where the host supports them.
 - Running the same setup command without `--global` is the repo-local path for one project only.
@@ -63,6 +63,7 @@ Generated guidance also has scope:
 | Kiro | `memorix setup --agent kiro --global` | Kiro MCP/steering/hooks config | MCP config, `.kiro/steering/memorix.md`, `.kiro/hooks/*.kiro.hook` | Uses Kiro steering and hook files. |
 | Antigravity | `memorix setup --agent antigravity --global` | Antigravity plugin | Plugin under `~/.gemini/config/plugins/memorix` or `.agents/plugins/memorix`, with `plugin.json`, `mcp_config.json`, `hooks.json`, rules, and skills | Uses Antigravity's official plugin layout. Dedicated MCP configs live at `~/.gemini/config/mcp_config.json` or `.agents/mcp_config.json`; legacy Gemini settings are read only for compatibility. |
 | Trae | `memorix setup --agent trae --global` | Trae MCP/rules config | MCP config and `.trae/rules/project_rules.md` | Current support is MCP plus project rules. |
+| DeepSeek Harness | `memorix setup --agent dsh --global` | DeepSeek Harness MCP patch | Memorix `@deepseek-ai/dsh-mcp-client` row in `$DSH_HOME/cordis.patch.yml` (default `~/.dsh/cordis.patch.yml`), guidance in the harness `AGENTS.md`, and official skills under `$DSH_HOME/skills` | Tools appear as `mcp__memorix__*`. No hooks surface. Project-local setup writes project `AGENTS.md` guidance and `.dsh/skills`; the MCP row always lives in the harness-level patch file. |
 | memcode | `memorix` or `memcode` | Bundled terminal agent | Built-in Memorix memory access | memcode uses the same project memory pool; it is not a separate memory silo. |
 | Any MCP client | Manual MCP config | MCP stdio or HTTP | `memorix serve` or `memorix background start` | Use stdio first unless you need a shared HTTP endpoint. |
 
@@ -95,6 +96,7 @@ memorix setup --agent openclaw --global
 memorix setup --agent hermes --global
 memorix setup --agent codebuddy --global
 memorix setup --agent omp --global
+memorix setup --agent dsh --global
 ```
 
 Use `memorix setup --agent all --global` only when you intentionally want every supported agent integration generated for the current machine/user scope.

--- a/docs/KNOWN_ISSUES_AND_ROADMAP.md
+++ b/docs/KNOWN_ISSUES_AND_ROADMAP.md
@@ -63,6 +63,7 @@ Memorix 是本地优先、可插拔的 Agent Memory 系统。它给不同 Agent 
 
 - 跟进受用户需求推动的集成，例如 [Qwen 自动 hooks](https://github.com/AVIDS2/memorix/issues/3) 与 [持久化 Agent 身份](https://github.com/AVIDS2/memorix/issues/49)；
 - 独立推进记忆能力的实证研究，例如[模型能力如何改变项目记忆收益与伤害边界](https://github.com/AVIDS2/memorix/issues/152)，不把研究假设当作产品已经证明的效果。
+- DeepSeek Harness 支持已随 `memorix setup --agent dsh` 发布：写入 MCP 行（`$DSH_HOME/cordis.patch.yml`，默认 `~/.dsh/cordis.patch.yml`）、AGENTS.md 使用规范与官方 skills；工具以 `mcp__memorix__*` 形式出现。
 
 ---
 

--- a/docs/MEMCODE.md
+++ b/docs/MEMCODE.md
@@ -224,7 +224,7 @@ memcode update self
 
 Memorix is the shared memory layer. memcode is the bundled terminal agent built on top of it.
 
-Use Memorix when you want Claude Code, Codex, Cursor, Windsurf, Copilot, Gemini CLI, OpenCode, OpenClaw, Hermes Agent, Oh-my-Pi, Kiro, Antigravity, Trae, or another MCP client to share project memory.
+Use Memorix when you want Claude Code, Codex, Cursor, Windsurf, Copilot, Gemini CLI, OpenCode, OpenClaw, Hermes Agent, Oh-my-Pi, Kiro, Antigravity, Trae, DeepSeek Harness, or another MCP client to share project memory.
 
 Use memcode when you want a terminal agent that already uses that memory layer.
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -76,6 +76,7 @@ memorix setup --agent openclaw --global
 memorix setup --agent hermes --global
 memorix setup --agent codebuddy --global
 memorix setup --agent omp --global
+memorix setup --agent dsh --global
 ```
 
 What this does:
@@ -91,6 +92,7 @@ What this does:
 - OpenClaw: installs `~/.openclaw/extensions/memorix` as an OpenClaw-compatible bundle with bundled stdio MCP, skills, and an OpenClaw `HOOK.md`/`handler.ts` hook pack.
 - Hermes Agent: installs into Hermes home (`%LOCALAPPDATA%\hermes` on native Windows, `~/.hermes` elsewhere, or `HERMES_HOME`), enables it in `config.yaml`, registers plugin hooks, a slash command, a CLI command, skills, and writes MCP config in `mcp_servers`.
 - Oh-my-Pi: installs an `omp.extensions` package, links it with `omp plugin link <path>` when available, and writes `.omp/mcp.json` or `~/.omp/agent/mcp.json` for MCP.
+- DeepSeek Harness: writes a Memorix `@deepseek-ai/dsh-mcp-client` row into `$DSH_HOME/cordis.patch.yml` (default `~/.dsh/cordis.patch.yml`), appends guidance to the harness `AGENTS.md` (`$DSH_HOME/AGENTS.md`, default `~/.dsh/AGENTS.md`), and installs official skills under `$DSH_HOME/skills` (default `~/.dsh/skills`). Tools appear as `mcp__memorix__*`; there is no hooks surface. Project-local setup (without `--global`) appends guidance to the project-root `AGENTS.md` and installs skills under `.dsh/skills`, while the MCP row still goes to the harness-level patch file.
 - Other supported agents: writes their MCP/rules/hooks files according to agent support.
 
 Global setup writes user-level plugin, config, and hook files where the host supports them. Use the same command without `--global` only when you explicitly want repo-local guidance, rules, or hooks for the current project.
@@ -122,7 +124,7 @@ memorix doctor agents --agent <agent>
 memorix setup --agent <agent> --global
 ```
 
-Use this for Claude Code, Codex, Cursor, Windsurf, Copilot, Gemini CLI, OpenCode, OpenClaw, Hermes Agent, Oh-my-Pi, Pi, Kiro, Antigravity, Trae, or any supported agent. It is the default user-facing install path.
+Use this for Claude Code, Codex, Cursor, Windsurf, Copilot, Gemini CLI, OpenCode, OpenClaw, Hermes Agent, Oh-my-Pi, Pi, Kiro, Antigravity, Trae, DeepSeek Harness, or any supported agent. It is the default user-facing install path.
 
 To see the current setup matrix:
 
@@ -671,6 +673,7 @@ Common MCP config locations:
 | Hermes Agent | `%LOCALAPPDATA%\hermes\config.yaml` on native Windows, `~/.hermes/config.yaml` elsewhere, or `HERMES_HOME\config.yaml` |
 | Oh-my-Pi | `.omp/mcp.json` or `~/.omp/agent/mcp.json` |
 | Trae | `%APPDATA%/Trae/User/mcp.json` on Windows |
+| DeepSeek Harness | `$DSH_HOME/cordis.patch.yml` (default `~/.dsh/cordis.patch.yml`) |
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -2,7 +2,7 @@
 
 > Local-first shared memory layer for AI coding agents.
 
-Memorix is a TypeScript/Node.js project that gives AI coding agents persistent, project-aware memory. It targets software development workflows, not generic chat. It works across Claude Code, Codex, CodeBuddy Code, Cursor, Windsurf, GitHub Copilot CLI, Gemini CLI, OpenCode, OpenClaw, Hermes Agent, Oh-my-Pi, Pi, Kiro, Antigravity, Trae, and any agent that can speak MCP over stdio or HTTP. Integrations usually start with `memorix setup --agent <agent> --global`, which installs the recommended user-level package or config for that agent: plugin packages when supported, package or extension entries, MCP config, generated guidance, hooks, skills, or the bundled terminal agent.
+Memorix is a TypeScript/Node.js project that gives AI coding agents persistent, project-aware memory. It targets software development workflows, not generic chat. It works across Claude Code, Codex, CodeBuddy Code, Cursor, Windsurf, GitHub Copilot CLI, Gemini CLI, OpenCode, OpenClaw, Hermes Agent, Oh-my-Pi, Pi, Kiro, Antigravity, Trae, DeepSeek Harness, and any agent that can speak MCP over stdio or HTTP. Integrations usually start with `memorix setup --agent <agent> --global`, which installs the recommended user-level package or config for that agent: plugin packages when supported, package or extension entries, MCP config, generated guidance, hooks, skills, or the bundled terminal agent.
 
 If you are an AI coding agent helping a user install, operate, or troubleshoot Memorix, read `docs/AGENT_OPERATOR_PLAYBOOK.md` before taking action. It is the main reference for install, runtime selection, Git/project binding, MCP integration, hooks, and troubleshooting.
 
@@ -36,6 +36,7 @@ It installs the recommended Memorix integration for the target agent:
 - Gemini CLI: local Gemini extension package with MCP and `GEMINI.md` context.
 - OpenCode: local plugin file, `opencode.json` MCP config, OpenCode skill, and `AGENTS.md` guidance.
 - Windsurf, Kiro, Antigravity, Trae: MCP config plus rules/hooks where supported.
+- DeepSeek Harness: MCP patch row (`$DSH_HOME/cordis.patch.yml`) plus `AGENTS.md` guidance and official skills.
 
 Use:
 
@@ -131,7 +132,7 @@ memorix orchestrate --goal "Add authentication"
 - plugin packages: Claude Code, Codex, and GitHub Copilot CLI
 - package or extension entries: Pi package and Gemini CLI extension package
 - local plugins: OpenCode local plugin file and skill
-- project instructions and rules: AGENTS.md, GEMINI.md, Cursor rules, Windsurf rules, Kiro steering, Trae rules
+- project instructions and rules: AGENTS.md, GEMINI.md, Cursor rules, Windsurf rules, Kiro steering, Trae rules, DeepSeek Harness AGENTS.md
 - hooks: agent event capture routed through `memorix hook`
 - skills: durable project knowledge promoted into reusable task guidance
 
@@ -365,7 +366,7 @@ Docker is for the HTTP service. The container must have access to the repositori
 
 ## Supported Clients
 
-Memorix supports Claude Code, Codex, CodeBuddy Code, Cursor, Windsurf, GitHub Copilot CLI, Gemini CLI, OpenCode, OpenClaw, Hermes Agent, Oh-my-Pi, Pi, Kiro, Antigravity, Trae, memcode, and other stdio or HTTP MCP clients.
+Memorix supports Claude Code, Codex, CodeBuddy Code, Cursor, Windsurf, GitHub Copilot CLI, Gemini CLI, OpenCode, OpenClaw, Hermes Agent, Oh-my-Pi, Pi, Kiro, Antigravity, Trae, DeepSeek Harness, memcode, and other stdio or HTTP MCP clients.
 
 Support depth differs by client:
 
@@ -374,7 +375,7 @@ Support depth differs by client:
 - Claude Code, Codex, and GitHub Copilot CLI receive local plugin packages.
 - Pi receives a user-level package when setup runs with `--global`; Gemini CLI receives a local extension package.
 - OpenClaw receives a compatible bundle; Hermes Agent receives a plugin package; Oh-my-Pi receives a package/extension entry.
-- Project instructions and rules include AGENTS.md, GEMINI.md, Cursor rules, Windsurf rules, Kiro steering, and Trae rules.
+- Project instructions and rules include AGENTS.md, GEMINI.md, Cursor rules, Windsurf rules, Kiro steering, Trae rules, and DeepSeek Harness AGENTS.md.
 - Hooks are generated for agents that expose usable hook events.
 - OpenCode receives a local plugin file at `.opencode/plugins/memorix.js`, an OpenCode skill at `.opencode/skills/memorix-memory/SKILL.md`, plus `opencode.json` MCP config.
 - memcode is the bundled terminal agent and uses the same project memory pool.

--- a/llms.txt
+++ b/llms.txt
@@ -2,7 +2,7 @@
 
 > Local-first shared memory layer for AI coding agents.
 
-Memorix gives coding agents persistent, project-aware memory across sessions, IDEs, terminals, and MCP clients. It stores project knowledge once so multiple agents can retrieve it through plugin packages, MCP, CLI, SDK, generated rules/instructions, hooks, skills, local plugins, or the bundled terminal agent. It works with Claude Code, Codex, CodeBuddy Code, Cursor, Windsurf, GitHub Copilot CLI, Gemini CLI, OpenCode, OpenClaw, Hermes Agent, Oh-my-Pi, Pi, Kiro, Antigravity, Trae, and other MCP-capable agents.
+Memorix gives coding agents persistent, project-aware memory across sessions, IDEs, terminals, and MCP clients. It stores project knowledge once so multiple agents can retrieve it through plugin packages, MCP, CLI, SDK, generated rules/instructions, hooks, skills, local plugins, or the bundled terminal agent. It works with Claude Code, Codex, CodeBuddy Code, Cursor, Windsurf, GitHub Copilot CLI, Gemini CLI, OpenCode, OpenClaw, Hermes Agent, Oh-my-Pi, Pi, Kiro, Antigravity, Trae, DeepSeek Harness, and other MCP-capable agents.
 
 ## Entry Points
 

--- a/src/cli/commands/agent-integrations.ts
+++ b/src/cli/commands/agent-integrations.ts
@@ -124,6 +124,7 @@ const GUIDANCE_AGENTS = new Set<AgentName>([
   'kiro',
   'opencode',
   'trae',
+  'dsh',
 ]);
 
 const CODEX_PLUGIN_NAME = 'memorix';
@@ -787,7 +788,12 @@ async function inspectMcp(agent: AgentName, projectRoot: string, scope: AgentInt
     }
 
     const configPath = adapter.getConfigPath(targetScope === 'project' ? projectRoot : undefined);
-    if (targetScope === 'global' && configPath === adapter.getConfigPath(projectRoot)) continue;
+    if (targetScope === 'global' && configPath === adapter.getConfigPath(projectRoot) && scope === 'all') {
+      // User-level-only adapters (Trae, DSH) resolve one path for every
+      // scope. Deduplicate only when the project iteration also runs;
+      // an explicit global-only scope must still inspect the shared path.
+      continue;
+    }
 
     if (!existsSync(configPath)) {
       checks.push({

--- a/src/cli/commands/hooks-install.ts
+++ b/src/cli/commands/hooks-install.ts
@@ -159,6 +159,7 @@ function getAgentLabel(agent: string): string {
     hermes: 'Hermes Agent',
     omp: 'Oh-my-Pi',
     trae: 'Trae',
+    dsh: 'DeepSeek Harness',
   };
   return labels[agent] || agent;
 }
@@ -177,6 +178,7 @@ function getAgentHint(agent: string): string {
     hermes: 'Hermes plugin hooks; use `memorix setup --agent hermes`',
     omp: 'Oh-my-Pi package hooks; use `memorix setup --agent omp`',
     trae: '.trae/rules/project_rules.md (rules only, no hooks system)',
+    dsh: '~/.dsh/cordis.patch.yml MCP row via `memorix setup --agent dsh` (no hooks system)',
     codex: 'Codex plugin hooks; use `memorix setup --agent codex`',
   };
   return hints[agent] || '';

--- a/src/cli/commands/hooks-preview.ts
+++ b/src/cli/commands/hooks-preview.ts
@@ -152,6 +152,7 @@ function estimateFileSize(agent: string, configPath: string): string {
     antigravity: '~2KB',
     opencode: '~3KB',
     trae: '~1KB',
+    dsh: '~1KB',
   };
   return sizes[agent] || '~2KB';
 }
@@ -171,6 +172,8 @@ function getRulesPath(agent: string, cwd: string, global: boolean): string {
         return path.join(home, '.gemini', 'GEMINI.md');
       case 'trae':
         return path.join(home, '.trae', 'rules', 'project_rules.md');
+      case 'dsh':
+        return path.join(process.env.DSH_HOME?.trim() || path.join(home, '.dsh'), 'AGENTS.md');
       default:
         return '';
     }
@@ -186,6 +189,8 @@ function getRulesPath(agent: string, cwd: string, global: boolean): string {
         return path.join(cwd, 'GEMINI.md');
       case 'trae':
         return path.join(cwd, '.trae', 'rules', 'project_rules.md');
+      case 'dsh':
+        return path.join(cwd, 'AGENTS.md');
       default:
         return '';
     }

--- a/src/cli/commands/integrate.ts
+++ b/src/cli/commands/integrate.ts
@@ -114,6 +114,7 @@ function getAgentLabel(agent: string): string {
     antigravity: 'Antigravity',
     'gemini-cli': 'Gemini CLI',
     trae: 'Trae',
+    dsh: 'DeepSeek Harness',
   };
   return labels[agent] || agent;
 }
@@ -130,6 +131,7 @@ function getAgentHint(agent: string): string {
     antigravity: 'plugin + MCP + hooks + skills',
     'gemini-cli': 'settings + GEMINI.md',
     trae: 'rules',
+    dsh: 'MCP patch + AGENTS.md + skills',
   };
   return hints[agent] || 'integration files';
 }

--- a/src/cli/commands/setup.ts
+++ b/src/cli/commands/setup.ts
@@ -30,6 +30,7 @@ import { OmpMCPAdapter } from '../../workspace/mcp-adapters/omp.js';
 import { KiroMCPAdapter } from '../../workspace/mcp-adapters/kiro.js';
 import { OpenCodeMCPAdapter } from '../../workspace/mcp-adapters/opencode.js';
 import { TraeMCPAdapter } from '../../workspace/mcp-adapters/trae.js';
+import { DshMCPAdapter } from '../../workspace/mcp-adapters/dsh.js';
 import { CodeBuddyMCPAdapter } from '../../workspace/mcp-adapters/codebuddy.js';
 import { getSetupIntegrationRows as readSetupIntegrationRows } from '../../integrations/registry.js';
 import { OFFICIAL_MEMORIX_SKILLS } from '../../hooks/official-skills.js';
@@ -190,6 +191,7 @@ const SUPPORTED_SETUP_AGENTS: AgentName[] = [
   'omp',
   'kiro',
   'trae',
+  'dsh',
   'pi',
 ];
 
@@ -402,6 +404,7 @@ export function getMcpAdapter(agent: McpConfigAgent): MCPConfigAdapter {
     kiro: new KiroMCPAdapter(),
     opencode: new OpenCodeMCPAdapter(),
     trae: new TraeMCPAdapter(),
+    dsh: new DshMCPAdapter(),
   };
   return adapters[agent];
 }
@@ -699,6 +702,55 @@ function mergeYamlMcpConfig(existingContent: string | null, generatedContent: st
   return stringifyYaml(merged, { lineWidth: 0 });
 }
 
+/**
+ * Merge the generated DeepSeek Harness patch rows into an existing
+ * `cordis.patch.yml` without clobbering unrelated user patches.
+ *
+ * DSH patch files are lists of Cordis patch operations. Memorix owns exactly
+ * the `@deepseek-ai/dsh-mcp-client` row whose config.serverName is `memorix`;
+ * every other operation is user-owned and must survive the merge. When the
+ * existing file is not a parseable list, the generated rows are appended to
+ * the raw content instead of overwriting it.
+ */
+function mergeDshPatchConfig(existingContent: string | null, generatedContent: string): string {
+  const generatedTrimmed = generatedContent.trimEnd();
+  if (!existingContent?.trim()) {
+    return generatedTrimmed.endsWith('\n') ? generatedTrimmed : `${generatedTrimmed}\n`;
+  }
+
+  const isMemorixInsertRow = (row: unknown): boolean => {
+    if (!row || typeof row !== 'object' || Array.isArray(row)) return false;
+    const record = row as Record<string, unknown>;
+    if (record.name !== '@deepseek-ai/dsh-mcp-client') return false;
+    const config = record.config;
+    return Boolean(
+      config && typeof config === 'object' && !Array.isArray(config)
+      && (config as Record<string, unknown>).serverName === 'memorix',
+    );
+  };
+
+  const opContainsMemorixRow = (op: unknown): boolean => {
+    if (!op || typeof op !== 'object' || Array.isArray(op)) return false;
+    const insert = (op as Record<string, unknown>).insert;
+    return Array.isArray(insert) && insert.some(isMemorixInsertRow);
+  };
+
+  let existingDocument: unknown;
+  try {
+    existingDocument = parseYaml(existingContent);
+  } catch {
+    return `${existingContent.trimEnd()}\n\n${generatedTrimmed}\n`;
+  }
+  if (!Array.isArray(existingDocument)) {
+    // A scalar or mapping document is not a patch list — never rewrite it.
+    return `${existingContent.trimEnd()}\n\n${generatedTrimmed}\n`;
+  }
+
+  const kept = existingDocument.filter((op) => !opContainsMemorixRow(op));
+  const merged = [...kept, ...(parseYaml(generatedContent) as unknown[])];
+  return stringifyYaml(merged, { lineWidth: 0 }) + '\n';
+}
+
 export async function installMcpConfig(options: {
   agent: McpConfigAgent;
   projectRoot?: string;
@@ -725,7 +777,9 @@ export async function installMcpConfig(options: {
     ? mergeTomlMcpConfig(existingContent, generated)
     : options.agent === 'hermes'
       ? mergeYamlMcpConfig(existingContent, generated)
-    : mergeJsonMcpConfig(existingContent, generated);
+      : options.agent === 'dsh'
+        ? mergeDshPatchConfig(existingContent, generated)
+        : mergeJsonMcpConfig(existingContent, generated);
 
   await mkdir(path.dirname(configPath), { recursive: true });
   await writeFile(configPath, content, 'utf-8');
@@ -1603,7 +1657,7 @@ export default defineCommand({
   args: {
     agent: {
       type: 'string',
-      description: 'Target agent (claude, codex, codebuddy, opencode, cursor, windsurf, copilot, gemini-cli, antigravity, openclaw, hermes, omp, kiro, trae, pi, all)',
+      description: 'Target agent (claude, codex, codebuddy, opencode, cursor, windsurf, copilot, gemini-cli, antigravity, openclaw, hermes, omp, kiro, trae, dsh, pi, all)',
       required: false,
     },
     mcp: {
@@ -1677,6 +1731,7 @@ export default defineCommand({
           { value: 'hermes', label: 'Hermes Agent', hint: 'plugin + hooks + commands + skills + MCP' },
           { value: 'omp', label: 'Oh-my-Pi', hint: 'package + extension + command + MCP' },
           { value: 'pi', label: 'Pi coding agent', hint: 'package + extension + skill' },
+          { value: 'dsh', label: 'DeepSeek Harness', hint: 'MCP patch + AGENTS.md + skills' },
           { value: 'opencode', label: 'OpenCode', hint: 'local plugin + AGENTS.md + MCP' },
           { value: 'windsurf', label: 'Windsurf', hint: 'rules + hooks + MCP' },
           { value: 'all', label: 'All supported agents', hint: 'install detected-compatible files' },

--- a/src/cli/commands/uninstall.ts
+++ b/src/cli/commands/uninstall.ts
@@ -56,6 +56,15 @@ function checkTOML(p: string): boolean {
   } catch { return false; }
 }
 
+function checkDshPatch(p: string): boolean {
+  if (!exists(p)) return false;
+  try {
+    const content = fs.readFileSync(p, 'utf-8');
+    if (!content.includes('memory-memorix')) return false;
+    return /serverName:\s*['"]?memorix['"]?/.test(content);
+  } catch { return false; }
+}
+
 /** Detects memorix MCP config entries in both global and project-level paths. */
 function getMCPConfigEntries(home: string, cwd: string): MCPConfigEntry[] {
   const entries: MCPConfigEntry[] = [];
@@ -214,6 +223,17 @@ function getMCPConfigEntries(home: string, cwd: string): MCPConfigEntry[] {
     format: 'json',
     detected: checkJSON(traeCfg),
     note: 'Remove the "memorix" key from mcpServers in this file.',
+  });
+
+  // DeepSeek Harness
+  const dshPatchPath = path.join(process.env.DSH_HOME?.trim() || path.join(home, '.dsh'), 'cordis.patch.yml');
+  entries.push({
+    agent: 'DeepSeek Harness',
+    path: dshPatchPath,
+    kind: 'global',
+    format: 'json',
+    detected: checkDshPatch(dshPatchPath),
+    note: 'Remove the memory-memorix insert row from this patch file.',
   });
 
   return entries;

--- a/src/hooks/installers/index.ts
+++ b/src/hooks/installers/index.ts
@@ -360,6 +360,9 @@ const AGENT_SKILL_DIRS: Partial<Record<AgentName, { project: string; global?: st
   kiro: { project: path.join('.kiro', 'skills'), global: path.join('.kiro', 'skills') },
   opencode: { project: path.join('.opencode', 'skills'), global: path.join('.config', 'opencode', 'skills') },
   trae: { project: path.join('.trae', 'skills'), global: path.join('.trae', 'skills') },
+  // DSH's user skill root is <harness home>/skills; the global root below is
+  // resolved to $DSH_HOME (or ~/.dsh) for dsh by installOfficialSkillsForAgent.
+  dsh: { project: path.join('.dsh', 'skills'), global: 'skills' },
 };
 
 const PACKAGE_OWNED_HOOK_AGENTS = new Set<AgentName>(['openclaw', 'hermes', 'omp']);
@@ -384,7 +387,11 @@ async function installOfficialSkillsForAgent(
   const relativeDir = global ? dirs?.global : dirs?.project;
   if (!relativeDir) return [];
 
-  const root = global ? os.homedir() : projectRoot;
+  const root = global
+    ? (agent === 'dsh'
+      ? (process.env.DSH_HOME?.trim() || path.join(os.homedir(), '.dsh'))
+      : os.homedir())
+    : projectRoot;
   const skillPaths: string[] = [];
   for (const skillEntry of OFFICIAL_MEMORIX_SKILLS) {
     const skillPath = path.join(root, relativeDir, skillEntry.name, 'SKILL.md');
@@ -626,6 +633,9 @@ export function getProjectConfigPath(agent: AgentName, projectRoot: string): str
     case 'trae':
       // Trae has no hooks system — only rules (.trae/rules/project_rules.md)
       return path.join(projectRoot, '.trae', 'rules', 'project_rules.md');
+    case 'dsh':
+      // DeepSeek Harness has no hooks system — only guidance (AGENTS.md)
+      return path.join(projectRoot, 'AGENTS.md');
     case 'opencode':
       // OpenCode uses plugin files for hooks
       return path.join(projectRoot, '.opencode', 'plugins', 'memorix.js');
@@ -684,6 +694,9 @@ export function getGlobalConfigPath(agent: AgentName): string {
       return path.join(home, '.omp', 'agent', 'packages', 'memorix', 'extensions', 'memorix.js');
     case 'trae':
       return path.join(home, '.trae', 'rules', 'project_rules.md');
+    case 'dsh':
+      // DSH reads the user-global AGENTS.md from its harness home.
+      return path.join(process.env.DSH_HOME?.trim() || path.join(home, '.dsh'), 'AGENTS.md');
     default:
       return path.join(home, '.memorix', 'hooks.json');
   }
@@ -709,6 +722,9 @@ export function getAgentRulesPath(agent: AgentName, root: string, global = false
         return path.join(root, '.gemini', 'GEMINI.md');
       case 'trae':
         return path.join(root, '.trae', 'rules', 'project_rules.md');
+      case 'dsh':
+        // The user-global AGENTS.md lives in the harness home DSH reads.
+        return path.join(process.env.DSH_HOME?.trim() || path.join(root, '.dsh'), 'AGENTS.md');
       default:
         return path.join(root, '.agent', 'rules', 'memorix.md');
     }
@@ -734,6 +750,8 @@ export function getAgentRulesPath(agent: AgentName, root: string, global = false
       return path.join(root, 'GEMINI.md');
     case 'trae':
       return path.join(root, '.trae', 'rules', 'project_rules.md');
+    case 'dsh':
+      return path.join(root, 'AGENTS.md');
     default:
       return path.join(root, '.agent', 'rules', 'memorix.md');
   }
@@ -842,6 +860,13 @@ export async function detectInstalledAgents(): Promise<AgentName[]> {
     agents.push('trae');
   } catch { /* not installed */ }
 
+  // Check for DeepSeek Harness (its home dir or an explicit DSH_HOME)
+  const dshDir = process.env.DSH_HOME?.trim() || path.join(home, '.dsh');
+  try {
+    await fs.access(dshDir);
+    agents.push('dsh');
+  } catch { /* not installed */ }
+
   return agents;
 }
 
@@ -945,6 +970,22 @@ export async function installHooks(
           configPath: rulesPath,
           events: [],
           generated: { note: 'Trae has no hooks system, only rules (.trae/rules/project_rules.md) installed' },
+        };
+      }
+    case 'dsh':
+      // DeepSeek Harness has no hook system — install AGENTS.md guidance and
+      // skills; the MCP row is installed by `memorix setup --agent dsh`.
+      {
+        const rulesPath = await installAgentRules(agent, projectRoot, global);
+        const skillPaths = await installOfficialSkillsForAgent(agent, projectRoot, global);
+        return {
+          agent,
+          configPath: rulesPath,
+          events: [],
+          generated: {
+            note: 'DeepSeek Harness has no hook system — installed AGENTS.md guidance and skills; the MCP row is installed by `memorix setup --agent dsh`.',
+            ...(skillPaths.length > 0 ? { skillPaths, skillPath: skillPaths[0] } : {}),
+          },
         };
       }
     case 'opencode': {
@@ -1127,7 +1168,7 @@ async function installAgentRules(agent: AgentName, projectRoot: string, global =
   try {
     await fs.mkdir(path.dirname(rulesPath), { recursive: true });
 
-    if (agent === 'claude' || agent === 'codex' || agent === 'opencode' || agent === 'antigravity' || agent === 'gemini-cli') {
+    if (agent === 'claude' || agent === 'codex' || agent === 'opencode' || agent === 'antigravity' || agent === 'gemini-cli' || agent === 'dsh') {
       // For shared context files (CLAUDE.md / AGENTS.md / GEMINI.md), append rather than overwrite.
       try {
         const existing = await fs.readFile(rulesPath, 'utf-8');

--- a/src/hooks/types.ts
+++ b/src/hooks/types.ts
@@ -41,6 +41,7 @@ export type AgentName =
   | 'hermes'
   | 'opencode'
   | 'trae'
+  | 'dsh'
   | 'pi'
   | 'omp';
 
@@ -61,6 +62,7 @@ export const AGENT_SUPPORT_TIER: Record<AgentName, SupportTier> = {
   hermes: 'community',
   opencode: 'community',
   trae: 'community',
+  dsh: 'community',
   pi: 'community',
   omp: 'community',
   antigravity: 'community',

--- a/src/integrations/registry.ts
+++ b/src/integrations/registry.ts
@@ -151,6 +151,15 @@ export const MEMORIX_INTEGRATIONS: MemorixIntegration[] = [
     surfaces: ['MCP', 'rules'],
   },
   {
+    agent: 'dsh',
+    name: 'DeepSeek Harness',
+    entry: 'official-config',
+    status: 'ready',
+    install: 'memorix setup --agent dsh',
+    surfaces: ['MCP', 'AGENTS.md', 'skills'],
+    note: 'DeepSeek Harness support writes a @deepseek-ai/dsh-mcp-client row into $DSH_HOME/cordis.patch.yml (default ~/.dsh/cordis.patch.yml), guidance into the harness AGENTS.md, and skills under $DSH_HOME/skills.',
+  },
+  {
     agent: 'memcode',
     name: 'memcode',
     entry: 'native',

--- a/src/types.ts
+++ b/src/types.ts
@@ -654,7 +654,7 @@ export interface MemoryRef {
 /** MCP config format adapter interface */
 export interface MCPConfigAdapter {
   /** Setup-only adapters may support a host that does not participate in workspace sync. */
-  readonly source: AgentTarget | 'codebuddy';
+  readonly source: AgentTarget | 'codebuddy' | 'dsh';
   /** Parse MCP server entries from a config file */
   parse(content: string): MCPServerEntry[];
   /** Generate config file content from MCP server entries */

--- a/src/workspace/mcp-adapters/dsh.ts
+++ b/src/workspace/mcp-adapters/dsh.ts
@@ -1,0 +1,147 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { parse as parseYaml, stringify as stringifyYaml } from 'yaml';
+import type { MCPConfigAdapter, MCPServerEntry } from '../../types.js';
+
+/**
+ * DeepSeek Harness (DSH) MCP Configuration Adapter.
+ *
+ * DSH composes its runtime from Cordis patch layers. External MCP servers are
+ * registered as rows of the `@deepseek-ai/dsh-mcp-client` plugin inside a
+ * patch list. The user-level layer that applies to every profile lives at:
+ *
+ *   $DSH_HOME/cordis.patch.yml   (default: ~/.dsh/cordis.patch.yml)
+ *
+ * Row shape follows DSH's own shipped Memorix reference
+ * (examples/mcp-memory/memorix.cordis.yml in deepseek-ai/deepseek-harness):
+ *
+ *   - insert:
+ *       - id: memory-memorix
+ *         name: '@deepseek-ai/dsh-mcp-client'
+ *         config:
+ *           serverName: memorix
+ *           transport: stdio
+ *           command: memorix
+ *           args: [serve]
+ *
+ * The `cwd` key is deliberately omitted so the MCP child inherits the DSH
+ * process working directory — the workspace DSH was launched from — which is
+ * what keeps Memorix bound to the current Git project.
+ *
+ * Source: https://github.com/deepseek-ai/deepseek-harness/tree/master/packages/mcp/mcp-client
+ */
+
+const MCP_CLIENT_PLUGIN = '@deepseek-ai/dsh-mcp-client';
+const MEMORIX_ROW_ID = 'memory-memorix';
+
+function resolveDshHome(): string {
+  const configured = process.env.DSH_HOME?.trim();
+  if (configured) return configured;
+  return join(homedir(), '.dsh');
+}
+
+function isMemorixRow(row: unknown): row is Record<string, unknown> {
+  if (!row || typeof row !== 'object' || Array.isArray(row)) return false;
+  const record = row as Record<string, unknown>;
+  if (record.name !== MCP_CLIENT_PLUGIN) return false;
+  const config = record.config;
+  return Boolean(
+    config && typeof config === 'object' && !Array.isArray(config)
+    && (config as Record<string, unknown>).serverName === 'memorix',
+  );
+}
+
+function rowToEntry(row: Record<string, unknown>): MCPServerEntry | null {
+  const config = row.config as Record<string, unknown>;
+  if (!config || typeof config !== 'object') return null;
+  const entry: MCPServerEntry = {
+    name: 'memorix',
+    command: typeof config.command === 'string' ? config.command : '',
+    args: Array.isArray(config.args) ? config.args.filter((arg): arg is string => typeof arg === 'string') : [],
+  };
+  if (typeof config.url === 'string' && config.url) entry.url = config.url;
+  if (config.env && typeof config.env === 'object' && !Array.isArray(config.env)) {
+    const env: Record<string, string> = {};
+    for (const [key, value] of Object.entries(config.env as Record<string, unknown>)) {
+      if (typeof value === 'string') env[key] = value;
+    }
+    if (Object.keys(env).length > 0) entry.env = env;
+  }
+  if (config.disabled === true) entry.disabled = true;
+  return entry;
+}
+
+/** Flatten one parsed patch document into its row list, tolerating both
+ *  `- insert: [...]` operations and bare row lists. */
+function patchRows(document: unknown): Record<string, unknown>[] {
+  const rows: Record<string, unknown>[] = [];
+  if (!Array.isArray(document)) return rows;
+  for (const item of document) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
+    const record = item as Record<string, unknown>;
+    if (Array.isArray(record.insert)) {
+      for (const row of record.insert) {
+        if (row && typeof row === 'object' && !Array.isArray(row)) {
+          rows.push(row as Record<string, unknown>);
+        }
+      }
+      continue;
+    }
+    rows.push(record);
+  }
+  return rows;
+}
+
+export class DshMCPAdapter implements MCPConfigAdapter {
+  readonly source = 'dsh' as const;
+
+  parse(content: string): MCPServerEntry[] {
+    if (!content.trim()) return [];
+    let document: unknown;
+    try {
+      document = parseYaml(content);
+    } catch {
+      return [];
+    }
+    return patchRows(document)
+      .filter(isMemorixRow)
+      .map(rowToEntry)
+      .filter((entry): entry is MCPServerEntry => entry !== null);
+  }
+
+  generate(servers: MCPServerEntry[]): string {
+    const rows = servers
+      .filter((server) => server.name === 'memorix')
+      .map((server) => {
+        const config: Record<string, unknown> = {
+          serverName: server.name,
+        };
+        if (server.url) {
+          config.transport = 'streamable-http';
+          config.url = server.url;
+          if (server.headers && Object.keys(server.headers).length > 0) config.headers = server.headers;
+        } else {
+          config.transport = 'stdio';
+          config.command = server.command;
+          if (server.args && server.args.length > 0) config.args = server.args;
+          if (server.env && Object.keys(server.env).length > 0) config.env = server.env;
+        }
+        const row: Record<string, unknown> = {
+          id: MEMORIX_ROW_ID,
+          name: MCP_CLIENT_PLUGIN,
+          config,
+        };
+        if (server.disabled === true) row.disabled = true;
+        return row;
+      });
+
+    if (rows.length === 0) return '';
+    return stringifyYaml([{ insert: rows }], { lineWidth: 0 }) + '\n';
+  }
+
+  getConfigPath(_projectRoot?: string): string {
+    return join(resolveDshHome(), 'cordis.patch.yml');
+  }
+}
+
+export { MEMORIX_ROW_ID };

--- a/tests/cli/dsh-setup.test.ts
+++ b/tests/cli/dsh-setup.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { DshMCPAdapter } from '../../src/workspace/mcp-adapters/dsh.js';
+import { buildSetupPlan, installMcpConfig } from '../../src/cli/commands/setup.js';
+import { inspectAgentIntegrations } from '../../src/cli/commands/agent-integrations.js';
+import { getAgentRulesPath } from '../../src/hooks/installers/index.js';
+
+const MEMORIX_ROW_ID = 'memory-memorix';
+
+describe('DeepSeek Harness (DSH) integration', () => {
+  const originalDshHome = process.env.DSH_HOME;
+  let tempHome = '';
+
+  beforeEach(() => {
+    tempHome = mkdtempSync(path.join(tmpdir(), 'memorix-dsh-'));
+    process.env.DSH_HOME = tempHome;
+  });
+
+  afterEach(() => {
+    if (originalDshHome === undefined) delete process.env.DSH_HOME;
+    else process.env.DSH_HOME = originalDshHome;
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  describe('DshMCPAdapter', () => {
+    it('resolves the config path under $DSH_HOME/cordis.patch.yml', () => {
+      const adapter = new DshMCPAdapter();
+      expect(adapter.getConfigPath('/any/project')).toBe(path.join(tempHome, 'cordis.patch.yml'));
+    });
+
+    it('round-trips a stdio Memorix row through generate/parse', () => {
+      const adapter = new DshMCPAdapter();
+      const generated = adapter.generate([{
+        name: 'memorix',
+        command: 'memorix',
+        args: ['serve'],
+      }]);
+
+      expect(generated).toContain('name: "@deepseek-ai/dsh-mcp-client"');
+      expect(generated).toContain('serverName: memorix');
+      expect(generated).toContain('transport: stdio');
+
+      const entries = adapter.parse(generated);
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({ name: 'memorix', command: 'memorix', args: ['serve'] });
+    });
+
+    it('round-trips a streamable-http row', () => {
+      const adapter = new DshMCPAdapter();
+      const generated = adapter.generate([{
+        name: 'memorix',
+        command: '',
+        args: [],
+        url: 'http://localhost:3211/mcp',
+      }]);
+
+      const entries = adapter.parse(generated);
+      expect(entries).toHaveLength(1);
+      expect(entries[0]).toMatchObject({ name: 'memorix', url: 'http://localhost:3211/mcp' });
+      expect(generated).toContain('transport: streamable-http');
+    });
+
+    it('ignores unrelated rows when parsing', () => {
+      const adapter = new DshMCPAdapter();
+      const content = [
+        '- insert:',
+        '    - id: mcp-other',
+        "      name: '@deepseek-ai/dsh-mcp-client'",
+        '      config:',
+        '        serverName: other',
+        '        transport: stdio',
+        '        command: other-tool',
+        '- insert:',
+        `    - id: ${MEMORIX_ROW_ID}`,
+        "      name: '@deepseek-ai/dsh-mcp-client'",
+        '      config:',
+        '        serverName: memorix',
+        '        transport: stdio',
+        '        command: memorix',
+        '        args: [serve]',
+      ].join('\n');
+
+      const entries = adapter.parse(content);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].name).toBe('memorix');
+    });
+  });
+
+  describe('installMcpConfig', () => {
+    const userPatch = [
+      '# user-owned comment',
+      '- insert:',
+      '    - id: mcp-user',
+      "      name: '@deepseek-ai/dsh-mcp-client'",
+      '      config:',
+      '        serverName: other',
+      '        transport: stdio',
+      '        command: other-tool',
+    ].join('\n');
+
+    it('merges the Memorix row into an existing user patch without clobbering', async () => {
+      writeFileSync(path.join(tempHome, 'cordis.patch.yml'), userPatch, 'utf-8');
+      await installMcpConfig({ agent: 'dsh', mcp: 'stdio' });
+
+      const content = readFileSync(path.join(tempHome, 'cordis.patch.yml'), 'utf-8');
+      expect(content).toContain('mcp-user');
+      expect(content).toContain(MEMORIX_ROW_ID);
+      expect(content).toContain('serverName: memorix');
+
+      const entries = new DshMCPAdapter().parse(content);
+      expect(entries.map((entry) => entry.name)).toEqual(['memorix']);
+    });
+
+    it('is idempotent across repeated installs', async () => {
+      await installMcpConfig({ agent: 'dsh', mcp: 'stdio' });
+      await installMcpConfig({ agent: 'dsh', mcp: 'stdio' });
+
+      const content = readFileSync(path.join(tempHome, 'cordis.patch.yml'), 'utf-8');
+      const occurrences = content.split(MEMORIX_ROW_ID).length - 1;
+      expect(occurrences).toBe(1);
+    });
+
+    it('appends to a file that is not a parseable patch list instead of overwriting it', async () => {
+      writeFileSync(path.join(tempHome, 'cordis.patch.yml'), 'not: [valid\n  user content:', 'utf-8');
+      await installMcpConfig({ agent: 'dsh', mcp: 'stdio' });
+
+      const content = readFileSync(path.join(tempHome, 'cordis.patch.yml'), 'utf-8');
+      expect(content).toContain('user content');
+      expect(content).toContain(MEMORIX_ROW_ID);
+    });
+  });
+
+  describe('setup wiring', () => {
+    it('plans stdio MCP and project guidance without a plugin package', () => {
+      const plan = buildSetupPlan({ agent: 'dsh' });
+      expect(plan.actions).toContain('mcp-stdio');
+      expect(plan.actions).toContain('project-guidance');
+      expect(plan.actions).not.toContain('plugin-package');
+      expect(plan.actions).not.toContain('extension-package');
+    });
+
+    it('uses AGENTS.md for project guidance and the harness home globally', () => {
+      expect(getAgentRulesPath('dsh', path.join(tmpdir(), 'root'))).toBe(path.join(tmpdir(), 'root', 'AGENTS.md'));
+      // With $DSH_HOME set, global guidance lands in the harness home DSH reads.
+      expect(getAgentRulesPath('dsh', path.join(tmpdir(), 'home'), true)).toBe(path.join(tempHome, 'AGENTS.md'));
+    });
+
+    it('falls back to ~/.dsh/AGENTS.md when $DSH_HOME is unset', () => {
+      delete process.env.DSH_HOME;
+      expect(getAgentRulesPath('dsh', path.join(tmpdir(), 'home'), true))
+        .toBe(path.join(tmpdir(), 'home', '.dsh', 'AGENTS.md'));
+    });
+
+    it('is reported OK by the agent doctor under an explicit global scope', async () => {
+      await installMcpConfig({ agent: 'dsh', mcp: 'stdio' });
+      const report = await inspectAgentIntegrations({ agent: 'dsh', scope: 'global' });
+      expect(report.entries).toHaveLength(1);
+      expect(report.entries[0].mcp.status).toBe('ok');
+      expect(report.entries[0].mcp.checks?.[0]?.path).toBe(path.join(tempHome, 'cordis.patch.yml'));
+    });
+  });
+});


### PR DESCRIPTION
Adds DeepSeek Harness (DSH) as a first-class Memorix setup target.

## What's new

`memorix setup --agent dsh` installs Memorix into DeepSeek's official
harness (github.com/deepseek-ai/deepseek-harness, CLI `dsh`):

- **MCP** — writes a `@deepseek-ai/dsh-mcp-client` row into
  `$DSH_HOME/cordis.patch.yml` (default `~/.dsh/cordis.patch.yml`),
  following the exact row shape of DSH's own shipped Memorix reference
  (`examples/mcp-memory/memorix.cordis.yml`). Tools appear as
  `mcp__memorix__*`. The merge preserves unrelated user patch rows and is
  idempotent across repeated installs; unparseable files are appended to,
  never overwritten.
- **Guidance** — appends Memorix usage guidance to the harness user-global
  `AGENTS.md` (`$DSH_HOME/AGENTS.md`, default `~/.dsh/AGENTS.md`) and, for
  project-local setup, to the project-root `AGENTS.md` that DSH reads
  natively (first candidate of `['AGENTS.md', 'CLAUDE.md']`).
- **Skills** — installs the official Memorix skills into `$DSH_HOME/skills`
  (global) or `<project>/.dsh/skills` (project), both of which are DSH's
  documented skill-discovery roots.
- DSH has no hook surface, so no hook files are written.

`memorix doctor agents --agent dsh`, `repair`, `uninstall`, and
`setup --list` all cover the new target. While wiring this, the MCP check
for user-level-only adapters (config path identical across scopes) was
fixed so an explicit `--scope global` actually inspects the shared path —
this also repaired the same latent skip for Trae.

## Honest boundary

DSH is MCP + AGENTS.md + skills today; it does not participate in
`memorix sync` rules/workspace sync, because DSH has no rule-file format.

## Validation

- New regression tests (`tests/cli/dsh-setup.test.ts`, 11 tests): adapter
  round-trips, patch merge/idempotence/non-clobber, guidance paths,
  setup-plan actions, and doctor detection under an explicit global scope.
- Full suite: 2882 tests passed, 0 failed.
- **Native host evidence**: the real `@deepseek-ai/dsh@0.1.0-rc.6`
  launcher composed the generated patch (`dsh --profile web --patch
  cordis.patch.yml --dump-config`) and rendered the `memory-memorix` row
  in the live config tree. An isolated `memorix setup --agent dsh
  --global` and project-local setup both produced the expected file set.
