### PR TITLE
fix(release): support Registry-only publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,12 @@ name: Publish to npm and MCP Registry
 
 on:
   workflow_dispatch:
+    inputs:
+      publish_npm:
+        description: "Publish the npm package before publishing the MCP Registry record"
+        required: true
+        type: boolean
+        default: true
 
 jobs:
   publish:
@@ -21,6 +27,7 @@ jobs:
       - run: npm run build
       - run: npm test
       - run: npm publish --provenance --access public
+        if: ${{ inputs.publish_npm }}
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Install the official MCP Registry publisher

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -326,9 +326,11 @@ Notes:
 - `server.json` is the official MCP Registry record. Keep it synchronized with
   `package.json` by running `npm run sync:mcp-registry`; verify it with
   `npm run check:mcp-registry` before a release.
-- The GitHub publish workflow publishes npm first, then uses GitHub OIDC to
-  publish the same verified version to the official MCP Registry. It does not
-  require a Registry token or private key in repository secrets.
+- The GitHub publish workflow can publish npm first, then uses GitHub OIDC to
+  publish the same verified version to the official MCP Registry. When npm was
+  already published manually, run the workflow with `publish_npm=false` to
+  publish only the Registry record. It does not require a Registry token or
+  private key in repository secrets.
 - `@memorix/ai`, `@memorix/agent-core`, `@memorix/tui`, and `@memorix/memcode` are internal workspaces. Their code is bundled into the root `memorix` distribution and they must stay `private` unless the project deliberately establishes an owned npm scope and a separate package-support contract.
 - npm publish is usually manual, especially when 2FA is enabled
 - GitHub release automation should not be treated as a substitute for manual runtime validation


### PR DESCRIPTION
## Why\nManual npm releases previously made the official MCP Registry step impossible to rerun because the workflow always tried to publish the same npm version again.\n\n## Change\n- Add a publish_npm workflow-dispatch input (default 	rue).\n- With publish_npm=false, keep all metadata/build/test/oidc Registry gates and skip only duplicate npm publication.\n- Document the manual npm -> Registry-only workflow.\n\nThis unblocks publishing the already-verified memorix@1.5.1 Registry record without changing its package artifact.