### PR TITLE
fix(runtime): bound hook and HTTP control-plane recovery

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        # The CLI launches child processes and serves HTTP on every supported
+        # desktop platform. Keep macOS in the normal release gate rather than
+        # treating it as an unverified compatibility target.
+        os: [ubuntu-latest, windows-latest, macos-latest]
         node-version: [22]
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.6.1] - 2026-08-17
+
+### Fixed
+- **Bounded hook lifecycle on every desktop platform** -- `memorix hook` now
+  reads stdin with an idle bound, performs embedding writes in the deferred
+  lane, and has a hard process deadline. The hook-specific V8 heap is 512 MiB
+  instead of the control plane's 4 GiB. This prevents hung hook processes and
+  associated CPU or memory pressure on macOS, Windows, and Linux. The Windows
+  CLI heap restart also hides its child console window.
+- **Recoverable HTTP MCP sessions** -- HTTP MCP sessions now default to a
+  12-hour idle window. An expired or unknown session receives a fast `404`
+  with a reinitialize hint instead of looking like a silent client hang. Set
+  `MEMORIX_SESSION_TIMEOUT_MS=0` only when the host owns lifecycle cleanup.
+- **Truthful embedding diagnostics** -- the HTTP control plane exposes its
+  real runtime embedding state. `memorix doctor` reads that state instead of
+  reporting a fresh local probe as ready while the running service is degraded
+  by authorization, billing, timeout, or upstream failure.
+- **Accurate doctor JSON health** -- a live PID with an unreachable HTTP
+  control plane now reports `healthy: false` rather than a false positive.
+
+### Changed
+- **macOS release coverage** -- normal CI now runs the full build and test
+  suite on `macos-latest` in addition to Ubuntu and Windows.
+
 ## [1.6.0] - 2026-08-17
 
 ### Added

--- a/docs/AGENT_OPERATOR_PLAYBOOK.md
+++ b/docs/AGENT_OPERATOR_PLAYBOOK.md
@@ -58,7 +58,7 @@ An unbound terminal is intentionally project-scoped: it reads and writes project
 
 Long-term memory is a reviewed layer, not a generic global note store. `memorix memory long-term add` creates a candidate; `qualify` and `approve` are explicit audit transitions before it can appear in a bounded task Workset. A project-derived observation, code fact, Git fact, test, session, Claim, or workflow stays project-bound. Only manual or user-confirmed `user + portable` records can cross local projects for the same local installation identity. When one is task-matched in a Workset, it is intentionally usable background even if its origin differs; use its `durable:<id>` reference with `memorix_detail` only when the full record is needed. Use `archive` or `supersede` when a durable item is no longer current.
 
-`--cwd <git-project>` is the canonical way to run direct CLI work from outside a repository. It changes the command's project anchor only; Git remains the source of truth for final project identity.
+`--cwd <git-project>` is the canonical way to run direct CLI work from outside a repository. It changes the command's project anchor only; Git remains the source of truth for final project identity. Existing directories are canonicalized to their real filesystem paths before binding, which prevents macOS aliases such as `/var` and `/private/var` from splitting one project or hiding a Claude local MCP entry.
 
 Use MCP when:
 

--- a/docs/AGENT_OPERATOR_PLAYBOOK.md
+++ b/docs/AGENT_OPERATOR_PLAYBOOK.md
@@ -164,7 +164,12 @@ Do not assume the HTTP connection alone tells Memorix which project the user mea
 
 The HTTP service is normally started with `memorix background start`; the same project-binding rules apply when you run `memorix serve-http --port 3211` in the foreground.
 
-HTTP MCP sessions idle out after 30 minutes by default. If the user's HTTP MCP client is sensitive to stale session IDs after long idle periods, set `MEMORIX_SESSION_TIMEOUT_MS` before starting or restarting the service. Example: `MEMORIX_SESSION_TIMEOUT_MS=86400000` keeps sessions alive for 24 hours.
+HTTP MCP sessions idle out after 12 hours by default. An expired session now
+receives a fast `404` reinitialize hint instead of a generic transport failure.
+If the user's HTTP MCP client needs a longer idle period, set
+`MEMORIX_SESSION_TIMEOUT_MS` before starting or restarting the service.
+Example: `MEMORIX_SESSION_TIMEOUT_MS=86400000` keeps sessions alive for 24
+hours. Set it to `0` only when the host has its own reliable session cleanup.
 
 ### Do not confuse project config and global config
 
@@ -702,7 +707,10 @@ If it shows "Not running" or "dead":
 memorix background ensure
 ```
 
-If the client is connected but starts failing after roughly 30 minutes of no Memorix tool use, check for stale HTTP session expiry rather than treating it as project binding failure. Restart the service with a longer idle timeout:
+If the client is connected but starts failing after a long inactive period,
+check for the explicit stale-session `404` reinitialize hint rather than
+treating it as a project-binding failure. The default idle window is 12 hours;
+restart with a longer window only when the client genuinely needs it:
 
 ```powershell
 $env:MEMORIX_SESSION_TIMEOUT_MS = "86400000"

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -652,7 +652,7 @@ Coordination state is opt-in project state for tasks, handoff messages, locks, a
 
 Runtime environment:
 
-- `MEMORIX_SESSION_TIMEOUT_MS` — HTTP MCP session idle timeout in milliseconds. Default: `1800000` (30 minutes). Increase this for clients that do not transparently reinitialize after stale HTTP session IDs, for example `86400000` for 24 hours.
+- `MEMORIX_SESSION_TIMEOUT_MS` — HTTP MCP session idle timeout in milliseconds. Default: `43200000` (12 hours). Expired session IDs receive a fast `404` with a reinitialize hint. Increase this for long-lived clients, for example `86400000` for 24 hours; set `0` only when the host provides reliable lifecycle cleanup.
 
 ### `team_manage`
 

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -128,7 +128,11 @@ docker compose ps
 
 ### HTTP session idle timeout
 
-The HTTP MCP transport defaults to a 30-minute idle timeout. The example `compose.yaml` raises this to 24 hours for IDEs that keep one HTTP MCP session open while the user reads diffs, runs tests, or switches focus.
+The HTTP MCP transport defaults to a 12-hour idle timeout. The example
+`compose.yaml` raises this to 24 hours for IDEs that keep one HTTP MCP session
+open while the user reads diffs, runs tests, or switches focus. When a session
+does expire, the service returns a fast `404` so the client can initialize a
+fresh MCP session.
 
 To change it:
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -71,7 +71,7 @@ On the release development machine used for this check, the healthy HTTP service
 
 | Knob | Default | Use When |
 | --- | --- | --- |
-| `MEMORIX_SESSION_TIMEOUT_MS` | `1800000` (30 min) | Increase for HTTP MCP clients that do not recover from stale session IDs after idle time |
+| `MEMORIX_SESSION_TIMEOUT_MS` | `43200000` (12 h) | Set a shorter GC window for supervised clients, or `0` to disable idle session GC |
 | `MEMORIX_FORMATION_TIMEOUT_MS` | `12000` (12 s) | Raise when LLM-backed formation should outlive slow proxy/provider hops |
 | `MEMORIX_LLM_API_KEY` / `OPENAI_API_KEY` | unset | Enable LLM-backed enrichment, extraction, rerank, or skill generation |
 | `MEMORIX_LLM_TIMEOUT_MS` | `30000` (30 s) | Bound a single LLM-backed extraction/resolve call |
@@ -86,7 +86,7 @@ On the release development machine used for this check, the healthy HTTP service
 ## Operator Guidance
 
 - For memory-only use, prefer stdio MCP or a lightweight `memorix_session_start`; do not join orchestration coordination state by default.
