### PR TITLE
fix(cli): stop memorix hook from hanging for hours and leaking 4GB Node processes

### DIFF
--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -4,8 +4,16 @@
  * Entry point called by agent hooks via stdin/stdout.
  * Reads agent's JSON from stdin, normalizes, auto-stores, outputs response.
  *
+ * This command is short-lived. A leftover `memorix hook` process is a bug:
+ * hosts invoke it on every event, and hung copies exhaust RAM.
+ *
  * Usage (called by agent hook configs, not by users directly):
  *   memorix hook
+ *
+ * Env:
+ *   MEMORIX_HOOK_TIMEOUT_MS — wall-clock budget (default 20000)
+ *   MEMORIX_HOOK_STDIN_TIMEOUT_MS — stdin idle budget (default 3000)
+ *   MEMORIX_HOOK_HEAP_MB — V8 heap for this command only (default 512)
  */
 
 import { defineCommand } from 'citty';
@@ -29,6 +37,10 @@ export default defineCommand({
   },
   run: async ({ args }) => {
     const { runHook } = await import('../../hooks/handler.js');
-    await runHook(args.agent as string | undefined, args.event as string | undefined);
+    const { resolveHookTimeoutMs, runHookWithDeadline } = await import('../../hooks/lifecycle.js');
+    await runHookWithDeadline({
+      timeoutMs: resolveHookTimeoutMs(),
+      run: () => runHook(args.agent as string | undefined, args.event as string | undefined),
+    });
   },
 });

--- a/src/cli/heap.ts
+++ b/src/cli/heap.ts
@@ -1,0 +1,76 @@
+/**
+ * CLI heap selection for the tsup respawn banner.
+ *
+ * `memorix serve` and other long-lived commands need a large V8 heap for
+ * embeddings and the in-memory index. `memorix hook` is a per-event
+ * lifecycle process and must not reserve a 4 GB heap — copies accumulate.
+ */
+
+export const DEFAULT_CLI_HEAP_MB = 4096;
+export const DEFAULT_HOOK_HEAP_MB = 512;
+export const MIN_HEAP_MB = 64;
+export const MAX_HEAP_MB = 16_384;
+
+function parseHeapMb(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return fallback;
+  const mb = Math.floor(parsed);
+  if (mb < MIN_HEAP_MB || mb > MAX_HEAP_MB) return fallback;
+  return mb;
+}
+
+/**
+ * True when the CLI argv selects the short-lived `hook` command.
+ * `hooks` (install/status) is a different command and keeps the large heap.
+ */
+export function isHookCliInvocation(argv: string[]): boolean {
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--') break;
+    if (argument.startsWith('-')) {
+      if (!argument.includes('=') && argv[index + 1] && !argv[index + 1].startsWith('-')) {
+        index += 1;
+      }
+      continue;
+    }
+    return argument === 'hook';
+  }
+  return false;
+}
+
+export function resolveCliHeapMb(
+  argv: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  if (isHookCliInvocation(argv)) {
+    return parseHeapMb(env.MEMORIX_HOOK_HEAP_MB, DEFAULT_HOOK_HEAP_MB);
+  }
+  return parseHeapMb(env.MEMORIX_HEAP_MB, DEFAULT_CLI_HEAP_MB);
+}
+
+/**
+ * Self-contained JS prepended to the bundled CLI. It runs before the bundle
+ * loads, so the selection logic is inlined rather than imported.
+ */
+export function buildCliHeapBannerPrelude(): string {
+  return [
+    '#!/usr/bin/env node',
+    'import {spawnSync as __ms} from "node:child_process";',
+    'import {fileURLToPath as __fu} from "node:url";',
+    'if(!process.env.__MEMORIX_HEAP){process.env.__MEMORIX_HEAP="1";',
+    'const __args=process.argv.slice(2);',
+    'let __cmd;',
+    'for(let __i=0;__i<__args.length;__i++){',
+    'const __a=__args[__i];',
+    'if(__a==="--")break;',
+    'if(__a.startsWith("-")){if(!__a.includes("=")&&__args[__i+1]&&!__args[__i+1].startsWith("-"))__i++;continue;}',
+    '__cmd=__a;break;}',
+    `const __fallback=__cmd==="hook"?${DEFAULT_HOOK_HEAP_MB}:${DEFAULT_CLI_HEAP_MB};`,
+    'const __raw=__cmd==="hook"?process.env.MEMORIX_HOOK_HEAP_MB:process.env.MEMORIX_HEAP_MB;',
+    'const __n=Number(__raw);',
+    `const __heap=(Number.isFinite(__n)&&__n>=${MIN_HEAP_MB}&&__n<=${MAX_HEAP_MB})?String(Math.floor(__n)):String(__fallback);`,
+    'let r=__ms(process.execPath,["--max-old-space-size="+__heap,__fu(import.meta.url),...process.argv.slice(2)],{stdio:"inherit",env:process.env,windowsHide:true});',
+    'process.exit(r.status??1);}',
+  ].join('\n');
+}

