### PR TITLE
feat(rerank): add optional HTTP rerank provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,14 @@
 # MEMORIX_EMBEDDING_API_KEY=sk-your-key-here
 # MEMORIX_EMBEDDING_BASE_URL=https://api.openai.com/v1
 
+# ── HTTP rerank (optional) ──
+# Cohere-compatible POST {base_url}/rerank. Works with Cohere, Jina, TEI, vLLM, etc.
+# Model id is sent as configured. Bearer inherits the memory LLM key when unset.
+# MEMORIX_RERANK_PROVIDER=http
+# MEMORIX_RERANK_MODEL=rerank-v3.5
+# MEMORIX_RERANK_BASE_URL=https://api.example.com/v1
+# MEMORIX_RERANK_API_KEY=
+
 # ── Unified Key (optional) ──
 # Single key that works for both LLM and Embedding
 # MEMORIX_API_KEY=sk-your-key-here

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Optional HTTP rerank** -- Thorough/heavy/ambiguous search can reorder
+  top hits through a configurable Cohere-compatible `POST {base_url}/rerank`
+  endpoint (`{model, query, documents}`). Works with Cohere, Jina, TEI, vLLM,
+  or any compatible `/rerank` API. Configure `[rerank]` or `MEMORIX_RERANK_*`;
+  base URL and bearer inherit the memory LLM lane when unset. The model id is
+  user-configured. LLM rerank remains the fallback.
+
 ## [1.6.0] - 2026-08-17
 
 ### Added

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -391,7 +391,7 @@ Resolution order:
 2. project `.env`
 3. user `~/.memorix/.env`
 
-The primary lanes are `[agent]` for memcode, `[memory.llm]` for formation/rerank/summaries, and `[embedding]` for semantic search. The dashboard and `memorix status` expose config provenance so the active value source is visible.
+The primary lanes are `[agent]` for memcode, `[memory.llm]` for formation/summaries/LLM-rerank fallback, `[rerank]` for optional HTTP rerank against a compatible `/rerank` API, and `[embedding]` for semantic search. The dashboard and `memorix status` expose config provenance so the active value source is visible.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -47,6 +47,12 @@ model = "text-embedding-v4"
 base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
 api_key = "..."
 
+# Optional HTTP rerank. Off unless provider = "http".
+# [rerank]
+# provider = "http"
+# model = "rerank-v3.5"
+# base_url = "https://api.example.com/v1"
+
 [memory]
 inject = "minimal"
 formation = "active"
@@ -127,7 +133,7 @@ Used by Memorix background memory intelligence:
 - memory formation
 - summarization
 - deduplication
-- optional reranking
+- optional LLM reranking fallback
 - cleanup assistance
 
 Common keys:
@@ -185,6 +191,49 @@ defaults to `qwen/qwen3-embedding-8b` (4096 dimensions) instead of the
 OpenAI-only default. The equivalent env-var form is
 `MEMORIX_EMBEDDING=api`, `MEMORIX_EMBEDDING_BASE_URL=https://openrouter.ai/api/v1`,
 `MEMORIX_EMBEDDING_MODEL=qwen/qwen3-embedding-8b`.
+
+### `[rerank]`
+
+Optional HTTP rerank for thorough/heavy/ambiguous search. Off by default.
+When `provider = "http"`, Memorix POSTs a Cohere-compatible
+`{model, query, documents}` body to `{base_url}/rerank` (or an explicit
+`/rerank` path). Any compatible endpoint works — Cohere, Jina, TEI, vLLM,
+or a local/OpenAI-compatible gateway. Memorix sends the configured `model`
+string unchanged.
+
+Common keys:
+
+- `provider` — `off` (default) or `http` (`jina` is accepted as an alias for `http`)
+- `model` — user-configured model id (no built-in default). Example:
+  `rerank-v3.5`
+- `base_url` — API root that serves `/rerank`, for example
+  `https://api.cohere.com/v1` or `http://127.0.0.1:8080`. When unset and
+  `provider = "http"`, Memorix inherits `[memory.llm].base_url`.
+- `api_key` — bearer token. When unset, inherits the memory LLM key
+  (`MEMORIX_LLM_API_KEY`, `MEMORIX_API_KEY`, or `[memory.llm].api_key`).
+
+Environment overrides (highest priority after CLI flags):
+
+```bash
+MEMORIX_RERANK_PROVIDER=http
+MEMORIX_RERANK_MODEL=rerank-v3.5
+MEMORIX_RERANK_BASE_URL=https://api.example.com/v1
+# MEMORIX_RERANK_API_KEY=   # optional; inherits the memory LLM bearer
+```
+
+If the memory LLM lane already points at the same gateway, you can enable
+rerank with:
+
+```toml
+[rerank]
+provider = "http"
+model = "rerank-v3.5"
+```
+
+or set `MEMORIX_RERANK_PROVIDER=http` and `MEMORIX_RERANK_MODEL=...`.
+Timeout is `MEMORIX_RERANK_TIMEOUT_MS` (default 5000). HTTP rerank runs
+first on the existing thorough/heavy/ambiguous search gate; LLM rerank is
+the fallback.
 
 Image analysis (visual description for ingested images) runs on the LLM lane
 through an OpenAI-compatible vision endpoint, so it can also use OpenRouter

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -75,7 +75,9 @@ On the release development machine used for this check, the healthy HTTP service
 | `MEMORIX_FORMATION_TIMEOUT_MS` | `12000` (12 s) | Raise when LLM-backed formation should outlive slow proxy/provider hops |
 | `MEMORIX_LLM_API_KEY` / `OPENAI_API_KEY` | unset | Enable LLM-backed enrichment, extraction, rerank, or skill generation |
 | `MEMORIX_LLM_TIMEOUT_MS` | `30000` (30 s) | Bound a single LLM-backed extraction/resolve call |
-| `MEMORIX_RERANK_TIMEOUT_MS` | provider default | Bound slow LLM rerank calls |
+| `MEMORIX_RERANK_TIMEOUT_MS` | 5000 | Bound HTTP and LLM rerank calls |
+| `MEMORIX_RERANK_PROVIDER` | `off` | Set `http` to enable optional HTTP rerank |
+| `MEMORIX_RERANK_BASE_URL` | `[memory.llm].base_url` | Compatible `/rerank` API root (path `/rerank` is appended) |
 | `memorix memory search --quality fast` | n/a | Force a fully local retrieval path for a latency-sensitive call |
 | `npm run benchmark:retrieval -- --records 1000 --runs 100` | n/a | Reproduce hot in-process lexical retrieval latency; not an end-to-end claim |
 | `[codegraph].max_file_bytes` | `2097152` | Raise only when a large file is intentional source that should enter Code Memory |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -492,7 +492,8 @@ What each lane does:
 | Lane | Used by |
 | --- | --- |
 | `[agent]` | model used by memcode while coding |