-- For long-lived IDE sessions over HTTP, set `MEMORIX_SESSION_TIMEOUT_MS=86400000` before `memorix background start` if your client is stale-session-sensitive.
+- HTTP sessions now default to 12 hours and return a fast `404` with a reinitialize hint after expiry. Set `MEMORIX_SESSION_TIMEOUT_MS=0` only when the host has its own reliable lifecycle cleanup; otherwise retain a bounded GC window.
 - If LLM-backed formation is timing out against a slow proxy/provider, raise `MEMORIX_FORMATION_TIMEOUT_MS` and keep it higher than `MEMORIX_LLM_TIMEOUT_MS`, because the full pipeline can include multiple LLM-backed stages.
 - For Docker, use it when you want a managed HTTP service. Do not use image size alone as the runtime memory estimate.
 - For orchestrated subagent work, expect CPU and disk activity proportional to the spawned agents and verification commands.

--- a/docs/README.md
+++ b/docs/README.md
@@ -117,11 +117,13 @@ Historical/deep-reference documents may describe older designs. If they conflict
 
 ## Current Product Line
 
-The released product is on the **1.4 line**. The current baseline has:
+The released product is on the **1.6 line**. The current baseline has:
 
 - `memorix setup --agent <agent> --global` is the default agent integration command
 - `memorix serve` is the manual stdio MCP server for external agents
 - `memorix background start` runs the shared HTTP MCP service and dashboard
+- context and CodeGraph commands return bounded task receipts before detailed diagnostics
+- HTTP MCP sessions have a bounded, explicit lifecycle and fail with a reinitialize hint after expiry
 - `memorix integrate --agent <agent>` and `memorix hooks install --agent <agent>` remain manual/fallback generation commands
 - `memorix` / `memcode` open memcode, the bundled terminal agent that uses the same Memorix memory pool
 - `~/.memorix/config.toml` and project `memorix.toml` are the user-facing configuration model

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -247,12 +247,18 @@ Generic HTTP MCP config:
 
 For multi-project HTTP usage, agents should call `memorix_session_start(projectRoot=...)` with the absolute workspace path when available. This prevents cross-project drift when the background service is shared.
 
-HTTP sessions idle out after 30 minutes by default. For clients that do not recover gracefully from stale HTTP session IDs:
+HTTP sessions idle out after 12 hours by default. An expired session receives a
+fast `404` that tells the client to initialize again, rather than being treated
+as a project-binding failure. For clients that intentionally need a longer
+window:
 
 ```powershell
 $env:MEMORIX_SESSION_TIMEOUT_MS = "86400000"
 memorix background restart
 ```
+
+Set `MEMORIX_SESSION_TIMEOUT_MS=0` only when the host has its own reliable
+session cleanup; otherwise keep a bounded idle window.
 
 ### Option E: Docker HTTP service
 

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -42,7 +42,7 @@ Memorix project identity comes from Git. Open or initialize a real Git repositor
 git init
 ```
 
-`projectRoot` and current working directory are detection anchors. The final project identity is derived from the real Git root and remote metadata.
+`projectRoot` and current working directory are detection anchors. The final project identity is derived from the real Git root and remote metadata. Memorix resolves an existing project directory to its real filesystem path before binding it, so equivalent macOS paths such as `/var/...` and `/private/var/...` do not create separate project or Claude local-MCP entries.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memorix",
   "mcpName": "io.github.AVIDS2/memorix",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
+++ b/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Local-first project memory for CodeBuddy Code and other coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AVIDS2/memorix",
     "source": "github"
   },
-  "version": "1.6.0",
+  "version": "1.6.1",
   "websiteUrl": "https://github.com/AVIDS2/memorix#readme",
   "icons": [
     {
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "memorix",
-      "version": "1.6.0",
+      "version": "1.6.1",
       "runtimeHint": "npx",
       "packageArguments": [
         {

--- a/src/cli/commands/agent-integrations.ts
+++ b/src/cli/commands/agent-integrations.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, realpathSync } from 'node:fs';
 import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { basename, dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
@@ -580,11 +580,17 @@ function sanitizeServer(server: MCPServerEntry): AgentMcpCheck['server'] {
 }
 
 function normalizeProjectKey(projectRoot: string): string {
-  return resolve(projectRoot).replace(/\\/g, '/').toLowerCase();
+  return canonicalProjectPath(projectRoot).toLowerCase();
 }
 
 function defaultClaudeProjectKey(projectRoot: string): string {
-  return resolve(projectRoot).replace(/\\/g, '/');
+  return canonicalProjectPath(projectRoot);
+}
+
+function canonicalProjectPath(projectRoot: string): string {
+  const resolved = resolve(projectRoot);
+  const canonical = existsSync(resolved) ? realpathSync(resolved) : resolved;
+  return canonical.replace(/\\/g, '/');
 }
 
 function getClaudeLocalConfigPath(): string {

--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -131,6 +131,7 @@ export default defineCommand({
     let bgRunning = false;
     let bgPort = 0;
     let bgPid = 0;
+    let backgroundHealthy = false;
 
     try {
       if (existsSync(bgStatePath)) {
@@ -148,7 +149,7 @@ export default defineCommand({
       // Health check
       try {
         const http = await import('node:http');
-        const healthy = await new Promise<boolean>((resolve) => {
+        backgroundHealthy = await new Promise<boolean>((resolve) => {
           const req = http.request({ hostname: '127.0.0.1', port: bgPort, path: '/api/team', timeout: 3000 }, (res) => {
             res.resume();
             resolve(res.statusCode === 200);
@@ -157,7 +158,7 @@ export default defineCommand({
           req.on('timeout', () => { req.destroy(); resolve(false); });
           req.end();
         });
-        if (healthy) {
+        if (backgroundHealthy) {
           lines.push(ok('Health check: OK'));
         } else {
           lines.push(warn('Health check: FAILED (process alive but not responding)'));
@@ -165,8 +166,9 @@ export default defineCommand({
         }
       } catch {
         lines.push(warn('Health check: could not connect'));
+        issues.push('Background process is alive but its health endpoint could not be reached. Try "memorix background restart".');
       }
-      report.mode = { type: 'background', pid: bgPid, port: bgPort, healthy: true };
+      report.mode = { type: 'background', pid: bgPid, port: bgPort, healthy: backgroundHealthy };
     } else {
       lines.push(info('Background control plane: not running'));
       lines.push(info('Current invocation: CLI (stdio)'));
@@ -210,20 +212,49 @@ export default defineCommand({
       } else {
         lines.push(ok(`Mode: ${mode}`));
 
-        // Try to initialize provider to check real status
-        const { getEmbeddingProvider } = await import('../../embedding/provider.js');
-        const provider = await getEmbeddingProvider();
+        // A running control plane is the source of truth for runtime health.
+        // A fresh doctor process must not overwrite a live 401/402/timeout
+        // diagnosis with a static "configured = ready" result.
+        let controlPlaneEmbedding: {
+          status?: string;
+          provider?: { name?: string; dimensions?: number };
+          failure?: { kind?: string; retryAfterMs?: number };
+        } | undefined;
+        if (bgRunning) {
+          try {
+            const response = await fetch(`http://127.0.0.1:${bgPort}/health`, { signal: AbortSignal.timeout(3_000) });
+            if (response.ok) {
+              const health = await response.json() as { embedding?: typeof controlPlaneEmbedding };
+              controlPlaneEmbedding = health.embedding;
+            }
+          } catch { /* health is advisory; fall back to a local probe */ }
+        }
 