--- a/src/hooks/handler.ts
+++ b/src/hooks/handler.ts
@@ -21,6 +21,11 @@ import { normalizeHookInput } from './normalizer.js';
 import { detectBestPattern, patternToObservationType } from './pattern-detector.js';
 import { isSignificantKnowledge, isRetrievedResult, isTrivialCommand } from './significance-filter.js';
 import type { AgentName, HookEvent, HookOutput, NormalizedHookInput } from './types.js';
+import {
+  hookObservationRuntimeOptions,
+  readHookStdin,
+  resolveHookStdinTimeoutMs,
+} from './lifecycle.js';
 
 type HookInjectionMode = 'full' | 'minimal' | 'silent';
 type HookContextTarget = 'hook-session-start' | 'hook-user-prompt';
@@ -762,23 +767,9 @@ export function formatHookOutput(
  * Called by the CLI: `memorix hook`
  */
 export async function runHook(agentOverride?: string, eventOverride?: string): Promise<void> {
-  // Read stdin with a timeout — some hosts (e.g. Gemini CLI) may not close
-  // stdin promptly, causing `for await` to hang until the process is killed.
-  const rawInput = await new Promise<string>((resolve) => {
-    const chunks: Buffer[] = [];
-    const finish = () => resolve(Buffer.concat(chunks).toString('utf-8').trim());
-
-    // Hard timeout: resolve with whatever we have after 3 s
-    const timer = setTimeout(() => {
-      process.stdin.removeAllListeners('data');
-      process.stdin.removeAllListeners('end');
-      finish();
-    }, 3_000);
-
-    process.stdin.on('data', (chunk: Buffer) => { chunks.push(chunk); });
-    process.stdin.on('end', () => { clearTimeout(timer); finish(); });
-    process.stdin.on('error', () => { clearTimeout(timer); finish(); });
-  });
+  // Some hosts (e.g. Gemini CLI) may not close stdin promptly. Bound the
+  // read and release the stream so an open pipe cannot keep Node alive.
+  const rawInput = await readHookStdin(process.stdin, resolveHookStdinTimeoutMs());
 
   if (!rawInput) {
     process.stdout.write(JSON.stringify({ continue: true }));
@@ -841,7 +832,7 @@ export async function runHook(agentOverride?: string, eventOverride?: string): P
       await initObservationStore(dataDir);
       await initMSStore(dataDir);
       await initSessStore(dataDir);
-      await initObservations(dataDir);
+      await initObservations(dataDir, hookObservationRuntimeOptions(rawProject.rootPath));
       await storeObservation({ ...observation, projectId, sourceDetail: 'hook' });
       // Automatic capture is deliberately quiet. Candidate state and later
       // qualification are visible through Memorix inspection, not injected as

--- a/src/hooks/lifecycle.ts
+++ b/src/hooks/lifecycle.ts
@@ -1,0 +1,173 @@
+/**
+ * Process-level lifecycle for `memorix hook`.
+ *
+ * Hosts invoke this command on every agent event. It must read stdin, emit
+ * one JSON object, and exit. Leftover hook processes are a bug: they reserve
+ * heap, orphan onto PID 1, and can exhaust a laptop.
+ */
+
+import type { ObservationRuntimeOptions } from '../memory/observations.js';
+
+export const DEFAULT_HOOK_TIMEOUT_MS = 20_000;
+export const MIN_HOOK_TIMEOUT_MS = 1_000;
+export const MAX_HOOK_TIMEOUT_MS = 120_000;
+
+export const DEFAULT_HOOK_STDIN_TIMEOUT_MS = 3_000;
+export const MIN_HOOK_STDIN_TIMEOUT_MS = 100;
+export const MAX_HOOK_STDIN_TIMEOUT_MS = 30_000;
+
+type EnvMap = NodeJS.ProcessEnv | Record<string, string | undefined>;
+
+function parseBoundedMs(
+  raw: string | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  const value = raw?.trim();
+  if (!value) return fallback;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.max(min, Math.min(max, Math.floor(parsed)));
+}
+
+export function resolveHookTimeoutMs(env: EnvMap = process.env): number {
+  return parseBoundedMs(
+    env.MEMORIX_HOOK_TIMEOUT_MS,
+    DEFAULT_HOOK_TIMEOUT_MS,
+    MIN_HOOK_TIMEOUT_MS,
+    MAX_HOOK_TIMEOUT_MS,
+  );
+}
+
+export function resolveHookStdinTimeoutMs(env: EnvMap = process.env): number {
+  return parseBoundedMs(
+    env.MEMORIX_HOOK_STDIN_TIMEOUT_MS,
+    DEFAULT_HOOK_STDIN_TIMEOUT_MS,
+    MIN_HOOK_STDIN_TIMEOUT_MS,
+    MAX_HOOK_STDIN_TIMEOUT_MS,
+  );
+}
+
+export function hookObservationRuntimeOptions(projectRoot: string): ObservationRuntimeOptions {
+  return {
+    embeddingWriteMode: 'deferred',
+    projectRoot,
+  };
+}
+
+type HookStdin = NodeJS.ReadableStream & {
+  pause?: () => void;
+  destroy?: (error?: Error) => void;
+  unref?: () => void;
+  isTTY?: boolean;
+};
+
+/**
+ * Read hook JSON from a pipe. Resolves on EOF, stream error, or idle timeout.
+ * Always releases the stream so an open stdin cannot keep Node alive.
+ */
+export async function readHookStdin(stdin: HookStdin, timeoutMs: number): Promise<string> {
+  return new Promise<string>((resolve) => {
+    const chunks: Buffer[] = [];
+    let settled = false;
+
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      stdin.removeListener('data', onData);
+      stdin.removeListener('end', finish);
+      stdin.removeListener('error', finish);
+      stdin.pause?.();
+      if (!stdin.isTTY) {
+        stdin.destroy?.();
+      } else {
+        stdin.unref?.();
+      }
+      resolve(Buffer.concat(chunks).toString('utf-8').trim());
+    };
+
+    const onData = (chunk: Buffer | string) => {
+      chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+    };
+
+    const timer = setTimeout(finish, timeoutMs);
+    stdin.on('data', onData);
+    stdin.on('end', finish);
+    stdin.on('error', finish);
+  });
+}
+
+export interface HookDeadlineIo {
+  write(chunk: string): unknown;
+}
+
+export interface HookDeadlineOptions {
+  timeoutMs: number;
+  run: () => Promise<void>;
+  stdout?: HookDeadlineIo;
+  stderr?: HookDeadlineIo;
+  exit?: (code: number) => void;
+}
+
+function writeContinue(stdout: HookDeadlineIo): void {
+  try {
+    stdout.write(JSON.stringify({ continue: true }));
+  } catch {
+    // The host already closed the pipe. Exiting is still required.
+  }
+}
+
+/**
+ * Run a hook body under a hard deadline, then force-exit.
+ * `withTimeout` cannot abort in-flight fetches; process.exit is the backstop.
+ */
+export async function runHookWithDeadline(options: HookDeadlineOptions): Promise<void> {
+  const stdout = options.stdout ?? process.stdout;
+  const stderr = options.stderr ?? process.stderr;
+  const exit = options.exit ?? ((code: number) => { process.exit(code); });
+
+  await new Promise<void>((resolve) => {
+    let finished = false;
+
+    const settle = () => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timer);
+      resolve();
+    };
+
+    const timer = setTimeout(() => {
+      if (finished) return;
+      try {
+        stderr.write(`[memorix] hook timed out after ${options.timeoutMs}ms\n`);
+      } catch {
+        // stderr may already be closed
+      }
+      writeContinue(stdout);
+      exit(0);
+      settle();
+    }, options.timeoutMs);
+
+    options.run().then(
+      () => {
+        if (finished) return;
+        exit(0);
+        settle();
+      },
+      (error: unknown) => {
+        if (finished) return;
+        try {
+          const message = error instanceof Error ? error.message : String(error);
+          stderr.write(`[memorix] hook failed: ${message}\n`);
+        } catch {
+          // stderr may already be closed
+        }
+        writeContinue(stdout);
+        exit(0);
+        settle();
+      },
+    );
+  });
+}