-| `[memory.llm]` | memory formation, summaries, deduplication, optional rerank |
+| `[memory.llm]` | memory formation, summaries, deduplication, optional LLM rerank fallback |
+| `[rerank]` | optional HTTP rerank against a compatible `/rerank` API |
 | `[embedding]` | semantic/vector search |
 | `[memory]` | memory injection and formation behavior |
 | `[git]` | Git Memory hook and ingestion behavior |

--- a/memorix.example.yml
+++ b/memorix.example.yml
@@ -34,6 +34,14 @@ embedding:
   # model: qwen/qwen3-embedding-8b
   # dimensions: 1024        # Override auto-detected dimensions
 
+# ── HTTP rerank (optional) ───────────────────────────────────
+# Cohere-compatible POST {baseUrl}/rerank. Model id is sent as configured.
+# Bearer inherits MEMORIX_LLM_API_KEY when apiKey is omitted.
+# rerank:
+#   provider: http
+#   model: rerank-v3.5
+#   baseUrl: https://api.example.com/v1
+
 # ── Git-Memory Pipeline ──────────────────────────────────────
 # Automatically capture engineering knowledge from git commits.
 # Every commit becomes a searchable, immutable memory.

--- a/src/cli/commands/config-migrate.ts
+++ b/src/cli/commands/config-migrate.ts
@@ -69,6 +69,13 @@ export function serializeResolvedConfigToToml(
     dimensions: config.embedding.dimensions,
   });
 
