### PR TITLE
feat(rerank): add optional HTTP rerank provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,8 @@
 
 # ── HTTP rerank (optional) ──
 # Cohere-compatible POST {base_url}/rerank. Model id is sent as configured.
-# Bearer inherits the memory LLM key when unset.
+# Bearer inherits the memory LLM key only when BASE_URL matches the LLM endpoint.
+# Set MEMORIX_RERANK_API_KEY when the rerank host is different.
 # MEMORIX_RERANK_PROVIDER=http
 # MEMORIX_RERANK_MODEL=rerank-model
 # MEMORIX_RERANK_BASE_URL=https://api.example.com/v1

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,14 @@
 # MEMORIX_EMBEDDING_API_KEY=sk-your-key-here
 # MEMORIX_EMBEDDING_BASE_URL=https://api.openai.com/v1
 
+# ── HTTP rerank (optional) ──
+# Cohere-compatible POST {base_url}/rerank. Model id is sent as configured.
+# Bearer inherits the memory LLM key when unset.
+# MEMORIX_RERANK_PROVIDER=http
+# MEMORIX_RERANK_MODEL=rerank-model
+# MEMORIX_RERANK_BASE_URL=https://api.example.com/v1
+# MEMORIX_RERANK_API_KEY=
+
 # ── Unified Key (optional) ──
 # Single key that works for both LLM and Embedding
 # MEMORIX_API_KEY=sk-your-key-here

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ All notable changes to this project will be documented in this file.
   hooks, and HTTP MCP instead of the retired per-project directory layout.
 - **Correct background entrypoint** -- `memorix background start` launches the
   built HTTP CLI entrypoint rather than the stdio library entry.
+
 ## [1.6.1] - 2026-08-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ All notable changes to this project will be documented in this file.
   when `rerank.base_url` points at a different endpoint. If a Memory LLM
   key is present, that foreign host is not called until
   `MEMORIX_RERANK_API_KEY` / `rerank.api_key` is set.
+- Codegraph CLI tests close git/sqlite sandboxes with retries so Windows
+  `afterEach` cannot hang past vitest's 10s hookTimeout.
 
 ## [1.7.2] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,18 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- **Optional HTTP rerank** -- Thorough/heavy/ambiguous search can reorder
-  top hits through a configurable Cohere-compatible `POST {base_url}/rerank`
-  endpoint (`{model, query, documents}`). Works with any compatible `/rerank`
-  API. Configure `[rerank]` or `MEMORIX_RERANK_*`; base URL and bearer inherit
-  the memory LLM lane when unset. The model id is user-configured. LLM rerank
-  remains the fallback.
+- **Optional HTTP rerank** -- Thorough search with at least 3 candidates can
+  reorder top hits through a configurable Cohere-compatible
+  `POST {base_url}/rerank` endpoint (`{model, query, documents}`). Works with
+  any compatible `/rerank` API. Configure `[rerank]` or `MEMORIX_RERANK_*`;
+  base URL and bearer inherit the memory LLM lane when unset. The model id is
+  user-configured. When HTTP rerank is configured, a miss or timeout keeps
+  the original order (no LLM fallback). LLM rerank remains available when
+  HTTP rerank is off.
+
+### Fixed
+- HTTP rerank honors `MEMORIX_RERANK_TIMEOUT_MS` on the inner fetch
+  (default 30s) instead of aborting at 5s.
 
 ## [1.7.2] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ All notable changes to this project will be documented in this file.
 - HTTP rerank honors `MEMORIX_RERANK_TIMEOUT_MS` on the inner fetch
   (default 30s) instead of aborting at 5s.
 - HTTP rerank no longer inherits or transmits the memory LLM credential
-  when `rerank.base_url` points at a different endpoint.
+  when `rerank.base_url` points at a different endpoint. If a Memory LLM
+  key is present, that foreign host is not called until
+  `MEMORIX_RERANK_API_KEY` / `rerank.api_key` is set.
 
 ## [1.7.2] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,18 @@ All notable changes to this project will be documented in this file.
   reorder top hits through a configurable Cohere-compatible
   `POST {base_url}/rerank` endpoint (`{model, query, documents}`). Works with
   any compatible `/rerank` API. Configure `[rerank]` or `MEMORIX_RERANK_*`;
-  base URL and bearer inherit the memory LLM lane when unset. The model id is
-  user-configured. When HTTP rerank is configured, a miss or timeout keeps
-  the original order (no LLM fallback). LLM rerank remains available when
-  HTTP rerank is off.
+  base URL inherits the memory LLM lane when unset. Bearer inherits only
+  when the effective rerank URL is that same trusted endpoint; a different
+  host requires `MEMORIX_RERANK_API_KEY` / `rerank.api_key`. The model id
+  is user-configured. When HTTP rerank is configured, a miss or timeout
+  keeps the original order (no LLM fallback). LLM rerank remains available
+  when HTTP rerank is off.
 
 ### Fixed
 - HTTP rerank honors `MEMORIX_RERANK_TIMEOUT_MS` on the inner fetch
   (default 30s) instead of aborting at 5s.
+- HTTP rerank no longer inherits or transmits the memory LLM credential
+  when `rerank.base_url` points at a different endpoint.
 
 ## [1.7.2] - 2026-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Optional HTTP rerank** -- Thorough/heavy/ambiguous search can reorder
+  top hits through a configurable Cohere-compatible `POST {base_url}/rerank`
+  endpoint (`{model, query, documents}`). Works with any compatible `/rerank`
+  API. Configure `[rerank]` or `MEMORIX_RERANK_*`; base URL and bearer inherit
+  the memory LLM lane when unset. The model id is user-configured. LLM rerank
+  remains the fallback.
+
 ## [1.7.2] - 2026-08-19
 
 ### Changed
@@ -29,7 +37,6 @@ All notable changes to this project will be documented in this file.
 - **Centered maintenance preview** -- the Cleanup preview dialog is centered
   on desktop and narrow screens, including after the Dashboard global reset
   styles are applied.
-
 ## [1.7.0] - 2026-08-18
 
 ### Added
@@ -85,7 +92,6 @@ All notable changes to this project will be documented in this file.
   hooks, and HTTP MCP instead of the retired per-project directory layout.
 - **Correct background entrypoint** -- `memorix background start` launches the
   built HTTP CLI entrypoint rather than the stdio library entry.
-
 ## [1.6.1] - 2026-08-17
 
 ### Fixed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -391,7 +391,7 @@ Resolution order:
 2. project `.env`
 3. user `~/.memorix/.env`
 
-The primary lanes are `[agent]` for memcode, `[memory.llm]` for formation/rerank/summaries, and `[embedding]` for semantic search. The dashboard and `memorix status` expose config provenance so the active value source is visible.
+The primary lanes are `[agent]` for memcode, `[memory.llm]` for formation/summaries/LLM-rerank fallback, `[rerank]` for optional HTTP rerank against a compatible `/rerank` API, and `[embedding]` for semantic search. The dashboard and `memorix status` expose config provenance so the active value source is visible.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -209,7 +209,10 @@ Common keys:
   `https://api.example.com/v1` or `http://127.0.0.1:8080`. When unset and
   `provider = "http"`, Memorix inherits `[memory.llm].base_url`.
 - `api_key` — bearer token. When unset, inherits the memory LLM key
-  (`MEMORIX_LLM_API_KEY`, `MEMORIX_API_KEY`, or `[memory.llm].api_key`).
+  (`MEMORIX_LLM_API_KEY`, `MEMORIX_API_KEY`, or `[memory.llm].api_key`)
+  only if the effective `base_url` is the same trusted endpoint as
+  `[memory.llm].base_url`. A different rerank URL requires
+  `MEMORIX_RERANK_API_KEY` or `rerank.api_key`.
 
 Environment overrides (highest priority after CLI flags):
 
@@ -217,7 +220,7 @@ Environment overrides (highest priority after CLI flags):
 MEMORIX_RERANK_PROVIDER=http
 MEMORIX_RERANK_MODEL=rerank-model
 MEMORIX_RERANK_BASE_URL=https://api.example.com/v1
-# MEMORIX_RERANK_API_KEY=   # optional; inherits the memory LLM bearer
+# MEMORIX_RERANK_API_KEY=   # required when base_url is not the memory LLM endpoint
 ```
 
 If the memory LLM lane already points at the same gateway, you can enable

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -194,7 +194,7 @@ OpenAI-only default. The equivalent env-var form is
 
 ### `[rerank]`
 
-Optional HTTP rerank for thorough/heavy/ambiguous search. Off by default.
+Optional HTTP rerank for thorough search. Off by default.
 When `provider = "http"`, Memorix POSTs a Cohere-compatible
 `{model, query, documents}` body to `{base_url}/rerank` (or an explicit
 `/rerank` path). Any compatible endpoint works — hosted APIs, TEI, vLLM,
@@ -230,9 +230,11 @@ model = "rerank-model"
 ```
 
 or set `MEMORIX_RERANK_PROVIDER=http` and `MEMORIX_RERANK_MODEL=...`.
-Timeout is `MEMORIX_RERANK_TIMEOUT_MS` (default 5000). HTTP rerank runs
-first on the existing thorough/heavy/ambiguous search gate; LLM rerank is
-the fallback.
+Timeout is `MEMORIX_RERANK_TIMEOUT_MS` (default 30000). Thorough search
+with at least 3 candidates uses HTTP rerank when configured. On HTTP miss
+or timeout, Memorix keeps the original order and does not fall through to
+LLM rerank. LLM rerank remains available when HTTP rerank is off, on the
+existing thorough/heavy/ambiguous gate.
 
 Image analysis (visual description for ingested images) runs on the LLM lane
 through an OpenAI-compatible vision endpoint, so it can also use OpenRouter

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -47,6 +47,12 @@ model = "text-embedding-v4"
 base_url = "https://dashscope.aliyuncs.com/compatible-mode/v1"
 api_key = "..."
 
+# Optional HTTP rerank. Off unless provider = "http".
+# [rerank]
+# provider = "http"
+# model = "rerank-model"
+# base_url = "https://api.example.com/v1"
+
 [memory]
 inject = "minimal"
 formation = "active"
@@ -127,7 +133,7 @@ Used by Memorix background memory intelligence:
 - memory formation
 - summarization
 - deduplication
-- optional reranking
+- optional LLM reranking fallback
 - cleanup assistance
 
 Common keys:
@@ -185,6 +191,48 @@ defaults to `qwen/qwen3-embedding-8b` (4096 dimensions) instead of the
 OpenAI-only default. The equivalent env-var form is
 `MEMORIX_EMBEDDING=api`, `MEMORIX_EMBEDDING_BASE_URL=https://openrouter.ai/api/v1`,
 `MEMORIX_EMBEDDING_MODEL=qwen/qwen3-embedding-8b`.
+
+### `[rerank]`
+
+Optional HTTP rerank for thorough/heavy/ambiguous search. Off by default.
+When `provider = "http"`, Memorix POSTs a Cohere-compatible
+`{model, query, documents}` body to `{base_url}/rerank` (or an explicit
+`/rerank` path). Any compatible endpoint works — hosted APIs, TEI, vLLM,
+or a local gateway. Memorix sends the configured `model` string unchanged.
+
+Common keys:
+
+- `provider` — `off` (default) or `http`
+- `model` — user-configured model id (no built-in default). Example:
+  `rerank-model`
+- `base_url` — API root that serves `/rerank`, for example
+  `https://api.example.com/v1` or `http://127.0.0.1:8080`. When unset and
+  `provider = "http"`, Memorix inherits `[memory.llm].base_url`.
+- `api_key` — bearer token. When unset, inherits the memory LLM key
+  (`MEMORIX_LLM_API_KEY`, `MEMORIX_API_KEY`, or `[memory.llm].api_key`).
+
+Environment overrides (highest priority after CLI flags):
+
+```bash
+MEMORIX_RERANK_PROVIDER=http
+MEMORIX_RERANK_MODEL=rerank-model
+MEMORIX_RERANK_BASE_URL=https://api.example.com/v1
+# MEMORIX_RERANK_API_KEY=   # optional; inherits the memory LLM bearer
+```
+
+If the memory LLM lane already points at the same gateway, you can enable
+rerank with:
+
+```toml
+[rerank]
+provider = "http"
+model = "rerank-model"
+```
+
+or set `MEMORIX_RERANK_PROVIDER=http` and `MEMORIX_RERANK_MODEL=...`.
+Timeout is `MEMORIX_RERANK_TIMEOUT_MS` (default 5000). HTTP rerank runs
+first on the existing thorough/heavy/ambiguous search gate; LLM rerank is
+the fallback.
 
 Image analysis (visual description for ingested images) runs on the LLM lane
 through an OpenAI-compatible vision endpoint, so it can also use OpenRouter

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -75,7 +75,7 @@ On the release development machine used for this check, the healthy HTTP service
 | `MEMORIX_FORMATION_TIMEOUT_MS` | `12000` (12 s) | Raise when LLM-backed formation should outlive slow proxy/provider hops |
 | `MEMORIX_LLM_API_KEY` / `OPENAI_API_KEY` | unset | Enable LLM-backed enrichment, extraction, rerank, or skill generation |
 | `MEMORIX_LLM_TIMEOUT_MS` | `30000` (30 s) | Bound a single LLM-backed extraction/resolve call |