--- a/tests/cli/heap.test.ts
+++ b/tests/cli/heap.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_CLI_HEAP_MB,
+  DEFAULT_HOOK_HEAP_MB,
+  buildCliHeapBannerPrelude,
+  isHookCliInvocation,
+  resolveCliHeapMb,
+} from '../../src/cli/heap.js';
+
+describe('CLI heap selection', () => {
+  it('uses a small heap for memorix hook and keeps the large heap for serve', () => {
+    expect(isHookCliInvocation(['hook'])).toBe(true);
+    expect(isHookCliInvocation(['hook', '--agent', 'claude'])).toBe(true);
+    expect(isHookCliInvocation(['--cwd', '/tmp/project', 'hook'])).toBe(true);
+    expect(isHookCliInvocation(['hooks'])).toBe(false);
+    expect(isHookCliInvocation(['hooks', 'install'])).toBe(false);
+    expect(isHookCliInvocation(['serve'])).toBe(false);
+    expect(isHookCliInvocation(['serve-http'])).toBe(false);
+
+    expect(resolveCliHeapMb(['hook'])).toBe(DEFAULT_HOOK_HEAP_MB);
+    expect(resolveCliHeapMb(['serve'])).toBe(DEFAULT_CLI_HEAP_MB);
+    expect(resolveCliHeapMb(['hooks', 'install'])).toBe(DEFAULT_CLI_HEAP_MB);
+    expect(DEFAULT_HOOK_HEAP_MB).toBeLessThanOrEqual(512);
+    expect(DEFAULT_CLI_HEAP_MB).toBe(4096);
+  });
+
+  it('lets MEMORIX_HOOK_HEAP_MB override only the hook command', () => {
+    expect(resolveCliHeapMb(['hook'], { MEMORIX_HOOK_HEAP_MB: '256' })).toBe(256);
+    expect(resolveCliHeapMb(['serve'], { MEMORIX_HOOK_HEAP_MB: '256' })).toBe(DEFAULT_CLI_HEAP_MB);
+    expect(resolveCliHeapMb(['hook'], { MEMORIX_HOOK_HEAP_MB: 'nope' })).toBe(DEFAULT_HOOK_HEAP_MB);
+    expect(resolveCliHeapMb(['serve'], { MEMORIX_HEAP_MB: '2048' })).toBe(2048);
+  });
+
+  it('bakes hook-aware heap selection into the CLI respawn banner', () => {
+    const banner = buildCliHeapBannerPrelude();
+    expect(banner).toContain('--max-old-space-size=');
+    expect(banner).toContain('__cmd==="hook"');
+    expect(banner).toContain(String(DEFAULT_HOOK_HEAP_MB));
+    expect(banner).toContain(String(DEFAULT_CLI_HEAP_MB));
+    expect(banner).toContain('MEMORIX_HOOK_HEAP_MB');
+  });
+});