-        if (provider) {
-          lines.push(ok(`Provider: ${provider.name} (${provider.dimensions}d)`));
-          lines.push(ok('Status: ready'));
-          lines.push(info('Search: hybrid (BM25 + vector)'));
-          report.embedding = { mode, status: 'ready', provider: provider.name, dimensions: provider.dimensions };
+        if (controlPlaneEmbedding?.status === 'degraded') {
+          const kind = controlPlaneEmbedding.failure?.kind ?? 'upstream';
+          const retryAfterMs = controlPlaneEmbedding.failure?.retryAfterMs;
+          const retry = typeof retryAfterMs === 'number' && retryAfterMs > 0
+            ? `; retry in ${Math.ceil(retryAfterMs / 1000)}s`
+            : '';
+          lines.push(warn(`Status: degraded in the running control plane (${kind}${retry})`));
+          lines.push(info('Search: degraded to BM25 fulltext until the provider recovers'));
+          issues.push('The running control plane has an unavailable embedding provider. Check provider credentials, billing, or connectivity.');
+          report.embedding = { mode, status: 'degraded', failure: kind };
         } else {
-          lines.push(warn('Status: temporarily unavailable'));
-          lines.push(info('Search: degraded to BM25 fulltext (no vector similarity)'));
-          issues.push(`Embedding mode is "${mode}" but provider failed to initialize. Check API keys/connectivity.`);
-          report.embedding = { mode, status: 'temporarily_unavailable' };
+          const { getEmbeddingProvider } = await import('../../embedding/provider.js');
+          const provider = await getEmbeddingProvider();
+
+          if (provider) {
+            lines.push(ok(`Provider: ${provider.name} (${provider.dimensions}d)`));
+            lines.push(ok('Status: ready'));
+            lines.push(info('Search: hybrid (BM25 + vector)'));
+            report.embedding = { mode, status: 'ready', provider: provider.name, dimensions: provider.dimensions };
+          } else {
+            lines.push(warn('Status: temporarily unavailable'));
+            lines.push(info('Search: degraded to BM25 fulltext (no vector similarity)'));
+            issues.push(`Embedding mode is "${mode}" but provider failed to initialize. Check API keys/connectivity.`);
+            report.embedding = { mode, status: 'temporarily_unavailable' };
+          }
         }
 
         // Check cached embeddings count

--- a/src/cli/commands/hook.ts
+++ b/src/cli/commands/hook.ts
@@ -4,8 +4,16 @@
  * Entry point called by agent hooks via stdin/stdout.
  * Reads agent's JSON from stdin, normalizes, auto-stores, outputs response.
  *
+ * This command is short-lived. A leftover `memorix hook` process is a bug:
+ * hosts invoke it on every event, and hung copies exhaust RAM.
+ *
  * Usage (called by agent hook configs, not by users directly):
  *   memorix hook
+ *
+ * Env:
+ *   MEMORIX_HOOK_TIMEOUT_MS — wall-clock budget (default 20000)
+ *   MEMORIX_HOOK_STDIN_TIMEOUT_MS — stdin idle budget (default 3000)
+ *   MEMORIX_HOOK_HEAP_MB — V8 heap for this command only (default 512)
  */
 
 import { defineCommand } from 'citty';
@@ -29,6 +37,10 @@ export default defineCommand({
   },
   run: async ({ args }) => {
     const { runHook } = await import('../../hooks/handler.js');
-    await runHook(args.agent as string | undefined, args.event as string | undefined);
+    const { resolveHookTimeoutMs, runHookWithDeadline } = await import('../../hooks/lifecycle.js');
+    await runHookWithDeadline({
+      timeoutMs: resolveHookTimeoutMs(),
+      run: () => runHook(args.agent as string | undefined, args.event as string | undefined),
+    });
   },
 });

--- a/src/cli/commands/serve-http.ts
+++ b/src/cli/commands/serve-http.ts
@@ -29,13 +29,19 @@ import { canManageObservation, filterReadableObservations } from '../../memory/v
 import { parseTcpPortOrReport } from '../port.js';
 import { mcpFileUriToPath } from '../mcp-root-path.js';
 
-export const DEFAULT_SESSION_TIMEOUT_MS = 30 * 60 * 1000;
+/**
+ * HTTP MCP is a shared control plane. A normal thinking break should not
+ * silently invalidate a client session. Operators can choose a shorter GC
+ * window, or set 0 to disable idle GC entirely.
+ */
+export const DEFAULT_SESSION_TIMEOUT_MS = 12 * 60 * 60 * 1000;
+export const EXPIRED_SESSION_TTL_MS = 10 * 60 * 1000;
 
 export function parseSessionTimeoutMs(raw: string | undefined): number {
   const value = raw?.trim();
   if (!value) return DEFAULT_SESSION_TIMEOUT_MS;
   const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_SESSION_TIMEOUT_MS;
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_SESSION_TIMEOUT_MS;
   return Math.floor(parsed);
 }
 