+  writeSection(lines, 'rerank', {
+    provider: config.rerank.provider,
+    model: config.rerank.model,
+    base_url: config.rerank.baseUrl,
+    api_key: includeSecrets ? config.rerank.apiKey : undefined,
+  });
+
   writeSection(lines, 'memory', {
     inject: config.memory.inject,
     formation: config.memory.formation,

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -486,7 +486,11 @@ export default defineCommand({
       if (isLLMEnabled()) {
         const config = getLLMConfig();
         lines.push(ok(`Provider: ${config?.provider}/${config?.model}`));
-        lines.push(info('Capabilities: fact extraction, auto-dedup, LLM rerank'));
+        const { isNeuralRerankEnabled } = await import('../../rerank/index.js');
+        const rerankCap = isNeuralRerankEnabled()
+          ? 'HTTP rerank, LLM rerank fallback'
+          : 'LLM rerank';
+        lines.push(info(`Capabilities: fact extraction, auto-dedup, ${rerankCap}`));
         report.llm = { enabled: true, provider: config?.provider, model: config?.model };
       } else {
         lines.push(info('LLM mode: off (heuristic dedup only)'));

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -183,6 +183,11 @@ export default defineCommand({
       envLines.push('');
     }
 
+    envLines.push('# Optional HTTP rerank (Cohere-compatible POST {base_url}/rerank)');
+    envLines.push('# MEMORIX_RERANK_PROVIDER=http');
+    envLines.push('# MEMORIX_RERANK_MODEL=rerank-v3.5');
+    envLines.push('# MEMORIX_RERANK_BASE_URL=https://api.example.com/v1');
+    envLines.push('');
     envLines.push('# Optional memory LLM simple key (does not apply to embedding or agent lanes)');
     envLines.push('# MEMORIX_API_KEY=sk-your-key-here');
     envLines.push('');
@@ -307,6 +312,16 @@ export function buildInitTomlConfig(options: {
     if (isGlobal) {
       lines.push('# api_key = "..."');
     }
+  }
+  lines.push('');
+
+  lines.push('[rerank]');
+  lines.push('# Optional HTTP rerank against any Cohere-compatible /rerank API.');
+  lines.push('# provider = "http"');
+  lines.push('# model = "rerank-v3.5"');
+  lines.push('# base_url inherits [memory.llm] when unset.');
+  if (isGlobal) {
+    lines.push('# Bearer inherits the memory LLM key when unset.');
   }
   lines.push('');
 

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -104,6 +104,7 @@ export default defineCommand({
       diagLines.push(`  Agent lane:      ${formatLane(agent.provider, agent.model, agent.baseUrl, agent.apiKey)}`);
       diagLines.push(`  Memory LLM lane: ${formatLane(resolved.memory.llm.provider, resolved.memory.llm.model, resolved.memory.llm.baseUrl, resolved.memory.llm.apiKey)}`);
       diagLines.push(`  Embedding lane:  ${formatLane(resolved.embedding.provider, resolved.embedding.model, resolved.embedding.baseUrl, resolved.embedding.apiKey)}`);
+      diagLines.push(`  Rerank lane:     ${formatLane(resolved.rerank.provider, resolved.rerank.model, resolved.rerank.baseUrl, resolved.rerank.apiKey)}`);
       diagLines.push(`  Memory behavior: inject=${resolved.memory.inject ?? 'default'}, formation=${resolved.memory.formation ?? 'default'}, autoCleanup=${resolved.memory.autoCleanup ?? 'default'}`);
       diagLines.push(`  Git behavior:    autoHook=${resolved.git.autoHook ?? 'default'}, ingestOnCommit=${resolved.git.ingestOnCommit ?? 'default'}, maxDiffSize=${resolved.git.maxDiffSize ?? 'default'}, skipMergeCommits=${resolved.git.skipMergeCommits ?? 'default'}`);
       diagLines.push(`  Server:          transport=${resolved.server.transport ?? 'default'}, dashboard=${resolved.server.dashboard ?? 'default'}, dashboardPort=${resolved.server.dashboardPort ?? 'default'}`);
@@ -141,6 +142,7 @@ export default defineCommand({
           agent: summarizeLane(agent.provider, agent.model, agent.baseUrl, agent.apiKey),
           memoryLlm: summarizeLane(resolved.memory.llm.provider, resolved.memory.llm.model, resolved.memory.llm.baseUrl, resolved.memory.llm.apiKey),
           embedding: summarizeLane(resolved.embedding.provider, resolved.embedding.model, resolved.embedding.baseUrl, resolved.embedding.apiKey),
+          rerank: summarizeLane(resolved.rerank.provider, resolved.rerank.model, resolved.rerank.baseUrl, resolved.rerank.apiKey),
         },
         memory: {
           inject: resolved.memory.inject ?? 'default',

--- a/src/config/resolved-config.ts
+++ b/src/config/resolved-config.ts
@@ -9,8 +9,8 @@ import {
   getProjectYamlPath,
 } from './config-paths.js';
 import { loadFileConfig } from './legacy-loader.js';
-import { loadTomlConfig } from './toml-loader.js';
-import { loadYamlConfig } from './yaml-loader.js';
+import { loadTomlConfig, type MemorixTomlConfig } from './toml-loader.js';
+import { loadYamlConfig, type MemorixYamlConfig } from './yaml-loader.js';
 import { loadDotenv } from './dotenv-loader.js';
 
 export interface ResolvedLaneOptions {
@@ -43,6 +43,12 @@ export interface ResolvedMemorixConfig {
     baseUrl?: string;
     apiKey?: string;
     dimensions?: number;
+  };
+  rerank: {
+    provider: 'off' | 'http';
+    model?: string;
+    baseUrl?: string;
+    apiKey?: string;
   };
   git: {
     autoHook?: boolean;
@@ -109,6 +115,16 @@ export function getResolvedConfig(options: ResolvedLaneOptions = {}): ResolvedMe
   const openRouterMemoryLlmApiKey = isOpenRouterMemoryLane(memoryLlmProvider, memoryLlmBaseUrl)
     ? process.env.OPENROUTER_API_KEY
     : undefined;
+  const memoryLlmApiKey = first(
+    process.env.MEMORIX_LLM_API_KEY,
+    process.env.MEMORIX_API_KEY,
+    toml.memory?.llm?.api_key,
+    yaml.llm?.apiKey,
+    legacy.llm?.apiKey,
+    process.env.OPENAI_API_KEY,
+    process.env.ANTHROPIC_API_KEY,
+    openRouterMemoryLlmApiKey,
+  );
 
   const resolved: ResolvedMemorixConfig = {
     agent: {
@@ -150,16 +166,7 @@ export function getResolvedConfig(options: ResolvedLaneOptions = {}): ResolvedMe
         provider: memoryLlmProvider,
         model: memoryLlmModel,
         baseUrl: memoryLlmBaseUrl,
-        apiKey: first(
-          process.env.MEMORIX_LLM_API_KEY,
-          process.env.MEMORIX_API_KEY,
-          toml.memory?.llm?.api_key,
-          yaml.llm?.apiKey,
-          legacy.llm?.apiKey,
-          process.env.OPENAI_API_KEY,
-          process.env.ANTHROPIC_API_KEY,
-          openRouterMemoryLlmApiKey,
-        ),
+        apiKey: memoryLlmApiKey,
       },
     },
     embedding: {
@@ -169,6 +176,12 @@ export function getResolvedConfig(options: ResolvedLaneOptions = {}): ResolvedMe
       apiKey: first(process.env.MEMORIX_EMBEDDING_API_KEY, toml.embedding?.api_key, yaml.embedding?.apiKey, legacy.embeddingApi?.apiKey, openRouterEmbeddingApiKey),
       dimensions: firstNumber(parseNumber(process.env.MEMORIX_EMBEDDING_DIMENSIONS), toml.embedding?.dimensions, yaml.embedding?.dimensions, legacy.embeddingApi?.dimensions),
     },
+    rerank: resolveRerankLane({
+      toml,
+      yaml,
+      memoryLlmApiKey,
+      memoryLlmBaseUrl,
+    }),
     git: {
       autoHook: firstBool(toml.git?.auto_hook, yaml.git?.autoHook),
       ingestOnCommit: firstBool(toml.git?.ingest_on_commit, yaml.git?.ingestOnCommit),
@@ -244,6 +257,10 @@ export function getResolvedEmbeddingLane(options: ResolvedLaneOptions = {}): Res
   return getResolvedConfig(options).embedding;
 }
 
+export function getResolvedRerankLane(options: ResolvedLaneOptions = {}): ResolvedMemorixConfig['rerank'] {
+  return getResolvedConfig(options).rerank;
+}
+
 export function resetResolvedConfigCache(): void {
   // Kept as a public test helper. File-level caches live in individual loaders.
 }
@@ -294,6 +311,10 @@ function getEnvSourceNames(): string[] {
     'MEMORIX_EMBEDDING_BASE_URL',
     'MEMORIX_EMBEDDING_MODEL',
     'MEMORIX_EMBEDDING_DIMENSIONS',
+    'MEMORIX_RERANK_PROVIDER',
+    'MEMORIX_RERANK_MODEL',
+    'MEMORIX_RERANK_BASE_URL',
+    'MEMORIX_RERANK_API_KEY',
     'MEMORIX_CODEGRAPH_EXTERNAL_CONTEXT',
     'MEMORIX_CODEGRAPH_EXTERNAL_COMMAND',
     'MEMORIX_CODEGRAPH_EXTERNAL_TIMEOUT_MS',
@@ -319,4 +340,46 @@ function normalizeExternalContext(value: string | undefined): 'auto' | 'off' | u
   const normalized = value?.trim().toLowerCase();
   if (normalized === 'auto' || normalized === 'off') return normalized;
   return undefined;
+}
+
+function normalizeRerankProvider(value: string | undefined): 'off' | 'http' {
+  const normalized = value?.trim().toLowerCase();
+  // `jina` is accepted as an alias for `http`.
+  if (normalized === 'http' || normalized === 'jina') return 'http';
+  return 'off';
+}
+
+function resolveRerankLane(args: {
+  toml: MemorixTomlConfig;
+  yaml: MemorixYamlConfig;
+  memoryLlmApiKey?: string;
+  memoryLlmBaseUrl?: string;
+}): ResolvedMemorixConfig['rerank'] {
+  const provider = normalizeRerankProvider(first(
+    process.env.MEMORIX_RERANK_PROVIDER,
+    args.toml.rerank?.provider,
+    args.yaml.rerank?.provider,
+    'off',
+  ));
+  const model = first(
+    process.env.MEMORIX_RERANK_MODEL,
+    args.toml.rerank?.model,
+    args.yaml.rerank?.model,
+  );
+  const explicitBaseUrl = first(
+    process.env.MEMORIX_RERANK_BASE_URL,
+    args.toml.rerank?.base_url,
+    args.yaml.rerank?.baseUrl,
+  );
+  const baseUrl = provider === 'http'
+    ? first(explicitBaseUrl, args.memoryLlmBaseUrl)
+    : explicitBaseUrl;
+  const apiKey = first(
+    process.env.MEMORIX_RERANK_API_KEY,
+    args.toml.rerank?.api_key,
+    args.yaml.rerank?.apiKey,
+    args.memoryLlmApiKey,
+  );
+
+  return { provider, model, baseUrl, apiKey };
 }

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -28,6 +28,13 @@ export interface MemorixTomlConfig {
     api_key?: string;
     dimensions?: number;
   };
+  /** Optional HTTP rerank against a compatible /rerank API. */
+  rerank?: {
+    provider?: 'off' | 'jina' | 'http' | string;
+    model?: string;
+    base_url?: string;
+    api_key?: string;
+  };
   hooks?: {
     native_memcode?: boolean;
     external_agents?: boolean;
@@ -97,6 +104,7 @@ function mergeTomlConfig(base: MemorixTomlConfig, override: MemorixTomlConfig): 
       llm: { ...base.memory?.llm, ...override.memory?.llm },
     },
     embedding: { ...base.embedding, ...override.embedding },
+    rerank: { ...base.rerank, ...override.rerank },
     hooks: { ...base.hooks, ...override.hooks },
     git: { ...base.git, ...override.git },
     codegraph: { ...base.codegraph, ...override.codegraph },

--- a/src/config/yaml-loader.ts
+++ b/src/config/yaml-loader.ts
@@ -48,6 +48,14 @@ export interface MemorixYamlConfig {
     dimensions?: number;
   };
 
+  /** Remote neural rerank (HTTP only) */
+  rerank?: {
+    provider?: 'off' | 'jina' | 'http' | string;
+    model?: string;
+    apiKey?: string;
+    baseUrl?: string;
+  };
+
   /** Git-Memory pipeline configuration */
   git?: {
     /** Auto-install post-commit hook on first run (default: false) */
@@ -190,6 +198,7 @@ export function loadYamlConfig(projectRoot?: string | null): MemorixYamlConfig {
     llm: { ...userConfig.llm, ...projectConfig.llm },
     agent: { ...userConfig.agent, ...projectConfig.agent },
     embedding: { ...userConfig.embedding, ...projectConfig.embedding },
+    rerank: { ...userConfig.rerank, ...projectConfig.rerank },
     git: { ...userConfig.git, ...projectConfig.git },
     codegraph: { ...userConfig.codegraph, ...projectConfig.codegraph },
     behavior: { ...userConfig.behavior, ...projectConfig.behavior },

--- a/src/rerank/http-provider.ts
+++ b/src/rerank/http-provider.ts
@@ -1,0 +1,123 @@
+/**
+ * Optional HTTP rerank client.
+ *
+ * Posts a Cohere-compatible `{model, query, documents}` body to
+ * `{base_url}/rerank` (or an explicit `/rerank` path). Compatible with
+ * Cohere, Jina, TEI, vLLM, and other `/rerank` endpoints. The model id is
+ * whatever the user configured — Memorix does not rewrite it.
+ */
+
+export type NeuralRerankProviderName = 'http';
+
+export interface NeuralRerankRequestConfig {
+  provider: NeuralRerankProviderName;
+  model?: string;
+  baseUrl: string;
+  apiKey?: string;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+export interface RerankedDocument {
+  index: number;
+  score: number;
+}
+
+/**
+ * Join a provider base URL with `/rerank`, leaving an explicit path intact.
+ */
+export function buildRerankUrl(baseUrl: string): string {
+  const trimmed = baseUrl.trim().replace(/\/+$/, '');
+  if (trimmed.endsWith('/rerank')) return trimmed;
+  return `${trimmed}/rerank`;
+}
+
+/**
+ * Accept Cohere/Jina `{results:[{index,relevance_score}]}` and TEI `[{index,score}]`.
+ */
+export function parseRerankResponse(payload: unknown): RerankedDocument[] {
+  const rows = extractRows(payload);
+  if (rows.length === 0) {
+    throw new Error('Neural rerank response contained no ranked results');
+  }
+  return rows.sort((a, b) => b.score - a.score);
+}
+
+function extractRows(payload: unknown): RerankedDocument[] {
+  if (Array.isArray(payload)) {
+    return payload.map(rowFromUnknown).filter((row): row is RerankedDocument => row !== null);
+  }
+  if (payload && typeof payload === 'object' && 'results' in payload) {
+    const results = (payload as { results: unknown }).results;
+    if (Array.isArray(results)) {
+      return results.map(rowFromUnknown).filter((row): row is RerankedDocument => row !== null);
+    }
+  }
+  throw new Error('Neural rerank response was not Cohere or TEI shaped');
+}
+
+function rowFromUnknown(value: unknown): RerankedDocument | null {
+  if (!value || typeof value !== 'object') return null;
+  const row = value as { index?: unknown; relevance_score?: unknown; score?: unknown };
+  if (typeof row.index !== 'number' || !Number.isFinite(row.index)) return null;
+  const score = typeof row.relevance_score === 'number'
+    ? row.relevance_score
+    : typeof row.score === 'number'
+      ? row.score
+      : null;
+  if (score === null || !Number.isFinite(score)) return null;
+  return { index: row.index, score };
+}
+
+function buildRerankBody(query: string, documents: string[], model?: string): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    query,
+    documents,
+    top_n: documents.length,
+    return_documents: false,
+  };
+  const trimmed = model?.trim();
+  if (trimmed) body.model = trimmed;
+  return body;
+}
+
+/**
+ * POST query + documents to a compatible `/rerank` endpoint and return ranked indexes.
+ */
+export async function rerankViaHttp(
+  query: string,
+  documents: string[],
+  config: NeuralRerankRequestConfig,
+): Promise<RerankedDocument[]> {
+  if (documents.length === 0) return [];
+
+  const url = buildRerankUrl(config.baseUrl);
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+  };
+  if (config.apiKey) {
+    headers.authorization = `Bearer ${config.apiKey}`;
+  }
+
+  const controller = new AbortController();
+  const timeoutMs = config.timeoutMs && config.timeoutMs > 0 ? config.timeoutMs : 5000;
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const fetchImpl = config.fetchImpl ?? fetch;
+    const response = await fetchImpl(url, {
+      method: 'POST',
+      headers,
+      signal: controller.signal,
+      body: JSON.stringify(buildRerankBody(query, documents, config.model)),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Neural rerank HTTP ${response.status} from ${url}`);
+    }
+
+    return parseRerankResponse(await response.json());
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/rerank/index.ts
+++ b/src/rerank/index.ts
@@ -1,0 +1,69 @@
+/**
+ * Optional HTTP rerank lane. LLM fallback lives in quality.ts.
+ */
+
+import { getResolvedRerankLane, type ResolvedLaneOptions } from '../config/resolved-config.js';
+import { rerankViaHttp } from './http-provider.js';
+
+/** Minimal search hit the HTTP reranker can reorder. */
+export interface NeuralRerankCandidate {
+  id: string;
+  title: string;
+  type: string;
+  score: number;
+  narrative?: string;
+}
+
+const MAX_RERANK = 10;
+
+/**
+ * True when an HTTP `/rerank` endpoint is configured.
+ */
+export function isNeuralRerankEnabled(options: ResolvedLaneOptions = {}): boolean {
+  const lane = getResolvedRerankLane(options);
+  return lane.provider === 'http' && Boolean(lane.baseUrl);
+}
+
+/**
+ * Reorder search candidates via the configured remote reranker.
+ * Returns null when the provider is off or the HTTP call cannot be used.
+ */
+export async function neuralRerankCandidates(
+  query: string,
+  candidates: NeuralRerankCandidate[],
+  options: ResolvedLaneOptions = {},
+): Promise<NeuralRerankCandidate[] | null> {
+  if (!isNeuralRerankEnabled(options) || candidates.length === 0) return null;
+
+  const lane = getResolvedRerankLane(options);
+  const toRerank = candidates.slice(0, MAX_RERANK);
+  const rest = candidates.slice(MAX_RERANK);
+  const documents = toRerank.map((candidate) => candidateText(candidate));
+
+  const ranked = await rerankViaHttp(query, documents, {
+    provider: 'http',
+    model: lane.model,
+    baseUrl: lane.baseUrl!,
+    apiKey: lane.apiKey,
+  });
+
+  const seen = new Set<number>();
+  const reranked: NeuralRerankCandidate[] = [];
+  for (const row of ranked) {
+    const candidate = toRerank[row.index];
+    if (!candidate || seen.has(row.index)) continue;
+    reranked.push(candidate);
+    seen.add(row.index);
+  }
+  for (const [index, candidate] of toRerank.entries()) {
+    if (!seen.has(index)) reranked.push(candidate);
+  }
+  reranked.push(...rest);
+  return reranked;
+}
+
+function candidateText(candidate: NeuralRerankCandidate): string {
+  const narrative = candidate.narrative?.trim();
+  if (narrative) return `${candidate.title} — ${narrative.slice(0, 200)}`;
+  return candidate.title;
+}

--- a/src/store/orama-store.ts
+++ b/src/store/orama-store.ts
@@ -1031,47 +1031,70 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
     })();
 
   if (shouldRerank) {
+    const narrativeMap = new Map<string, string>();
+    for (const hit of results.hits) {
+      const doc = hit.document as unknown as MemorixDocument;
+      narrativeMap.set(makeEntryKey(doc.projectId, doc.observationId), doc.narrative);
+    }
+    const RERANK_TOP_K = 5;
+    const toRerank = intermediate.slice(0, RERANK_TOP_K);
+    const candidates = toRerank.map((e, index) => ({
+      id: `r${index + 1}`,
+      title: e.title,
+      type: e.type,
+      score: e.score,
+      narrative: narrativeMap.get(makeEntryKey(e.projectId, e.id)),
+    }));
+    const _parsedRerank = parseInt(process.env.MEMORIX_RERANK_TIMEOUT_MS || '', 10);
+    const RERANK_TIMEOUT_MS = Number.isFinite(_parsedRerank) && _parsedRerank > 0 ? _parsedRerank : 5000;
+    const candidateMap = new Map(candidates.map((candidate, index) => [candidate.id, toRerank[index]]));
+    let applied = false;
+
     try {
-      const { rerankResults } = await import('../llm/quality.js');
-      const narrativeMap = new Map<string, string>();
-      for (const hit of results.hits) {
-        const doc = hit.document as unknown as MemorixDocument;
-        narrativeMap.set(makeEntryKey(doc.projectId, doc.observationId), doc.narrative);
-      }
-      // Rerank only top-5 (was 10) to save LLM tokens and latency
-      const RERANK_TOP_K = 5;
-      const toRerank = intermediate.slice(0, RERANK_TOP_K);
-      const candidates = toRerank.map((e, index) => ({
-        id: `r${index + 1}`,
-        title: e.title,
-        type: e.type,
-        score: e.score,
-        narrative: narrativeMap.get(makeEntryKey(e.projectId, e.id)),
-      }));
-      
-      // LLM rerank timeout: configurable via MEMORIX_RERANK_TIMEOUT_MS, default 5s
-      const _parsedRerank = parseInt(process.env.MEMORIX_RERANK_TIMEOUT_MS || '', 10);
-      const RERANK_TIMEOUT_MS = Number.isFinite(_parsedRerank) && _parsedRerank > 0 ? _parsedRerank : 5000;
-      const { reranked, usedLLM } = await withTimeout(
-        rerankResults(originalQuery!, candidates),
-        RERANK_TIMEOUT_MS,
-        'LLM rerank',
-      );
-      mark(`rerank(usedLLM=${usedLLM})`);
-      
-      if (usedLLM) {
-        lastSearchModeByProject.set(modeKey, (lastSearchModeByProject.get(modeKey) ?? 'fulltext') + ' + LLM rerank');
-        const candidateMap = new Map(candidates.map((candidate, index) => [candidate.id, toRerank[index]]));
-        const rerankedTop = reranked
-          .map(r => candidateMap.get(r.id))
-          .filter((e): e is NonNullable<typeof e> => e != null);
-        if (rerankedTop.length > 0) {
-          intermediate = [...rerankedTop, ...intermediate.slice(RERANK_TOP_K)];
+      const { isNeuralRerankEnabled, neuralRerankCandidates } = await import('../rerank/index.js');
+      if (isNeuralRerankEnabled()) {
+        const neural = await withTimeout(
+          neuralRerankCandidates(originalQuery!, candidates),
+          RERANK_TIMEOUT_MS,
+          'neural rerank',
+        );
+        if (neural && neural.length > 0) {
+          const rerankedTop = neural
+            .map((row) => candidateMap.get(row.id))
+            .filter((entry): entry is NonNullable<typeof entry> => entry != null);
+          if (rerankedTop.length > 0) {
+            intermediate = [...rerankedTop, ...intermediate.slice(RERANK_TOP_K)];
+            lastSearchModeByProject.set(modeKey, (lastSearchModeByProject.get(modeKey) ?? 'fulltext') + ' + neural rerank');
+            mark('rerank(usedNeural=true)');
+            applied = true;
+          }
         }
       }
-    } catch (error) {
-      // Reranking is best-effort: fall back to original order on timeout or error
-      console.error('[memorix] LLM rerank failed or timed out, using original order');
+    } catch {
+      console.error('[memorix] neural rerank failed or timed out, trying LLM fallback');
+    }
+
+    if (!applied) {
+      try {
+        const { rerankResults } = await import('../llm/quality.js');
+        const { reranked, usedLLM } = await withTimeout(
+          rerankResults(originalQuery!, candidates),
+          RERANK_TIMEOUT_MS,
+          'LLM rerank',
+        );
+        mark(`rerank(usedLLM=${usedLLM})`);
+        if (usedLLM) {
+          lastSearchModeByProject.set(modeKey, (lastSearchModeByProject.get(modeKey) ?? 'fulltext') + ' + LLM rerank');
+          const rerankedTop = reranked
+            .map((row) => candidateMap.get(row.id))
+            .filter((entry): entry is NonNullable<typeof entry> => entry != null);
+          if (rerankedTop.length > 0) {
+            intermediate = [...rerankedTop, ...intermediate.slice(RERANK_TOP_K)];
+          }
+        }
+      } catch {
+        console.error('[memorix] LLM rerank failed or timed out, using original order');
+      }
     }
   } else {
     mark(`rerank(skipped,tier=${tier})`);

--- a/tests/cli/config-command.test.ts
+++ b/tests/cli/config-command.test.ts
@@ -156,6 +156,7 @@ describe('memorix config commands', () => {
     expect(notes).toContain('Agent lane');
     expect(notes).toContain('Memory LLM lane');
     expect(notes).toContain('Embedding lane');
+    expect(notes).toContain('Rerank lane');
     expect(notes).toContain('<redacted>');
     expect(notes).not.toContain('status-secret-key');
   });

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -80,6 +80,8 @@ describe('init TOML templates', () => {
     expect(content).toContain('[memory.llm]');
     expect(content).toContain('provider = "openai"');
     expect(content).toContain('[embedding]');
+    expect(content).toContain('[rerank]');
+    expect(content).toContain('rerank-v3.5');
     expect(content).toContain('# api_key = "..."');
     expect(content).toContain('Global config may store local credentials');
   });
@@ -99,6 +101,7 @@ describe('init TOML templates', () => {
     expect(content).toContain('[agent]');
     expect(content).toContain('[memory.llm]');
     expect(content).toContain('[embedding]');
+    expect(content).toContain('[rerank]');
     expect(content).toContain('Project config should not store credentials');
     expect(content).not.toContain('api_key');
   });

--- a/tests/config/resolved-config.test.ts
+++ b/tests/config/resolved-config.test.ts
@@ -7,6 +7,7 @@ import {
   getResolvedConfigForCwd,
   getResolvedEmbeddingLane,
   getResolvedMemoryLane,
+  getResolvedRerankLane,
   resetResolvedConfigCache,
 } from '../../src/config/resolved-config.js';
 import { resetTomlConfigCache } from '../../src/config/toml-loader.js';
@@ -32,6 +33,10 @@ const ENV_KEYS = [
   'MEMORIX_EMBEDDING_BASE_URL',
   'MEMORIX_EMBEDDING_MODEL',
   'MEMORIX_EMBEDDING_DIMENSIONS',
+  'MEMORIX_RERANK_PROVIDER',
+  'MEMORIX_RERANK_MODEL',
+  'MEMORIX_RERANK_BASE_URL',
+  'MEMORIX_RERANK_API_KEY',
   'MEMORIX_CODEGRAPH_EXTERNAL_CONTEXT',
   'MEMORIX_CODEGRAPH_EXTERNAL_COMMAND',
   'MEMORIX_CODEGRAPH_EXTERNAL_TIMEOUT_MS',
@@ -195,6 +200,39 @@ describe('resolved config', () => {
     expect(cfg.git.maxDiffSize).toBe(2048);
     expect(cfg.git.skipMergeCommits).toBe(false);
     expect(cfg.git.excludePatterns).toEqual(['dist/**', '*.lock']);
+  });
+
+  it('resolves HTTP rerank from env above TOML and inherits the LLM bearer', () => {
+    writeFileSync(join(HOME, '.memorix', 'config.toml'), [
+      '[memory.llm]',
+      'base_url = "https://llm.example/v1"',
+      'api_key = "llm-key"',
+      '',
+      '[rerank]',
+      'provider = "http"',
+      'model = "rerank-v3.5"',
+    ].join('\n'), 'utf8');
+    process.env.MEMORIX_RERANK_PROVIDER = 'http';
+
+    const lane = getResolvedRerankLane({ projectRoot: null, homeDir: HOME });
+
+    expect(lane.provider).toBe('http');
+    expect(lane.model).toBe('rerank-v3.5');
+    expect(lane.baseUrl).toBe('https://llm.example/v1');
+    expect(lane.apiKey).toBe('llm-key');
+    expect(getResolvedConfig({ projectRoot: null, homeDir: HOME }).sources.env).toContain('MEMORIX_RERANK_PROVIDER');
+  });
+
+  it('keeps a public Jina-compatible host when the user configured it', () => {
+    process.env.MEMORIX_RERANK_PROVIDER = 'http';
+    process.env.MEMORIX_RERANK_BASE_URL = 'https://api.jina.ai/v1';
+    process.env.MEMORIX_RERANK_MODEL = 'jina-reranker-v2-base-multilingual';
+    process.env.MEMORIX_RERANK_API_KEY = 'jina-key';
+
+    const lane = getResolvedRerankLane({ projectRoot: null, homeDir: HOME });
+    expect(lane.provider).toBe('http');
+    expect(lane.baseUrl).toBe('https://api.jina.ai/v1');
+    expect(lane.model).toBe('jina-reranker-v2-base-multilingual');
   });
 
   it('resolves CodeGraph scan limits from TOML above legacy YAML', () => {

--- a/tests/rerank/http-provider.test.ts
+++ b/tests/rerank/http-provider.test.ts
@@ -1,0 +1,179 @@
+/**
+ * HTTP rerank provider tests.
+ *
+ * Cohere-compatible POST {base_url}/rerank. Model id is sent as configured.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildRerankUrl,
+  parseRerankResponse,
+  rerankViaHttp,
+} from '../../src/rerank/http-provider.js';
+
+const EXAMPLE_BASE = 'https://rerank.example/v1';
+const EXAMPLE_MODEL = 'rerank-v3.5';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('buildRerankUrl', () => {
+  it('appends /rerank to a v1 base URL', () => {
+    expect(buildRerankUrl(EXAMPLE_BASE)).toBe(`${EXAMPLE_BASE}/rerank`);
+    expect(buildRerankUrl('https://api.example.com/v1/')).toBe('https://api.example.com/v1/rerank');
+  });
+
+  it('keeps an explicit /rerank path', () => {
+    expect(buildRerankUrl('http://127.0.0.1:8080/rerank')).toBe('http://127.0.0.1:8080/rerank');
+  });
+});
+
+describe('parseRerankResponse', () => {
+  it('reads Cohere results[].relevance_score', () => {
+    const ranked = parseRerankResponse({
+      results: [
+        { index: 2, relevance_score: 0.91 },
+        { index: 0, relevance_score: 0.4 },
+      ],
+    });
+    expect(ranked).toEqual([
+      { index: 2, score: 0.91 },
+      { index: 0, score: 0.4 },
+    ]);
+  });
+
+  it('reads TEI [{index, score}] arrays', () => {
+    const ranked = parseRerankResponse([
+      { index: 1, score: 0.8 },
+      { index: 0, score: 0.2 },
+    ]);
+    expect(ranked).toEqual([
+      { index: 1, score: 0.8 },
+      { index: 0, score: 0.2 },
+    ]);
+  });
+
+  it('rejects empty or malformed payloads', () => {
+    expect(() => parseRerankResponse({})).toThrow(/rerank/i);
+    expect(() => parseRerankResponse({ results: [] })).toThrow(/rerank/i);
+  });
+});
+
+describe('rerankViaHttp', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('posts the Cohere wire format to {base_url}/rerank', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe(`${EXAMPLE_BASE}/rerank`);
+      expect(init?.method).toBe('POST');
+      const headers = new Headers(init?.headers);
+      expect(headers.get('authorization')).toBe('Bearer rerank-key');
+      const body = JSON.parse(String(init?.body));
+      expect(body).toEqual({
+        model: EXAMPLE_MODEL,
+        query: 'JWT expiry',
+        documents: ['gotcha about tokens', 'unrelated database note'],
+        top_n: 2,
+        return_documents: false,
+      });
+      return jsonResponse({
+        model: EXAMPLE_MODEL,
+        results: [
+          { index: 0, relevance_score: 0.88 },
+          { index: 1, relevance_score: 0.11 },
+        ],
+      });
+    });
+
+    const ranked = await rerankViaHttp(
+      'JWT expiry',
+      ['gotcha about tokens', 'unrelated database note'],
+      {
+        provider: 'http',
+        model: EXAMPLE_MODEL,
+        baseUrl: EXAMPLE_BASE,
+        apiKey: 'rerank-key',
+        fetchImpl,
+      },
+    );
+
+    expect(ranked.map((row) => row.index)).toEqual([0, 1]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends the configured model string unchanged', async () => {
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.model).toBe('vendor/rerank-large');
+      return jsonResponse({ results: [{ index: 0, relevance_score: 1 }] });
+    });
+
+    await rerankViaHttp('q', ['a'], {
+      provider: 'http',
+      model: 'vendor/rerank-large',
+      baseUrl: EXAMPLE_BASE,
+      fetchImpl,
+    });
+  });
+
+  it('omits model when none is configured', async () => {
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.model).toBeUndefined();
+      return jsonResponse({ results: [{ index: 0, relevance_score: 1 }] });
+    });
+
+    await rerankViaHttp('q', ['a'], {
+      provider: 'http',
+      baseUrl: EXAMPLE_BASE,
+      fetchImpl,
+    });
+  });
+
+  it('calls a public Jina-compatible host when the user configured it', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL) => {
+      expect(String(input)).toBe('https://api.jina.ai/v1/rerank');
+      return jsonResponse({ results: [{ index: 0, relevance_score: 1 }] });
+    });
+
+    await rerankViaHttp('q', ['a'], {
+      provider: 'http',
+      model: 'jina-reranker-v2-base-multilingual',
+      baseUrl: 'https://api.jina.ai/v1',
+      apiKey: 'jina-key',
+      fetchImpl,
+    });
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits Authorization when no API key is configured', async () => {
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      expect(headers.get('authorization')).toBeNull();
+      return jsonResponse({ results: [{ index: 0, relevance_score: 1 }] });
+    });
+
+    await rerankViaHttp('q', ['only'], {
+      provider: 'http',
+      baseUrl: 'http://127.0.0.1:8080',
+      fetchImpl,
+    });
+  });
+
+  it('throws on HTTP errors so the caller can fall back to LLM rerank', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ error: 'nope' }, 502));
+
+    await expect(rerankViaHttp('q', ['a', 'b'], {
+      provider: 'http',
+      baseUrl: EXAMPLE_BASE,
+      apiKey: 'k',
+      fetchImpl,
+    })).rejects.toThrow(/502/);
+  });
+});

--- a/tests/rerank/neural-rerank.test.ts
+++ b/tests/rerank/neural-rerank.test.ts
@@ -1,0 +1,111 @@
+/**
+ * HTTP rerank lane: configured /rerank endpoint, then original order on failure.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { resetTomlConfigCache } from '../../src/config/toml-loader.js';
+import { resetYamlConfigCache } from '../../src/config/yaml-loader.js';
+import { resetResolvedConfigCache } from '../../src/config/resolved-config.js';
+
+const TMP = join(process.cwd(), '.tmp-neural-rerank-test');
+const HOME = join(TMP, 'home');
+
+const ENV_KEYS = [
+  'MEMORIX_RERANK_PROVIDER',
+  'MEMORIX_RERANK_MODEL',
+  'MEMORIX_RERANK_BASE_URL',
+  'MEMORIX_RERANK_API_KEY',
+  'MEMORIX_LLM_BASE_URL',
+  'MEMORIX_LLM_API_KEY',
+];
+
+async function loadLane() {
+  const { isNeuralRerankEnabled, neuralRerankCandidates } = await import('../../src/rerank/index.js');
+  return { isNeuralRerankEnabled, neuralRerankCandidates };
+}
+
+describe('neural rerank lane', () => {
+  afterEach(() => {
+    rmSync(TMP, { recursive: true, force: true });
+    resetTomlConfigCache();
+    resetYamlConfigCache();
+    resetResolvedConfigCache();
+    for (const key of ENV_KEYS) delete process.env[key];
+    vi.resetModules();
+  });
+
+  it('is off by default', async () => {
+    mkdirSync(join(HOME, '.memorix'), { recursive: true });
+    const { isNeuralRerankEnabled } = await loadLane();
+    expect(isNeuralRerankEnabled({ projectRoot: null, homeDir: HOME })).toBe(false);
+  });
+
+  it('inherits base URL and bearer from the memory LLM lane', async () => {
+    mkdirSync(join(HOME, '.memorix'), { recursive: true });
+    writeFileSync(join(HOME, '.memorix', 'config.toml'), [
+      '[memory.llm]',
+      'base_url = "https://llm.example/v1"',
+      'api_key = "llm-from-memory"',
+      '',
+      '[rerank]',
+      'provider = "http"',
+      'model = "rerank-v3.5"',
+    ].join('\n'), 'utf8');
+
+    const { getResolvedRerankLane } = await import('../../src/config/resolved-config.js');
+    const lane = getResolvedRerankLane({ projectRoot: null, homeDir: HOME });
+    expect(lane.provider).toBe('http');
+    expect(lane.model).toBe('rerank-v3.5');
+    expect(lane.baseUrl).toBe('https://llm.example/v1');
+    expect(lane.apiKey).toBe('llm-from-memory');
+  });
+
+  it('keeps a public Jina-compatible host enabled when configured', async () => {
+    mkdirSync(join(HOME, '.memorix'), { recursive: true });
+    writeFileSync(join(HOME, '.memorix', 'config.toml'), [
+      '[rerank]',
+      'provider = "http"',
+      'base_url = "https://api.jina.ai/v1"',
+      'model = "jina-reranker-v2-base-multilingual"',
+      'api_key = "jina-key"',
+    ].join('\n'), 'utf8');
+
+    const { getResolvedRerankLane } = await import('../../src/config/resolved-config.js');
+    const { isNeuralRerankEnabled } = await loadLane();
+    const lane = getResolvedRerankLane({ projectRoot: null, homeDir: HOME });
+    expect(lane.provider).toBe('http');
+    expect(lane.baseUrl).toBe('https://api.jina.ai/v1');
+    expect(lane.model).toBe('jina-reranker-v2-base-multilingual');
+    expect(isNeuralRerankEnabled({ projectRoot: null, homeDir: HOME })).toBe(true);
+  });
+
+  it('reorders candidates from a Cohere-shaped response', async () => {
+    process.env.MEMORIX_RERANK_PROVIDER = 'http';
+    process.env.MEMORIX_RERANK_BASE_URL = 'https://rerank.example/v1';
+    process.env.MEMORIX_RERANK_MODEL = 'rerank-v3.5';
+    process.env.MEMORIX_RERANK_API_KEY = 'rerank-key';
+    mkdirSync(join(HOME, '.memorix'), { recursive: true });
+
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      results: [
+        { index: 2, relevance_score: 0.99 },
+        { index: 0, relevance_score: 0.4 },
+        { index: 1, relevance_score: 0.1 },
+      ],
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+    vi.stubGlobal('fetch', fetchImpl);
+
+    const { neuralRerankCandidates } = await loadLane();
+    const reranked = await neuralRerankCandidates('JWT', [
+      { id: 'r1', title: 'alpha', type: 'gotcha', score: 1 },
+      { id: 'r2', title: 'beta', type: 'gotcha', score: 0.9 },
+      { id: 'r3', title: 'gamma', type: 'gotcha', score: 0.8 },
+    ], { projectRoot: null, homeDir: HOME });
+
+    expect(reranked?.map((row) => row.id)).toEqual(['r3', 'r1', 'r2']);
+    expect(String(fetchImpl.mock.calls[0]?.[0])).toBe('https://rerank.example/v1/rerank');
+    vi.unstubAllGlobals();
+  });
+});


### PR DESCRIPTION
## Summary
Search ranking today is lexical plus an optional LLM rerank. There is no hook for a dedicated neural rerank API.

This adds an optional HTTP rerank lane. When `[rerank] provider = "http"`, thorough/heavy/ambiguous search POSTs a Cohere-compatible `{model, query, documents}` body to `{base_url}/rerank` (or an explicit `/rerank` path). Responses accept Cohere `{results:[{index,relevance_score}]}` and TEI `[{index,score}]`.

The model id is user-configured and sent unchanged. Auth reuses the existing memory LLM bearer (`MEMORIX_LLM_API_KEY` / `MEMORIX_API_KEY` / `[memory.llm].api_key`) unless `MEMORIX_RERANK_API_KEY` is set. Compatible with any Cohere-style `/rerank` endpoint. LLM rerank remains the fallback. Off by default.

## Enable

```toml
[rerank]
provider = "http"
model = "rerank-model"
base_url = "https://api.example.com/v1"
```

`base_url` and the bearer inherit `[memory.llm]` when unset. Timeout: `MEMORIX_RERANK_TIMEOUT_MS` (default 5000).

## Test plan
- [x] `vitest run tests/rerank tests/config/resolved-config.test.ts tests/cli/init.test.ts tests/cli/config-command.test.ts`
- [ ] `memorix status` shows the rerank lane when configured
- [ ] With a compatible `/rerank` endpoint, thorough search reorders top hits; on HTTP failure, LLM rerank still runs