--- a/tests/hooks/lifecycle.test.ts
+++ b/tests/hooks/lifecycle.test.ts
@@ -1,0 +1,100 @@
+import { PassThrough } from 'node:stream';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_HOOK_TIMEOUT_MS,
+  hookObservationRuntimeOptions,
+  readHookStdin,
+  resolveHookStdinTimeoutMs,
+  resolveHookTimeoutMs,
+  runHookWithDeadline,
+} from '../../src/hooks/lifecycle.js';
+
+describe('hook process lifecycle', () => {
+  const originalTimeout = process.env.MEMORIX_HOOK_TIMEOUT_MS;
+  const originalStdinTimeout = process.env.MEMORIX_HOOK_STDIN_TIMEOUT_MS;
+
+  afterEach(() => {
+    if (originalTimeout === undefined) delete process.env.MEMORIX_HOOK_TIMEOUT_MS;
+    else process.env.MEMORIX_HOOK_TIMEOUT_MS = originalTimeout;
+    if (originalStdinTimeout === undefined) delete process.env.MEMORIX_HOOK_STDIN_TIMEOUT_MS;
+    else process.env.MEMORIX_HOOK_STDIN_TIMEOUT_MS = originalStdinTimeout;
+  });
+
+  it('bounds the wall-clock budget and keeps it env-overridable', () => {
+    expect(resolveHookTimeoutMs({})).toBe(DEFAULT_HOOK_TIMEOUT_MS);
+    expect(DEFAULT_HOOK_TIMEOUT_MS).toBeGreaterThanOrEqual(15_000);
+    expect(DEFAULT_HOOK_TIMEOUT_MS).toBeLessThanOrEqual(30_000);
+    expect(resolveHookTimeoutMs({ MEMORIX_HOOK_TIMEOUT_MS: '8000' })).toBe(8_000);
+    expect(resolveHookTimeoutMs({ MEMORIX_HOOK_TIMEOUT_MS: 'nope' })).toBe(DEFAULT_HOOK_TIMEOUT_MS);
+    expect(resolveHookStdinTimeoutMs({})).toBe(3_000);
+    expect(resolveHookStdinTimeoutMs({ MEMORIX_HOOK_STDIN_TIMEOUT_MS: '500' })).toBe(500);
+  });
+
+  it('returns stdin on EOF and does not wait for a producer that already finished', async () => {
+    const stdin = new PassThrough();
+    const pending = readHookStdin(stdin, 5_000);
+    stdin.write('{"hook_event_name":"Stop"}');
+    stdin.end();
+    await expect(pending).resolves.toBe('{"hook_event_name":"Stop"}');
+  });
+
+  it('releases a pipe after the idle timeout so the event loop can exit', async () => {
+    const stdin = new PassThrough();
+    const pause = vi.spyOn(stdin, 'pause');
+    const destroy = vi.spyOn(stdin, 'destroy');
+    const pending = readHookStdin(stdin, 40);
+    stdin.write('{"partial":true}');
+    await expect(pending).resolves.toBe('{"partial":true}');
+    expect(pause).toHaveBeenCalled();
+    expect(destroy).toHaveBeenCalled();
+  });
+
+  it('exits after a successful hook so leftover handles cannot keep Node alive', async () => {
+    const exits: number[] = [];
+    await runHookWithDeadline({
+      timeoutMs: 1_000,
+      run: async () => undefined,
+      stdout: { write: () => true },
+      stderr: { write: () => true },
+      exit: (code) => { exits.push(code); },
+    });
+    expect(exits).toEqual([0]);
+  });
+
+  it('writes continue:true and exits when hook work exceeds the deadline', async () => {
+    const writes: string[] = [];
+    const stderr: string[] = [];
+    const exits: number[] = [];
+    await runHookWithDeadline({
+      timeoutMs: 25,
+      run: () => new Promise(() => {}),
+      stdout: { write: (chunk) => { writes.push(String(chunk)); return true; } },
+      stderr: { write: (chunk) => { stderr.push(String(chunk)); return true; } },
+      exit: (code) => { exits.push(code); },
+    });
+    expect(JSON.parse(writes.join(''))).toMatchObject({ continue: true });
+    expect(stderr.join('')).toMatch(/timed out after 25ms/i);
+    expect(exits).toEqual([0]);
+  });
+
+  it('writes continue:true and exits when hook work throws', async () => {
+    const writes: string[] = [];
+    const exits: number[] = [];
+    await runHookWithDeadline({
+      timeoutMs: 1_000,
+      run: async () => { throw new Error('store exploded'); },
+      stdout: { write: (chunk) => { writes.push(String(chunk)); return true; } },
+      stderr: { write: () => true },
+      exit: (code) => { exits.push(code); },
+    });
+    expect(JSON.parse(writes.join(''))).toMatchObject({ continue: true });
+    expect(exits).toEqual([0]);
+  });
+
+  it('defers hook embeddings so a remote fetch cannot pin the CLI process', () => {
+    expect(hookObservationRuntimeOptions('/repo')).toEqual({
+      embeddingWriteMode: 'deferred',
+      projectRoot: '/repo',
+    });
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'tsup';
 import { readFileSync } from 'node:fs';
+import { buildCliHeapBannerPrelude } from './src/cli/heap.js';
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 const define = { __MEMORIX_VERSION__: JSON.stringify(pkg.version) };
@@ -49,14 +50,8 @@ export default defineConfig([
     define,
     banner: {
       js: [
-        '#!/usr/bin/env node',
-        // Ensure Node has enough heap for embedding models + Orama index.
-        // Re-exec with --max-old-space-size=4096 if not already set.
-        'import {spawnSync as __ms} from "node:child_process";',
-        'import {fileURLToPath as __fu} from "node:url";',
-        'if(!process.env.__MEMORIX_HEAP){process.env.__MEMORIX_HEAP="1";',
-        'let r=__ms(process.execPath,["--max-old-space-size=4096",__fu(import.meta.url),...process.argv.slice(2)],{stdio:"inherit",env:process.env,windowsHide:true});',
-        'process.exit(r.status??1);}',
+        // serve / index keep a large heap; hook uses a small default (see src/cli/heap.ts).
+        buildCliHeapBannerPrelude(),
         'import {createRequire as __memorix_cjsRequire} from "module";',
         'const require = __memorix_cjsRequire(import.meta.url);',
       ].join('\n'),


### PR DESCRIPTION
## Summary

Fixes #205.

`memorix hook` is a per-event lifecycle command: read stdin JSON, write one stdout JSON object, exit in seconds. In **1.5.0** it can stay alive for **40 minutes to 2h45m**, orphan onto **PPID 1**, and accumulate **15–19** Node processes, each respawned with `--max-old-space-size=4096`.

On a 16 GB Mac (darwin 25.6.0, 2026-08-16 ~00:18–00:25 UTC+2) that exhausted RAM and drove the compressor / `kernel_task` until the machine was at **0.0% idle**.

This is related to #196 (`memorix_store` hang until MCP client timeout) and #200 (`withTimeout` does not abort in-flight fetches). Those explain why hook *work* can stall. They do **not** explain why the CLI process is allowed to live for hours, or why every hook reserves a 4 GB heap. **Do not close #196.**

A host-side 20s timeout was added on this laptop as a seatbelt. That is **not** this PR. This PR fixes the official CLI entrypoint.

---

## Problem (live numbers from #205)

| Metric | Before killing hung hooks |
| --- | --- |
| Load | 39.76 / 36.41 / 42.29 |
| CPU | 45.81% user, 54.18% sys, **0.0% idle** |
| `kernel_task` | ~119.9% |
| PhysMem | 15G used, ~125M unused, ~6962M compressor |
| Swap | ~71.9M swapins, ~73.5M swapouts |
| Compressor pages | ~448k occupied / ~2.19M stored |
| Processes | ~25 memorix-related, ~44 Node |
| Hung hooks | ~15–19, many PPID 1, etime 42m–2h45m |
| RSS | 86–249 MB per hook (VSZ huge because of the 4 GB heap cap) |

**Exact hung argv:**

```text
<home> \
  --max-old-space-size=4096 \
  <home> \
  hook
```

Host path: Cursor agent hooks → `bash ~/.agents/hooks/quiet-memorix-hook.sh` → `printf '%s' "$input" | memorix hook` → blocked forever.

Local LaunchAgents (`io.tharuma.memorix-control-plane.plist` StartInterval 120 / port 3211, `io.tharuma.memorix-sync.plist`) were present and are **not** the leak.

After killing hung hooks + leftover orphaned `serve` (live MCP `serve` and `serve-http :3211` left alone): idle 13–32%, ~2 GB free, compressor ~1.7 GB, `kernel_task` ~30%.

---

## Root cause

1. **No process-level deadline.** `src/cli/commands/hook.ts` only `await runHook(...)`. `runHook()` had a 3s stdin timer, then unbounded work (`handleHookEvent` → `storeObservation` → `queueCodegraphRefreshForMutation`). `withTimeout` cannot abort in-flight `fetch`s (#200), so a slow embedding / LLM / codegraph call keeps the event loop alive for hours.

2. **Stdin was not released.** After the 3s timer, listeners were removed but the pipe was left open. An open stdin is enough to keep Node alive. Some hosts (Gemini CLI) also never close stdin; the existing comment already knew that, but the process still did not exit.

3. **Background embeddings in the parent.** Hook storage called `initObservations()` with the default `embeddingWriteMode: 'background'`, which starts `void generateEmbedding(...)`. A network fetch keeps Node alive even when the Promise is not awaited. Other short-lived CLI writes already use `deferred` + a detached worker.

4. **4 GB heap for every CLI command.** The tsup respawn banner in `dist/cli/index.js` always did `node --max-old-space-size=4096 … hook`. Reasonable for `serve` / the in-memory index. Fatal for a command that can fire many times per minute: 15 copies × 4 GB reserved address space + 86–249 MB RSS each is enough to trip the compressor on a 16 GB Mac.

---

## Files changed and why

| File | Why |
| --- | --- |
| `src/hooks/lifecycle.ts` | New process-lifecycle helpers: `MEMORIX_HOOK_TIMEOUT_MS` (default **20s**, clamp 1s–120s), stdin idle/EOF read that **pauses + destroys** a non-TTY pipe, `runHookWithDeadline` that always `process.exit(0)` after success / timeout / throw (writes `{"continue":true}` on failure/timeout). `withTimeout` cannot abort fetches; `process.exit` is the backstop. |
| `src/cli/commands/hook.ts` | Official CLI entry wraps `runHook` in `runHookWithDeadline`. Documents the env knobs. A leftover `memorix hook` is treated as a bug. |
| `src/hooks/handler.ts` | Replaces the inline 3s stdin reader with `readHookStdin` (releases the pipe). Hook observation writes use `embeddingWriteMode: 'deferred'` so a remote embed cannot pin the parent. |
| `src/cli/heap.ts` | Heap policy: `hook` → **512 MB** (`MEMORIX_HOOK_HEAP_MB`); everything else including `serve` / `hooks` → **4096** (`MEMORIX_HEAP_MB`). `hooks` (install/status) is **not** `hook`. |
| `tsup.config.ts` | CLI banner uses `buildCliHeapBannerPrelude()` instead of a hardcoded 4096 respawn. |
| `tests/hooks/lifecycle.test.ts` | Timeout bounds, EOF, idle stdin release, success exit, deadline exit, thrown-work exit, deferred embeddings. |
| `tests/cli/heap.test.ts` | `hook` vs `serve` vs `hooks` heap selection, env overrides, banner contents. |

No drive-by refactors. No single-instance lock: concurrent hooks from different events are legitimate; the deadline is what stops accumulation. Orphan reap of PPID-1 hooks (issue ask #4) is **not** in this PR — doing it safely without touching a live MCP `serve` needs a separate, conservative doctor/control-plane change.

---

## How to test

```bash
# Unit tests (no network)
npx vitest run --no-file-parallelism --maxWorkers=1 \
  tests/cli/heap.test.ts \
  tests/hooks/lifecycle.test.ts \
  tests/hooks/handler-e2e.test.ts
```

After `npm run build`:

```bash
# Happy path: print JSON and return immediately
printf '%s' '{"hook_event_name":"Stop"}' | node dist/cli/index.js hook

# Producer never closes stdin: must exit on the deadline, not hang
MEMORIX_HOOK_TIMEOUT_MS=2000 python3 -c 'import time; time.sleep(60)' | node dist/cli/index.js hook
# expect {"continue":true} and a process lifetime of ~2–3s, not minutes

# Heap: only hook should default to 512
head -n 25 dist/cli/index.js
# banner should branch on __cmd==="hook" and mention MEMORIX_HOOK_HEAP_MB
```

On a live agent host (after install of this build):

```bash
ps -axo pid,ppid,etime,rss,command | grep 'dist/cli/index.js hook' | grep -v grep
# expect: processes disappear in seconds; no PPID 1 hooks with etime of tens of minutes
# do not kill a live Cursor MCP `serve`
```

---

## Residual risk

- **Timeout vs in-flight work.** The deadline uses `process.exit(0)`. In-flight SQLite writes / fetches are aborted. Hook capture is best-effort; the host agent must continue. A 20s budget can drop a slow store rather than hang the machine. Override with `MEMORIX_HOOK_TIMEOUT_MS` if a site needs longer.
- **Double JSON on a late timeout.** If `runHook` already wrote a response and then stalled on leftover handles, a timeout would theoretically write a second `{"continue":true}`. In production `process.exit` on the success path runs as soon as `runHook` returns, so this is the failure/timeout path only. Hosts typically parse the first JSON object.
- **Stdin idle is a hard 3s from start** (same as 1.5.0), not a sliding idle window. Slow dribbled stdin over >3s can truncate. Hosts write the payload at once. Override with `MEMORIX_HOOK_STDIN_TIMEOUT_MS`.
- **No global single-instance lock.** Two overlapping events may still spawn two processes. They now die at 20s and reserve 512 MB, not 4 GB for hours. Full orphan reap without touching MCP `serve` is follow-up.
- **`serve` heap unchanged.** `MEMORIX_HEAP_MB` still defaults to 4096 for long-lived commands.
- **Host wrappers.** Operators who already added a 20s wrapper can keep it; it is defense in depth, not required after this lands.

---

## Test plan

- [x] New heap + lifecycle unit tests (EOF, idle stdin release, deadline exit, thrown work, deferred embeddings, hook vs serve vs `hooks` heap)
- [x] Existing hook handler e2e tests still pass (25 tests)
- [ ] CI on this PR
- [ ] After merge: confirm a live agent session no longer accumulates `node --max-old-space-size=4096 … hook` processes