-| `MEMORIX_RERANK_TIMEOUT_MS` | 5000 | Bound HTTP and LLM rerank calls |
+| `MEMORIX_RERANK_TIMEOUT_MS` | 30000 | Bound HTTP and LLM rerank calls |
 | `MEMORIX_RERANK_PROVIDER` | `off` | Set `http` to enable optional HTTP rerank |
 | `MEMORIX_RERANK_BASE_URL` | `[memory.llm].base_url` | Compatible `/rerank` API root (path `/rerank` is appended) |
 | `memorix memory search --quality fast` | n/a | Force a fully local retrieval path for a latency-sensitive call |

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -75,7 +75,9 @@ On the release development machine used for this check, the healthy HTTP service
 | `MEMORIX_FORMATION_TIMEOUT_MS` | `12000` (12 s) | Raise when LLM-backed formation should outlive slow proxy/provider hops |
 | `MEMORIX_LLM_API_KEY` / `OPENAI_API_KEY` | unset | Enable LLM-backed enrichment, extraction, rerank, or skill generation |
 | `MEMORIX_LLM_TIMEOUT_MS` | `30000` (30 s) | Bound a single LLM-backed extraction/resolve call |
-| `MEMORIX_RERANK_TIMEOUT_MS` | provider default | Bound slow LLM rerank calls |
+| `MEMORIX_RERANK_TIMEOUT_MS` | 5000 | Bound HTTP and LLM rerank calls |
+| `MEMORIX_RERANK_PROVIDER` | `off` | Set `http` to enable optional HTTP rerank |
+| `MEMORIX_RERANK_BASE_URL` | `[memory.llm].base_url` | Compatible `/rerank` API root (path `/rerank` is appended) |
 | `memorix memory search --quality fast` | n/a | Force a fully local retrieval path for a latency-sensitive call |
 | `npm run benchmark:retrieval -- --records 1000 --runs 100` | n/a | Reproduce hot in-process lexical retrieval latency; not an end-to-end claim |
 | `npm run gate:large-store -- --records 40000` | n/a | Exercise SDK, HTTP MCP, hook persistence, cache integrity, and reopen behavior against a large isolated store |

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -498,7 +498,8 @@ What each lane does:
 | Lane | Used by |
 | --- | --- |
 | `[agent]` | model used by memcode while coding |
-| `[memory.llm]` | memory formation, summaries, deduplication, optional rerank |
+| `[memory.llm]` | memory formation, summaries, deduplication, optional LLM rerank fallback |
+| `[rerank]` | optional HTTP rerank against a compatible `/rerank` API |
 | `[embedding]` | semantic/vector search |
 | `[memory]` | memory injection and formation behavior |
 | `[git]` | Git Memory hook and ingestion behavior |

--- a/memorix.example.yml
+++ b/memorix.example.yml
@@ -36,7 +36,8 @@ embedding:
 
 # ── HTTP rerank (optional) ───────────────────────────────────
 # Cohere-compatible POST {baseUrl}/rerank. Model id is sent as configured.
-# Bearer inherits MEMORIX_LLM_API_KEY when apiKey is omitted.
+# Bearer inherits MEMORIX_LLM_API_KEY only when baseUrl is that same endpoint.
+# A different rerank host requires MEMORIX_RERANK_API_KEY / rerank.apiKey.
 # rerank:
 #   provider: http
 #   model: rerank-model

--- a/memorix.example.yml
+++ b/memorix.example.yml
@@ -34,6 +34,14 @@ embedding:
   # model: qwen/qwen3-embedding-8b
   # dimensions: 1024        # Override auto-detected dimensions
 
+# ── HTTP rerank (optional) ───────────────────────────────────
+# Cohere-compatible POST {baseUrl}/rerank. Model id is sent as configured.
+# Bearer inherits MEMORIX_LLM_API_KEY when apiKey is omitted.
+# rerank:
+#   provider: http
+#   model: rerank-model
+#   baseUrl: https://api.example.com/v1
+
 # ── Git-Memory Pipeline ──────────────────────────────────────
 # Automatically capture engineering knowledge from git commits.
 # Every commit becomes a searchable, immutable memory.

--- a/src/cli/commands/config-migrate.ts
+++ b/src/cli/commands/config-migrate.ts
@@ -69,6 +69,13 @@ export function serializeResolvedConfigToToml(
     dimensions: config.embedding.dimensions,
   });
 