@@ -132,7 +138,11 @@ export default defineCommand({
     console.error(`[memorix] HTTP transport starting on ${host}:${port}`);
     console.error(`[memorix] Project root: ${projectRoot}`);
     const sessionTimeoutMs = parseSessionTimeoutMs(process.env.MEMORIX_SESSION_TIMEOUT_MS);
-    console.error(`[memorix] HTTP session idle timeout: ${Math.round(sessionTimeoutMs / 60000)}min (${sessionTimeoutMs}ms)`);
+    console.error(
+      sessionTimeoutMs === 0
+        ? '[memorix] HTTP session idle timeout: disabled'
+        : `[memorix] HTTP session idle timeout: ${Math.round(sessionTimeoutMs / 60000)}min (${sessionTimeoutMs}ms)`,
+    );
 
     // Per-project TeamStore cache (Option B) — each dataDir gets its own TeamStore instance.
     // This ensures true isolation between projects in HTTP control-plane mode.
@@ -166,6 +176,9 @@ export default defineCommand({
 
     // Session activity tracking (for GC timeout)
     const sessionLastActivity = new Map<string, number>();
+    // Keep a short-lived tombstone so an expired client gets an actionable
+    // reinitialize response instead of a generic bad request.
+    const expiredSessions = new Map<string, number>();
 
     // Probe session noise reduction: defer init logs, suppress short-lived sessions
     let suppressedProbeCount = 0;
@@ -180,6 +193,30 @@ export default defineCommand({
         suppressedProbeCount = 0;
         lastProbeSummaryTime = Date.now();
       }
+    }
+
+    function forgetExpiredSessions(now = Date.now()): void {
+      for (const [sessionId, expiresAt] of expiredSessions) {
+        if (expiresAt <= now) expiredSessions.delete(sessionId);
+      }
+    }
+
+    function sendUnknownSession(res: ServerResponse, sessionId: string | undefined, jsonRpc = false): void {
+      const expired = Boolean(sessionId && expiredSessions.has(sessionId));
+      const message = expired
+        ? 'MCP session expired after inactivity. Initialize a new session and retry the request.'
+        : 'MCP session not found. Initialize a new session and retry the request.';
+      if (jsonRpc) {
+        res.writeHead(404, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+          jsonrpc: '2.0',
+          error: { code: -32001, message },
+          id: null,
+        }));
+        return;
+      }
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end(message);
     }
 
     /**
@@ -360,6 +397,11 @@ export default defineCommand({
         return;
       }
 
+      if (sessionId) {
+        sendUnknownSession(res, sessionId, true);
+        return;
+      }
+
       if (!sessionId && isInitializeRequest(body)) {
         // New session — create transport + server
         let createdState: SessionState | null = null;
@@ -488,8 +530,12 @@ export default defineCommand({
     async function handleGet(req: IncomingMessage, res: ServerResponse) {
       const sessionId = req.headers['mcp-session-id'] as string | undefined;
       if (!sessionId || !sessions.has(sessionId)) {
-        res.writeHead(400, { 'Content-Type': 'text/plain' });
-        res.end('Invalid or missing session ID');
+        if (!sessionId) {
+          res.writeHead(400, { 'Content-Type': 'text/plain' });
+          res.end('Missing MCP session ID');
+          return;
+        }
+        sendUnknownSession(res, sessionId);
         return;
       }
 
@@ -502,8 +548,12 @@ export default defineCommand({
     async function handleDelete(req: IncomingMessage, res: ServerResponse) {
       const sessionId = req.headers['mcp-session-id'] as string | undefined;
       if (!sessionId || !sessions.has(sessionId)) {
-        res.writeHead(400, { 'Content-Type': 'text/plain' });
-        res.end('Invalid or missing session ID');
+        if (!sessionId) {
+          res.writeHead(400, { 'Content-Type': 'text/plain' });
+          res.end('Missing MCP session ID');
+          return;
+        }
+        sendUnknownSession(res, sessionId);
         return;
       }
 
@@ -1414,6 +1464,7 @@ export default defineCommand({
       // Lightweight health check — responds immediately, no heavy init required.
       // This is the readiness signal for background start / status.
       if (url.pathname === '/health') {
+        const { getEmbeddingRuntimeHealth } = await import('../../embedding/provider.js');
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({
           status: 'ok',
@@ -1421,6 +1472,7 @@ export default defineCommand({
           port,
           uptime: Math.round(process.uptime()),
           pid: process.pid,
+          embedding: getEmbeddingRuntimeHealth(),
         }));
         return;
       }
@@ -1491,6 +1543,12 @@ export default defineCommand({
       await serveDashStatic(req, res);
     });
 
+    // MCP session continuity is independent from one TCP socket. Keep Node's
+    // socket timeout above its 5s default while the session map remains the
+    // actual continuity boundary.
+    httpServer.keepAliveTimeout = 60_000;
+    httpServer.headersTimeout = 65_000;
+
     httpServer.listen(port, host, () => {
       // Write readiness file — background start polls this for out-of-band readiness detection
       try {
@@ -1521,10 +1579,13 @@ export default defineCommand({
     const gcInterval = setInterval(() => {
       maybeProbeSummary(); // Flush suppressed probe count periodically
       const now = Date.now();
+      forgetExpiredSessions(now);
+      if (SESSION_TIMEOUT_MS === 0) return;
       for (const [sid, state] of sessions) {
         const lastActive = sessionLastActivity.get(sid) ?? 0;
         if (now - lastActive > SESSION_TIMEOUT_MS) {
           console.error(`[memorix] Session ${sid.slice(0, 8)}… timed out (idle ${Math.round((now - lastActive) / 60000)}min), closing`);
+          expiredSessions.set(sid, now + EXPIRED_SESSION_TTL_MS);
           state.transport.close().catch(() => {});
           sessions.delete(sid);
           sessionLastActivity.delete(sid);

--- a/src/cli/heap.ts
+++ b/src/cli/heap.ts
@@ -1,0 +1,76 @@
+/**
+ * CLI heap selection for the tsup respawn banner.
+ *
+ * `memorix serve` and other long-lived commands need a large V8 heap for
+ * embeddings and the in-memory index. `memorix hook` is a per-event
+ * lifecycle process and must not reserve a 4 GB heap — copies accumulate.
+ */
+
+export const DEFAULT_CLI_HEAP_MB = 4096;
+export const DEFAULT_HOOK_HEAP_MB = 512;
+export const MIN_HEAP_MB = 64;
+export const MAX_HEAP_MB = 16_384;
+
+function parseHeapMb(raw: string | undefined, fallback: number): number {
+  if (raw === undefined || raw.trim() === '') return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return fallback;
+  const mb = Math.floor(parsed);
+  if (mb < MIN_HEAP_MB || mb > MAX_HEAP_MB) return fallback;
+  return mb;
+}
+
+/**
+ * True when the CLI argv selects the short-lived `hook` command.
+ * `hooks` (install/status) is a different command and keeps the large heap.
+ */
+export function isHookCliInvocation(argv: string[]): boolean {
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--') break;
+    if (argument.startsWith('-')) {
+      if (!argument.includes('=') && argv[index + 1] && !argv[index + 1].startsWith('-')) {
+        index += 1;
+      }
+      continue;
+    }
+    return argument === 'hook';
+  }
+  return false;
+}
+
+export function resolveCliHeapMb(
+  argv: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  if (isHookCliInvocation(argv)) {
+    return parseHeapMb(env.MEMORIX_HOOK_HEAP_MB, DEFAULT_HOOK_HEAP_MB);
+  }
+  return parseHeapMb(env.MEMORIX_HEAP_MB, DEFAULT_CLI_HEAP_MB);
+}
+
+/**
+ * Self-contained JS prepended to the bundled CLI. It runs before the bundle
+ * loads, so the selection logic is inlined rather than imported.
+ */
+export function buildCliHeapBannerPrelude(): string {
+  return [
+    '#!/usr/bin/env node',
+    'import {spawnSync as __ms} from "node:child_process";',
+    'import {fileURLToPath as __fu} from "node:url";',
+    'if(!process.env.__MEMORIX_HEAP){process.env.__MEMORIX_HEAP="1";',
+    'const __args=process.argv.slice(2);',
+    'let __cmd;',
+    'for(let __i=0;__i<__args.length;__i++){',
+    'const __a=__args[__i];',
+    'if(__a==="--")break;',
+    'if(__a.startsWith("-")){if(!__a.includes("=")&&__args[__i+1]&&!__args[__i+1].startsWith("-"))__i++;continue;}',
+    '__cmd=__a;break;}',
+    `const __fallback=__cmd==="hook"?${DEFAULT_HOOK_HEAP_MB}:${DEFAULT_CLI_HEAP_MB};`,
+    'const __raw=__cmd==="hook"?process.env.MEMORIX_HOOK_HEAP_MB:process.env.MEMORIX_HEAP_MB;',
+    'const __n=Number(__raw);',
+    `const __heap=(Number.isFinite(__n)&&__n>=${MIN_HEAP_MB}&&__n<=${MAX_HEAP_MB})?String(Math.floor(__n)):String(__fallback);`,
+    'let r=__ms(process.execPath,["--max-old-space-size="+__heap,__fu(import.meta.url),...process.argv.slice(2)],{stdio:"inherit",env:process.env,windowsHide:true});',
+    'process.exit(r.status??1);}',
+  ].join('\n');
+}

--- a/src/cli/invocation.ts
+++ b/src/cli/invocation.ts
@@ -1,4 +1,4 @@
-import { existsSync, statSync } from 'node:fs';
+import { existsSync, realpathSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 export interface CliInvocation {
@@ -88,10 +88,13 @@ export function normalizeCliInvocation(argv: string[] = process.argv): CliInvoca
   }
 
   if (invocation.projectRoot) {
-    const projectRoot = resolve(invocation.projectRoot);
-    if (!existsSync(projectRoot) || !statSync(projectRoot).isDirectory()) {
-      throw new Error(`CLI project directory does not exist: ${projectRoot}`);
+    const resolvedProjectRoot = resolve(invocation.projectRoot);
+    if (!existsSync(resolvedProjectRoot) || !statSync(resolvedProjectRoot).isDirectory()) {
+      throw new Error(`CLI project directory does not exist: ${resolvedProjectRoot}`);
     }
+    // Keep one project identity when an OS exposes the same directory through
+    // two paths (for example /var and /private/var on macOS).
+    const projectRoot = realpathSync(resolvedProjectRoot);
     process.chdir(projectRoot);
     process.env.MEMORIX_CLI_PROJECT_ROOT = projectRoot;
     invocation.projectRoot = projectRoot;

--- a/src/embedding/provider.ts
+++ b/src/embedding/provider.ts
@@ -175,12 +175,26 @@ let initPromise: Promise<EmbeddingProvider | null> | null = null;
 type EmbeddingMode = 'off' | 'fastembed' | 'transformers' | 'api' | 'auto';
 type ProviderKind = 'api' | 'fastembed' | 'transformers' | 'unknown';
 
+export type EmbeddingRuntimeStatus = 'disabled' | 'uninitialized' | 'ready' | 'degraded';
+export type EmbeddingFailureKind = 'authorization' | 'billing' | 'timeout' | 'upstream';
+
+export interface EmbeddingRuntimeHealth {
+  status: EmbeddingRuntimeStatus;
+  provider?: { name: string; dimensions: number };
+  failure?: {
+    kind: EmbeddingFailureKind;
+    occurredAt: string;
+    retryAfterMs: number;
+  };
+}
+
 /**
  * Tracks whether the last init attempt resulted in a temporary failure
  * (mode != 'off' but provider returned null). When true, the next
  * getEmbeddingProvider() call will retry instead of returning cached null.
  */
 let lastInitWasTemporaryFailure = false;
+let lastEmbeddingFailure: { kind: EmbeddingFailureKind; occurredAt: number } | null = null;
 let lastEmbeddingWarning = '';
 let lastEmbeddingWarningAt = 0;
 const WARNING_COOLDOWN_MS = 30_000;
@@ -271,13 +285,38 @@ function isTemporaryEmbeddingFailure(error: unknown): boolean {
   );
 }
 
+function classifyEmbeddingFailure(error: unknown): EmbeddingFailureKind {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/embedding api error \(401\)|invalid_api_key|incorrect api key|unauthorized/i.test(message)) {
+    return 'authorization';
+  }
+  if (/embedding api error \(402\)|quota exceeded|account balance/i.test(message)) {
+    return 'billing';
+  }
+  if (/embedding api timeout|abort/i.test(message)) {
+    return 'timeout';
+  }
+  return 'upstream';
+}
+
 function markTemporaryFailure(reason: unknown): void {
   provider = null;
   initPromise = null;
   lastInitWasTemporaryFailure = true;
   lastFailureTimestamp = Date.now();
+  lastEmbeddingFailure = {
+    kind: classifyEmbeddingFailure(reason),
+    occurredAt: lastFailureTimestamp,
+  };
   const message = reason instanceof Error ? reason.message : String(reason);
-  warnOnce(`[memorix] Embedding provider temporarily unavailable at runtime: ${message}`);
+  warnOnce(`[memorix] Embedding provider unavailable at runtime: ${message}`);
+}
+
+function markProviderReady(candidate: EmbeddingProvider): EmbeddingProvider {
+  provider = wrapProvider(candidate);
+  lastInitWasTemporaryFailure = false;
+  lastEmbeddingFailure = null;
+  return provider;
 }
 
 async function createFastEmbedProvider(): Promise<EmbeddingProvider | null> {
@@ -438,7 +477,7 @@ export async function getEmbeddingProvider(
     if (mode === 'fastembed') {
       const initialized = await createFastEmbedProvider();
       if (!initialized) return null;
-      provider = wrapProvider(initialized);
+      provider = markProviderReady(initialized);
       warnOnce(`[memorix] Embedding provider: ${provider.name} (${provider.dimensions}d)`);
       return provider;
     }
@@ -447,7 +486,7 @@ export async function getEmbeddingProvider(
     if (mode === 'transformers') {
       const initialized = await createTransformersProvider();
       if (!initialized) return null;
-      provider = wrapProvider(initialized);
+      provider = markProviderReady(initialized);
       warnOnce(`[memorix] Embedding provider: ${provider.name} (${provider.dimensions}d)`);
       return provider;
     }
@@ -456,7 +495,7 @@ export async function getEmbeddingProvider(
     if (mode === 'api') {
       const initialized = await createAPIProvider(options);
       if (!initialized) return null;
-      provider = wrapProvider(initialized);
+      provider = markProviderReady(initialized);
       warnOnce(`[memorix] Embedding provider: ${provider.name} (${provider.dimensions}d)`);
       return provider;
     }
@@ -465,7 +504,7 @@ export async function getEmbeddingProvider(
     if (hasAPIEmbeddingConfig()) {
       const initialized = await createAPIProvider(options);
       if (initialized) {
-        provider = wrapProvider(initialized);
+        provider = markProviderReady(initialized);
         warnOnce(`[memorix] Embedding provider: ${provider.name} (${provider.dimensions}d)`);
         return provider;
       }
@@ -473,7 +512,7 @@ export async function getEmbeddingProvider(
 
     const localFallback = await createLocalFallbackProvider();
     if (localFallback) {
-      provider = wrapProvider(localFallback);
+      provider = markProviderReady(localFallback);
       warnOnce(`[memorix] Embedding provider: ${provider.name} (${provider.dimensions}d)`);
       return provider;
     }
@@ -508,6 +547,36 @@ export async function isVectorSearchAvailable(): Promise<boolean> {
 }
 
 /**
+ * Process-local embedding health, intentionally read-only and network-free.
+ * It lets the control plane distinguish a configured provider from one that
+ * has degraded after a live credential, billing, timeout, or upstream error.
+ */
+export function getEmbeddingRuntimeHealth(): EmbeddingRuntimeHealth {
+  const mode = getEmbeddingMode();
+  if (mode === 'off') return { status: 'disabled' };
+
+  if (lastInitWasTemporaryFailure && lastEmbeddingFailure) {
+    return {
+      status: 'degraded',
+      failure: {
+        kind: lastEmbeddingFailure.kind,
+        occurredAt: new Date(lastEmbeddingFailure.occurredAt).toISOString(),
+        retryAfterMs: Math.max(0, RETRY_COOLDOWN_MS - (Date.now() - lastEmbeddingFailure.occurredAt)),
+      },
+    };
+  }
+
+  if (provider) {
+    return {
+      status: 'ready',
+      provider: { name: provider.name, dimensions: provider.dimensions },
+    };
+  }
+
+  return { status: 'uninitialized' };
+}
+
+/**
  * Check if embedding is explicitly disabled by configuration (mode === 'off').
  *
  * When true, there is no provider to backfill from and observations can be
@@ -529,6 +598,7 @@ export function resetProvider(): void {
   initPromise = null;
   lastInitWasTemporaryFailure = false;
   lastFailureTimestamp = 0;
+  lastEmbeddingFailure = null;
   lastEmbeddingWarning = '';
   lastEmbeddingWarningAt = 0;
 }

--- a/src/hooks/handler.ts
+++ b/src/hooks/handler.ts
@@ -21,6 +21,11 @@ import { normalizeHookInput } from './normalizer.js';
 import { detectBestPattern, patternToObservationType } from './pattern-detector.js';
 import { isSignificantKnowledge, isRetrievedResult, isTrivialCommand } from './significance-filter.js';
 import type { AgentName, HookEvent, HookOutput, NormalizedHookInput } from './types.js';
+import {
+  hookObservationRuntimeOptions,
+  readHookStdin,
+  resolveHookStdinTimeoutMs,
+} from './lifecycle.js';
 
 type HookInjectionMode = 'full' | 'minimal' | 'silent';
 type HookContextTarget = 'hook-session-start' | 'hook-user-prompt';
@@ -762,23 +767,9 @@ export function formatHookOutput(
  * Called by the CLI: `memorix hook`
  */
 export async function runHook(agentOverride?: string, eventOverride?: string): Promise<void> {
-  // Read stdin with a timeout — some hosts (e.g. Gemini CLI) may not close
-  // stdin promptly, causing `for await` to hang until the process is killed.
-  const rawInput = await new Promise<string>((resolve) => {
-    const chunks: Buffer[] = [];
-    const finish = () => resolve(Buffer.concat(chunks).toString('utf-8').trim());
-
-    // Hard timeout: resolve with whatever we have after 3 s
-    const timer = setTimeout(() => {
-      process.stdin.removeAllListeners('data');
-      process.stdin.removeAllListeners('end');
-      finish();
-    }, 3_000);
-
-    process.stdin.on('data', (chunk: Buffer) => { chunks.push(chunk); });
-    process.stdin.on('end', () => { clearTimeout(timer); finish(); });
-    process.stdin.on('error', () => { clearTimeout(timer); finish(); });
-  });
+  // Some hosts (e.g. Gemini CLI) may not close stdin promptly. Bound the
+  // read and release the stream so an open pipe cannot keep Node alive.
+  const rawInput = await readHookStdin(process.stdin, resolveHookStdinTimeoutMs());
 
   if (!rawInput) {
     process.stdout.write(JSON.stringify({ continue: true }));
@@ -841,7 +832,7 @@ export async function runHook(agentOverride?: string, eventOverride?: string): P
       await initObservationStore(dataDir);
       await initMSStore(dataDir);
       await initSessStore(dataDir);
-      await initObservations(dataDir);
+      await initObservations(dataDir, hookObservationRuntimeOptions(rawProject.rootPath));
       await storeObservation({ ...observation, projectId, sourceDetail: 'hook' });
       // Automatic capture is deliberately quiet. Candidate state and later
       // qualification are visible through Memorix inspection, not injected as

--- a/src/hooks/lifecycle.ts
+++ b/src/hooks/lifecycle.ts
@@ -1,0 +1,173 @@
+/**
+ * Process-level lifecycle for `memorix hook`.
+ *
+ * Hosts invoke this command on every agent event. It must read stdin, emit
+ * one JSON object, and exit. Leftover hook processes are a bug: they reserve
+ * heap, orphan onto PID 1, and can exhaust a laptop.
+ */
+
+import type { ObservationRuntimeOptions } from '../memory/observations.js';
+
+export const DEFAULT_HOOK_TIMEOUT_MS = 20_000;
+export const MIN_HOOK_TIMEOUT_MS = 1_000;
+export const MAX_HOOK_TIMEOUT_MS = 120_000;
+
+export const DEFAULT_HOOK_STDIN_TIMEOUT_MS = 3_000;
+export const MIN_HOOK_STDIN_TIMEOUT_MS = 100;
+export const MAX_HOOK_STDIN_TIMEOUT_MS = 30_000;
+
+type EnvMap = NodeJS.ProcessEnv | Record<string, string | undefined>;
+
+function parseBoundedMs(
+  raw: string | undefined,
+  fallback: number,
+  min: number,
+  max: number,
+): number {
+  const value = raw?.trim();
+  if (!value) return fallback;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.max(min, Math.min(max, Math.floor(parsed)));
+}
+
+export function resolveHookTimeoutMs(env: EnvMap = process.env): number {
+  return parseBoundedMs(
+    env.MEMORIX_HOOK_TIMEOUT_MS,
+    DEFAULT_HOOK_TIMEOUT_MS,
+    MIN_HOOK_TIMEOUT_MS,
+    MAX_HOOK_TIMEOUT_MS,
+  );
+}
+
+export function resolveHookStdinTimeoutMs(env: EnvMap = process.env): number {
+  return parseBoundedMs(
+    env.MEMORIX_HOOK_STDIN_TIMEOUT_MS,
+    DEFAULT_HOOK_STDIN_TIMEOUT_MS,
+    MIN_HOOK_STDIN_TIMEOUT_MS,
+    MAX_HOOK_STDIN_TIMEOUT_MS,
+  );
+}
+
+export function hookObservationRuntimeOptions(projectRoot: string): ObservationRuntimeOptions {
+  return {
+    embeddingWriteMode: 'deferred',
+    projectRoot,
+  };
+}
+
+type HookStdin = NodeJS.ReadableStream & {
+  pause?: () => void;
+  destroy?: (error?: Error) => void;
+  unref?: () => void;
+  isTTY?: boolean;
+};
+
+/**
+ * Read hook JSON from a pipe. Resolves on EOF, stream error, or idle timeout.
+ * Always releases the stream so an open stdin cannot keep Node alive.
+ */
+export async function readHookStdin(stdin: HookStdin, timeoutMs: number): Promise<string> {
+  return new Promise<string>((resolve) => {
+    const chunks: Buffer[] = [];
+    let settled = false;
+
+    const finish = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      stdin.removeListener('data', onData);
+      stdin.removeListener('end', finish);
+      stdin.removeListener('error', finish);
+      stdin.pause?.();
+      if (!stdin.isTTY) {
+        stdin.destroy?.();
+      } else {
+        stdin.unref?.();
+      }
+      resolve(Buffer.concat(chunks).toString('utf-8').trim());
+    };
+
+    const onData = (chunk: Buffer | string) => {
+      chunks.push(typeof chunk === 'string' ? Buffer.from(chunk) : chunk);
+    };
+
+    const timer = setTimeout(finish, timeoutMs);
+    stdin.on('data', onData);
+    stdin.on('end', finish);
+    stdin.on('error', finish);
+  });
+}
+
+export interface HookDeadlineIo {
+  write(chunk: string): unknown;
+}
+
+export interface HookDeadlineOptions {
+  timeoutMs: number;
+  run: () => Promise<void>;
+  stdout?: HookDeadlineIo;
+  stderr?: HookDeadlineIo;
+  exit?: (code: number) => void;
+}
+
+function writeContinue(stdout: HookDeadlineIo): void {
+  try {
+    stdout.write(JSON.stringify({ continue: true }));
+  } catch {
+    // The host already closed the pipe. Exiting is still required.
+  }
+}
+
+/**
+ * Run a hook body under a hard deadline, then force-exit.
+ * `withTimeout` cannot abort in-flight fetches; process.exit is the backstop.
+ */
+export async function runHookWithDeadline(options: HookDeadlineOptions): Promise<void> {
+  const stdout = options.stdout ?? process.stdout;
+  const stderr = options.stderr ?? process.stderr;
+  const exit = options.exit ?? ((code: number) => { process.exit(code); });
+
+  await new Promise<void>((resolve) => {
+    let finished = false;
+
+    const settle = () => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timer);
+      resolve();
+    };
+
+    const timer = setTimeout(() => {
+      if (finished) return;
+      try {
+        stderr.write(`[memorix] hook timed out after ${options.timeoutMs}ms\n`);
+      } catch {
+        // stderr may already be closed
+      }
+      writeContinue(stdout);
+      exit(0);
+      settle();
+    }, options.timeoutMs);
+
+    options.run().then(
+      () => {
+        if (finished) return;
+        exit(0);
+        settle();
+      },
+      (error: unknown) => {
+        if (finished) return;
+        try {
+          const message = error instanceof Error ? error.message : String(error);
+          stderr.write(`[memorix] hook failed: ${message}\n`);
+        } catch {
+          // stderr may already be closed
+        }
+        writeContinue(stdout);
+        exit(0);
+        settle();
+      },
+    );
+  });
+}

--- a/tests/cli/codegraph-command.test.ts
+++ b/tests/cli/codegraph-command.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { execSync } from 'node:child_process';
-import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import codegraphCommand from '../../src/cli/commands/codegraph.js';
@@ -246,7 +246,7 @@ describe('codegraph CLI command', () => {
     await runCommand({ _: ['refresh'], json: true });
 
     expect(new MaintenanceTargetStore(dataDir).get('local/repo')).toMatchObject({
-      projectRoot: repoDir,
+      projectRoot: realpathSync(repoDir),
       dataDir,
     });
     expect(new MaintenanceJobStore(dataDir).list({ projectId: 'local/repo' })).toEqual(expect.arrayContaining([

--- a/tests/cli/heap.test.ts
+++ b/tests/cli/heap.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_CLI_HEAP_MB,
+  DEFAULT_HOOK_HEAP_MB,
+  buildCliHeapBannerPrelude,
+  isHookCliInvocation,
+  resolveCliHeapMb,
+} from '../../src/cli/heap.js';
+
+describe('CLI heap selection', () => {
+  it('uses a small heap for memorix hook and keeps the large heap for serve', () => {
+    expect(isHookCliInvocation(['hook'])).toBe(true);
+    expect(isHookCliInvocation(['hook', '--agent', 'claude'])).toBe(true);
+    expect(isHookCliInvocation(['--cwd', '/tmp/project', 'hook'])).toBe(true);
+    expect(isHookCliInvocation(['hooks'])).toBe(false);
+    expect(isHookCliInvocation(['hooks', 'install'])).toBe(false);
+    expect(isHookCliInvocation(['serve'])).toBe(false);
+    expect(isHookCliInvocation(['serve-http'])).toBe(false);
+
+    expect(resolveCliHeapMb(['hook'])).toBe(DEFAULT_HOOK_HEAP_MB);
+    expect(resolveCliHeapMb(['serve'])).toBe(DEFAULT_CLI_HEAP_MB);
+    expect(resolveCliHeapMb(['hooks', 'install'])).toBe(DEFAULT_CLI_HEAP_MB);
+    expect(DEFAULT_HOOK_HEAP_MB).toBeLessThanOrEqual(512);
+    expect(DEFAULT_CLI_HEAP_MB).toBe(4096);
+  });
+
+  it('lets MEMORIX_HOOK_HEAP_MB override only the hook command', () => {
+    expect(resolveCliHeapMb(['hook'], { MEMORIX_HOOK_HEAP_MB: '256' })).toBe(256);
+    expect(resolveCliHeapMb(['serve'], { MEMORIX_HOOK_HEAP_MB: '256' })).toBe(DEFAULT_CLI_HEAP_MB);
+    expect(resolveCliHeapMb(['hook'], { MEMORIX_HOOK_HEAP_MB: 'nope' })).toBe(DEFAULT_HOOK_HEAP_MB);
+    expect(resolveCliHeapMb(['serve'], { MEMORIX_HEAP_MB: '2048' })).toBe(2048);
+  });
+
+  it('bakes hook-aware heap selection into the CLI respawn banner', () => {
+    const banner = buildCliHeapBannerPrelude();
+    expect(banner).toContain('--max-old-space-size=');
+    expect(banner).toContain('__cmd==="hook"');
+    expect(banner).toContain(String(DEFAULT_HOOK_HEAP_MB));
+    expect(banner).toContain(String(DEFAULT_CLI_HEAP_MB));
+    expect(banner).toContain('MEMORIX_HOOK_HEAP_MB');
+  });
+});

--- a/tests/cli/invocation.test.ts
+++ b/tests/cli/invocation.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, realpathSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { normalizeCliInvocation } from '../../src/cli/invocation.js';
@@ -26,6 +26,7 @@ describe('CLI invocation normalization', () => {
   it('binds a common project root and normalizes shell-native flag spellings before command parsing', () => {
     const root = mkdtempSync(path.join(tmpdir(), 'memorix-cli-invocation-'));
     cleanupRoots.push(root);
+    const canonicalRoot = realpathSync(root);
     const invocation = normalizeCliInvocation([
       'node',
       'memorix',
@@ -41,9 +42,9 @@ describe('CLI invocation normalization', () => {
       '--instance-id=local-terminal',
     ]);
 
-    expect(invocation).toEqual({ projectRoot: root, actorId: 'agent-123' });
-    expect(process.cwd()).toBe(root);
-    expect(process.env.MEMORIX_CLI_PROJECT_ROOT).toBe(root);
+    expect(invocation).toEqual({ projectRoot: canonicalRoot, actorId: 'agent-123' });
+    expect(process.cwd()).toBe(canonicalRoot);
+    expect(process.env.MEMORIX_CLI_PROJECT_ROOT).toBe(canonicalRoot);
     expect(process.env.MEMORIX_CLI_ACTOR_ID).toBe('agent-123');
     expect(process.argv.slice(2)).toEqual([
       'session',

--- a/tests/cli/serve-http-session-timeout.test.ts
+++ b/tests/cli/serve-http-session-timeout.test.ts
@@ -3,17 +3,17 @@ import { describe, expect, it } from 'vitest';
 import { _testing } from '../../src/cli/commands/serve-http.js';
 
 describe('serve-http session timeout configuration', () => {
-  it('defaults to 30 minutes when no env value is provided', () => {
-    expect(_testing.parseSessionTimeoutMs(undefined)).toBe(30 * 60 * 1000);
+  it('defaults to 12 hours so ordinary long-lived MCP sessions do not expire mid-task', () => {
+    expect(_testing.parseSessionTimeoutMs(undefined)).toBe(12 * 60 * 60 * 1000);
   });
 
   it('accepts an explicit MEMORIX_SESSION_TIMEOUT_MS value', () => {
     expect(_testing.parseSessionTimeoutMs('86400000')).toBe(24 * 60 * 60 * 1000);
   });
 
-  it('falls back to the default for invalid or non-positive values', () => {
-    expect(_testing.parseSessionTimeoutMs('not-a-number')).toBe(30 * 60 * 1000);
-    expect(_testing.parseSessionTimeoutMs('0')).toBe(30 * 60 * 1000);
-    expect(_testing.parseSessionTimeoutMs('-1')).toBe(30 * 60 * 1000);
+  it('allows operators to disable idle session GC, while invalid values keep the default', () => {
+    expect(_testing.parseSessionTimeoutMs('0')).toBe(0);
+    expect(_testing.parseSessionTimeoutMs('not-a-number')).toBe(12 * 60 * 60 * 1000);
+    expect(_testing.parseSessionTimeoutMs('-1')).toBe(12 * 60 * 60 * 1000);
   });
 });

--- a/tests/cli/windows-child-process.test.ts
+++ b/tests/cli/windows-child-process.test.ts
@@ -10,6 +10,7 @@ const childProcess = vi.hoisted(() => ({
 vi.mock('node:child_process', () => childProcess);
 
 import { detectProjectWithDiagnostics } from '../../src/project/detector.js';
+import { buildCliHeapBannerPrelude } from '../../src/cli/heap.js';
 
 describe('Windows CLI child process behavior', () => {
   afterEach(() => {
@@ -17,8 +18,7 @@ describe('Windows CLI child process behavior', () => {
   });
 
   it('hides the heap-size restart subprocess in the published CLI banner', () => {
-    const config = readFileSync(join(process.cwd(), 'tsup.config.ts'), 'utf8');
-    expect(config).toContain('windowsHide:true');
+    expect(buildCliHeapBannerPrelude()).toContain('windowsHide:true');
   });
 
   it('uses the hidden Windows launcher for the background service', () => {

--- a/tests/embedding/provider.test.ts
+++ b/tests/embedding/provider.test.ts
@@ -26,7 +26,12 @@ vi.mock('../../src/embedding/api-provider.js', () => ({
     create: mockApiProviderCreate,
   },
 }));
-import { getEmbeddingProvider, isVectorSearchAvailable, resetProvider } from '../../src/embedding/provider.ts';
+import {
+  getEmbeddingProvider,
+  getEmbeddingRuntimeHealth,
+  isVectorSearchAvailable,
+  resetProvider,
+} from '../../src/embedding/provider.ts';
 import { resetDb, isEmbeddingEnabled, generateEmbedding, getDb } from '../../src/store/orama-store.js';
 import { resetConfigCache } from '../../src/config.ts';
 
@@ -263,6 +268,28 @@ describe('Embedding Provider', () => {
       const nextProvider = await getEmbeddingProvider();
       expect(nextProvider).toBeNull();
       expect(mockApiProviderCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it('reports a billing failure as degraded runtime health instead of configured-and-ready', async () => {
+      process.env.MEMORIX_EMBEDDING = 'api';
+      process.env.MEMORIX_EMBEDDING_API_KEY = 'api-key';
+      process.env.MEMORIX_EMBEDDING_BASE_URL = 'https://embeddings.example/v1';
+      process.env.MEMORIX_EMBEDDING_MODEL = 'text-embedding-3-small';
+
+      mockApiProviderCreate.mockResolvedValue({
+        name: 'api-text-embedding-3-small',
+        dimensions: 1536,
+        embed: vi.fn().mockRejectedValue(new Error('Embedding API error (402): account balance is exhausted')),
+        embedBatch: vi.fn(),
+      });
+
+      const provider = await getEmbeddingProvider();
+      await expect(provider!.embed('billing health')).rejects.toThrow('402');
+
+      expect(getEmbeddingRuntimeHealth()).toMatchObject({
+        status: 'degraded',
+        failure: { kind: 'billing' },
+      });
     });
   });
 });

--- a/tests/hooks/lifecycle.test.ts
+++ b/tests/hooks/lifecycle.test.ts
@@ -1,0 +1,100 @@
+import { PassThrough } from 'node:stream';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  DEFAULT_HOOK_TIMEOUT_MS,
+  hookObservationRuntimeOptions,
+  readHookStdin,
+  resolveHookStdinTimeoutMs,
+  resolveHookTimeoutMs,
+  runHookWithDeadline,
+} from '../../src/hooks/lifecycle.js';
+
+describe('hook process lifecycle', () => {
+  const originalTimeout = process.env.MEMORIX_HOOK_TIMEOUT_MS;
+  const originalStdinTimeout = process.env.MEMORIX_HOOK_STDIN_TIMEOUT_MS;
+
+  afterEach(() => {
+    if (originalTimeout === undefined) delete process.env.MEMORIX_HOOK_TIMEOUT_MS;
+    else process.env.MEMORIX_HOOK_TIMEOUT_MS = originalTimeout;
+    if (originalStdinTimeout === undefined) delete process.env.MEMORIX_HOOK_STDIN_TIMEOUT_MS;
+    else process.env.MEMORIX_HOOK_STDIN_TIMEOUT_MS = originalStdinTimeout;
+  });
+
+  it('bounds the wall-clock budget and keeps it env-overridable', () => {
+    expect(resolveHookTimeoutMs({})).toBe(DEFAULT_HOOK_TIMEOUT_MS);
+    expect(DEFAULT_HOOK_TIMEOUT_MS).toBeGreaterThanOrEqual(15_000);
+    expect(DEFAULT_HOOK_TIMEOUT_MS).toBeLessThanOrEqual(30_000);
+    expect(resolveHookTimeoutMs({ MEMORIX_HOOK_TIMEOUT_MS: '8000' })).toBe(8_000);
+    expect(resolveHookTimeoutMs({ MEMORIX_HOOK_TIMEOUT_MS: 'nope' })).toBe(DEFAULT_HOOK_TIMEOUT_MS);
+    expect(resolveHookStdinTimeoutMs({})).toBe(3_000);
+    expect(resolveHookStdinTimeoutMs({ MEMORIX_HOOK_STDIN_TIMEOUT_MS: '500' })).toBe(500);
+  });
+
+  it('returns stdin on EOF and does not wait for a producer that already finished', async () => {
+    const stdin = new PassThrough();
+    const pending = readHookStdin(stdin, 5_000);
+    stdin.write('{"hook_event_name":"Stop"}');
+    stdin.end();
+    await expect(pending).resolves.toBe('{"hook_event_name":"Stop"}');
+  });
+
+  it('releases a pipe after the idle timeout so the event loop can exit', async () => {
+    const stdin = new PassThrough();
+    const pause = vi.spyOn(stdin, 'pause');
+    const destroy = vi.spyOn(stdin, 'destroy');
+    const pending = readHookStdin(stdin, 40);
+    stdin.write('{"partial":true}');
+    await expect(pending).resolves.toBe('{"partial":true}');
+    expect(pause).toHaveBeenCalled();
+    expect(destroy).toHaveBeenCalled();
+  });
+
+  it('exits after a successful hook so leftover handles cannot keep Node alive', async () => {
+    const exits: number[] = [];
+    await runHookWithDeadline({
+      timeoutMs: 1_000,
+      run: async () => undefined,
+      stdout: { write: () => true },
+      stderr: { write: () => true },
+      exit: (code) => { exits.push(code); },
+    });
+    expect(exits).toEqual([0]);
+  });
+
+  it('writes continue:true and exits when hook work exceeds the deadline', async () => {
+    const writes: string[] = [];
+    const stderr: string[] = [];
+    const exits: number[] = [];
+    await runHookWithDeadline({
+      timeoutMs: 25,
+      run: () => new Promise(() => {}),
+      stdout: { write: (chunk) => { writes.push(String(chunk)); return true; } },
+      stderr: { write: (chunk) => { stderr.push(String(chunk)); return true; } },
+      exit: (code) => { exits.push(code); },
+    });
+    expect(JSON.parse(writes.join(''))).toMatchObject({ continue: true });
+    expect(stderr.join('')).toMatch(/timed out after 25ms/i);
+    expect(exits).toEqual([0]);
+  });
+
+  it('writes continue:true and exits when hook work throws', async () => {
+    const writes: string[] = [];
+    const exits: number[] = [];
+    await runHookWithDeadline({
+      timeoutMs: 1_000,
+      run: async () => { throw new Error('store exploded'); },
+      stdout: { write: (chunk) => { writes.push(String(chunk)); return true; } },
+      stderr: { write: () => true },
+      exit: (code) => { exits.push(code); },
+    });
+    expect(JSON.parse(writes.join(''))).toMatchObject({ continue: true });
+    expect(exits).toEqual([0]);
+  });
+
+  it('defers hook embeddings so a remote fetch cannot pin the CLI process', () => {
+    expect(hookObservationRuntimeOptions('/repo')).toEqual({
+      embeddingWriteMode: 'deferred',
+      projectRoot: '/repo',
+    });
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'tsup';
 import { readFileSync } from 'node:fs';
+import { buildCliHeapBannerPrelude } from './src/cli/heap.js';
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'));
 const define = { __MEMORIX_VERSION__: JSON.stringify(pkg.version) };
@@ -49,14 +50,8 @@ export default defineConfig([
     define,
     banner: {
       js: [
-        '#!/usr/bin/env node',
-        // Ensure Node has enough heap for embedding models + Orama index.
-        // Re-exec with --max-old-space-size=4096 if not already set.
-        'import {spawnSync as __ms} from "node:child_process";',
-        'import {fileURLToPath as __fu} from "node:url";',
-        'if(!process.env.__MEMORIX_HEAP){process.env.__MEMORIX_HEAP="1";',
-        'let r=__ms(process.execPath,["--max-old-space-size=4096",__fu(import.meta.url),...process.argv.slice(2)],{stdio:"inherit",env:process.env,windowsHide:true});',
-        'process.exit(r.status??1);}',
+        // serve / index keep a large heap; hook uses a small default (see src/cli/heap.ts).
+        buildCliHeapBannerPrelude(),
         'import {createRequire as __memorix_cjsRequire} from "module";',
         'const require = __memorix_cjsRequire(import.meta.url);',
       ].join('\n'),


### PR DESCRIPTION
## Summary
- Preserves Ravi Tharuma's original #206 hook lifecycle work for #205: bounded stdin, deferred embedding writes, a hard deadline, and a hook-sized heap.
- Makes stale HTTP MCP sessions recoverable: 12-hour default, explicit 404 reinitialize response, optional disabled GC, and sane socket keep-alives.
- Reports the running control plane's actual embedding failure state in `memorix doctor` and fixes its background health JSON false positive.
- Adds macOS to the normal build-and-test CI matrix and aligns all operator documentation with the new session contract.

## Verification
- `npm test -- --reporter=dot` - 283 files passed, 2 skipped; 2,853 tests passed, 3 skipped
- `npm run lint`
- `npm run build`
- `npm run check:mcp-registry`
- `npm run check:plugin-release`
- `npm pack --dry-run`
- Built-CLI smoke: hook exits with intentionally open stdin; HTTP health and stale-session 404 path