+  writeSection(lines, 'rerank', {
+    provider: config.rerank.provider,
+    model: config.rerank.model,
+    base_url: config.rerank.baseUrl,
+    api_key: includeSecrets ? config.rerank.apiKey : undefined,
+  });
+
   writeSection(lines, 'memory', {
     inject: config.memory.inject,
     formation: config.memory.formation,

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -519,7 +519,7 @@ export default defineCommand({
         lines.push(ok(`Provider: ${config?.provider}/${config?.model}`));
         const { isNeuralRerankEnabled } = await import('../../rerank/index.js');
         const rerankCap = isNeuralRerankEnabled()
-          ? 'HTTP rerank, LLM rerank fallback'
+          ? 'HTTP rerank'
           : 'LLM rerank';
         lines.push(info(`Capabilities: fact extraction, auto-dedup, ${rerankCap}`));
         report.llm = { enabled: true, provider: config?.provider, model: config?.model };

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -517,7 +517,11 @@ export default defineCommand({
       if (isLLMEnabled()) {
         const config = getLLMConfig();
         lines.push(ok(`Provider: ${config?.provider}/${config?.model}`));
-        lines.push(info('Capabilities: fact extraction, auto-dedup, LLM rerank'));
+        const { isNeuralRerankEnabled } = await import('../../rerank/index.js');
+        const rerankCap = isNeuralRerankEnabled()
+          ? 'HTTP rerank, LLM rerank fallback'
+          : 'LLM rerank';
+        lines.push(info(`Capabilities: fact extraction, auto-dedup, ${rerankCap}`));
         report.llm = { enabled: true, provider: config?.provider, model: config?.model };
       } else {
         lines.push(info('LLM mode: off (heuristic dedup only)'));

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -187,6 +187,7 @@ export default defineCommand({
     envLines.push('# MEMORIX_RERANK_PROVIDER=http');
     envLines.push('# MEMORIX_RERANK_MODEL=rerank-model');
     envLines.push('# MEMORIX_RERANK_BASE_URL=https://api.example.com/v1');
+    envLines.push('# MEMORIX_RERANK_API_KEY=  # required when BASE_URL is not the memory LLM endpoint');
     envLines.push('');
     envLines.push('# Optional memory LLM simple key (does not apply to embedding or agent lanes)');
     envLines.push('# MEMORIX_API_KEY=sk-your-key-here');

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -321,7 +321,8 @@ export function buildInitTomlConfig(options: {
   lines.push('# model = "rerank-model"');
   lines.push('# base_url inherits [memory.llm] when unset.');
   if (isGlobal) {
-    lines.push('# Bearer inherits the memory LLM key when unset.');
+    lines.push('# Bearer inherits the memory LLM key only when that endpoint matches.');
+    lines.push('# A different rerank URL needs MEMORIX_RERANK_API_KEY.');
   }
   lines.push('');
 

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -183,6 +183,11 @@ export default defineCommand({
       envLines.push('');
     }
 
+    envLines.push('# Optional HTTP rerank (Cohere-compatible POST {base_url}/rerank)');
+    envLines.push('# MEMORIX_RERANK_PROVIDER=http');
+    envLines.push('# MEMORIX_RERANK_MODEL=rerank-model');
+    envLines.push('# MEMORIX_RERANK_BASE_URL=https://api.example.com/v1');
+    envLines.push('');
     envLines.push('# Optional memory LLM simple key (does not apply to embedding or agent lanes)');
     envLines.push('# MEMORIX_API_KEY=sk-your-key-here');
     envLines.push('');
@@ -307,6 +312,16 @@ export function buildInitTomlConfig(options: {
     if (isGlobal) {
       lines.push('# api_key = "..."');
     }
+  }
+  lines.push('');
+
+  lines.push('[rerank]');
+  lines.push('# Optional HTTP rerank against any Cohere-compatible /rerank API.');
+  lines.push('# provider = "http"');
+  lines.push('# model = "rerank-model"');
+  lines.push('# base_url inherits [memory.llm] when unset.');
+  if (isGlobal) {
+    lines.push('# Bearer inherits the memory LLM key when unset.');
   }
   lines.push('');
 

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -104,6 +104,7 @@ export default defineCommand({
       diagLines.push(`  Agent lane:      ${formatLane(agent.provider, agent.model, agent.baseUrl, agent.apiKey)}`);
       diagLines.push(`  Memory LLM lane: ${formatLane(resolved.memory.llm.provider, resolved.memory.llm.model, resolved.memory.llm.baseUrl, resolved.memory.llm.apiKey)}`);
       diagLines.push(`  Embedding lane:  ${formatLane(resolved.embedding.provider, resolved.embedding.model, resolved.embedding.baseUrl, resolved.embedding.apiKey)}`);
+      diagLines.push(`  Rerank lane:     ${formatLane(resolved.rerank.provider, resolved.rerank.model, resolved.rerank.baseUrl, resolved.rerank.apiKey)}`);
       diagLines.push(`  Memory behavior: inject=${resolved.memory.inject ?? 'default'}, formation=${resolved.memory.formation ?? 'default'}, autoCleanup=${resolved.memory.autoCleanup ?? 'default'}`);
       diagLines.push(`  Git behavior:    autoHook=${resolved.git.autoHook ?? 'default'}, ingestOnCommit=${resolved.git.ingestOnCommit ?? 'default'}, maxDiffSize=${resolved.git.maxDiffSize ?? 'default'}, skipMergeCommits=${resolved.git.skipMergeCommits ?? 'default'}`);
       diagLines.push(`  Server:          transport=${resolved.server.transport ?? 'default'}, dashboard=${resolved.server.dashboard ?? 'default'}, dashboardPort=${resolved.server.dashboardPort ?? 'default'}`);
@@ -141,6 +142,7 @@ export default defineCommand({
           agent: summarizeLane(agent.provider, agent.model, agent.baseUrl, agent.apiKey),
           memoryLlm: summarizeLane(resolved.memory.llm.provider, resolved.memory.llm.model, resolved.memory.llm.baseUrl, resolved.memory.llm.apiKey),
           embedding: summarizeLane(resolved.embedding.provider, resolved.embedding.model, resolved.embedding.baseUrl, resolved.embedding.apiKey),
+          rerank: summarizeLane(resolved.rerank.provider, resolved.rerank.model, resolved.rerank.baseUrl, resolved.rerank.apiKey),
         },
         memory: {
           inject: resolved.memory.inject ?? 'default',

--- a/src/config/resolved-config.ts
+++ b/src/config/resolved-config.ts
@@ -373,12 +373,45 @@ function resolveRerankLane(args: {
   const baseUrl = provider === 'http'
     ? first(explicitBaseUrl, args.memoryLlmBaseUrl)
     : explicitBaseUrl;
-  const apiKey = first(
+  const dedicatedApiKey = first(
     process.env.MEMORIX_RERANK_API_KEY,
     args.toml.rerank?.api_key,
     args.yaml.rerank?.apiKey,
-    args.memoryLlmApiKey,
   );
+  const inheritedApiKey = provider === 'http' && sameTrustedEndpoint(baseUrl, args.memoryLlmBaseUrl)
+    ? args.memoryLlmApiKey
+    : undefined;
+  const apiKey = first(dedicatedApiKey, inheritedApiKey);
 
   return { provider, model, baseUrl, apiKey };
+}
+
+/**
+ * True when two API roots are the same host+path after trailing-slash
+ * and optional `/rerank` normalization. Used so a Memory LLM bearer is
+ * never sent to a different rerank provider.
+ */
+function sameTrustedEndpoint(left?: string, right?: string): boolean {
+  const a = normalizeTrustedEndpoint(left);
+  const b = normalizeTrustedEndpoint(right);
+  return Boolean(a && b && a === b);
+}
+
+function normalizeTrustedEndpoint(value?: string): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  try {
+    const url = new URL(trimmed);
+    const protocol = url.protocol.toLowerCase();
+    const hostname = url.hostname.toLowerCase();
+    const port = url.port;
+    let pathname = url.pathname.replace(/\/+$/, '');
+    if (pathname.toLowerCase().endsWith('/rerank')) {
+      pathname = pathname.slice(0, -'/rerank'.length).replace(/\/+$/, '');
+    }
+    return `${protocol}//${hostname}${port ? `:${port}` : ''}${pathname}`;
+  } catch {
+    const fallback = trimmed.replace(/\/+$/, '').replace(/\/rerank$/i, '').replace(/\/+$/, '');
+    return fallback.toLowerCase() || undefined;
+  }
 }

--- a/src/config/resolved-config.ts
+++ b/src/config/resolved-config.ts
@@ -49,6 +49,8 @@ export interface ResolvedMemorixConfig {
     model?: string;
     baseUrl?: string;
     apiKey?: string;
+    /** False when a Memory LLM key exists and the rerank URL is a different host without a dedicated key. */
+    canSendRequest: boolean;
   };
   git: {
     autoHook?: boolean;
@@ -378,12 +380,13 @@ function resolveRerankLane(args: {
     args.toml.rerank?.api_key,
     args.yaml.rerank?.apiKey,
   );
-  const inheritedApiKey = provider === 'http' && sameTrustedEndpoint(baseUrl, args.memoryLlmBaseUrl)
-    ? args.memoryLlmApiKey
-    : undefined;
+  const sameEndpoint = provider === 'http' && sameTrustedEndpoint(baseUrl, args.memoryLlmBaseUrl);
+  const inheritedApiKey = sameEndpoint ? args.memoryLlmApiKey : undefined;
   const apiKey = first(dedicatedApiKey, inheritedApiKey);
+  const canSendRequest = provider === 'http' && Boolean(baseUrl)
+    && (Boolean(apiKey) || !args.memoryLlmApiKey || sameEndpoint);
 
-  return { provider, model, baseUrl, apiKey };
+  return { provider, model, baseUrl, apiKey, canSendRequest };
 }
 
 /**

--- a/src/config/resolved-config.ts
+++ b/src/config/resolved-config.ts
@@ -9,8 +9,8 @@ import {
   getProjectYamlPath,
 } from './config-paths.js';
 import { loadFileConfig } from './legacy-loader.js';
-import { loadTomlConfig } from './toml-loader.js';
-import { loadYamlConfig } from './yaml-loader.js';
+import { loadTomlConfig, type MemorixTomlConfig } from './toml-loader.js';
+import { loadYamlConfig, type MemorixYamlConfig } from './yaml-loader.js';
 import { loadDotenv } from './dotenv-loader.js';
 
 export interface ResolvedLaneOptions {
@@ -43,6 +43,12 @@ export interface ResolvedMemorixConfig {
     baseUrl?: string;
     apiKey?: string;
     dimensions?: number;
+  };
+  rerank: {
+    provider: 'off' | 'http';
+    model?: string;
+    baseUrl?: string;
+    apiKey?: string;
   };
   git: {
     autoHook?: boolean;
@@ -109,6 +115,16 @@ export function getResolvedConfig(options: ResolvedLaneOptions = {}): ResolvedMe
   const openRouterMemoryLlmApiKey = isOpenRouterMemoryLane(memoryLlmProvider, memoryLlmBaseUrl)
     ? process.env.OPENROUTER_API_KEY
     : undefined;
+  const memoryLlmApiKey = first(
+    process.env.MEMORIX_LLM_API_KEY,
+    process.env.MEMORIX_API_KEY,
+    toml.memory?.llm?.api_key,
+    yaml.llm?.apiKey,
+    legacy.llm?.apiKey,
+    process.env.OPENAI_API_KEY,
+    process.env.ANTHROPIC_API_KEY,
+    openRouterMemoryLlmApiKey,
+  );
 
   const resolved: ResolvedMemorixConfig = {
     agent: {
@@ -150,16 +166,7 @@ export function getResolvedConfig(options: ResolvedLaneOptions = {}): ResolvedMe
         provider: memoryLlmProvider,
         model: memoryLlmModel,
         baseUrl: memoryLlmBaseUrl,
-        apiKey: first(
-          process.env.MEMORIX_LLM_API_KEY,
-          process.env.MEMORIX_API_KEY,
-          toml.memory?.llm?.api_key,
-          yaml.llm?.apiKey,
-          legacy.llm?.apiKey,
-          process.env.OPENAI_API_KEY,
-          process.env.ANTHROPIC_API_KEY,
-          openRouterMemoryLlmApiKey,
-        ),
+        apiKey: memoryLlmApiKey,
       },
     },
     embedding: {
@@ -169,6 +176,12 @@ export function getResolvedConfig(options: ResolvedLaneOptions = {}): ResolvedMe
       apiKey: first(process.env.MEMORIX_EMBEDDING_API_KEY, toml.embedding?.api_key, yaml.embedding?.apiKey, legacy.embeddingApi?.apiKey, openRouterEmbeddingApiKey),
       dimensions: firstNumber(parseNumber(process.env.MEMORIX_EMBEDDING_DIMENSIONS), toml.embedding?.dimensions, yaml.embedding?.dimensions, legacy.embeddingApi?.dimensions),
     },
+    rerank: resolveRerankLane({
+      toml,
+      yaml,
+      memoryLlmApiKey,
+      memoryLlmBaseUrl,
+    }),
     git: {
       autoHook: firstBool(toml.git?.auto_hook, yaml.git?.autoHook),
       ingestOnCommit: firstBool(toml.git?.ingest_on_commit, yaml.git?.ingestOnCommit),
@@ -244,6 +257,10 @@ export function getResolvedEmbeddingLane(options: ResolvedLaneOptions = {}): Res
   return getResolvedConfig(options).embedding;
 }
 
+export function getResolvedRerankLane(options: ResolvedLaneOptions = {}): ResolvedMemorixConfig['rerank'] {
+  return getResolvedConfig(options).rerank;
+}
+
 export function resetResolvedConfigCache(): void {
   // Kept as a public test helper. File-level caches live in individual loaders.
 }
@@ -294,6 +311,10 @@ function getEnvSourceNames(): string[] {
     'MEMORIX_EMBEDDING_BASE_URL',
     'MEMORIX_EMBEDDING_MODEL',
     'MEMORIX_EMBEDDING_DIMENSIONS',
+    'MEMORIX_RERANK_PROVIDER',
+    'MEMORIX_RERANK_MODEL',
+    'MEMORIX_RERANK_BASE_URL',
+    'MEMORIX_RERANK_API_KEY',
     'MEMORIX_CODEGRAPH_EXTERNAL_CONTEXT',
     'MEMORIX_CODEGRAPH_EXTERNAL_COMMAND',
     'MEMORIX_CODEGRAPH_EXTERNAL_TIMEOUT_MS',
@@ -319,4 +340,45 @@ function normalizeExternalContext(value: string | undefined): 'auto' | 'off' | u
   const normalized = value?.trim().toLowerCase();
   if (normalized === 'auto' || normalized === 'off') return normalized;
   return undefined;
+}
+
+function normalizeRerankProvider(value: string | undefined): 'off' | 'http' {
+  const normalized = value?.trim().toLowerCase();
+  if (normalized === 'http') return 'http';
+  return 'off';
+}
+
+function resolveRerankLane(args: {
+  toml: MemorixTomlConfig;
+  yaml: MemorixYamlConfig;
+  memoryLlmApiKey?: string;
+  memoryLlmBaseUrl?: string;
+}): ResolvedMemorixConfig['rerank'] {
+  const provider = normalizeRerankProvider(first(
+    process.env.MEMORIX_RERANK_PROVIDER,
+    args.toml.rerank?.provider,
+    args.yaml.rerank?.provider,
+    'off',
+  ));
+  const model = first(
+    process.env.MEMORIX_RERANK_MODEL,
+    args.toml.rerank?.model,
+    args.yaml.rerank?.model,
+  );
+  const explicitBaseUrl = first(
+    process.env.MEMORIX_RERANK_BASE_URL,
+    args.toml.rerank?.base_url,
+    args.yaml.rerank?.baseUrl,
+  );
+  const baseUrl = provider === 'http'
+    ? first(explicitBaseUrl, args.memoryLlmBaseUrl)
+    : explicitBaseUrl;
+  const apiKey = first(
+    process.env.MEMORIX_RERANK_API_KEY,
+    args.toml.rerank?.api_key,
+    args.yaml.rerank?.apiKey,
+    args.memoryLlmApiKey,
+  );
+
+  return { provider, model, baseUrl, apiKey };
 }

--- a/src/config/toml-loader.ts
+++ b/src/config/toml-loader.ts
@@ -28,6 +28,13 @@ export interface MemorixTomlConfig {
     api_key?: string;
     dimensions?: number;
   };
+  /** Optional HTTP rerank against a compatible /rerank API. */
+  rerank?: {
+    provider?: 'off' | 'http' | string;
+    model?: string;
+    base_url?: string;
+    api_key?: string;
+  };
   hooks?: {
     native_memcode?: boolean;
     external_agents?: boolean;
@@ -97,6 +104,7 @@ function mergeTomlConfig(base: MemorixTomlConfig, override: MemorixTomlConfig): 
       llm: { ...base.memory?.llm, ...override.memory?.llm },
     },
     embedding: { ...base.embedding, ...override.embedding },
+    rerank: { ...base.rerank, ...override.rerank },
     hooks: { ...base.hooks, ...override.hooks },
     git: { ...base.git, ...override.git },
     codegraph: { ...base.codegraph, ...override.codegraph },

--- a/src/config/yaml-loader.ts
+++ b/src/config/yaml-loader.ts
@@ -48,6 +48,14 @@ export interface MemorixYamlConfig {
     dimensions?: number;
   };
 
+  /** Remote neural rerank (HTTP only) */
+  rerank?: {
+    provider?: 'off' | 'http' | string;
+    model?: string;
+    apiKey?: string;
+    baseUrl?: string;
+  };
+
   /** Git-Memory pipeline configuration */
   git?: {
     /** Auto-install post-commit hook on first run (default: false) */
@@ -190,6 +198,7 @@ export function loadYamlConfig(projectRoot?: string | null): MemorixYamlConfig {
     llm: { ...userConfig.llm, ...projectConfig.llm },
     agent: { ...userConfig.agent, ...projectConfig.agent },
     embedding: { ...userConfig.embedding, ...projectConfig.embedding },
+    rerank: { ...userConfig.rerank, ...projectConfig.rerank },
     git: { ...userConfig.git, ...projectConfig.git },
     codegraph: { ...userConfig.codegraph, ...projectConfig.codegraph },
     behavior: { ...userConfig.behavior, ...projectConfig.behavior },

--- a/src/rerank/http-provider.ts
+++ b/src/rerank/http-provider.ts
@@ -7,6 +7,8 @@
  * whatever the user configured — Memorix does not rewrite it.
  */
 
+import { resolveRerankTimeoutMs } from './policy.js';
+
 export type NeuralRerankProviderName = 'http';
 
 export interface NeuralRerankRequestConfig {
@@ -100,7 +102,7 @@ export async function rerankViaHttp(
   }
 
   const controller = new AbortController();
-  const timeoutMs = config.timeoutMs && config.timeoutMs > 0 ? config.timeoutMs : 5000;
+  const timeoutMs = resolveRerankTimeoutMs(config.timeoutMs);
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
   try {

--- a/src/rerank/http-provider.ts
+++ b/src/rerank/http-provider.ts
@@ -1,0 +1,123 @@
+/**
+ * Optional HTTP rerank client.
+ *
+ * Posts a Cohere-compatible `{model, query, documents}` body to
+ * `{base_url}/rerank` (or an explicit `/rerank` path). Compatible with
+ * any `/rerank` endpoint that accepts that body. The model id is
+ * whatever the user configured — Memorix does not rewrite it.
+ */
+
+export type NeuralRerankProviderName = 'http';
+
+export interface NeuralRerankRequestConfig {
+  provider: NeuralRerankProviderName;
+  model?: string;
+  baseUrl: string;
+  apiKey?: string;
+  timeoutMs?: number;
+  fetchImpl?: typeof fetch;
+}
+
+export interface RerankedDocument {
+  index: number;
+  score: number;
+}
+
+/**
+ * Join a provider base URL with `/rerank`, leaving an explicit path intact.
+ */
+export function buildRerankUrl(baseUrl: string): string {
+  const trimmed = baseUrl.trim().replace(/\/+$/, '');
+  if (trimmed.endsWith('/rerank')) return trimmed;
+  return `${trimmed}/rerank`;
+}
+
+/**
+ * Accept Cohere-compatible `{results:[{index,relevance_score}]}` and TEI `[{index,score}]`.
+ */
+export function parseRerankResponse(payload: unknown): RerankedDocument[] {
+  const rows = extractRows(payload);
+  if (rows.length === 0) {
+    throw new Error('Neural rerank response contained no ranked results');
+  }
+  return rows.sort((a, b) => b.score - a.score);
+}
+
+function extractRows(payload: unknown): RerankedDocument[] {
+  if (Array.isArray(payload)) {
+    return payload.map(rowFromUnknown).filter((row): row is RerankedDocument => row !== null);
+  }
+  if (payload && typeof payload === 'object' && 'results' in payload) {
+    const results = (payload as { results: unknown }).results;
+    if (Array.isArray(results)) {
+      return results.map(rowFromUnknown).filter((row): row is RerankedDocument => row !== null);
+    }
+  }
+  throw new Error('Neural rerank response was not Cohere or TEI shaped');
+}
+
+function rowFromUnknown(value: unknown): RerankedDocument | null {
+  if (!value || typeof value !== 'object') return null;
+  const row = value as { index?: unknown; relevance_score?: unknown; score?: unknown };
+  if (typeof row.index !== 'number' || !Number.isFinite(row.index)) return null;
+  const score = typeof row.relevance_score === 'number'
+    ? row.relevance_score
+    : typeof row.score === 'number'
+      ? row.score
+      : null;
+  if (score === null || !Number.isFinite(score)) return null;
+  return { index: row.index, score };
+}
+
+function buildRerankBody(query: string, documents: string[], model?: string): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    query,
+    documents,
+    top_n: documents.length,
+    return_documents: false,
+  };
+  const trimmed = model?.trim();
+  if (trimmed) body.model = trimmed;
+  return body;
+}
+
+/**
+ * POST query + documents to a compatible `/rerank` endpoint and return ranked indexes.
+ */
+export async function rerankViaHttp(
+  query: string,
+  documents: string[],
+  config: NeuralRerankRequestConfig,
+): Promise<RerankedDocument[]> {
+  if (documents.length === 0) return [];
+
+  const url = buildRerankUrl(config.baseUrl);
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+  };
+  if (config.apiKey) {
+    headers.authorization = `Bearer ${config.apiKey}`;
+  }
+
+  const controller = new AbortController();
+  const timeoutMs = config.timeoutMs && config.timeoutMs > 0 ? config.timeoutMs : 5000;
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const fetchImpl = config.fetchImpl ?? fetch;
+    const response = await fetchImpl(url, {
+      method: 'POST',
+      headers,
+      signal: controller.signal,
+      body: JSON.stringify(buildRerankBody(query, documents, config.model)),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Neural rerank HTTP ${response.status} from ${url}`);
+    }
+
+    return parseRerankResponse(await response.json());
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/rerank/index.ts
+++ b/src/rerank/index.ts
@@ -1,0 +1,69 @@
+/**
+ * Optional HTTP rerank lane. LLM fallback lives in quality.ts.
+ */
+
+import { getResolvedRerankLane, type ResolvedLaneOptions } from '../config/resolved-config.js';
+import { rerankViaHttp } from './http-provider.js';
+
+/** Minimal search hit the HTTP reranker can reorder. */
+export interface NeuralRerankCandidate {
+  id: string;
+  title: string;
+  type: string;
+  score: number;
+  narrative?: string;
+}
+
+const MAX_RERANK = 10;
+
+/**
+ * True when an HTTP `/rerank` endpoint is configured.
+ */
+export function isNeuralRerankEnabled(options: ResolvedLaneOptions = {}): boolean {
+  const lane = getResolvedRerankLane(options);
+  return lane.provider === 'http' && Boolean(lane.baseUrl);
+}
+
+/**
+ * Reorder search candidates via the configured remote reranker.
+ * Returns null when the provider is off or the HTTP call cannot be used.
+ */
+export async function neuralRerankCandidates(
+  query: string,
+  candidates: NeuralRerankCandidate[],
+  options: ResolvedLaneOptions = {},
+): Promise<NeuralRerankCandidate[] | null> {
+  if (!isNeuralRerankEnabled(options) || candidates.length === 0) return null;
+
+  const lane = getResolvedRerankLane(options);
+  const toRerank = candidates.slice(0, MAX_RERANK);
+  const rest = candidates.slice(MAX_RERANK);
+  const documents = toRerank.map((candidate) => candidateText(candidate));
+
+  const ranked = await rerankViaHttp(query, documents, {
+    provider: 'http',
+    model: lane.model,
+    baseUrl: lane.baseUrl!,
+    apiKey: lane.apiKey,
+  });
+
+  const seen = new Set<number>();
+  const reranked: NeuralRerankCandidate[] = [];
+  for (const row of ranked) {
+    const candidate = toRerank[row.index];
+    if (!candidate || seen.has(row.index)) continue;
+    reranked.push(candidate);
+    seen.add(row.index);
+  }
+  for (const [index, candidate] of toRerank.entries()) {
+    if (!seen.has(index)) reranked.push(candidate);
+  }
+  reranked.push(...rest);
+  return reranked;
+}
+
+function candidateText(candidate: NeuralRerankCandidate): string {
+  const narrative = candidate.narrative?.trim();
+  if (narrative) return `${candidate.title} — ${narrative.slice(0, 200)}`;
+  return candidate.title;
+}

--- a/src/rerank/index.ts
+++ b/src/rerank/index.ts
@@ -46,6 +46,7 @@ export async function neuralRerankCandidates(
   if (!isNeuralRerankEnabled(options) || candidates.length === 0) return null;
 
   const lane = getResolvedRerankLane(options);
+  if (!lane.canSendRequest || !lane.baseUrl) return null;
   const toRerank = candidates.slice(0, MAX_RERANK);
   const rest = candidates.slice(MAX_RERANK);
   const documents = toRerank.map((candidate) => candidateText(candidate));

--- a/src/rerank/index.ts
+++ b/src/rerank/index.ts
@@ -1,9 +1,19 @@
 /**
- * Optional HTTP rerank lane. LLM fallback lives in quality.ts.
+ * Optional HTTP rerank lane. LLM rerank stays in quality.ts when HTTP is off.
  */
 
 import { getResolvedRerankLane, type ResolvedLaneOptions } from '../config/resolved-config.js';
 import { rerankViaHttp } from './http-provider.js';
+import { resolveRerankTimeoutMs } from './policy.js';
+
+export {
+  DEFAULT_RERANK_TIMEOUT_MS,
+  MIN_RERANK_CANDIDATES,
+  parseRerankTimeoutMs,
+  resolveRerankTimeoutMs,
+  shouldAttemptHttpRerank,
+  shouldAttemptLlmRerank,
+} from './policy.js';
 
 /** Minimal search hit the HTTP reranker can reorder. */
 export interface NeuralRerankCandidate {
@@ -45,6 +55,7 @@ export async function neuralRerankCandidates(
     model: lane.model,
     baseUrl: lane.baseUrl!,
     apiKey: lane.apiKey,
+    timeoutMs: resolveRerankTimeoutMs(),
   });
 
   const seen = new Set<number>();

--- a/src/rerank/policy.ts
+++ b/src/rerank/policy.ts
@@ -1,0 +1,88 @@
+/**
+ * Product rules for optional HTTP rerank and the existing LLM rerank path.
+ *
+ * HTTP rerank is opt-in. When it is configured, thorough search with enough
+ * candidates uses the HTTP lane only — a miss or timeout keeps the original
+ * order instead of falling through to LLM rerank.
+ */
+
+export const DEFAULT_RERANK_TIMEOUT_MS = 30_000;
+export const RERANK_TIMEOUT_MIN_MS = 1_000;
+export const RERANK_TIMEOUT_MAX_MS = 300_000;
+export const MIN_RERANK_CANDIDATES = 3;
+
+/**
+ * Parse and validate MEMORIX_RERANK_TIMEOUT_MS.
+ *
+ * @param raw - Environment value, or undefined when unset
+ * @returns Timeout in milliseconds (default 30000)
+ */
+export function parseRerankTimeoutMs(raw: string | undefined): number {
+  const value = raw?.trim();
+  if (!value) return DEFAULT_RERANK_TIMEOUT_MS;
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || Number.isNaN(parsed)) {
+    console.warn(
+      `[memorix] MEMORIX_RERANK_TIMEOUT_MS="${raw}" is invalid (must be a positive integer between ${RERANK_TIMEOUT_MIN_MS}-${RERANK_TIMEOUT_MAX_MS}ms). Using default ${DEFAULT_RERANK_TIMEOUT_MS}ms.`,
+    );
+    return DEFAULT_RERANK_TIMEOUT_MS;
+  }
+
+  if (parsed < RERANK_TIMEOUT_MIN_MS) return RERANK_TIMEOUT_MIN_MS;
+  if (parsed > RERANK_TIMEOUT_MAX_MS) return RERANK_TIMEOUT_MAX_MS;
+  return parsed;
+}
+
+/**
+ * Resolve the rerank timeout from an explicit override or the environment.
+ *
+ * @param explicitTimeoutMs - Caller-supplied timeout, when present
+ * @returns Timeout in milliseconds
+ */
+export function resolveRerankTimeoutMs(explicitTimeoutMs?: number): number {
+  if (typeof explicitTimeoutMs === 'number' && Number.isFinite(explicitTimeoutMs) && explicitTimeoutMs > 0) {
+    return explicitTimeoutMs;
+  }
+  return parseRerankTimeoutMs(process.env.MEMORIX_RERANK_TIMEOUT_MS);
+}
+
+/**
+ * True when thorough search has enough candidates for HTTP rerank.
+ *
+ * @param input - Retrieval quality, query presence, and hit count
+ * @returns Whether the HTTP rerank lane should run
+ */
+export function shouldAttemptHttpRerank(input: {
+  quality?: string;
+  hasQuery: boolean;
+  candidateCount: number;
+}): boolean {
+  return input.quality === 'thorough'
+    && input.hasQuery
+    && input.candidateCount >= MIN_RERANK_CANDIDATES;
+}
+
+/**
+ * True when the existing LLM rerank path should run.
+ *
+ * LLM rerank stays on the original thorough + heavy + close top-2 gate.
+ * It never runs when an HTTP rerank lane is configured.
+ *
+ * @param input - Search gate inputs plus whether HTTP rerank is configured
+ * @returns Whether LLM rerank should run
+ */
+export function shouldAttemptLlmRerank(input: {
+  quality?: string;
+  tier: string;
+  hasQuery: boolean;
+  candidateCount: number;
+  topScore: number;
+  secondScore: number;
+  httpRerankConfigured: boolean;
+}): boolean {
+  if (input.httpRerankConfigured) return false;
+  if (input.quality !== 'thorough' || input.tier !== 'heavy' || !input.hasQuery) return false;
+  if (input.candidateCount < MIN_RERANK_CANDIDATES) return false;
+  return input.topScore > 0 && input.secondScore / input.topScore > 0.7;
+}

--- a/src/store/orama-store.ts
+++ b/src/store/orama-store.ts
@@ -23,6 +23,7 @@ import {
 import { calculateProjectAffinity, extractProjectKeywords, type AffinityContext, type MemoryContent } from './project-affinity.js';
 import { detectQueryIntent, applyIntentBoost } from '../search/intent-detector.js';
 import { maybeExpandSearchQuery } from '../search/query-expansion.js';
+import { parseRerankTimeoutMs, shouldAttemptHttpRerank, shouldAttemptLlmRerank } from '../rerank/policy.js';
 import { withTimeout, withTimeoutSignal } from '../timeout.js';
 
 let db: AnyOrama | null = null;
@@ -1054,21 +1055,25 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
     }
   }
 
-  // ── LLM Reranking (heavy-tier only) ────────────────────────────
-  // Only triggered for heavy-tier queries with ambiguous top results.
-  // Non-thorough profiles, fast, and standard tiers skip entirely.
-  // Ambiguity check: top-2 scores within 30% → results are uncertain.
-  const shouldRerank = quality === 'thorough'
-    && tier === 'heavy'
-    && hasQuery
-    && intermediate.length > 2
-    && (() => {
-      const top = intermediate[0]?.score ?? 0;
-      const second = intermediate[1]?.score ?? 0;
-      return top > 0 && second / top > 0.7; // top-2 within 30% = ambiguous
-    })();
+  // HTTP rerank: thorough search with enough candidates.
+  // LLM rerank: original thorough + heavy + close top-2 gate, and only when
+  // HTTP rerank is not configured. A configured HTTP miss keeps original order.
+  const httpGate = shouldAttemptHttpRerank({
+    quality,
+    hasQuery: Boolean(hasQuery),
+    candidateCount: intermediate.length,
+  });
+  const llmGateWithoutHttp = shouldAttemptLlmRerank({
+    quality,
+    tier,
+    hasQuery: Boolean(hasQuery),
+    candidateCount: intermediate.length,
+    topScore: intermediate[0]?.score ?? 0,
+    secondScore: intermediate[1]?.score ?? 0,
+    httpRerankConfigured: false,
+  });
 
-  if (shouldRerank) {
+  if (httpGate || llmGateWithoutHttp) {
     const narrativeMap = new Map<string, string>();
     for (const hit of results.hits) {
       const doc = hit.document as unknown as MemorixDocument;
@@ -1083,14 +1088,13 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
       score: e.score,
       narrative: narrativeMap.get(makeEntryKey(e.projectId, e.id)),
     }));
-    const _parsedRerank = parseInt(process.env.MEMORIX_RERANK_TIMEOUT_MS || '', 10);
-    const RERANK_TIMEOUT_MS = Number.isFinite(_parsedRerank) && _parsedRerank > 0 ? _parsedRerank : 5000;
+    const RERANK_TIMEOUT_MS = parseRerankTimeoutMs(process.env.MEMORIX_RERANK_TIMEOUT_MS);
     const candidateMap = new Map(candidates.map((candidate, index) => [candidate.id, toRerank[index]]));
-    let applied = false;
+    const { isNeuralRerankEnabled, neuralRerankCandidates } = await import('../rerank/index.js');
+    const httpConfigured = isNeuralRerankEnabled();
 
-    try {
-      const { isNeuralRerankEnabled, neuralRerankCandidates } = await import('../rerank/index.js');
-      if (isNeuralRerankEnabled()) {
+    if (httpConfigured && httpGate) {
+      try {
         const neural = await withTimeout(
           neuralRerankCandidates(originalQuery!, candidates),
           RERANK_TIMEOUT_MS,
@@ -1104,15 +1108,12 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
             intermediate = [...rerankedTop, ...intermediate.slice(RERANK_TOP_K)];
             lastSearchModeByProject.set(modeKey, (lastSearchModeByProject.get(modeKey) ?? 'fulltext') + ' + neural rerank');
             mark('rerank(usedNeural=true)');
-            applied = true;
           }
         }
+      } catch {
+        console.error('[memorix] neural rerank failed or timed out; keeping original order');
       }
-    } catch {
-      console.error('[memorix] neural rerank failed or timed out, trying LLM fallback');
-    }
-
-    if (!applied) {
+    } else if (!httpConfigured && llmGateWithoutHttp) {
       try {
         const { rerankResults } = await import('../llm/quality.js');
         const { reranked, usedLLM } = await withTimeout(
@@ -1133,6 +1134,8 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
       } catch {
         console.error('[memorix] LLM rerank failed or timed out, using original order');
       }
+    } else {
+      mark(`rerank(skipped,tier=${tier})`);
     }
   } else {
     mark(`rerank(skipped,tier=${tier})`);

--- a/src/store/orama-store.ts
+++ b/src/store/orama-store.ts
@@ -1069,47 +1069,70 @@ export async function searchObservations(options: SearchOptions): Promise<IndexE
     })();
 
   if (shouldRerank) {
+    const narrativeMap = new Map<string, string>();
+    for (const hit of results.hits) {
+      const doc = hit.document as unknown as MemorixDocument;
+      narrativeMap.set(makeEntryKey(doc.projectId, doc.observationId), doc.narrative);
+    }
+    const RERANK_TOP_K = 5;
+    const toRerank = intermediate.slice(0, RERANK_TOP_K);
+    const candidates = toRerank.map((e, index) => ({
+      id: `r${index + 1}`,
+      title: e.title,
+      type: e.type,
+      score: e.score,
+      narrative: narrativeMap.get(makeEntryKey(e.projectId, e.id)),
+    }));
+    const _parsedRerank = parseInt(process.env.MEMORIX_RERANK_TIMEOUT_MS || '', 10);
+    const RERANK_TIMEOUT_MS = Number.isFinite(_parsedRerank) && _parsedRerank > 0 ? _parsedRerank : 5000;
+    const candidateMap = new Map(candidates.map((candidate, index) => [candidate.id, toRerank[index]]));
+    let applied = false;
+
     try {
-      const { rerankResults } = await import('../llm/quality.js');
-      const narrativeMap = new Map<string, string>();
-      for (const hit of results.hits) {
-        const doc = hit.document as unknown as MemorixDocument;
-        narrativeMap.set(makeEntryKey(doc.projectId, doc.observationId), doc.narrative);
-      }
-      // Rerank only top-5 (was 10) to save LLM tokens and latency
-      const RERANK_TOP_K = 5;
-      const toRerank = intermediate.slice(0, RERANK_TOP_K);
-      const candidates = toRerank.map((e, index) => ({
-        id: `r${index + 1}`,
-        title: e.title,
-        type: e.type,
-        score: e.score,
-        narrative: narrativeMap.get(makeEntryKey(e.projectId, e.id)),
-      }));
-      
-      // LLM rerank timeout: configurable via MEMORIX_RERANK_TIMEOUT_MS, default 5s
-      const _parsedRerank = parseInt(process.env.MEMORIX_RERANK_TIMEOUT_MS || '', 10);
-      const RERANK_TIMEOUT_MS = Number.isFinite(_parsedRerank) && _parsedRerank > 0 ? _parsedRerank : 5000;
-      const { reranked, usedLLM } = await withTimeout(
-        rerankResults(originalQuery!, candidates),
-        RERANK_TIMEOUT_MS,
-        'LLM rerank',
-      );
-      mark(`rerank(usedLLM=${usedLLM})`);
-      
-      if (usedLLM) {
-        lastSearchModeByProject.set(modeKey, (lastSearchModeByProject.get(modeKey) ?? 'fulltext') + ' + LLM rerank');
-        const candidateMap = new Map(candidates.map((candidate, index) => [candidate.id, toRerank[index]]));
-        const rerankedTop = reranked
-          .map(r => candidateMap.get(r.id))
-          .filter((e): e is NonNullable<typeof e> => e != null);
-        if (rerankedTop.length > 0) {
-          intermediate = [...rerankedTop, ...intermediate.slice(RERANK_TOP_K)];
+      const { isNeuralRerankEnabled, neuralRerankCandidates } = await import('../rerank/index.js');
+      if (isNeuralRerankEnabled()) {
+        const neural = await withTimeout(
+          neuralRerankCandidates(originalQuery!, candidates),
+          RERANK_TIMEOUT_MS,
+          'neural rerank',
+        );
+        if (neural && neural.length > 0) {
+          const rerankedTop = neural
+            .map((row) => candidateMap.get(row.id))
+            .filter((entry): entry is NonNullable<typeof entry> => entry != null);
+          if (rerankedTop.length > 0) {
+            intermediate = [...rerankedTop, ...intermediate.slice(RERANK_TOP_K)];
+            lastSearchModeByProject.set(modeKey, (lastSearchModeByProject.get(modeKey) ?? 'fulltext') + ' + neural rerank');
+            mark('rerank(usedNeural=true)');
+            applied = true;
+          }
         }
       }
-    } catch (error) {
-      // Reranking is best-effort: fall back to original order on timeout or error
-      console.error('[memorix] LLM rerank failed or timed out, using original order');
+    } catch {
+      console.error('[memorix] neural rerank failed or timed out, trying LLM fallback');
+    }
+
+    if (!applied) {
+      try {
+        const { rerankResults } = await import('../llm/quality.js');
+        const { reranked, usedLLM } = await withTimeout(
+          rerankResults(originalQuery!, candidates),
+          RERANK_TIMEOUT_MS,
+          'LLM rerank',
+        );
+        mark(`rerank(usedLLM=${usedLLM})`);
+        if (usedLLM) {
+          lastSearchModeByProject.set(modeKey, (lastSearchModeByProject.get(modeKey) ?? 'fulltext') + ' + LLM rerank');
+          const rerankedTop = reranked
+            .map((row) => candidateMap.get(row.id))
+            .filter((entry): entry is NonNullable<typeof entry> => entry != null);
+          if (rerankedTop.length > 0) {
+            intermediate = [...rerankedTop, ...intermediate.slice(RERANK_TOP_K)];
+          }
+        }
+      } catch {
+        console.error('[memorix] LLM rerank failed or timed out, using original order');
+      }
     }
   } else {
     mark(`rerank(skipped,tier=${tier})`);

--- a/tests/cli/codegraph-command.test.ts
+++ b/tests/cli/codegraph-command.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { execSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, realpathSync, unlinkSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import codegraphCommand from '../../src/cli/commands/codegraph.js';
@@ -39,6 +40,7 @@ describe('codegraph CLI command', () => {
   const originalCwd = process.cwd();
   const originalDataDir = process.env.MEMORIX_DATA_DIR;
   const originalEmbedding = process.env.MEMORIX_EMBEDDING;
+  const originalGitOptionalLocks = process.env.GIT_OPTIONAL_LOCKS;
   let sandboxRoot = '';
   let repoDir = '';
   let dataDir = '';
@@ -50,6 +52,7 @@ describe('codegraph CLI command', () => {
     mkdirSync(path.join(repoDir, 'src'), { recursive: true });
     writeFileSync(path.join(repoDir, 'src', 'jwt.ts'), 'export function verifyJwt(token: string) { return token.length > 0; }\n', 'utf8');
     writeFileSync(path.join(repoDir, 'src', 'auth.ts'), "import { verifyJwt } from './jwt';\nexport function authMiddleware(token: string) { return verifyJwt(token); }\n", 'utf8');
+    process.env.GIT_OPTIONAL_LOCKS = '0';
     execSync('git init', { cwd: repoDir, stdio: 'ignore' });
     process.chdir(repoDir);
     process.env.MEMORIX_DATA_DIR = dataDir;
@@ -68,13 +71,24 @@ describe('codegraph CLI command', () => {
     } else {
       process.env.MEMORIX_EMBEDDING = originalEmbedding;
     }
+    if (originalGitOptionalLocks === undefined) {
+      delete process.env.GIT_OPTIONAL_LOCKS;
+    } else {
+      process.env.GIT_OPTIONAL_LOCKS = originalGitOptionalLocks;
+    }
     resetObservationStore();
     resetSessionStore();
     resetTeamStore();
     await resetDb();
     closeAllDatabases();
-    rmSync(sandboxRoot, { recursive: true, force: true });
-  });
+    // Windows can keep a lock on the temp git/sqlite dir after close.
+    // Node retries EBUSY/EPERM; do not fail the suite if the dir remains.
+    try {
+      await rm(sandboxRoot, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+    } catch {
+      // leftover temp dir is unique per test via mkdtemp
+    }
+  }, 30_000);
 
   it('refreshes the lite index and reports status as JSON', async () => {
     const refreshed = await runCommand({ _: ['refresh'], json: true });

--- a/tests/cli/config-command.test.ts
+++ b/tests/cli/config-command.test.ts
@@ -156,6 +156,7 @@ describe('memorix config commands', () => {
     expect(notes).toContain('Agent lane');
     expect(notes).toContain('Memory LLM lane');
     expect(notes).toContain('Embedding lane');
+    expect(notes).toContain('Rerank lane');
     expect(notes).toContain('<redacted>');
     expect(notes).not.toContain('status-secret-key');
   });

--- a/tests/cli/init.test.ts
+++ b/tests/cli/init.test.ts
@@ -80,6 +80,8 @@ describe('init TOML templates', () => {
     expect(content).toContain('[memory.llm]');
     expect(content).toContain('provider = "openai"');
     expect(content).toContain('[embedding]');
+    expect(content).toContain('[rerank]');
+    expect(content).toContain('rerank-model');
     expect(content).toContain('# api_key = "..."');
     expect(content).toContain('Global config may store local credentials');
   });
@@ -99,6 +101,7 @@ describe('init TOML templates', () => {
     expect(content).toContain('[agent]');
     expect(content).toContain('[memory.llm]');
     expect(content).toContain('[embedding]');
+    expect(content).toContain('[rerank]');
     expect(content).toContain('Project config should not store credentials');
     expect(content).not.toContain('api_key');
   });

--- a/tests/config/resolved-config.test.ts
+++ b/tests/config/resolved-config.test.ts
@@ -220,6 +220,7 @@ describe('resolved config', () => {
     expect(lane.model).toBe('rerank-model');
     expect(lane.baseUrl).toBe('https://llm.example/v1');
     expect(lane.apiKey).toBe('llm-key');
+    expect(lane.canSendRequest).toBe(true);
     expect(getResolvedConfig({ projectRoot: null, homeDir: HOME }).sources.env).toContain('MEMORIX_RERANK_PROVIDER');
   });
 
@@ -252,6 +253,7 @@ describe('resolved config', () => {
     expect(lane.provider).toBe('http');
     expect(lane.baseUrl).toBe('https://LLM.example/v1/');
     expect(lane.apiKey).toBe('llm-key');
+    expect(lane.canSendRequest).toBe(true);
   });
 
   it('does not inherit the memory LLM key when the rerank URL is a different endpoint', () => {
@@ -271,6 +273,7 @@ describe('resolved config', () => {
     expect(lane.provider).toBe('http');
     expect(lane.baseUrl).toBe('https://api.example.com/v1');
     expect(lane.apiKey).toBeUndefined();
+    expect(lane.canSendRequest).toBe(false);
   });
 
   it('uses a dedicated rerank key when the endpoint differs from the memory LLM', () => {
@@ -289,6 +292,7 @@ describe('resolved config', () => {
     const lane = getResolvedRerankLane({ projectRoot: null, homeDir: HOME });
 
     expect(lane.apiKey).toBe('rerank-key');
+    expect(lane.canSendRequest).toBe(true);
   });
 
   it('resolves CodeGraph scan limits from TOML above legacy YAML', () => {

--- a/tests/config/resolved-config.test.ts
+++ b/tests/config/resolved-config.test.ts
@@ -7,6 +7,7 @@ import {
   getResolvedConfigForCwd,
   getResolvedEmbeddingLane,
   getResolvedMemoryLane,
+  getResolvedRerankLane,
   resetResolvedConfigCache,
 } from '../../src/config/resolved-config.js';
 import { resetTomlConfigCache } from '../../src/config/toml-loader.js';
@@ -32,6 +33,10 @@ const ENV_KEYS = [
   'MEMORIX_EMBEDDING_BASE_URL',
   'MEMORIX_EMBEDDING_MODEL',
   'MEMORIX_EMBEDDING_DIMENSIONS',
+  'MEMORIX_RERANK_PROVIDER',
+  'MEMORIX_RERANK_MODEL',
+  'MEMORIX_RERANK_BASE_URL',
+  'MEMORIX_RERANK_API_KEY',
   'MEMORIX_CODEGRAPH_EXTERNAL_CONTEXT',
   'MEMORIX_CODEGRAPH_EXTERNAL_COMMAND',
   'MEMORIX_CODEGRAPH_EXTERNAL_TIMEOUT_MS',
@@ -195,6 +200,39 @@ describe('resolved config', () => {
     expect(cfg.git.maxDiffSize).toBe(2048);
     expect(cfg.git.skipMergeCommits).toBe(false);
     expect(cfg.git.excludePatterns).toEqual(['dist/**', '*.lock']);
+  });
+
+  it('resolves HTTP rerank from env above TOML and inherits the LLM bearer', () => {
+    writeFileSync(join(HOME, '.memorix', 'config.toml'), [
+      '[memory.llm]',
+      'base_url = "https://llm.example/v1"',
+      'api_key = "llm-key"',
+      '',
+      '[rerank]',
+      'provider = "http"',
+      'model = "rerank-model"',
+    ].join('\n'), 'utf8');
+    process.env.MEMORIX_RERANK_PROVIDER = 'http';
+
+    const lane = getResolvedRerankLane({ projectRoot: null, homeDir: HOME });
+
+    expect(lane.provider).toBe('http');
+    expect(lane.model).toBe('rerank-model');
+    expect(lane.baseUrl).toBe('https://llm.example/v1');
+    expect(lane.apiKey).toBe('llm-key');
+    expect(getResolvedConfig({ projectRoot: null, homeDir: HOME }).sources.env).toContain('MEMORIX_RERANK_PROVIDER');
+  });
+
+  it('keeps an explicit public host when the user configured it', () => {
+    process.env.MEMORIX_RERANK_PROVIDER = 'http';
+    process.env.MEMORIX_RERANK_BASE_URL = 'https://api.example.com/v1';
+    process.env.MEMORIX_RERANK_MODEL = 'rerank-model';
+    process.env.MEMORIX_RERANK_API_KEY = 'rerank-key';
+
+    const lane = getResolvedRerankLane({ projectRoot: null, homeDir: HOME });
+    expect(lane.provider).toBe('http');
+    expect(lane.baseUrl).toBe('https://api.example.com/v1');
+    expect(lane.model).toBe('rerank-model');
   });
 
   it('resolves CodeGraph scan limits from TOML above legacy YAML', () => {

--- a/tests/config/resolved-config.test.ts
+++ b/tests/config/resolved-config.test.ts
@@ -235,6 +235,62 @@ describe('resolved config', () => {
     expect(lane.model).toBe('rerank-model');
   });
 
+  it('inherits the memory LLM key when the explicit rerank URL is the same endpoint', () => {
+    writeFileSync(join(HOME, '.memorix', 'config.toml'), [
+      '[memory.llm]',
+      'base_url = "https://llm.example/v1"',
+      'api_key = "llm-key"',
+      '',
+      '[rerank]',
+      'provider = "http"',
+      'model = "rerank-model"',
+      'base_url = "https://LLM.example/v1/"',
+    ].join('\n'), 'utf8');
+
+    const lane = getResolvedRerankLane({ projectRoot: null, homeDir: HOME });
+
+    expect(lane.provider).toBe('http');
+    expect(lane.baseUrl).toBe('https://LLM.example/v1/');
+    expect(lane.apiKey).toBe('llm-key');
+  });
+
+  it('does not inherit the memory LLM key when the rerank URL is a different endpoint', () => {
+    writeFileSync(join(HOME, '.memorix', 'config.toml'), [
+      '[memory.llm]',
+      'base_url = "https://llm.example/v1"',
+      'api_key = "llm-key"',
+      '',
+      '[rerank]',
+      'provider = "http"',
+      'model = "rerank-model"',
+      'base_url = "https://api.example.com/v1"',
+    ].join('\n'), 'utf8');
+
+    const lane = getResolvedRerankLane({ projectRoot: null, homeDir: HOME });
+
+    expect(lane.provider).toBe('http');
+    expect(lane.baseUrl).toBe('https://api.example.com/v1');
+    expect(lane.apiKey).toBeUndefined();
+  });
+
+  it('uses a dedicated rerank key when the endpoint differs from the memory LLM', () => {
+    writeFileSync(join(HOME, '.memorix', 'config.toml'), [
+      '[memory.llm]',
+      'base_url = "https://llm.example/v1"',
+      'api_key = "llm-key"',
+      '',
+      '[rerank]',
+      'provider = "http"',
+      'model = "rerank-model"',
+      'base_url = "https://api.example.com/v1"',
+      'api_key = "rerank-key"',
+    ].join('\n'), 'utf8');
+
+    const lane = getResolvedRerankLane({ projectRoot: null, homeDir: HOME });
+
+    expect(lane.apiKey).toBe('rerank-key');
+  });
+
   it('resolves CodeGraph scan limits from TOML above legacy YAML', () => {
     writeFileSync(join(HOME, '.memorix', 'config.toml'), [
       '[codegraph]',

--- a/tests/config/resolved-config.test.ts
+++ b/tests/config/resolved-config.test.ts
@@ -256,6 +256,25 @@ describe('resolved config', () => {
     expect(lane.canSendRequest).toBe(true);
   });
 
+  it('inherits the memory LLM key when the rerank URL only adds a /rerank suffix', () => {
+    writeFileSync(join(HOME, '.memorix', 'config.toml'), [
+      '[memory.llm]',
+      'base_url = "https://llm.example/v1"',
+      'api_key = "llm-key"',
+      '',
+      '[rerank]',
+      'provider = "http"',
+      'model = "rerank-model"',
+      'base_url = "https://llm.example/v1/rerank"',
+    ].join('\n'), 'utf8');
+
+    const lane = getResolvedRerankLane({ projectRoot: null, homeDir: HOME });
+
+    expect(lane.baseUrl).toBe('https://llm.example/v1/rerank');
+    expect(lane.apiKey).toBe('llm-key');
+    expect(lane.canSendRequest).toBe(true);
+  });
+
   it('does not inherit the memory LLM key when the rerank URL is a different endpoint', () => {
     writeFileSync(join(HOME, '.memorix', 'config.toml'), [
       '[memory.llm]',

--- a/tests/git/extractor.test.ts
+++ b/tests/git/extractor.test.ts
@@ -13,11 +13,11 @@ import { detectProject } from '../../src/project/detector.js';
 import { getCommitInfo, getRecentCommits, ingestCommit } from '../../src/git/extractor.js';
 
 describe('Git Project Detection', () => {
-  it('should detect AVIDS2/memorix from git remote', () => {
+  it('should detect this repository from git remote', () => {
     const project = detectProject();
     expect(project).not.toBeNull();
-    expect(project!.id).toBe('AVIDS2/memorix');
-    expect(project!.gitRemote).toBeTruthy();
+    expect(project!.id).toMatch(/^[\w.-]+\/memorix$/);
+    expect(project!.gitRemote).toMatch(/memorix/i);
     expect(project!.rootPath).toBeTruthy();
   }, 30_000);
 

--- a/tests/rerank/http-provider.test.ts
+++ b/tests/rerank/http-provider.test.ts
@@ -1,0 +1,163 @@
+/**
+ * HTTP rerank provider tests.
+ *
+ * Cohere-compatible POST {base_url}/rerank. Model id is sent as configured.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  buildRerankUrl,
+  parseRerankResponse,
+  rerankViaHttp,
+} from '../../src/rerank/http-provider.js';
+
+const EXAMPLE_BASE = 'https://api.example.com/v1';
+const EXAMPLE_MODEL = 'rerank-model';
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('buildRerankUrl', () => {
+  it('appends /rerank to a v1 base URL', () => {
+    expect(buildRerankUrl(EXAMPLE_BASE)).toBe(`${EXAMPLE_BASE}/rerank`);
+    expect(buildRerankUrl('https://api.example.com/v1/')).toBe('https://api.example.com/v1/rerank');
+  });
+
+  it('keeps an explicit /rerank path', () => {
+    expect(buildRerankUrl('http://127.0.0.1:8080/rerank')).toBe('http://127.0.0.1:8080/rerank');
+  });
+});
+
+describe('parseRerankResponse', () => {
+  it('reads Cohere results[].relevance_score', () => {
+    const ranked = parseRerankResponse({
+      results: [
+        { index: 2, relevance_score: 0.91 },
+        { index: 0, relevance_score: 0.4 },
+      ],
+    });
+    expect(ranked).toEqual([
+      { index: 2, score: 0.91 },
+      { index: 0, score: 0.4 },
+    ]);
+  });
+
+  it('reads TEI [{index, score}] arrays', () => {
+    const ranked = parseRerankResponse([
+      { index: 1, score: 0.8 },
+      { index: 0, score: 0.2 },
+    ]);
+    expect(ranked).toEqual([
+      { index: 1, score: 0.8 },
+      { index: 0, score: 0.2 },
+    ]);
+  });
+
+  it('rejects empty or malformed payloads', () => {
+    expect(() => parseRerankResponse({})).toThrow(/rerank/i);
+    expect(() => parseRerankResponse({ results: [] })).toThrow(/rerank/i);
+  });
+});
+
+describe('rerankViaHttp', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('posts the Cohere wire format to {base_url}/rerank', async () => {
+    const fetchImpl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      expect(String(input)).toBe(`${EXAMPLE_BASE}/rerank`);
+      expect(init?.method).toBe('POST');
+      const headers = new Headers(init?.headers);
+      expect(headers.get('authorization')).toBe('Bearer rerank-key');
+      const body = JSON.parse(String(init?.body));
+      expect(body).toEqual({
+        model: EXAMPLE_MODEL,
+        query: 'JWT expiry',
+        documents: ['gotcha about tokens', 'unrelated database note'],
+        top_n: 2,
+        return_documents: false,
+      });
+      return jsonResponse({
+        model: EXAMPLE_MODEL,
+        results: [
+          { index: 0, relevance_score: 0.88 },
+          { index: 1, relevance_score: 0.11 },
+        ],
+      });
+    });
+
+    const ranked = await rerankViaHttp(
+      'JWT expiry',
+      ['gotcha about tokens', 'unrelated database note'],
+      {
+        provider: 'http',
+        model: EXAMPLE_MODEL,
+        baseUrl: EXAMPLE_BASE,
+        apiKey: 'rerank-key',
+        fetchImpl,
+      },
+    );
+
+    expect(ranked.map((row) => row.index)).toEqual([0, 1]);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends the configured model string unchanged', async () => {
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.model).toBe('vendor/rerank-large');
+      return jsonResponse({ results: [{ index: 0, relevance_score: 1 }] });
+    });
+
+    await rerankViaHttp('q', ['a'], {
+      provider: 'http',
+      model: 'vendor/rerank-large',
+      baseUrl: EXAMPLE_BASE,
+      fetchImpl,
+    });
+  });
+
+  it('omits model when none is configured', async () => {
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const body = JSON.parse(String(init?.body));
+      expect(body.model).toBeUndefined();
+      return jsonResponse({ results: [{ index: 0, relevance_score: 1 }] });
+    });
+
+    await rerankViaHttp('q', ['a'], {
+      provider: 'http',
+      baseUrl: EXAMPLE_BASE,
+      fetchImpl,
+    });
+  });
+
+  it('omits Authorization when no API key is configured', async () => {
+    const fetchImpl = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      const headers = new Headers(init?.headers);
+      expect(headers.get('authorization')).toBeNull();
+      return jsonResponse({ results: [{ index: 0, relevance_score: 1 }] });
+    });
+
+    await rerankViaHttp('q', ['only'], {
+      provider: 'http',
+      baseUrl: 'http://127.0.0.1:8080',
+      fetchImpl,
+    });
+  });
+
+  it('throws on HTTP errors so the caller can fall back to LLM rerank', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({ error: 'nope' }, 502));
+
+    await expect(rerankViaHttp('q', ['a', 'b'], {
+      provider: 'http',
+      baseUrl: EXAMPLE_BASE,
+      apiKey: 'k',
+      fetchImpl,
+    })).rejects.toThrow(/502/);
+  });
+});

--- a/tests/rerank/http-provider.test.ts
+++ b/tests/rerank/http-provider.test.ts
@@ -150,7 +150,7 @@ describe('rerankViaHttp', () => {
     });
   });
 
-  it('throws on HTTP errors so the caller can fall back to LLM rerank', async () => {
+  it('throws on HTTP errors so the caller can keep the original order', async () => {
     const fetchImpl = vi.fn(async () => jsonResponse({ error: 'nope' }, 502));
 
     await expect(rerankViaHttp('q', ['a', 'b'], {
@@ -159,5 +159,44 @@ describe('rerankViaHttp', () => {
       apiKey: 'k',
       fetchImpl,
     })).rejects.toThrow(/502/);
+  });
+
+  it('aborts a hung request at the configured timeout', async () => {
+    const fetchImpl = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => (
+      new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        const onAbort = () => reject(Object.assign(new Error('aborted'), { name: 'AbortError' }));
+        if (!signal) return;
+        if (signal.aborted) onAbort();
+        else signal.addEventListener('abort', onAbort, { once: true });
+      })
+    ));
+
+    await expect(rerankViaHttp('q', ['doc'], {
+      provider: 'http',
+      baseUrl: EXAMPLE_BASE,
+      timeoutMs: 25,
+      fetchImpl: fetchImpl as typeof fetch,
+    })).rejects.toMatchObject({ name: 'AbortError' });
+  });
+
+  it('uses MEMORIX_RERANK_TIMEOUT_MS when timeoutMs is omitted', async () => {
+    const previous = process.env.MEMORIX_RERANK_TIMEOUT_MS;
+    process.env.MEMORIX_RERANK_TIMEOUT_MS = '12000';
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const fetchImpl = vi.fn(async () => jsonResponse({ results: [{ index: 0, relevance_score: 1 }] }));
+
+    try {
+      await rerankViaHttp('q', ['doc'], {
+        provider: 'http',
+        baseUrl: EXAMPLE_BASE,
+        fetchImpl,
+      });
+      expect(setTimeoutSpy.mock.calls.some((call) => call[1] === 12_000)).toBe(true);
+    } finally {
+      setTimeoutSpy.mockRestore();
+      if (previous === undefined) delete process.env.MEMORIX_RERANK_TIMEOUT_MS;
+      else process.env.MEMORIX_RERANK_TIMEOUT_MS = previous;
+    }
   });
 });

--- a/tests/rerank/neural-rerank.test.ts
+++ b/tests/rerank/neural-rerank.test.ts
@@ -1,0 +1,111 @@
+/**
+ * HTTP rerank lane: configured /rerank endpoint, then original order on failure.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { resetTomlConfigCache } from '../../src/config/toml-loader.js';
+import { resetYamlConfigCache } from '../../src/config/yaml-loader.js';
+import { resetResolvedConfigCache } from '../../src/config/resolved-config.js';
+
+const TMP = join(process.cwd(), '.tmp-neural-rerank-test');
+const HOME = join(TMP, 'home');
+
+const ENV_KEYS = [
+  'MEMORIX_RERANK_PROVIDER',
+  'MEMORIX_RERANK_MODEL',
+  'MEMORIX_RERANK_BASE_URL',
+  'MEMORIX_RERANK_API_KEY',
+  'MEMORIX_LLM_BASE_URL',
+  'MEMORIX_LLM_API_KEY',
+];
+
+async function loadLane() {
+  const { isNeuralRerankEnabled, neuralRerankCandidates } = await import('../../src/rerank/index.js');
+  return { isNeuralRerankEnabled, neuralRerankCandidates };
+}
+
+describe('neural rerank lane', () => {
+  afterEach(() => {
+    rmSync(TMP, { recursive: true, force: true });
+    resetTomlConfigCache();
+    resetYamlConfigCache();
+    resetResolvedConfigCache();
+    for (const key of ENV_KEYS) delete process.env[key];
+    vi.resetModules();
+  });
+
+  it('is off by default', async () => {
+    mkdirSync(join(HOME, '.memorix'), { recursive: true });
+    const { isNeuralRerankEnabled } = await loadLane();
+    expect(isNeuralRerankEnabled({ projectRoot: null, homeDir: HOME })).toBe(false);
+  });
+
+  it('inherits base URL and bearer from the memory LLM lane', async () => {
+    mkdirSync(join(HOME, '.memorix'), { recursive: true });
+    writeFileSync(join(HOME, '.memorix', 'config.toml'), [
+      '[memory.llm]',
+      'base_url = "https://llm.example/v1"',
+      'api_key = "llm-from-memory"',
+      '',
+      '[rerank]',
+      'provider = "http"',
+      'model = "rerank-model"',
+    ].join('\n'), 'utf8');
+
+    const { getResolvedRerankLane } = await import('../../src/config/resolved-config.js');
+    const lane = getResolvedRerankLane({ projectRoot: null, homeDir: HOME });
+    expect(lane.provider).toBe('http');
+    expect(lane.model).toBe('rerank-model');
+    expect(lane.baseUrl).toBe('https://llm.example/v1');
+    expect(lane.apiKey).toBe('llm-from-memory');
+  });
+
+  it('keeps an explicit public host enabled when configured', async () => {
+    mkdirSync(join(HOME, '.memorix'), { recursive: true });
+    writeFileSync(join(HOME, '.memorix', 'config.toml'), [
+      '[rerank]',
+      'provider = "http"',
+      'base_url = "https://api.example.com/v1"',
+      'model = "rerank-model"',
+      'api_key = "rerank-key"',
+    ].join('\n'), 'utf8');
+
+    const { getResolvedRerankLane } = await import('../../src/config/resolved-config.js');
+    const { isNeuralRerankEnabled } = await loadLane();
+    const lane = getResolvedRerankLane({ projectRoot: null, homeDir: HOME });
+    expect(lane.provider).toBe('http');
+    expect(lane.baseUrl).toBe('https://api.example.com/v1');
+    expect(lane.model).toBe('rerank-model');
+    expect(isNeuralRerankEnabled({ projectRoot: null, homeDir: HOME })).toBe(true);
+  });
+
+  it('reorders candidates from a Cohere-shaped response', async () => {
+    process.env.MEMORIX_RERANK_PROVIDER = 'http';
+    process.env.MEMORIX_RERANK_BASE_URL = 'https://api.example.com/v1';
+    process.env.MEMORIX_RERANK_MODEL = 'rerank-model';
+    process.env.MEMORIX_RERANK_API_KEY = 'rerank-key';
+    mkdirSync(join(HOME, '.memorix'), { recursive: true });
+
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      results: [
+        { index: 2, relevance_score: 0.99 },
+        { index: 0, relevance_score: 0.4 },
+        { index: 1, relevance_score: 0.1 },
+      ],
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+    vi.stubGlobal('fetch', fetchImpl);
+
+    const { neuralRerankCandidates } = await loadLane();
+    const reranked = await neuralRerankCandidates('JWT', [
+      { id: 'r1', title: 'alpha', type: 'gotcha', score: 1 },
+      { id: 'r2', title: 'beta', type: 'gotcha', score: 0.9 },
+      { id: 'r3', title: 'gamma', type: 'gotcha', score: 0.8 },
+    ], { projectRoot: null, homeDir: HOME });
+
+    expect(reranked?.map((row) => row.id)).toEqual(['r3', 'r1', 'r2']);
+    expect(String(fetchImpl.mock.calls[0]?.[0])).toBe('https://api.example.com/v1/rerank');
+    vi.unstubAllGlobals();
+  });
+});

--- a/tests/rerank/neural-rerank.test.ts
+++ b/tests/rerank/neural-rerank.test.ts
@@ -125,6 +125,7 @@ describe('neural rerank lane', () => {
     const { getResolvedRerankLane } = await import('../../src/config/resolved-config.js');
     const lane = getResolvedRerankLane({ projectRoot: null, homeDir: HOME });
     expect(lane.apiKey).toBeUndefined();
+    expect(lane.canSendRequest).toBe(false);
 
     const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
       results: [
@@ -135,17 +136,16 @@ describe('neural rerank lane', () => {
     }), { status: 200, headers: { 'content-type': 'application/json' } }));
     vi.stubGlobal('fetch', fetchImpl);
 
-    const { neuralRerankCandidates } = await loadLane();
-    await neuralRerankCandidates('JWT', [
+    const { isNeuralRerankEnabled, neuralRerankCandidates } = await loadLane();
+    expect(isNeuralRerankEnabled({ projectRoot: null, homeDir: HOME })).toBe(true);
+    const reranked = await neuralRerankCandidates('JWT', [
       { id: 'r1', title: 'alpha', type: 'gotcha', score: 1 },
       { id: 'r2', title: 'beta', type: 'gotcha', score: 0.9 },
       { id: 'r3', title: 'gamma', type: 'gotcha', score: 0.8 },
     ], { projectRoot: null, homeDir: HOME });
 
-    const headers = fetchImpl.mock.calls[0]?.[1]?.headers as Record<string, string>;
-    const authorization = headers?.authorization ?? headers?.Authorization;
-    expect(authorization).toBeUndefined();
-    expect(JSON.stringify(fetchImpl.mock.calls[0])).not.toContain('llm-from-memory');
+    expect(reranked).toBeNull();
+    expect(fetchImpl).not.toHaveBeenCalled();
     vi.unstubAllGlobals();
   });
 });

--- a/tests/rerank/neural-rerank.test.ts
+++ b/tests/rerank/neural-rerank.test.ts
@@ -148,4 +148,41 @@ describe('neural rerank lane', () => {
     expect(fetchImpl).not.toHaveBeenCalled();
     vi.unstubAllGlobals();
   });
+
+  it('sends the dedicated rerank key, not the memory LLM key, to a different host', async () => {
+    mkdirSync(join(HOME, '.memorix'), { recursive: true });
+    writeFileSync(join(HOME, '.memorix', 'config.toml'), [
+      '[memory.llm]',
+      'base_url = "https://llm.example/v1"',
+      'api_key = "llm-from-memory"',
+      '',
+      '[rerank]',
+      'provider = "http"',
+      'model = "rerank-model"',
+      'base_url = "https://api.example.com/v1"',
+      'api_key = "rerank-key"',
+    ].join('\n'), 'utf8');
+
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      results: [
+        { index: 0, relevance_score: 0.9 },
+        { index: 1, relevance_score: 0.1 },
+        { index: 2, relevance_score: 0.05 },
+      ],
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+    vi.stubGlobal('fetch', fetchImpl);
+
+    const { neuralRerankCandidates } = await loadLane();
+    await neuralRerankCandidates('JWT', [
+      { id: 'r1', title: 'alpha', type: 'gotcha', score: 1 },
+      { id: 'r2', title: 'beta', type: 'gotcha', score: 0.9 },
+      { id: 'r3', title: 'gamma', type: 'gotcha', score: 0.8 },
+    ], { projectRoot: null, homeDir: HOME });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const headers = fetchImpl.mock.calls[0]?.[1]?.headers as Record<string, string>;
+    expect(headers.authorization).toBe('Bearer rerank-key');
+    expect(JSON.stringify(fetchImpl.mock.calls[0])).not.toContain('llm-from-memory');
+    vi.unstubAllGlobals();
+  });
 });

--- a/tests/rerank/neural-rerank.test.ts
+++ b/tests/rerank/neural-rerank.test.ts
@@ -108,4 +108,44 @@ describe('neural rerank lane', () => {
     expect(String(fetchImpl.mock.calls[0]?.[0])).toBe('https://api.example.com/v1/rerank');
     vi.unstubAllGlobals();
   });
+
+  it('does not transmit the memory LLM key to a different rerank endpoint', async () => {
+    mkdirSync(join(HOME, '.memorix'), { recursive: true });
+    writeFileSync(join(HOME, '.memorix', 'config.toml'), [
+      '[memory.llm]',
+      'base_url = "https://llm.example/v1"',
+      'api_key = "llm-from-memory"',
+      '',
+      '[rerank]',
+      'provider = "http"',
+      'model = "rerank-model"',
+      'base_url = "https://api.example.com/v1"',
+    ].join('\n'), 'utf8');
+
+    const { getResolvedRerankLane } = await import('../../src/config/resolved-config.js');
+    const lane = getResolvedRerankLane({ projectRoot: null, homeDir: HOME });
+    expect(lane.apiKey).toBeUndefined();
+
+    const fetchImpl = vi.fn(async () => new Response(JSON.stringify({
+      results: [
+        { index: 0, relevance_score: 0.9 },
+        { index: 1, relevance_score: 0.1 },
+        { index: 2, relevance_score: 0.05 },
+      ],
+    }), { status: 200, headers: { 'content-type': 'application/json' } }));
+    vi.stubGlobal('fetch', fetchImpl);
+
+    const { neuralRerankCandidates } = await loadLane();
+    await neuralRerankCandidates('JWT', [
+      { id: 'r1', title: 'alpha', type: 'gotcha', score: 1 },
+      { id: 'r2', title: 'beta', type: 'gotcha', score: 0.9 },
+      { id: 'r3', title: 'gamma', type: 'gotcha', score: 0.8 },
+    ], { projectRoot: null, homeDir: HOME });
+
+    const headers = fetchImpl.mock.calls[0]?.[1]?.headers as Record<string, string>;
+    const authorization = headers?.authorization ?? headers?.Authorization;
+    expect(authorization).toBeUndefined();
+    expect(JSON.stringify(fetchImpl.mock.calls[0])).not.toContain('llm-from-memory');
+    vi.unstubAllGlobals();
+  });
 });

--- a/tests/rerank/neural-rerank.test.ts
+++ b/tests/rerank/neural-rerank.test.ts
@@ -1,5 +1,5 @@
 /**
- * HTTP rerank lane: configured /rerank endpoint, then original order on failure.
+ * HTTP rerank lane: configured /rerank endpoint. Failures keep original order.
  */
 
 import { afterEach, describe, expect, it, vi } from 'vitest';

--- a/tests/rerank/policy.test.ts
+++ b/tests/rerank/policy.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_RERANK_TIMEOUT_MS,
+  RERANK_TIMEOUT_MAX_MS,
+  RERANK_TIMEOUT_MIN_MS,
+  parseRerankTimeoutMs,
+  resolveRerankTimeoutMs,
+  shouldAttemptHttpRerank,
+  shouldAttemptLlmRerank,
+} from '../../src/rerank/policy.js';
+
+describe('parseRerankTimeoutMs', () => {
+  it('returns 30s when the env var is unset or empty', () => {
+    expect(parseRerankTimeoutMs(undefined)).toBe(DEFAULT_RERANK_TIMEOUT_MS);
+    expect(parseRerankTimeoutMs('')).toBe(DEFAULT_RERANK_TIMEOUT_MS);
+    expect(parseRerankTimeoutMs('   ')).toBe(DEFAULT_RERANK_TIMEOUT_MS);
+  });
+
+  it('parses a valid positive integer', () => {
+    expect(parseRerankTimeoutMs('45000')).toBe(45_000);
+  });
+
+  it('falls back to default and warns on invalid values', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    expect(parseRerankTimeoutMs('not-a-number')).toBe(DEFAULT_RERANK_TIMEOUT_MS);
+    expect(parseRerankTimeoutMs('1500.5')).toBe(DEFAULT_RERANK_TIMEOUT_MS);
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    warn.mockRestore();
+  });
+
+  it('clamps out-of-range values', () => {
+    expect(parseRerankTimeoutMs('0')).toBe(RERANK_TIMEOUT_MIN_MS);
+    expect(parseRerankTimeoutMs('999')).toBe(RERANK_TIMEOUT_MIN_MS);
+    expect(parseRerankTimeoutMs('999999')).toBe(RERANK_TIMEOUT_MAX_MS);
+  });
+});
+
+describe('resolveRerankTimeoutMs', () => {
+  const previous = process.env.MEMORIX_RERANK_TIMEOUT_MS;
+
+  afterEach(() => {
+    if (previous === undefined) delete process.env.MEMORIX_RERANK_TIMEOUT_MS;
+    else process.env.MEMORIX_RERANK_TIMEOUT_MS = previous;
+  });
+
+  it('prefers an explicit positive timeout over the environment', () => {
+    process.env.MEMORIX_RERANK_TIMEOUT_MS = '12000';
+    expect(resolveRerankTimeoutMs(8_000)).toBe(8_000);
+  });
+
+  it('honors MEMORIX_RERANK_TIMEOUT_MS when no explicit timeout is passed', () => {
+    process.env.MEMORIX_RERANK_TIMEOUT_MS = '12000';
+    expect(resolveRerankTimeoutMs()).toBe(12_000);
+  });
+
+  it('defaults to 30s when neither override nor env is set', () => {
+    delete process.env.MEMORIX_RERANK_TIMEOUT_MS;
+    expect(resolveRerankTimeoutMs()).toBe(DEFAULT_RERANK_TIMEOUT_MS);
+  });
+});
+
+describe('shouldAttemptHttpRerank', () => {
+  it('runs on thorough search with at least 3 candidates', () => {
+    expect(shouldAttemptHttpRerank({
+      quality: 'thorough',
+      hasQuery: true,
+      candidateCount: 3,
+    })).toBe(true);
+  });
+
+  it('does not require a long query or close top-2 scores', () => {
+    expect(shouldAttemptHttpRerank({
+      quality: 'thorough',
+      hasQuery: true,
+      candidateCount: 8,
+    })).toBe(true);
+  });
+
+  it('skips balanced/fast profiles and thin result sets', () => {
+    expect(shouldAttemptHttpRerank({
+      quality: 'balanced',
+      hasQuery: true,
+      candidateCount: 8,
+    })).toBe(false);
+    expect(shouldAttemptHttpRerank({
+      quality: 'thorough',
+      hasQuery: true,
+      candidateCount: 2,
+    })).toBe(false);
+    expect(shouldAttemptHttpRerank({
+      quality: 'thorough',
+      hasQuery: false,
+      candidateCount: 8,
+    })).toBe(false);
+  });
+});
+
+describe('shouldAttemptLlmRerank', () => {
+  const heavyAmbiguous = {
+    quality: 'thorough',
+    tier: 'heavy',
+    hasQuery: true,
+    candidateCount: 5,
+    topScore: 1,
+    secondScore: 0.8,
+    httpRerankConfigured: false,
+  };
+
+  it('keeps the original thorough + heavy + close top-2 gate when HTTP is off', () => {
+    expect(shouldAttemptLlmRerank(heavyAmbiguous)).toBe(true);
+  });
+
+  it('does not run when an HTTP rerank lane is configured', () => {
+    expect(shouldAttemptLlmRerank({
+      ...heavyAmbiguous,
+      httpRerankConfigured: true,
+    })).toBe(false);
+  });
+
+  it('skips standard-tier or decisive top-2 scores', () => {
+    expect(shouldAttemptLlmRerank({
+      ...heavyAmbiguous,
+      tier: 'standard',
+    })).toBe(false);
+    expect(shouldAttemptLlmRerank({
+      ...heavyAmbiguous,
+      secondScore: 0.4,
+    })).toBe(false);
+  });
+});

--- a/tests/rerank/search-http-rerank.test.ts
+++ b/tests/rerank/search-http-rerank.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Thorough search uses HTTP rerank when configured, even for short queries.
+ * HTTP miss/timeout keeps the original order and does not call LLM rerank.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockIsNeuralRerankEnabled,
+  mockNeuralRerankCandidates,
+  mockRerankResults,
+} = vi.hoisted(() => ({
+  mockIsNeuralRerankEnabled: vi.fn(() => true),
+  mockNeuralRerankCandidates: vi.fn(),
+  mockRerankResults: vi.fn(),
+}));
+
+vi.mock('../../src/rerank/index.js', () => ({
+  isNeuralRerankEnabled: mockIsNeuralRerankEnabled,
+  neuralRerankCandidates: mockNeuralRerankCandidates,
+}));
+
+vi.mock('../../src/llm/quality.js', () => ({
+  rerankResults: mockRerankResults,
+}));
+
+vi.mock('../../src/embedding/provider.js', () => ({
+  getEmbeddingProvider: vi.fn(async () => ({
+    name: 'mock-api',
+    dimensions: 2,
+    async embed() { return [0, 1]; },
+    async embedBatch(texts: string[]) { return texts.map(() => [0, 1]); },
+  })),
+  isEmbeddingExplicitlyDisabled: vi.fn(() => true),
+  resetProvider: vi.fn(),
+}));
+
+vi.mock('../../src/llm/provider.js', () => ({
+  callLLM: vi.fn(async () => ({ content: '' })),
+  isLLMEnabled: vi.fn(() => false),
+  initLLM: vi.fn(),
+}));
+
+async function insertTokenDocs() {
+  const {
+    insertObservation,
+    makeOramaObservationId,
+  } = await import('../../src/store/orama-store.js');
+  const now = new Date().toISOString();
+  const projectId = 'example/rerank';
+  const docs = [
+    { id: 1, title: 'token expiry in auth middleware', narrative: 'JWT refresh window' },
+    { id: 2, title: 'token table migration', narrative: 'unrelated schema note' },
+    { id: 3, title: 'token cache warmup', narrative: 'local cache priming' },
+  ];
+  for (const doc of docs) {
+    await insertObservation({
+      id: makeOramaObservationId(projectId, doc.id),
+      observationId: doc.id,
+      entityName: 'auth',
+      type: 'gotcha',
+      title: doc.title,
+      narrative: doc.narrative,
+      facts: 'token',
+      filesModified: 'src/auth.ts',
+      concepts: 'token\nauth',
+      tokens: 20,
+      createdAt: now,
+      projectId,
+      accessCount: 0,
+      lastAccessedAt: now,
+      status: 'active',
+      source: 'agent',
+    });
+  }
+  return projectId;
+}
+
+describe('search HTTP rerank gate', () => {
+  beforeEach(async () => {
+    mockIsNeuralRerankEnabled.mockReset();
+    mockNeuralRerankCandidates.mockReset();
+    mockRerankResults.mockReset();
+    mockIsNeuralRerankEnabled.mockReturnValue(true);
+    mockNeuralRerankCandidates.mockImplementation(async (_query: string, candidates: Array<{ id: string }>) => (
+      [...candidates].reverse()
+    ));
+    mockRerankResults.mockResolvedValue({ reranked: [], usedLLM: false });
+    vi.resetModules();
+    const { resetDb } = await import('../../src/store/orama-store.js');
+    await resetDb();
+  });
+
+  it('reranks a short thorough query with 3 hits (no heavy-tier or close top-2 required)', async () => {
+    const projectId = await insertTokenDocs();
+    const { searchObservations, getLastSearchMode } = await import('../../src/store/orama-store.js');
+
+    await searchObservations({
+      query: 'token expiry',
+      projectId,
+      limit: 5,
+      quality: 'thorough',
+    });
+
+    expect(mockNeuralRerankCandidates).toHaveBeenCalledTimes(1);
+    expect(mockRerankResults).not.toHaveBeenCalled();
+    expect(getLastSearchMode(projectId)).toContain('neural rerank');
+  });
+
+  it('does not call HTTP rerank on balanced search', async () => {
+    const projectId = await insertTokenDocs();
+    const { searchObservations } = await import('../../src/store/orama-store.js');
+
+    await searchObservations({
+      query: 'token expiry',
+      projectId,
+      limit: 5,
+      quality: 'balanced',
+    });
+
+    expect(mockNeuralRerankCandidates).not.toHaveBeenCalled();
+    expect(mockRerankResults).not.toHaveBeenCalled();
+  });
+
+  it('keeps original order and skips LLM rerank when HTTP rerank fails', async () => {
+    mockNeuralRerankCandidates.mockRejectedValue(new Error('HTTP rerank timed out'));
+    const projectId = await insertTokenDocs();
+    const { searchObservations, getLastSearchMode } = await import('../../src/store/orama-store.js');
+
+    const entries = await searchObservations({
+      query: 'token expiry',
+      projectId,
+      limit: 5,
+      quality: 'thorough',
+    });
+
+    expect(entries.length).toBeGreaterThanOrEqual(3);
+    expect(mockNeuralRerankCandidates).toHaveBeenCalledTimes(1);
+    expect(mockRerankResults).not.toHaveBeenCalled();
+    expect(getLastSearchMode(projectId)).not.toContain('LLM rerank');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,6 +36,8 @@ export default defineConfig({
             'tests/cli/receipt.test.ts',
             'tests/cli/operator-surface.test.ts',
             'tests/cli/uninstall.test.ts',
+            // Mutates process.cwd/env and tears down git+sqlite sandboxes.
+            'tests/cli/codegraph-command.test.ts',
           ],
         },
       },
@@ -59,8 +61,10 @@ export default defineConfig({
             'tests/cli/receipt.test.ts',
             'tests/cli/operator-surface.test.ts',
             'tests/cli/uninstall.test.ts',
+            'tests/cli/codegraph-command.test.ts',
           ],
           testTimeout: 15_000,
+          hookTimeout: 30_000,
           // Run one file at a time — no parallelism, no port/CPU races
           // @ts-expect-error — fileParallelism is valid at project level per vitest docs
           fileParallelism: false,


### PR DESCRIPTION
## Summary
Search ranking today is lexical plus an optional LLM rerank. There is no hook for a dedicated neural rerank API.

This adds an optional HTTP rerank lane. When `[rerank] provider = "http"`, thorough search with at least 3 candidates POSTs a Cohere-compatible `{model, query, documents}` body to `{base_url}/rerank` (or an explicit `/rerank` path). Responses accept Cohere `{results:[{index,relevance_score}]}` and TEI `[{index,score}]`.

The model id is user-configured and sent unchanged. Off by default.

Auth:
- `base_url` still inherits `[memory.llm].base_url` when unset.
- The Memory LLM bearer (`MEMORIX_LLM_API_KEY` / `MEMORIX_API_KEY` / `[memory.llm].api_key`) is inherited only when the effective rerank URL is that same trusted endpoint (scheme/host/port/path; trailing slash and `/rerank` stripped).
- A different host requires `MEMORIX_RERANK_API_KEY` / `rerank.api_key`. If a Memory LLM key is present and that dedicated key is missing, Memorix does not call the foreign host and does not send the LLM key.
- HTTP remains configured in that case, so LLM rerank is not used as a fallback. Miss/timeout also keeps the original order.

Timeout: `MEMORIX_RERANK_TIMEOUT_MS` (default 30000), honored by both the inner HTTP fetch and the outer search bound.

Supersedes #210 after the head branch was renamed to a vendor-agnostic name.

## Enable

Same gateway as the memory LLM:

```toml
[rerank]
provider = "http"
model = "rerank-model"
```

Different host:

```toml
[rerank]
provider = "http"
model = "rerank-model"
base_url = "https://api.example.com/v1"
api_key = "..."
```

or `MEMORIX_RERANK_API_KEY`.

## Test plan
- [x] `vitest run tests/rerank tests/config/resolved-config.test.ts tests/cli/init.test.ts tests/cli/config-command.test.ts tests/search/orama-store-semantic.test.ts tests/search/query-tier.test.ts tests/llm/quality.test.ts`
- [x] Same-endpoint inherit vs different-endpoint no inherit / no transmit / no fetch
- [x] `memorix status` shows the rerank lane when configured
- [x] On HTTP failure, original order is kept and LLM rerank does not run
