### PR TITLE
Keep HTTP control plane responsive on large stores

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "test:e2e": "vitest run tests/e2e/",
     "benchmark:codegraph": "node scripts/benchmark-codegraph-provider.cjs",
     "benchmark:retrieval": "npm run build && node scripts/benchmark-retrieval.mjs",
+    "gate:large-store": "npm run build && node scripts/large-store-gate.mjs",
     "generate:star-history": "node scripts/generate-star-history.mjs",
     "sync:mcp-registry": "node scripts/sync-mcp-registry-manifest.mjs",
     "check:mcp-registry": "node scripts/check-mcp-registry-manifest.mjs",

--- a/scripts/large-store-gate.mjs
+++ b/scripts/large-store-gate.mjs
@@ -5,16 +5,23 @@
  *
  * Measures the same seedAndIndex path as scripts/benchmark-retrieval.mjs,
  * plus steady-state write latency, search, peak RSS, and cache integrity.
- * Hook-write coverage lives in tests/stress/large-store-gate.test.ts.
+ * After the SDK seed closes, this also writes via HTTP MCP and `memorix hook`
+ * in child processes, then reopens the SDK in this same Node process.
  *
  *   node scripts/large-store-gate.mjs
  *   node scripts/large-store-gate.mjs --records 40000
  */
-import { spawnSync } from 'node:child_process';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { spawn, spawnSync } from 'node:child_process';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:net';
+import { createRequire } from 'node:module';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { performance } from 'node:perf_hooks';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const cliEntry = path.join(repoRoot, 'dist/cli/index.js');
 
 function readPositiveOption(name, fallback, maximum) {
   const index = process.argv.indexOf(name);
@@ -41,6 +48,257 @@ function percentile(samples, fraction) {
   samples.sort((left, right) => left - right);
   const index = Math.min(samples.length - 1, Math.max(0, Math.ceil(samples.length * fraction) - 1));
   return samples[index];
+}
+
+function allocatePort() {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      const port = typeof address === 'object' && address ? address.port : 0;
+      server.close((error) => (error ? reject(error) : resolve(port)));
+    });
+    server.on('error', reject);
+  });
+}
+
+function waitForListening(child, timeoutMs = 30_000) {
+  return new Promise((resolve, reject) => {
+    let stderr = '';
+    const timer = setTimeout(() => {
+      reject(new Error(`serve-http did not start within ${timeoutMs}ms. stderr:\n${stderr}`));
+    }, timeoutMs);
+    const onData = (chunk) => {
+      stderr += chunk.toString();
+      if (stderr.includes('listening')) {
+        cleanup();
+        resolve();
+      }
+    };
+    const onExit = (code) => {
+      cleanup();
+      reject(new Error(`serve-http exited early (code ${code}). stderr:\n${stderr}`));
+    };
+    const cleanup = () => {
+      clearTimeout(timer);
+      child.stderr?.off('data', onData);
+      child.off('exit', onExit);
+    };
+    child.stderr?.on('data', onData);
+    child.on('exit', onExit);
+    child.on('error', (error) => {
+      cleanup();
+      reject(error);
+    });
+  });
+}
+
+function waitForExit(child, timeoutMs = 10_000) {
+  return new Promise((resolve) => {
+    if (child.exitCode !== null || child.signalCode) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      try { child.kill('SIGKILL'); } catch { /* already gone */ }
+      resolve();
+    }, timeoutMs);
+    child.once('exit', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+}
+
+async function mcpPost(port, body, sessionId) {
+  const headers = {
+    'Content-Type': 'application/json',
+    Accept: 'application/json, text/event-stream',
+  };
+  if (sessionId) headers['Mcp-Session-Id'] = sessionId;
+  const response = await fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+  });
+  const text = await response.text();
+  let json;
+  const dataLines = text.split('\n').filter((line) => line.startsWith('data:'));
+  if (dataLines.length > 0) {
+    try {
+      json = JSON.parse(dataLines[0].replace('data: ', ''));
+    } catch {
+      // not JSON
+    }
+  }
+  if (!json && response.headers.get('content-type')?.includes('application/json')) {
+    try {
+      json = JSON.parse(text);
+    } catch {
+      // not JSON
+    }
+  }
+  return { status: response.status, headers: response.headers, text, json };
+}
+
+function toolText(result) {
+  const content = result?.json?.result?.content;
+  if (!Array.isArray(content)) return result.text ?? '';
+  return content.map((part) => part.text ?? '').join('\n');
+}
+
+async function storeViaHttpMcp(port, projectRoot) {
+  const init = await mcpPost(port, {
+    jsonrpc: '2.0',
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'large-store-gate', version: '1.0' },
+    },
+    id: 1,
+  });
+  const sessionId = init.headers.get('mcp-session-id');
+  if (!sessionId) {
+    throw new Error(`HTTP MCP initialize returned no session id: ${init.text}`);
+  }
+  await fetch(`http://127.0.0.1:${port}/mcp`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      'Mcp-Session-Id': sessionId,
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+  });
+
+  const started = await mcpPost(port, {
+    jsonrpc: '2.0',
+    method: 'tools/call',
+    params: {
+      name: 'memorix_session_start',
+      arguments: { agent: 'large-store-gate', projectRoot },
+    },
+    id: 2,
+  }, sessionId);
+  if (started.json?.result?.isError) {
+    throw new Error(`HTTP MCP session_start failed: ${toolText(started)}`);
+  }
+
+  const stored = await mcpPost(port, {
+    jsonrpc: '2.0',
+    method: 'tools/call',
+    params: {
+      name: 'memorix_store',
+      arguments: {
+        entityName: 'large-store-mcp',
+        type: 'discovery',
+        title: 'MCP marker 1',
+        narrative: 'HTTP MCP write after the SDK client closed. The next SDK open must see this row.',
+      },
+    },
+    id: 3,
+  }, sessionId);
+  if (stored.json?.result?.isError) {
+    throw new Error(`HTTP MCP memorix_store failed: ${toolText(stored)}`);
+  }
+}
+
+function storeViaHook(projectRoot, dataDir, childHome) {
+  const hookFile = path.join(projectRoot, 'src', 'gate-hook.ts');
+  const payload = {
+    hook_event_name: 'PostToolUse',
+    session_id: 'large-store-gate-hook',
+    cwd: projectRoot,
+    tool_name: 'Write',
+    tool_input: {
+      file_path: hookFile,
+      content: [
+        'export function largeStoreHookMarker(): string {',
+        '  return "large-store-hook-marker";',
+        '}',
+        'export const largeStoreHookFacts = [',
+        '  "PostToolUse must persist after the SDK client released SQLite",',
+        '  "The next in-process SDK open must reload this hook row",',
+        '];',
+      ].join('\n'),
+    },
+    tool_response: 'File written successfully',
+  };
+  const result = spawnSync(process.execPath, [cliEntry, 'hook', '--agent', 'claude'], {
+    cwd: projectRoot,
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+    windowsHide: true,
+    timeout: 20_000,
+    env: {
+      ...process.env,
+      MEMORIX_DATA_DIR: dataDir,
+      MEMORIX_EMBEDDING: 'off',
+      HOME: childHome,
+      USERPROFILE: childHome,
+      HOMEPATH: childHome,
+    },
+  });
+  if (result.status !== 0) {
+    throw new Error(`memorix hook failed: ${result.stderr || result.stdout || `exit ${result.status}`}`);
+  }
+}
+
+function listDiskObservations(dataDir) {
+  const require = createRequire(import.meta.url);
+  function openDatabase(dbPath) {
+    try {
+      const Database = require('better-sqlite3');
+      return new Database(dbPath);
+    } catch {
+      // Native binding may be compiled for a different Node than this process.
+    }
+    return new (require('node:sqlite').DatabaseSync)(dbPath);
+  }
+  const db = openDatabase(path.join(dataDir, 'memorix.db'));
+  try {
+    return db.prepare('SELECT title, sourceDetail, visibility FROM observations').all();
+  } finally {
+    db.close();
+  }
+}
+
+async function writeAcrossTransports(projectRoot, dataDir, sandbox) {
+  const childHome = path.join(sandbox, 'home');
+  await mkdir(path.join(projectRoot, 'src'), { recursive: true });
+  await mkdir(childHome, { recursive: true });
+  await writeFile(
+    path.join(projectRoot, 'src', 'gate-hook.ts'),
+    'export function largeStoreHookMarker(): string { return "large-store-hook-marker"; }\n',
+  );
+
+  const port = await allocatePort();
+  const server = spawn(process.execPath, [cliEntry, 'serve-http', '--port', String(port), '--cwd', projectRoot], {
+    cwd: projectRoot,
+    env: {
+      ...process.env,
+      MEMORIX_DATA_DIR: dataDir,
+      MEMORIX_EMBEDDING: 'off',
+      HOME: childHome,
+      USERPROFILE: childHome,
+      HOMEPATH: childHome,
+      // Skip the CLI heap respawn so this child is the listener we can stop.
+      __MEMORIX_HEAP: '1',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+    windowsHide: true,
+  });
+
+  try {
+    await waitForListening(server);
+    await storeViaHttpMcp(port, projectRoot);
+  } finally {
+    try { server.kill('SIGKILL'); } catch { /* already gone */ }
+    await waitForExit(server);
+  }
+
+  storeViaHook(projectRoot, dataDir, childHome);
 }
 
 async function main() {
@@ -85,6 +343,16 @@ async function main() {
     const hits = await client.search({ query: uniqueLookupToken(0), quality: 'fast', limit: 10 });
     const searchMs = performance.now() - searchStarted;
     await client.close();
+    client = undefined;
+
+    await writeAcrossTransports(projectRoot, dataDir, sandbox);
+    const diskRows = listDiskObservations(dataDir);
+    const diskCount = diskRows.length;
+    client = await createMemoryClient({ projectRoot, silent: true });
+    const reopenedCount = await client.count();
+    const reopened = await client.getAll();
+    await client.close();
+    client = undefined;
 
     const jsonlPath = path.join(dataDir, '.embedding-api-cache.jsonl');
     await writeFile(
@@ -100,13 +368,15 @@ async function main() {
       platform: process.platform,
       seedAndIndexMs: Number(seedAndIndexMs.toFixed(3)),
       steadyStateWriteMs: {
-        p50: Number(percentile(steady, 0.5).toFixed(3)),
-        p95: Number(percentile(steady, 0.95).toFixed(3)),
+        p50: Number((steady.length ? percentile(steady, 0.5) : 0).toFixed(3)),
+        p95: Number((steady.length ? percentile(steady, 0.95) : 0).toFixed(3)),
       },
       searchMs: Number(searchMs.toFixed(3)),
       searchHits: hits.length,
       peakRssMb: Number((peakRss / (1024 * 1024)).toFixed(1)),
       cacheLines: cacheLines.length,
+      diskCount,
+      reopenedCount,
     };
 
     const failed = [];
@@ -117,6 +387,19 @@ async function main() {
     if (report.peakRssMb > rssBudgetMb) failed.push(`peak RSS ${report.peakRssMb}MB > ${rssBudgetMb}MB`);
     if (report.cacheLines !== 2) failed.push(`cache lines ${report.cacheLines} !== 2`);
     if (hits.length < 1) failed.push('search returned no hits');
+    if (diskCount < records + 2) failed.push(`SQLite count ${diskCount} < ${records + 2} after MCP/hook writes`);
+    if (!diskRows.some((row) => row.title === 'MCP marker 1')) {
+      failed.push('SQLite missed the HTTP MCP marker');
+    }
+    if (!diskRows.some((row) => row.sourceDetail === 'hook')) {
+      failed.push('SQLite missed the hook write');
+    }
+    if (reopenedCount <= records) {
+      failed.push(`reopened SDK count ${reopenedCount} stayed at the pre-close snapshot of ${records}`);
+    }
+    if (!reopened.some((row) => row.title === 'MCP marker 1')) {
+      failed.push('reopened SDK missed the HTTP MCP marker');
+    }
 
     console.log(JSON.stringify({ ...report, ok: failed.length === 0, failed }, null, 2));
     if (failed.length > 0) process.exitCode = 1;

--- a/scripts/large-store-gate.mjs
+++ b/scripts/large-store-gate.mjs
@@ -52,6 +52,7 @@ async function main() {
   process.env.MEMORIX_DATA_DIR = dataDir;
   process.env.MEMORIX_EMBEDDING = 'off';
 
+  let client;
   try {
     const git = spawnSync('git', ['init', '--quiet', projectRoot], { encoding: 'utf8', windowsHide: true });
     if (git.status !== 0) {
@@ -59,7 +60,7 @@ async function main() {
     }
 
     const { createMemoryClient } = await import('../dist/sdk.js');
-    const client = await createMemoryClient({ projectRoot, silent: true });
+    client = await createMemoryClient({ projectRoot, silent: true });
     const seedStarted = performance.now();
     const steady = [];
     let peakRss = process.memoryUsage().rss;
@@ -120,6 +121,13 @@ async function main() {
     console.log(JSON.stringify({ ...report, ok: failed.length === 0, failed }, null, 2));
     if (failed.length > 0) process.exitCode = 1;
   } finally {
+    if (client) {
+      try {
+        await client.close();
+      } catch {
+        // already closed or close failed; still try sandbox cleanup
+      }
+    }
     await rm(sandbox, { recursive: true, force: true });
   }
 }

--- a/scripts/large-store-gate.mjs
+++ b/scripts/large-store-gate.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+/*
+ * Reproducible large-store acceptance gate.
+ *
+ * Measures the same seedAndIndex path as scripts/benchmark-retrieval.mjs,
+ * plus steady-state write latency, search, peak RSS, and cache integrity.
+ * Hook-write coverage lives in tests/stress/large-store-gate.test.ts.
+ *
+ *   node scripts/large-store-gate.mjs
+ *   node scripts/large-store-gate.mjs --records 40000
+ */
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+
+function readPositiveOption(name, fallback, maximum) {
+  const index = process.argv.indexOf(name);
+  const raw = index >= 0 ? process.argv[index + 1] : undefined;
+  if (raw === undefined) return fallback;
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(value) || value <= 0 || value > maximum) {
+    throw new Error(`${name} must be an integer between 1 and ${maximum}.`);
+  }
+  return value;
+}
+
+function uniqueLookupToken(index) {
+  let value = index;
+  let suffix = '';
+  do {
+    suffix = String.fromCharCode(97 + (value % 26)) + suffix;
+    value = Math.floor(value / 26) - 1;
+  } while (value >= 0);
+  return `lookupkey${suffix}`;
+}
+
+function percentile(samples, fraction) {
+  samples.sort((left, right) => left - right);
+  const index = Math.min(samples.length - 1, Math.max(0, Math.ceil(samples.length * fraction) - 1));
+  return samples[index];
+}
+
+async function main() {
+  const records = readPositiveOption('--records', 1_000, 100_000);
+  const sandbox = await mkdtemp(path.join(tmpdir(), 'memorix-large-store-gate-'));
+  const projectRoot = path.join(sandbox, 'project');
+  const dataDir = path.join(sandbox, 'data');
+
+  process.env.MEMORIX_DATA_DIR = dataDir;
+  process.env.MEMORIX_EMBEDDING = 'off';
+
+  try {
+    const git = spawnSync('git', ['init', '--quiet', projectRoot], { encoding: 'utf8', windowsHide: true });
+    if (git.status !== 0) {
+      throw new Error(`git init failed: ${git.stderr || git.stdout || 'unknown error'}`);
+    }
+
+    const { createMemoryClient } = await import('../dist/sdk.js');
+    const client = await createMemoryClient({ projectRoot, silent: true });
+    const seedStarted = performance.now();
+    const steady = [];
+    let peakRss = process.memoryUsage().rss;
+
+    for (let index = 0; index < records; index += 1) {
+      const lookupToken = uniqueLookupToken(index);
+      const writeStarted = performance.now();
+      await client.store({
+        entityName: `module-${index % 64}`,
+        type: index % 5 === 0 ? 'decision' : 'discovery',
+        title: `Large-store gate record ${index}`,
+        narrative: `Module ${index % 64} recorded gate evidence for scenario ${index} with ${lookupToken}.`,
+        facts: [`scenario=${index}`, `module=${index % 64}`, lookupToken],
+        concepts: ['gate', 'large-store', `module-${index % 64}`, lookupToken],
+      });
+      if (index >= 20) steady.push(performance.now() - writeStarted);
+      peakRss = Math.max(peakRss, process.memoryUsage().rss);
+    }
+
+    const seedAndIndexMs = performance.now() - seedStarted;
+    const searchStarted = performance.now();
+    const hits = await client.search({ query: uniqueLookupToken(0), quality: 'fast', limit: 10 });
+    const searchMs = performance.now() - searchStarted;
+    await client.close();
+
+    const jsonlPath = path.join(dataDir, '.embedding-api-cache.jsonl');
+    await writeFile(
+      jsonlPath,
+      `${JSON.stringify({ h: 'gatehash00000001', v: [0.11, 0.12] })}\n${JSON.stringify({ h: 'gatehash00000002', v: [0.21, 0.22] })}\n`,
+    );
+    const cacheText = await readFile(jsonlPath, 'utf8');
+    const cacheLines = cacheText.trim().split('\n');
+
+    const report = {
+      records,
+      node: process.version,
+      platform: process.platform,
+      seedAndIndexMs: Number(seedAndIndexMs.toFixed(3)),
+      steadyStateWriteMs: {
+        p50: Number(percentile(steady, 0.5).toFixed(3)),
+        p95: Number(percentile(steady, 0.95).toFixed(3)),
+      },
+      searchMs: Number(searchMs.toFixed(3)),
+      searchHits: hits.length,
+      peakRssMb: Number((peakRss / (1024 * 1024)).toFixed(1)),
+      cacheLines: cacheLines.length,
+    };
+
+    const failed = [];
+    if (report.steadyStateWriteMs.p50 > 25) failed.push(`steady p50 ${report.steadyStateWriteMs.p50}ms > 25ms`);
+    const searchBudget = records <= 1_000 ? 250 : 1_500;
+    if (report.searchMs > searchBudget) failed.push(`search ${report.searchMs}ms > ${searchBudget}ms`);
+    const rssBudgetMb = records <= 1_000 ? 512 : 2048;
+    if (report.peakRssMb > rssBudgetMb) failed.push(`peak RSS ${report.peakRssMb}MB > ${rssBudgetMb}MB`);
+    if (report.cacheLines !== 2) failed.push(`cache lines ${report.cacheLines} !== 2`);
+    if (hits.length < 1) failed.push('search returned no hits');
+
+    console.log(JSON.stringify({ ...report, ok: failed.length === 0, failed }, null, 2));
+    if (failed.length > 0) process.exitCode = 1;
+  } finally {
+    await rm(sandbox, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});

--- a/src/cli/commands/background.ts
+++ b/src/cli/commands/background.ts
@@ -19,6 +19,8 @@
 
 import { defineCommand } from 'citty';
 import * as fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { spawn, execFileSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import { parseTcpPort } from '../port.js';
@@ -71,6 +73,33 @@ function parseBoundedPositiveInteger(value: string | undefined, fallback: number
 
 function parseBackgroundPort(value: string | undefined): number {
   return parseTcpPort(value, 3211);
+}
+
+/**
+ * Resolve the CLI file that `background start` should spawn.
+ * `process.argv[1]` follows the launcher shim and can point at a different
+ * install (for example `$HOME/node_modules/memorix` after `bun add` in $HOME).
+ * When this module is bundled into `dist/cli/index.js`, `../index.js` is the
+ * library stdio entry (`dist/index.js`) — never spawn that.
+ */
+function resolveBackgroundCliEntryFrom(here: string, argv1: string): string {
+  const dir = path.dirname(here);
+  if (path.basename(here) === 'index.js' && path.basename(dir) === 'cli') {
+    return here;
+  }
+  const compiledSibling = path.resolve(dir, '..', 'index.js');
+  if (fs.existsSync(compiledSibling) && path.basename(path.dirname(compiledSibling)) === 'cli') {
+    return compiledSibling;
+  }
+  return argv1;
+}
+
+function resolveBackgroundCliEntry(argv1 = process.argv[1]): string {
+  try {
+    return resolveBackgroundCliEntryFrom(fileURLToPath(import.meta.url), argv1);
+  } catch {
+    return argv1;
+  }
 }
 
 function parseLogLines(value: string | undefined): number {
@@ -343,8 +372,9 @@ export async function doStart(port: number): Promise<void> {
 
   // 5. Find the memorix CLI entry point
   // We need to spawn `node <cli-entry> serve-http --port <port>`
-  // The entry point is the same binary that's running now
-  const cliEntry = process.argv[1]; // e.g., dist/cli/index.js or node_modules/.bin/memorix
+  // Prefer this package's compiled CLI so a bun/npm shim cannot spawn a
+  // different (often unpatched) memorix from ~/node_modules.
+  const cliEntry = resolveBackgroundCliEntry();
 
   // 6. Start the service without a visible console. A regular non-detached child
   // can be reclaimed with its parent by terminal hosts on Windows; a detached Node
@@ -792,4 +822,6 @@ export const _testing = {
   parseBackgroundPort,
   parseLogLines,
   formatBackgroundCommandError,
+  resolveBackgroundCliEntry,
+  resolveBackgroundCliEntryFrom,
 };

--- a/src/cli/commands/operator-shared.ts
+++ b/src/cli/commands/operator-shared.ts
@@ -65,10 +65,13 @@ async function resolveCliProjectContext(options?: CliContextOptions): Promise<{
  */
 export async function getCliReadContext(options?: CliContextOptions): Promise<CliReadContext> {
   const { project, dataDir, invocation } = await resolveCliProjectContext(options);
-  await initObservations(dataDir);
+  await initObservations(dataDir, {
+    embeddingWriteMode: 'deferred',
+    projectRoot: project.rootPath,
+  });
 
   if (options?.searchIndex) {
-    await prepareSearchIndex();
+    await prepareSearchIndex({ skipCachedVectors: true });
   }
 
   const storedIdentity = await loadCliIdentity(dataDir, project.id);
@@ -118,7 +121,7 @@ export async function getCliProjectContext(options?: CliContextOptions): Promise
   const teamStore = await initTeamStore(dataDir);
 
   if (options?.searchIndex) {
-    await prepareSearchIndex();
+    await prepareSearchIndex({ skipCachedVectors: true });
   }
 
   const identity = await resolveCliIdentity({

--- a/src/cli/commands/serve-http.ts
+++ b/src/cli/commands/serve-http.ts
@@ -450,6 +450,10 @@ export default defineCommand({
           {
             allowUntrackedFallback: false,
             deferProjectInitUntilBound: true,
+            // Same as stdio: initialize/tools/list must not hydrate 40k+
+            // observations on the HTTP thread. /health and the LaunchAgent
+            // watchdog die if createMemorixServer blocks here.
+            deferProjectRuntimeInit: true,
             dashboardMode: 'control-plane',
             dashboardPort: port,
             toolProfile,

--- a/src/embedding/api-provider.ts
+++ b/src/embedding/api-provider.ts
@@ -7,7 +7,7 @@
 
 import { createHash } from 'node:crypto';
 import { createReadStream, createWriteStream, constants as fsConstants } from 'node:fs';
-import { access, readFile, writeFile, mkdir, rename, stat } from 'node:fs/promises';
+import { access, readFile, writeFile, mkdir, rename, stat, unlink } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { createInterface } from 'node:readline';
@@ -37,17 +37,138 @@ function dimsCacheFile(): string {
 function cacheMetaFile(): string {
   return join(cacheDir(), '.embedding-api-cache-meta.json');
 }
+function cacheStatFile(): string {
+  return join(cacheDir(), '.embedding-api-cache-stat.json');
+}
 
 const cache = new Map<string, number[]>();
-const MAX_CACHE_SIZE = 200000;
+/** Hard entry ceiling. The real load cap is dimension-aware payload bytes. */
+const MAX_CACHE_ENTRIES = 200000;
+/** 256 MiB of Float64 payload. 4096d × 8 bytes → 8,192 entries, not 200k. */
+const MAX_CACHE_PAYLOAD_BYTES = 256 * 1024 * 1024;
+const BYTES_PER_DIM = 8;
+const DEFAULT_ASSUMED_DIMENSIONS = 4096;
+const MAX_MIGRATION_VALUE_BYTES = 16 * 1024 * 1024;
+
+let cachePayloadBytes = 0;
+let cacheDimensions: number | null = null;
+let diskCacheEntryCount = 0;
 let diskCacheDirty = false;
 let diskSaveTimer: ReturnType<typeof setTimeout> | null = null;
 let diskCacheLoaded = false;
 let diskCacheLoadPromise: Promise<void> | null = null;
 let diskCacheLoadCount = 0;
+let jsonlLineCountCalls = 0;
 
-/** JSON.parse of a multi-hundred-MB cache on the HTTP thread wedges /health. */
-const OFF_THREAD_CACHE_PARSE_BYTES = 8 * 1024 * 1024;
+interface CacheStat {
+  version: 1;
+  entryCount: number;
+  dimensions: number | null;
+}
+
+function payloadBytes(vector: number[]): number {
+  return vector.length * BYTES_PER_DIM;
+}
+
+function maxCachePayloadBytes(): number {
+  const raw = process.env.MEMORIX_EMBEDDING_CACHE_MAX_BYTES;
+  if (raw) {
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  }
+  return MAX_CACHE_PAYLOAD_BYTES;
+}
+
+function maxEntriesForDimensions(dimensions: number): number {
+  const dim = Math.max(1, Math.floor(dimensions));
+  const byBytes = Math.floor(maxCachePayloadBytes() / (dim * BYTES_PER_DIM));
+  return Math.max(1, Math.min(MAX_CACHE_ENTRIES, byBytes));
+}
+
+function rememberDimensions(vector: number[]): void {
+  if (vector.length > 0 && (cacheDimensions === null || vector.length > cacheDimensions)) {
+    cacheDimensions = vector.length;
+  }
+}
+
+function evictOldest(): void {
+  const firstKey = cache.keys().next().value;
+  if (firstKey === undefined) return;
+  const old = cache.get(firstKey);
+  cache.delete(firstKey);
+  if (old) cachePayloadBytes -= payloadBytes(old);
+}
+
+function evictToFit(incomingBytes: number, incomingDims: number): void {
+  const limit = maxEntriesForDimensions(incomingDims);
+  while (
+    cache.size > 0 &&
+    (cache.size >= limit || cachePayloadBytes + incomingBytes > maxCachePayloadBytes())
+  ) {
+    evictOldest();
+  }
+}
+
+function isNumberArray(value: unknown): value is number[] {
+  return Array.isArray(value) && value.every((entry): entry is number => typeof entry === 'number');
+}
+
+function parseCacheRow(raw: unknown): { hash: string; vector: number[] } | null {
+  if (Array.isArray(raw)) {
+    const hash = raw[0];
+    const vector = raw[1];
+    if (typeof hash === 'string' && isNumberArray(vector)) {
+      return { hash, vector };
+    }
+    return null;
+  }
+  if (raw && typeof raw === 'object') {
+    const row = raw as { h?: unknown; v?: unknown };
+    if (typeof row.h === 'string' && isNumberArray(row.v)) {
+      return { hash: row.h, vector: row.v };
+    }
+  }
+  return null;
+}
+
+function cacheInsert(hash: string, value: number[], dirty: boolean): void {
+  rememberDimensions(value);
+  const incoming = payloadBytes(value);
+  const existing = cache.get(hash);
+  if (existing) {
+    cachePayloadBytes -= payloadBytes(existing);
+    cache.delete(hash);
+  }
+  evictToFit(incoming, value.length || cacheDimensions || DEFAULT_ASSUMED_DIMENSIONS);
+  cache.set(hash, value);
+  cachePayloadBytes += incoming;
+  if (dirty) diskCacheDirty = true;
+}
+
+async function readCacheStat(): Promise<CacheStat | null> {
+  try {
+    const data = JSON.parse(await readFile(cacheStatFile(), 'utf-8')) as Partial<CacheStat>;
+    if (typeof data.entryCount === 'number' && Number.isFinite(data.entryCount) && data.entryCount >= 0) {
+      return {
+        version: 1,
+        entryCount: Math.floor(data.entryCount),
+        dimensions: isValidDimension(data.dimensions) ? data.dimensions : null,
+      };
+    }
+  } catch {
+    // Stat is an acceleration sidecar, not the source of truth for vectors.
+  }
+  return null;
+}
+
+async function writeCacheStat(stat: CacheStat): Promise<void> {
+  try {
+    await mkdir(cacheDir(), { recursive: true });
+    await writeFile(cacheStatFile(), JSON.stringify(stat));
+  } catch {
+    // Best-effort sidecar.
+  }
+}
 
 const MAX_INPUT_CHARS = 32000;
 const MAX_CONCURRENCY = 4;
@@ -200,49 +321,142 @@ export function parseCacheJsonInWorker(filePath: string): Promise<[string, numbe
   });
 }
 
+function findJsonValueEnd(source: string): number {
+  let i = 0;
+  while (i < source.length && /\s/.test(source[i])) i += 1;
+  if (i >= source.length) return -1;
+  const start = source[i];
+  if (start === '"') {
+    i += 1;
+    while (i < source.length) {
+      if (source[i] === '\\') {
+        i += 2;
+        continue;
+      }
+      if (source[i] === '"') return i + 1;
+      i += 1;
+    }
+    return -1;
+  }
+  if (start === '{' || start === '[') {
+    const close = start === '{' ? '}' : ']';
+    let depth = 0;
+    let inString = false;
+    for (; i < source.length; i += 1) {
+      const ch = source[i];
+      if (inString) {
+        if (ch === '\\') {
+          i += 1;
+          continue;
+        }
+        if (ch === '"') inString = false;
+        continue;
+      }
+      if (ch === '"') {
+        inString = true;
+        continue;
+      }
+      if (ch === start) depth += 1;
+      else if (ch === close) {
+        depth -= 1;
+        if (depth === 0) return i + 1;
+      }
+    }
+    return -1;
+  }
+  const rest = source.slice(i);
+  const match = rest.match(/^(?:-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?|true|false|null)/);
+  return match ? i + match[0].length : -1;
+}
+
+async function streamJsonArrayToJsonl(filePath: string, tmpPath: string): Promise<number> {
+  const input = createReadStream(filePath, { encoding: 'utf8' });
+  const out = createWriteStream(tmpPath);
+  let buf = '';
+  let started = false;
+  let count = 0;
+  const writeLine = async (line: string): Promise<void> => {
+    if (!out.write(line)) {
+      await new Promise<void>((resolve, reject) => {
+        out.once('drain', resolve);
+        out.once('error', reject);
+      });
+    }
+  };
+
+  try {
+    for await (const chunk of input) {
+      buf += chunk;
+      if (!started) {
+        const idx = buf.search(/\S/);
+        if (idx < 0) continue;
+        if (buf[idx] !== '[') throw new Error('embedding cache is not a JSON array');
+        buf = buf.slice(idx + 1);
+        started = true;
+      }
+      while (true) {
+        buf = buf.replace(/^\s*,?\s*/, '');
+        if (!buf) break;
+        if (buf[0] === ']') {
+          buf = '';
+          break;
+        }
+        const end = findJsonValueEnd(buf);
+        if (end < 0) break;
+        const value = JSON.parse(buf.slice(0, end));
+        buf = buf.slice(end);
+        const row = parseCacheRow(value);
+        if (row) {
+          await writeLine(`${JSON.stringify({ h: row.hash, v: row.vector })}\n`);
+          count += 1;
+          if (count % 50 === 0) {
+            await new Promise<void>((resolve) => setImmediate(resolve));
+          }
+        }
+      }
+      if (buf.length > MAX_MIGRATION_VALUE_BYTES) {
+        throw new Error('embedding cache entry too large to migrate safely');
+      }
+    }
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      out.end(() => resolve());
+      out.once('error', reject);
+    });
+  }
+  return count;
+}
+
+/**
+ * Convert a JSON-array cache to JSONL with one-entry-at-a-time parsing,
+ * a temp file, and an atomic rename. The HTTP process never holds the full
+ * array plus a lines[] copy.
+ */
+export async function migrateJsonArrayCacheToJsonl(filePath: string, jsonlPath: string): Promise<number> {
+  const tmpPath = `${jsonlPath}.tmp`;
+  try {
+    const count = await streamJsonArrayToJsonl(filePath, tmpPath);
+    await rename(tmpPath, jsonlPath);
+    diskCacheEntryCount = count;
+    await writeCacheStat({
+      version: 1,
+      entryCount: count,
+      dimensions: cacheDimensions,
+    });
+    return count;
+  } catch (err) {
+    await unlink(tmpPath).catch(() => undefined);
+    throw err;
+  }
+}
+
 /**
  * Convert a giant JSON-array cache to JSONL on disk. Never postMessage the
  * vectors — structured clone of 27k×1024 floats OOMs the HTTP process and
  * the subsequent empty save overwrites the real cache.
  */
 export function convertArrayCacheToJsonl(filePath: string, jsonlPath: string): Promise<number> {
-  return new Promise((resolve, reject) => {
-    void import('node:worker_threads').then(({ Worker }) => {
-      const worker = new Worker(
-        `
-        const { parentPort, workerData } = require('node:worker_threads');
-        const { readFileSync, writeFileSync } = require('node:fs');
-        try {
-          const parsed = JSON.parse(readFileSync(workerData.filePath, 'utf8'));
-          if (!Array.isArray(parsed)) throw new Error('embedding cache is not a JSON array');
-          const lines = [];
-          for (const entry of parsed) {
-            if (Array.isArray(entry) && typeof entry[0] === 'string' && Array.isArray(entry[1])) {
-              lines.push(JSON.stringify({ h: entry[0], v: entry[1] }));
-            }
-          }
-          writeFileSync(workerData.jsonlPath, lines.join('\\n') + (lines.length ? '\\n' : ''));
-          parentPort.postMessage({ ok: true, count: lines.length });
-        } catch (err) {
-          parentPort.postMessage({
-            ok: false,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-        `,
-        { eval: true, workerData: { filePath, jsonlPath } },
-      );
-      worker.once('message', (msg: { ok?: boolean; count?: number; error?: string }) => {
-        void worker.terminate();
-        if (msg?.ok && typeof msg.count === 'number') {
-          resolve(msg.count);
-          return;
-        }
-        reject(new Error(msg?.error || 'embedding cache jsonl convert failed'));
-      });
-      worker.once('error', reject);
-    }).catch(reject);
-  });
+  return migrateJsonArrayCacheToJsonl(filePath, jsonlPath);
 }
 
 async function loadCacheJsonl(filePath: string): Promise<number> {
@@ -251,29 +465,34 @@ async function loadCacheJsonl(filePath: string): Promise<number> {
     crlfDelay: Infinity,
   });
   let loaded = 0;
+  let onDiskCount = 0;
   for await (const line of rl) {
     const trimmed = line.trim();
     if (!trimmed) continue;
     try {
-      const row = JSON.parse(trimmed) as { h?: string; v?: number[] } | [string, number[]];
-      if (Array.isArray(row) && typeof row[0] === 'string' && Array.isArray(row[1])) {
-        cache.set(row[0], row[1]);
-        loaded += 1;
-      } else if (row && typeof row === 'object' && typeof row.h === 'string' && Array.isArray(row.v)) {
-        cache.set(row.h, row.v);
-        loaded += 1;
-      }
+      const row = parseCacheRow(JSON.parse(trimmed));
+      if (!row) continue;
+      onDiskCount += 1;
+      cacheInsert(row.hash, row.vector, false);
+      loaded = cache.size;
     } catch {
       // Skip a corrupt line; the rest of the cache remains usable.
     }
-    if (loaded % 100 === 0) {
+    if (onDiskCount % 250 === 0) {
       await new Promise<void>((resolve) => setImmediate(resolve));
     }
   }
+  diskCacheEntryCount = onDiskCount;
+  await writeCacheStat({
+    version: 1,
+    entryCount: onDiskCount,
+    dimensions: cacheDimensions,
+  });
   return loaded;
 }
 
 async function countJsonlLines(filePath: string): Promise<number> {
+  jsonlLineCountCalls += 1;
   try {
     const rl = createInterface({
       input: createReadStream(filePath, { encoding: 'utf8' }),
@@ -287,6 +506,30 @@ async function countJsonlLines(filePath: string): Promise<number> {
   } catch {
     return 0;
   }
+}
+
+async function resolveOnDiskCount(jsonlPath: string): Promise<number> {
+  if (diskCacheEntryCount > 0) return diskCacheEntryCount;
+  const sidecar = await readCacheStat();
+  if (sidecar) {
+    diskCacheEntryCount = sidecar.entryCount;
+    if (sidecar.dimensions && cacheDimensions === null) cacheDimensions = sidecar.dimensions;
+    return sidecar.entryCount;
+  }
+  try {
+    await access(jsonlPath, fsConstants.R_OK);
+  } catch {
+    return 0;
+  }
+  // Legacy JSONL without a sidecar: one-time count, then persist so saves stay O(1).
+  const counted = await countJsonlLines(jsonlPath);
+  diskCacheEntryCount = counted;
+  await writeCacheStat({
+    version: 1,
+    entryCount: counted,
+    dimensions: cacheDimensions,
+  });
+  return counted;
 }
 
 async function loadDiskCache(): Promise<number> {
@@ -305,16 +548,9 @@ async function loadDiskCache(): Promise<number> {
       loaded = await loadCacheJsonl(jsonlPath);
     } else {
       const filePath = cacheFile();
-      const info = await stat(filePath);
-      if (info.size >= OFF_THREAD_CACHE_PARSE_BYTES) {
-        await convertArrayCacheToJsonl(filePath, jsonlPath);
-        loaded = await loadCacheJsonl(jsonlPath);
-      } else {
-        const raw = await readFile(filePath, 'utf-8');
-        const entries: [string, number[]][] = JSON.parse(raw);
-        for (const [key, value] of entries) cache.set(key, value);
-        loaded = entries.length;
-      }
+      await stat(filePath);
+      await migrateJsonArrayCacheToJsonl(filePath, jsonlPath);
+      loaded = await loadCacheJsonl(jsonlPath);
     }
     diskCacheLoadCount += 1;
     console.error(`[memorix] Loaded ${loaded} cached API embeddings from disk`);
@@ -350,18 +586,39 @@ export function getApiEmbeddingDiskCacheLoadCountForTests(): number {
 /** @internal Reset in-process API embedding cache between tests. */
 export function resetApiEmbeddingCacheForTests(): void {
   cache.clear();
+  cachePayloadBytes = 0;
+  cacheDimensions = null;
+  diskCacheEntryCount = 0;
   diskCacheLoaded = false;
   diskCacheLoadPromise = null;
   diskCacheLoadCount = 0;
   diskCacheDirty = false;
+  jsonlLineCountCalls = 0;
 }
 
 /** @internal Seed the in-memory API embedding cache for shrink-guard tests. */
 export function seedApiEmbeddingCacheForTests(entries: Map<string, number[]>): void {
   cache.clear();
-  for (const [key, value] of entries) cache.set(key, value);
+  cachePayloadBytes = 0;
+  cacheDimensions = null;
+  for (const [key, value] of entries) cacheInsert(key, value, true);
   diskCacheLoaded = true;
   diskCacheDirty = true;
+}
+
+/** @internal In-memory vector payload bytes retained after load/eviction. */
+export function getApiEmbeddingCachePayloadBytesForTests(): number {
+  return cachePayloadBytes;
+}
+
+/** @internal How many times a full JSONL line scan ran (must stay off the save path). */
+export function getApiEmbeddingJsonlLineCountCallsForTests(): number {
+  return jsonlLineCountCalls;
+}
+
+/** @internal Dimension-aware in-memory entry cap for a vector width. */
+export function getApiEmbeddingMaxEntriesForDimensionsForTests(dimensions: number): number {
+  return maxEntriesForDimensions(dimensions);
 }
 
 function dimsCacheKey(config: Pick<APIEmbeddingConfig, 'baseUrl' | 'model' | 'requestedDimensions'>): string {
@@ -544,7 +801,7 @@ export async function saveDiskCacheNow(): Promise<void> {
   try {
     await mkdir(cacheDir(), { recursive: true });
     const jsonlPath = cacheJsonlFile();
-    const existing = await countJsonlLines(jsonlPath);
+    const existing = await resolveOnDiskCount(jsonlPath);
     if (existing > 0 && cache.size < Math.ceil(existing * 0.5)) {
       console.error(
         `[memorix] Refusing to overwrite embedding cache (${existing} on disk vs ${cache.size} in memory)`,
@@ -576,6 +833,12 @@ export async function saveDiskCacheNow(): Promise<void> {
       writeBatch();
     });
     await rename(tmpPath, jsonlPath);
+    diskCacheEntryCount = cache.size;
+    await writeCacheStat({
+      version: 1,
+      entryCount: cache.size,
+      dimensions: cacheDimensions,
+    });
     diskCacheDirty = false;
   } catch {
     // Cache persistence is best-effort only.
@@ -591,12 +854,7 @@ function scheduleDiskSave(): void {
 }
 
 function cacheSet(hash: string, value: number[]): void {
-  if (cache.size >= MAX_CACHE_SIZE) {
-    const firstKey = cache.keys().next().value;
-    if (firstKey !== undefined) cache.delete(firstKey);
-  }
-  cache.set(hash, value);
-  diskCacheDirty = true;
+  cacheInsert(hash, value, true);
 }
 
 interface EmbeddingAPIResponse {

--- a/src/embedding/api-provider.ts
+++ b/src/embedding/api-provider.ts
@@ -44,6 +44,7 @@ let diskCacheDirty = false;
 let diskSaveTimer: ReturnType<typeof setTimeout> | null = null;
 let diskCacheLoaded = false;
 let diskCacheLoadPromise: Promise<void> | null = null;
+let diskCacheLoadCount = 0;
 
 /** JSON.parse of a multi-hundred-MB cache on the HTTP thread wedges /health. */
 const OFF_THREAD_CACHE_PARSE_BYTES = 8 * 1024 * 1024;
@@ -315,6 +316,7 @@ async function loadDiskCache(): Promise<number> {
         loaded = entries.length;
       }
     }
+    diskCacheLoadCount += 1;
     console.error(`[memorix] Loaded ${loaded} cached API embeddings from disk`);
   } catch {
     // No cache file or corrupt cache; start fresh. Never save an empty map
@@ -333,12 +335,16 @@ function startDiskCacheLoad(): void {
 /** Ensure disk cache is loaded (await if still in progress). */
 export async function ensureDiskCacheLoaded(): Promise<number> {
   if (diskCacheLoaded) return cache.size;
-  if (diskCacheLoadPromise) {
-    await diskCacheLoadPromise;
-    return cache.size;
+  if (!diskCacheLoadPromise) {
+    diskCacheLoadPromise = loadDiskCache().then(() => undefined).catch(() => {});
   }
-  await loadDiskCache();
+  await diskCacheLoadPromise;
   return cache.size;
+}
+
+/** @internal How many times the on-disk embedding cache was parsed. */
+export function getApiEmbeddingDiskCacheLoadCountForTests(): number {
+  return diskCacheLoadCount;
 }
 
 /** @internal Reset in-process API embedding cache between tests. */
@@ -346,6 +352,7 @@ export function resetApiEmbeddingCacheForTests(): void {
   cache.clear();
   diskCacheLoaded = false;
   diskCacheLoadPromise = null;
+  diskCacheLoadCount = 0;
   diskCacheDirty = false;
 }
 

--- a/src/embedding/api-provider.ts
+++ b/src/embedding/api-provider.ts
@@ -6,9 +6,11 @@
  */
 
 import { createHash } from 'node:crypto';
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { createReadStream, createWriteStream, constants as fsConstants } from 'node:fs';
+import { access, readFile, writeFile, mkdir, rename, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
+import { createInterface } from 'node:readline';
 import {
   EmbeddingInputError,
   UnsupportedEmbeddingModalityError,
@@ -26,6 +28,9 @@ function cacheDir(): string {
 function cacheFile(): string {
   return join(cacheDir(), '.embedding-api-cache.json');
 }
+function cacheJsonlFile(): string {
+  return join(cacheDir(), '.embedding-api-cache.jsonl');
+}
 function dimsCacheFile(): string {
   return join(cacheDir(), '.embedding-dims-cache.json');
 }
@@ -34,11 +39,14 @@ function cacheMetaFile(): string {
 }
 
 const cache = new Map<string, number[]>();
-const MAX_CACHE_SIZE = 10000;
+const MAX_CACHE_SIZE = 200000;
 let diskCacheDirty = false;
 let diskSaveTimer: ReturnType<typeof setTimeout> | null = null;
 let diskCacheLoaded = false;
 let diskCacheLoadPromise: Promise<void> | null = null;
+
+/** JSON.parse of a multi-hundred-MB cache on the HTTP thread wedges /health. */
+const OFF_THREAD_CACHE_PARSE_BYTES = 8 * 1024 * 1024;
 
 const MAX_INPUT_CHARS = 32000;
 const MAX_CONCURRENCY = 4;
@@ -154,30 +162,199 @@ function toProviderInput(input: EmbeddingInput, baseUrl: string): unknown {
   return { type: input.modality, url: input.url };
 }
 
-async function loadDiskCache(): Promise<void> {
-  if (diskCacheLoaded) return;
+/**
+ * Parse a large embedding cache off the HTTP event loop.
+ * JSON.parse of a 300MB file on the serve-http thread makes /health time out
+ * and the LaunchAgent watchdog restart a healthy-but-busy control plane.
+ */
+export function parseCacheJsonInWorker(filePath: string): Promise<[string, number[]][]> {
+  return new Promise((resolve, reject) => {
+    void import('node:worker_threads').then(({ Worker }) => {
+      const worker = new Worker(
+        `
+        const { parentPort, workerData } = require('node:worker_threads');
+        const { readFileSync } = require('node:fs');
+        try {
+          const raw = readFileSync(workerData.filePath, 'utf8');
+          parentPort.postMessage({ ok: true, entries: JSON.parse(raw) });
+        } catch (err) {
+          parentPort.postMessage({
+            ok: false,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+        `,
+        { eval: true, workerData: { filePath } },
+      );
+      worker.once('message', (msg: { ok?: boolean; entries?: [string, number[]][]; error?: string }) => {
+        void worker.terminate();
+        if (msg?.ok && Array.isArray(msg.entries)) {
+          resolve(msg.entries);
+          return;
+        }
+        reject(new Error(msg?.error || 'embedding cache worker parse failed'));
+      });
+      worker.once('error', reject);
+    }).catch(reject);
+  });
+}
+
+/**
+ * Convert a giant JSON-array cache to JSONL on disk. Never postMessage the
+ * vectors — structured clone of 27k×1024 floats OOMs the HTTP process and
+ * the subsequent empty save overwrites the real cache.
+ */
+export function convertArrayCacheToJsonl(filePath: string, jsonlPath: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    void import('node:worker_threads').then(({ Worker }) => {
+      const worker = new Worker(
+        `
+        const { parentPort, workerData } = require('node:worker_threads');
+        const { readFileSync, writeFileSync } = require('node:fs');
+        try {
+          const parsed = JSON.parse(readFileSync(workerData.filePath, 'utf8'));
+          if (!Array.isArray(parsed)) throw new Error('embedding cache is not a JSON array');
+          const lines = [];
+          for (const entry of parsed) {
+            if (Array.isArray(entry) && typeof entry[0] === 'string' && Array.isArray(entry[1])) {
+              lines.push(JSON.stringify({ h: entry[0], v: entry[1] }));
+            }
+          }
+          writeFileSync(workerData.jsonlPath, lines.join('\\n') + (lines.length ? '\\n' : ''));
+          parentPort.postMessage({ ok: true, count: lines.length });
+        } catch (err) {
+          parentPort.postMessage({
+            ok: false,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+        `,
+        { eval: true, workerData: { filePath, jsonlPath } },
+      );
+      worker.once('message', (msg: { ok?: boolean; count?: number; error?: string }) => {
+        void worker.terminate();
+        if (msg?.ok && typeof msg.count === 'number') {
+          resolve(msg.count);
+          return;
+        }
+        reject(new Error(msg?.error || 'embedding cache jsonl convert failed'));
+      });
+      worker.once('error', reject);
+    }).catch(reject);
+  });
+}
+
+async function loadCacheJsonl(filePath: string): Promise<number> {
+  const rl = createInterface({
+    input: createReadStream(filePath, { encoding: 'utf8' }),
+    crlfDelay: Infinity,
+  });
+  let loaded = 0;
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const row = JSON.parse(trimmed) as { h?: string; v?: number[] } | [string, number[]];
+      if (Array.isArray(row) && typeof row[0] === 'string' && Array.isArray(row[1])) {
+        cache.set(row[0], row[1]);
+        loaded += 1;
+      } else if (row && typeof row === 'object' && typeof row.h === 'string' && Array.isArray(row.v)) {
+        cache.set(row.h, row.v);
+        loaded += 1;
+      }
+    } catch {
+      // Skip a corrupt line; the rest of the cache remains usable.
+    }
+    if (loaded % 100 === 0) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+  }
+  return loaded;
+}
+
+async function countJsonlLines(filePath: string): Promise<number> {
   try {
-    const raw = await readFile(cacheFile(), 'utf-8');
-    const entries: [string, number[]][] = JSON.parse(raw);
-    for (const [k, v] of entries) cache.set(k, v);
-    console.error(`[memorix] Loaded ${entries.length} cached API embeddings from disk`);
+    const rl = createInterface({
+      input: createReadStream(filePath, { encoding: 'utf8' }),
+      crlfDelay: Infinity,
+    });
+    let count = 0;
+    for await (const line of rl) {
+      if (line.trim()) count += 1;
+    }
+    return count;
   } catch {
-    // No cache file or corrupt cache; start fresh.
+    return 0;
+  }
+}
+
+async function loadDiskCache(): Promise<number> {
+  if (diskCacheLoaded) return cache.size;
+  let loaded = 0;
+  try {
+    const jsonlPath = cacheJsonlFile();
+    let hasJsonl = false;
+    try {
+      await access(jsonlPath, fsConstants.R_OK);
+      hasJsonl = true;
+    } catch {
+      hasJsonl = false;
+    }
+    if (hasJsonl) {
+      loaded = await loadCacheJsonl(jsonlPath);
+    } else {
+      const filePath = cacheFile();
+      const info = await stat(filePath);
+      if (info.size >= OFF_THREAD_CACHE_PARSE_BYTES) {
+        await convertArrayCacheToJsonl(filePath, jsonlPath);
+        loaded = await loadCacheJsonl(jsonlPath);
+      } else {
+        const raw = await readFile(filePath, 'utf-8');
+        const entries: [string, number[]][] = JSON.parse(raw);
+        for (const [key, value] of entries) cache.set(key, value);
+        loaded = entries.length;
+      }
+    }
+    console.error(`[memorix] Loaded ${loaded} cached API embeddings from disk`);
+  } catch {
+    // No cache file or corrupt cache; start fresh. Never save an empty map
+    // over a larger on-disk cache — saveDiskCacheNow refuses that shrink.
   }
   diskCacheLoaded = true;
+  return loaded;
 }
 
 /** Start loading disk cache in background (non-blocking). */
 function startDiskCacheLoad(): void {
   if (diskCacheLoaded || diskCacheLoadPromise) return;
-  diskCacheLoadPromise = loadDiskCache().catch(() => {});
+  diskCacheLoadPromise = loadDiskCache().then(() => undefined).catch(() => {});
 }
 
 /** Ensure disk cache is loaded (await if still in progress). */
-async function ensureDiskCacheLoaded(): Promise<void> {
-  if (diskCacheLoaded) return;
-  if (diskCacheLoadPromise) { await diskCacheLoadPromise; return; }
+export async function ensureDiskCacheLoaded(): Promise<number> {
+  if (diskCacheLoaded) return cache.size;
+  if (diskCacheLoadPromise) {
+    await diskCacheLoadPromise;
+    return cache.size;
+  }
   await loadDiskCache();
+  return cache.size;
+}
+
+/** @internal Reset in-process API embedding cache between tests. */
+export function resetApiEmbeddingCacheForTests(): void {
+  cache.clear();
+  diskCacheLoaded = false;
+  diskCacheLoadPromise = null;
+  diskCacheDirty = false;
+}
+
+/** @internal Seed the in-memory API embedding cache for shrink-guard tests. */
+export function seedApiEmbeddingCacheForTests(entries: Map<string, number[]>): void {
+  cache.clear();
+  for (const [key, value] of entries) cache.set(key, value);
+  diskCacheLoaded = true;
+  diskCacheDirty = true;
 }
 
 function dimsCacheKey(config: Pick<APIEmbeddingConfig, 'baseUrl' | 'model' | 'requestedDimensions'>): string {
@@ -355,12 +532,43 @@ async function saveCachedDims(config: Pick<APIEmbeddingConfig, 'baseUrl' | 'mode
   await saveCachedVectorDimensions(config, dimensions);
 }
 
-async function saveDiskCacheNow(): Promise<void> {
+export async function saveDiskCacheNow(): Promise<void> {
   if (!diskCacheDirty) return;
   try {
     await mkdir(cacheDir(), { recursive: true });
-    const entries = Array.from(cache.entries());
-    await writeFile(cacheFile(), JSON.stringify(entries));
+    const jsonlPath = cacheJsonlFile();
+    const existing = await countJsonlLines(jsonlPath);
+    if (existing > 0 && cache.size < Math.ceil(existing * 0.5)) {
+      console.error(
+        `[memorix] Refusing to overwrite embedding cache (${existing} on disk vs ${cache.size} in memory)`,
+      );
+      diskCacheDirty = false;
+      return;
+    }
+    const tmpPath = `${jsonlPath}.tmp`;
+    await new Promise<void>((resolve, reject) => {
+      const out = createWriteStream(tmpPath);
+      const entries = cache.entries();
+      const writeBatch = (): void => {
+        for (let i = 0; i < 50; i++) {
+          const next = entries.next();
+          if (next.done) {
+            out.end();
+            return;
+          }
+          const [hash, vector] = next.value;
+          if (!out.write(`${JSON.stringify({ h: hash, v: vector })}\n`)) {
+            out.once('drain', writeBatch);
+            return;
+          }
+        }
+        setImmediate(writeBatch);
+      };
+      out.on('finish', resolve);
+      out.on('error', reject);
+      writeBatch();
+    });
+    await rename(tmpPath, jsonlPath);
     diskCacheDirty = false;
   } catch {
     // Cache persistence is best-effort only.

--- a/src/embedding/api-provider.ts
+++ b/src/embedding/api-provider.ts
@@ -724,10 +724,13 @@ export class APIEmbeddingProvider implements EmbeddingProvider {
       console.error(`[memorix] Dimension shortening: ${config.requestedDimensions}d requested`);
     }
 
-    // The cache can only be used after dimensions are known. In cache-only
-    // startup with no metadata, skip parsing the potentially large cache file
-    // altogether and stay lexical until a normal embedding lane is needed.
-    startDiskCacheLoad();
+    // Startup / CLI lexical lanes pass allowNetworkProbe=false. Do not begin
+    // the 300MB JSONL parse here — that keeps one-shot CLI processes alive
+    // after search already printed. getCachedEmbeddings() still loads the
+    // cache when a later hybrid/attach path actually needs vectors.
+    if (allowNetworkProbe) {
+      startDiskCacheLoad();
+    }
 
     return new APIEmbeddingProvider(config, probeDimensions);
   }

--- a/src/embedding/provider.ts
+++ b/src/embedding/provider.ts
@@ -173,6 +173,8 @@ let provider: EmbeddingProvider | null = null;
 let initPromise: Promise<EmbeddingProvider | null> | null = null;
 
 type EmbeddingMode = 'off' | 'fastembed' | 'transformers' | 'api' | 'auto';
+let cachedEmbeddingMode: EmbeddingMode | null = null;
+let cachedEmbeddingModeToken: string | null = null;
 type ProviderKind = 'api' | 'fastembed' | 'transformers' | 'unknown';
 
 export type EmbeddingRuntimeStatus = 'disabled' | 'uninitialized' | 'ready' | 'degraded';
@@ -213,7 +215,13 @@ function warnOnce(message: string): void {
  * Get configured embedding mode from environment.
  * Default is 'off' to minimize resource usage.
  */
+function embeddingModeToken(): string {
+  return process.env.MEMORIX_EMBEDDING?.toLowerCase()?.trim() ?? '';
+}
+
 function getEmbeddingMode(): EmbeddingMode {
+  const token = embeddingModeToken();
+  if (cachedEmbeddingMode && cachedEmbeddingModeToken === token) return cachedEmbeddingMode;
   // Unified: env vars > config.json > 'off'
   try {
     let cfg: { getEmbeddingMode: () => EmbeddingMode };
@@ -223,11 +231,18 @@ function getEmbeddingMode(): EmbeddingMode {
       cfg = require('../config.js');
     }
     const { getEmbeddingMode: cfgMode } = cfg;
-    return cfgMode();
+    cachedEmbeddingMode = cfgMode();
+    cachedEmbeddingModeToken = token;
+    return cachedEmbeddingMode;
   } catch {
     // Fallback if config module not available
-    const env = process.env.MEMORIX_EMBEDDING?.toLowerCase()?.trim();
-    if (env === 'fastembed' || env === 'transformers' || env === 'api' || env === 'auto') return env;
+    if (token === 'fastembed' || token === 'transformers' || token === 'api' || token === 'auto') {
+      cachedEmbeddingMode = token;
+      cachedEmbeddingModeToken = token;
+      return token;
+    }
+    cachedEmbeddingMode = 'off';
+    cachedEmbeddingModeToken = token;
     return 'off';
   }
 }
@@ -596,6 +611,8 @@ export function isEmbeddingExplicitlyDisabled(): boolean {
 export function resetProvider(): void {
   provider = null;
   initPromise = null;
+  cachedEmbeddingMode = null;
+  cachedEmbeddingModeToken = null;
   lastInitWasTemporaryFailure = false;
   lastFailureTimestamp = 0;
   lastEmbeddingFailure = null;

--- a/src/hooks/lifecycle.ts
+++ b/src/hooks/lifecycle.ts
@@ -51,6 +51,7 @@ export function resolveHookStdinTimeoutMs(env: EnvMap = process.env): number {
 
 export function hookObservationRuntimeOptions(projectRoot: string): ObservationRuntimeOptions {
   return {
+    skipCorpusLoad: true,
     embeddingWriteMode: 'deferred',
     projectRoot,
   };

--- a/src/memory/observations.ts
+++ b/src/memory/observations.ts
@@ -1201,10 +1201,12 @@ export async function reindexObservations(): Promise<number> {
  * coupled to embedding provider throughput. Missing vectors are queued for the
  * existing background backfill cycle.
  */
-export async function prepareSearchIndex(): Promise<number> {
+export async function prepareSearchIndex(options: { skipCachedVectors?: boolean } = {}): Promise<number> {
   if (searchIndexPrepared) return 0;
 
-  const count = await hydrateIndexForStartup(observations as unknown as any[]);
+  const count = await hydrateIndexForStartup(observations as unknown as any[], {
+    skipCachedVectors: options.skipCachedVectors,
+  });
   if (count === 0) {
     searchIndexPrepared = true;
     return 0;

--- a/src/memory/observations.ts
+++ b/src/memory/observations.ts
@@ -280,14 +280,18 @@ function scheduleObservationEmbedding(input: {
   const { observationId, projectId, searchableText, doc } = input;
   vectorMissingIds.add(observationId);
 
+  // Ordinary store must not pay embedding-provider or cache I/O when vectors
+  // are disabled. Check before generateEmbedding() so MEMORIX_EMBEDDING=off
+  // stays on the lexical write path.
+  if (isEmbeddingExplicitlyDisabled()) {
+    vectorMissingIds.delete(observationId);
+    return;
+  }
+
   // A network fetch keeps Node's event loop alive even when its Promise is not
   // awaited. One-shot CLI commands therefore persist first and let a detached
   // worker consume the same durable queue.
   if (embeddingWriteMode === 'deferred') {
-    if (isEmbeddingExplicitlyDisabled()) {
-      vectorMissingIds.delete(observationId);
-      return;
-    }
     queueVectorBackfill(projectId, {
       detachedWorker: true,
       projectRoot: embeddingWorkerProjectRoot,

--- a/src/memory/observations.ts
+++ b/src/memory/observations.ts
@@ -57,10 +57,30 @@ export interface ObservationRuntimeOptions {
   embeddingWriteMode?: ObservationEmbeddingWriteMode;
   /** Git root used by the detached vector worker. */
   projectRoot?: string;
+  /**
+   * Open SQLite and the ID counter without materializing the full corpus.
+   * Hook writes use disk atomic() + findByTopicKey; they must not loadAll()
+   * tens of thousands of rows on every PostToolUse.
+   */
+  skipCorpusLoad?: boolean;
 }
 
 let embeddingWriteMode: ObservationEmbeddingWriteMode = 'background';
 let embeddingWorkerProjectRoot: string | undefined;
+let corpusLoaded = false;
+
+/** @internal Reset in-process observation state between tests. */
+export function resetObservationRuntime(): void {
+  observations = [];
+  nextId = 1;
+  projectDir = null;
+  searchIndexPrepared = false;
+  corpusLoaded = false;
+  embeddingWriteMode = 'background';
+  embeddingWorkerProjectRoot = undefined;
+  vectorMissingIds.clear();
+  vectorSchemaUpgradePromise = null;
+}
 
 // ── Vector-missing tracking ──────────────────────────────────────
 // Tracks observation IDs whose async embedding write failed or was skipped.
@@ -233,14 +253,22 @@ export async function initObservations(
 ): Promise<void> {
   embeddingWriteMode = options.embeddingWriteMode ?? 'background';
   embeddingWorkerProjectRoot = options.projectRoot;
-  if (projectDir === dir) return;
+  if (projectDir === dir) {
+    if (options.skipCorpusLoad || corpusLoaded) return;
+  }
   await initObservationStore(dir);
   const store = getObservationStore();
-  observations = await store.loadAll();
   nextId = await store.loadIdCounter();
   projectDir = dir;
   searchIndexPrepared = false;
   vectorSchemaUpgradePromise = null;
+  if (options.skipCorpusLoad) {
+    observations = [];
+    corpusLoaded = false;
+    return;
+  }
+  observations = await store.loadAll();
+  corpusLoaded = true;
 }
 
 function scheduleObservationEmbedding(input: {
@@ -322,7 +350,7 @@ function scheduleObservationEmbedding(input: {
  * For DegradedBackend this is a no-op (always returns false).
  */
 export async function ensureFreshObservations(): Promise<boolean> {
-  if (!projectDir) return false;
+  if (!projectDir || !corpusLoaded) return false;
   try {
     const store = getObservationStore();
     const wasStale = await store.ensureFresh();
@@ -424,12 +452,13 @@ export async function storeObservation(input: {
 
   // Sync the local cache before using it as the topicKey fast path. This costs a
   // generation read in the normal case and only reloads when another process wrote.
+  // Write-only / hook processes skip the corpus cache; disk findByTopicKey is authoritative.
   await ensureFreshObservations();
 
   // Topic key upsert: fast-path check in-memory (optimistic, may be stale).
   // A second authoritative check happens inside the file lock to prevent TOCTOU races
   // where two concurrent calls with the same topicKey both miss this check.
-  if (input.topicKey) {
+  if (input.topicKey && corpusLoaded) {
     const existing = observations.find(
       o => o.topicKey === input.topicKey && o.projectId === input.projectId,
     );
@@ -546,14 +575,18 @@ export async function storeObservation(input: {
       observation.writeGeneration = store.getGeneration();
 
       if (upsertedInsideLock || reloadCacheAfterCommit) {
-        observations = await store.loadAll();
-        nextId = await store.loadIdCounter();
-        if (upsertedInsideLock) {
-          observation = observations.find((candidate) => candidate.id === observation.id)
-            ?? observation;
+        if (corpusLoaded) {
+          observations = await store.loadAll();
+          nextId = await store.loadIdCounter();
+          if (upsertedInsideLock) {
+            observation = observations.find((candidate) => candidate.id === observation.id)
+              ?? observation;
+          }
+        } else {
+          nextId = await store.loadIdCounter();
         }
       } else {
-        observations.push(observation);
+        if (corpusLoaded) observations.push(observation);
         nextId = observation.id + 1;
       }
 
@@ -627,7 +660,12 @@ export async function storeObservation(input: {
       sharedWithAgentIds: JSON.stringify(input.sharedWithAgentIds ?? []),
     };
 
-    await insertObservation(doc);
+    // Hook / write-only processes persist SQLite only. The control plane
+    // picks the row up via ensureFresh. Creating Orama here would load the
+    // embedding provider and the on-disk vector cache in a 10s hook budget.
+    if (corpusLoaded) {
+      await insertObservation(doc);
+    }
   };
 
   await assignAndPersist();

--- a/src/memory/observations.ts
+++ b/src/memory/observations.ts
@@ -37,7 +37,7 @@ import {
   searchObservations,
   updateObservationMetadata,
 } from '../store/orama-store.js';
-import { getObservationStore, initObservationStore } from '../store/obs-store.js';
+import { getObservationStore, initObservationStore, type ObservationStore } from '../store/obs-store.js';
 import { countTextTokens } from '../compact/token-budget.js';
 import { extractEntities, enrichConcepts } from './entity-extractor.js';
 import { getEmbeddingProvider, isEmbeddingExplicitlyDisabled, validateEmbeddingInput } from '../embedding/provider.js';
@@ -68,6 +68,7 @@ export interface ObservationRuntimeOptions {
 let embeddingWriteMode: ObservationEmbeddingWriteMode = 'background';
 let embeddingWorkerProjectRoot: string | undefined;
 let corpusLoaded = false;
+let loadedObservationStore: ObservationStore | null = null;
 
 /** @internal Reset in-process observation state between tests. */
 export function resetObservationRuntime(): void {
@@ -76,6 +77,7 @@ export function resetObservationRuntime(): void {
   projectDir = null;
   searchIndexPrepared = false;
   corpusLoaded = false;
+  loadedObservationStore = null;
   embeddingWriteMode = 'background';
   embeddingWorkerProjectRoot = undefined;
   vectorMissingIds.clear();
@@ -253,11 +255,13 @@ export async function initObservations(
 ): Promise<void> {
   embeddingWriteMode = options.embeddingWriteMode ?? 'background';
   embeddingWorkerProjectRoot = options.projectRoot;
-  if (projectDir === dir) {
-    if (options.skipCorpusLoad || corpusLoaded) return;
-  }
   await initObservationStore(dir);
   const store = getObservationStore();
+
+  if (projectDir === dir && loadedObservationStore === store) {
+    if (options.skipCorpusLoad || corpusLoaded) return;
+  }
+
   nextId = await store.loadIdCounter();
   projectDir = dir;
   searchIndexPrepared = false;
@@ -265,10 +269,12 @@ export async function initObservations(
   if (options.skipCorpusLoad) {
     observations = [];
     corpusLoaded = false;
+    loadedObservationStore = store;
     return;
   }
   observations = await store.loadAll();
   corpusLoaded = true;
+  loadedObservationStore = store;
 }
 
 function scheduleObservationEmbedding(input: {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -303,6 +303,14 @@ export class MemoryClient {
     } catch {
       // best-effort cleanup
     }
+    // ObservationStore.close() only detaches from the shared handle.
+    // Release this dataDir so Windows can unlink memorix.db after close().
+    try {
+      const { closeDatabase } = await import('./store/sqlite-db.js');
+      closeDatabase(this._dataDir);
+    } catch {
+      // best-effort cleanup
+    }
   }
 }
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -346,10 +346,12 @@ export async function createMemoryClient(options: MemoryClientOptions): Promise<
     );
   }
 
-  // Resolve data directory
+  // Honor MEMORIX_DATA_DIR so isolated benchmarks and tests do not write
+  // into ~/.memorix/data. Unset, keep the per-project home path.
   const path = await import('node:path');
   const os = await import('node:os');
-  const dataDir = path.join(os.homedir(), '.memorix', 'data', project.id.replace(/\//g, path.sep));
+  const dataDir = process.env.MEMORIX_DATA_DIR
+    || path.join(os.homedir(), '.memorix', 'data', project.id.replace(/\//g, path.sep));
 
   // Ensure data directory exists
   const fs = await import('node:fs');

--- a/src/store/orama-store.ts
+++ b/src/store/orama-store.ts
@@ -380,11 +380,9 @@ async function attachCachedVectors(
     } catch {
       // Vector cache hydration is best-effort. The normal backfill lane owns misses.
     }
-    if (index % 10 === 0) {
-      await new Promise<void>((resolve) => setImmediate(resolve));
-    }
-    if (index % 50 === 0) {
-      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    if (index % 25 === 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 10));
     }
   }
 }

--- a/src/store/orama-store.ts
+++ b/src/store/orama-store.ts
@@ -378,6 +378,12 @@ async function attachCachedVectors(
     } catch {
       // Vector cache hydration is best-effort. The normal backfill lane owns misses.
     }
+    if (index % 10 === 0) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    if (index % 50 === 0) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    }
   }
 }
 
@@ -437,6 +443,13 @@ export async function hydrateIndex(
       await insert(database, doc);
       rememberObservationDoc(doc);
       inserted++;
+      // Keep the HTTP event loop alive on large corpora so /health still answers.
+      if (inserted % 50 === 0) {
+        await new Promise<void>((resolve) => setImmediate(resolve));
+      }
+      if (inserted % 200 === 0) {
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      }
     } catch { /* skip malformed entries */ }
   }
 

--- a/src/store/orama-store.ts
+++ b/src/store/orama-store.ts
@@ -331,6 +331,8 @@ export interface HydrateIndexOptions {
   allowNetworkProbe?: boolean;
   /** Attach cached vectors after lexical hydration instead of awaiting cache I/O. */
   deferCachedVectors?: boolean;
+  /** Skip cached-vector attach entirely (one-shot CLI reads). */
+  skipCachedVectors?: boolean;
 }
 
 type HydrationCandidate = { observation: any; id: string };
@@ -453,8 +455,10 @@ export async function hydrateIndex(
     } catch { /* skip malformed entries */ }
   }
 
-  deferredCachedVectorHydration = deferCachedVectors
-    ? attachCachedVectors(database, candidates).catch(() => {})
+  deferredCachedVectorHydration = options.skipCachedVectors
+    ? null
+    : deferCachedVectors
+      ? attachCachedVectors(database, candidates).catch(() => {})
     : null;
   return inserted;
 }
@@ -463,10 +467,14 @@ export async function hydrateIndex(
  * Prepare the lexical index without probing a remote embedding API. Cached
  * vectors attach after the disk cache is ready, outside the startup path.
  */
-export async function hydrateIndexForStartup(observations: any[]): Promise<number> {
+export async function hydrateIndexForStartup(
+  observations: any[],
+  options: Pick<HydrateIndexOptions, 'skipCachedVectors'> = {},
+): Promise<number> {
   return hydrateIndex(observations, {
     allowNetworkProbe: false,
     deferCachedVectors: true,
+    skipCachedVectors: options.skipCachedVectors,
   });
 }
 

--- a/src/store/orama-store.ts
+++ b/src/store/orama-store.ts
@@ -380,9 +380,8 @@ async function attachCachedVectors(
     } catch {
       // Vector cache hydration is best-effort. The normal backfill lane owns misses.
     }
-    await new Promise<void>((resolve) => setImmediate(resolve));
-    if (index % 25 === 0) {
-      await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    if (index % 50 === 0) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
     }
   }
 }

--- a/tests/cli/background-launcher.test.ts
+++ b/tests/cli/background-launcher.test.ts
@@ -38,6 +38,17 @@ describe('Windows background launcher', () => {
     expect(() => _testing.parseLogLines('10001')).toThrow(/Log line count must be/);
   });
 
+  it('falls back to argv[1] when this module is not a compiled dist sibling', () => {
+    const fallback = '/tmp/wrong-memorix/dist/cli/index.js';
+    expect(_testing.resolveBackgroundCliEntry(fallback)).toBe(fallback);
+  });
+
+  it('spawns the bundled CLI file, not the library stdio entry', () => {
+    const bundledCli = '/opt/memorix/dist/cli/index.js';
+    const libraryStdio = '/opt/memorix/dist/index.js';
+    expect(_testing.resolveBackgroundCliEntryFrom(bundledCli, libraryStdio)).toBe(bundledCli);
+  });
+
   it('keeps normal CLI errors concise but preserves opt-in diagnostics', () => {
     const error = new Error('Port must be a whole number');
     error.stack = 'Error: Port must be a whole number\n    at internal-frame';

--- a/tests/embedding/cache-jsonl-and-guard.test.ts
+++ b/tests/embedding/cache-jsonl-and-guard.test.ts
@@ -1,10 +1,14 @@
-import { mkdtemp, writeFile, readFile, rm, stat } from 'node:fs/promises';
+import { access, mkdtemp, writeFile, readFile, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   ensureDiskCacheLoaded,
+  getApiEmbeddingCachePayloadBytesForTests,
   getApiEmbeddingDiskCacheLoadCountForTests,
+  getApiEmbeddingJsonlLineCountCallsForTests,
+  getApiEmbeddingMaxEntriesForDimensionsForTests,
+  migrateJsonArrayCacheToJsonl,
   resetApiEmbeddingCacheForTests,
   saveDiskCacheNow,
   seedApiEmbeddingCacheForTests,
@@ -66,5 +70,87 @@ describe('embedding cache jsonl + shrink guard', () => {
     expect(after.size).toBe(before.size);
     const text = await readFile(jsonl, 'utf8');
     expect(text.trim().split('\n')).toHaveLength(8);
+  });
+
+  it('narrows tuple and object jsonl rows without treating arrays as {h,v}', async () => {
+    const jsonl = join(dir, '.embedding-api-cache.jsonl');
+    await writeFile(
+      jsonl,
+      `${JSON.stringify(['tuplehash0000001', [1, 2, 3]])}\n${JSON.stringify({ h: 'objecthash0000001', v: [4, 5, 6] })}\n`,
+    );
+
+    const count = await ensureDiskCacheLoaded();
+    expect(count).toBe(2);
+  });
+
+  it('does not rescan jsonl on save after a sidecar count exists', async () => {
+    const jsonl = join(dir, '.embedding-api-cache.jsonl');
+    await writeFile(jsonl, `${JSON.stringify({ h: 'aaa111aaa111aaaa', v: [0.1, 0.2] })}\n`);
+    await ensureDiskCacheLoaded();
+    const scansAfterLoad = getApiEmbeddingJsonlLineCountCallsForTests();
+
+    seedApiEmbeddingCacheForTests(new Map([
+      ['aaa111aaa111aaaa', [0.1, 0.2]],
+      ['bbb222bbb222bbbb', [0.3, 0.4]],
+    ]));
+    await saveDiskCacheNow();
+    await saveDiskCacheNow();
+
+    expect(getApiEmbeddingJsonlLineCountCallsForTests()).toBe(scansAfterLoad);
+    const text = await readFile(jsonl, 'utf8');
+    expect(text.trim().split('\n')).toHaveLength(2);
+  });
+
+  it('migrates a JSON array through a temp file and atomic rename', async () => {
+    const jsonPath = join(dir, '.embedding-api-cache.json');
+    const jsonlPath = join(dir, '.embedding-api-cache.jsonl');
+    const entries: [string, number[]][] = [
+      ['mig111mig111mig1', [0.2, 0.3, 0.4]],
+      ['mig222mig222mig2', [0.5, 0.6, 0.7]],
+    ];
+    await writeFile(jsonPath, JSON.stringify(entries));
+
+    const count = await migrateJsonArrayCacheToJsonl(jsonPath, jsonlPath);
+    expect(count).toBe(2);
+    await expect(access(`${jsonlPath}.tmp`)).rejects.toThrow();
+    const lines = (await readFile(jsonlPath, 'utf8')).trim().split('\n');
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0])).toEqual({ h: 'mig111mig111mig1', v: [0.2, 0.3, 0.4] });
+  });
+
+  it('removes the migration temp file when the JSON array is invalid', async () => {
+    const jsonPath = join(dir, '.embedding-api-cache.json');
+    const jsonlPath = join(dir, '.embedding-api-cache.jsonl');
+    await writeFile(jsonPath, '{"not":"an-array"}');
+
+    await expect(migrateJsonArrayCacheToJsonl(jsonPath, jsonlPath)).rejects.toThrow(
+      'embedding cache is not a JSON array',
+    );
+    await expect(access(`${jsonlPath}.tmp`)).rejects.toThrow();
+    await expect(access(jsonlPath)).rejects.toThrow();
+  });
+
+  it('caps retained vectors by payload bytes, not a 200k entry ceiling', async () => {
+    const previousBudget = process.env.MEMORIX_EMBEDDING_CACHE_MAX_BYTES;
+    process.env.MEMORIX_EMBEDDING_CACHE_MAX_BYTES = String(3 * 4096 * 8);
+    try {
+      expect(getApiEmbeddingMaxEntriesForDimensionsForTests(4096)).toBe(3);
+
+      const jsonl = join(dir, '.embedding-api-cache.jsonl');
+      const lines = Array.from({ length: 12 }, (_, i) =>
+        JSON.stringify({
+          h: `dim4k${i.toString().padStart(11, '0')}`,
+          v: Array.from({ length: 4096 }, () => i + 0.25),
+        }),
+      );
+      await writeFile(jsonl, `${lines.join('\n')}\n`);
+
+      const loaded = await ensureDiskCacheLoaded();
+      expect(loaded).toBeLessThanOrEqual(3);
+      expect(getApiEmbeddingCachePayloadBytesForTests()).toBeLessThanOrEqual(3 * 4096 * 8);
+    } finally {
+      if (previousBudget === undefined) delete process.env.MEMORIX_EMBEDDING_CACHE_MAX_BYTES;
+      else process.env.MEMORIX_EMBEDDING_CACHE_MAX_BYTES = previousBudget;
+    }
   });
 });

--- a/tests/embedding/cache-jsonl-and-guard.test.ts
+++ b/tests/embedding/cache-jsonl-and-guard.test.ts
@@ -1,0 +1,58 @@
+import { mkdtemp, writeFile, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  ensureDiskCacheLoaded,
+  resetApiEmbeddingCacheForTests,
+  saveDiskCacheNow,
+  seedApiEmbeddingCacheForTests,
+} from '../../src/embedding/api-provider.ts';
+
+describe('embedding cache jsonl + shrink guard', () => {
+  let dir: string;
+  let previousDataDir: string | undefined;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'memorix-embed-cache-'));
+    previousDataDir = process.env.MEMORIX_DATA_DIR;
+    process.env.MEMORIX_DATA_DIR = dir;
+    resetApiEmbeddingCacheForTests();
+  });
+
+  afterEach(async () => {
+    resetApiEmbeddingCacheForTests();
+    if (previousDataDir === undefined) delete process.env.MEMORIX_DATA_DIR;
+    else process.env.MEMORIX_DATA_DIR = previousDataDir;
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('loads a jsonl cache without JSON.parse of the whole file', async () => {
+    const jsonl = join(dir, '.embedding-api-cache.jsonl');
+    const lines = [
+      JSON.stringify({ h: 'aaa111aaa111aaaa', v: [0.1, 0.2, 0.3] }),
+      JSON.stringify({ h: 'bbb222bbb222bbbb', v: [0.4, 0.5, 0.6] }),
+    ];
+    await writeFile(jsonl, `${lines.join('\n')}\n`);
+
+    const count = await ensureDiskCacheLoaded();
+    expect(count).toBe(2);
+  });
+
+  it('refuses to overwrite a larger on-disk cache with a smaller in-memory map', async () => {
+    const jsonl = join(dir, '.embedding-api-cache.jsonl');
+    const lines = Array.from({ length: 8 }, (_, i) =>
+      JSON.stringify({ h: `hash${i.toString().padStart(12, '0')}`, v: [i, i + 0.5] }),
+    );
+    await writeFile(jsonl, `${lines.join('\n')}\n`);
+    const before = await stat(jsonl);
+
+    seedApiEmbeddingCacheForTests(new Map([['only-one', [1, 2, 3]]]));
+    await saveDiskCacheNow();
+
+    const after = await stat(jsonl);
+    expect(after.size).toBe(before.size);
+    const text = await readFile(jsonl, 'utf8');
+    expect(text.trim().split('\n')).toHaveLength(8);
+  });
+});

--- a/tests/embedding/cache-jsonl-and-guard.test.ts
+++ b/tests/embedding/cache-jsonl-and-guard.test.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   ensureDiskCacheLoaded,
+  getApiEmbeddingDiskCacheLoadCountForTests,
   resetApiEmbeddingCacheForTests,
   saveDiskCacheNow,
   seedApiEmbeddingCacheForTests,
@@ -37,6 +38,17 @@ describe('embedding cache jsonl + shrink guard', () => {
 
     const count = await ensureDiskCacheLoaded();
     expect(count).toBe(2);
+  });
+
+  it('single-flights concurrent disk cache loads', async () => {
+    const jsonl = join(dir, '.embedding-api-cache.jsonl');
+    await writeFile(jsonl, `${JSON.stringify({ h: 'aaa111aaa111aaaa', v: [0.1, 0.2] })}\n`);
+
+    const [first, second] = await Promise.all([ensureDiskCacheLoaded(), ensureDiskCacheLoaded()]);
+
+    expect(first).toBe(1);
+    expect(second).toBe(1);
+    expect(getApiEmbeddingDiskCacheLoadCountForTests()).toBe(1);
   });
 
   it('refuses to overwrite a larger on-disk cache with a smaller in-memory map', async () => {

--- a/tests/embedding/cache-worker-parse.test.ts
+++ b/tests/embedding/cache-worker-parse.test.ts
@@ -1,0 +1,30 @@
+import { mkdtemp, writeFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { parseCacheJsonInWorker } from '../../src/embedding/api-provider.ts';
+
+describe('parseCacheJsonInWorker', () => {
+  it('parses a cache file without blocking the event loop', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'memorix-cache-worker-'));
+    const filePath = join(dir, '.embedding-api-cache.json');
+    const entries: [string, number[]][] = [
+      ['abc123', Array.from({ length: 8 }, (_, i) => i + 0.25)],
+      ['def456', Array.from({ length: 8 }, (_, i) => i + 0.5)],
+    ];
+    await writeFile(filePath, JSON.stringify(entries));
+
+    let ticks = 0;
+    const timer = setInterval(() => {
+      ticks += 1;
+    }, 5);
+
+    const parsed = await parseCacheJsonInWorker(filePath);
+    clearInterval(timer);
+
+    expect(parsed).toEqual(entries);
+    expect(ticks).toBeGreaterThan(0);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+});

--- a/tests/hooks/lifecycle.test.ts
+++ b/tests/hooks/lifecycle.test.ts
@@ -93,6 +93,7 @@ describe('hook process lifecycle', () => {
 
   it('defers hook embeddings so a remote fetch cannot pin the CLI process', () => {
     expect(hookObservationRuntimeOptions('/repo')).toEqual({
+      skipCorpusLoad: true,
       embeddingWriteMode: 'deferred',
       projectRoot: '/repo',
     });

--- a/tests/memory/embedding-off-write-path.test.ts
+++ b/tests/memory/embedding-off-write-path.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Ordinary store must stay on the lexical path when embeddings are off.
+ * generateEmbedding() used to run on every write and pulled config + provider
+ * init into the hot path even for MEMORIX_EMBEDDING=off.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { resetConfigCache } from '../../src/config.js';
+import { resetProvider } from '../../src/embedding/provider.js';
+import {
+  initObservations,
+  resetObservationRuntime,
+  storeObservation,
+} from '../../src/memory/observations.js';
+import { initObservationStore, resetObservationStore } from '../../src/store/obs-store.js';
+import * as oramaStore from '../../src/store/orama-store.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+
+describe('embedding-off write path', () => {
+  let sandbox = '';
+  let previousEmbedding: string | undefined;
+
+  beforeEach(async () => {
+    sandbox = mkdtempSync(path.join(tmpdir(), 'memorix-embed-off-write-'));
+    previousEmbedding = process.env.MEMORIX_EMBEDDING;
+    process.env.MEMORIX_EMBEDDING = 'off';
+    resetConfigCache();
+    resetProvider();
+    resetObservationRuntime();
+    await initObservationStore(path.join(sandbox, 'data'));
+    await initObservations(path.join(sandbox, 'data'));
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    resetObservationStore();
+    resetObservationRuntime();
+    await oramaStore.resetDb();
+    closeAllDatabases();
+    resetProvider();
+    if (previousEmbedding === undefined) delete process.env.MEMORIX_EMBEDDING;
+    else process.env.MEMORIX_EMBEDDING = previousEmbedding;
+    resetConfigCache();
+    if (sandbox) rmSync(sandbox, { recursive: true, force: true });
+    sandbox = '';
+  });
+
+  it('does not call generateEmbedding on ordinary store', async () => {
+    const generate = vi.spyOn(oramaStore, 'generateEmbedding');
+    await storeObservation({
+      entityName: 'embed-off',
+      type: 'discovery',
+      title: 'Lexical write only',
+      narrative: 'Embedding is disabled so the write path must not start a provider.',
+      projectId: 'test/embed-off',
+    });
+    expect(generate).not.toHaveBeenCalled();
+  });
+});

--- a/tests/memory/hook-write-without-corpus-load.test.ts
+++ b/tests/memory/hook-write-without-corpus-load.test.ts
@@ -113,4 +113,20 @@ describe('hook write without corpus load', () => {
     const all = await store.loadAll();
     expect(all).toHaveLength(6);
   });
+
+  it('does not reuse an empty skipCorpusLoad snapshot for a later full read', async () => {
+    const store = getObservationStore();
+    const loadAll = vi.spyOn(store, 'loadAll');
+
+    await initObservations(testDir, {
+      skipCorpusLoad: true,
+      embeddingWriteMode: 'deferred',
+    });
+    expect(getAllObservations()).toEqual([]);
+    expect(loadAll).not.toHaveBeenCalled();
+
+    await initObservations(testDir);
+    expect(loadAll).toHaveBeenCalledOnce();
+    expect(getAllObservations()).toHaveLength(5);
+  });
 });

--- a/tests/memory/hook-write-without-corpus-load.test.ts
+++ b/tests/memory/hook-write-without-corpus-load.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Hook writes must persist to SQLite without materializing the full corpus.
+ * loadAll() of 40k+ rows is what made PostToolUse hang and forced OpenCode
+ * to skip per-tool events.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('../../src/embedding/provider.js', () => ({
+  getEmbeddingProvider: async () => null,
+  isVectorSearchAvailable: async () => false,
+  isEmbeddingExplicitlyDisabled: () => true,
+  resetProvider: () => {},
+  validateEmbeddingInput: () => {},
+}));
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  initObservations,
+  storeObservation,
+  getAllObservations,
+  resetObservationRuntime,
+} from '../../src/memory/observations.js';
+import {
+  initObservationStore,
+  getObservationStore,
+  resetObservationStore,
+} from '../../src/store/obs-store.js';
+import { resetDb } from '../../src/store/orama-store.js';
+import { closeDatabase } from '../../src/store/sqlite-db.js';
+import type { Observation } from '../../src/types.js';
+
+function makeObs(id: number): Observation {
+  return {
+    id,
+    entityName: `seed-${id}`,
+    type: 'discovery',
+    title: `Seed observation ${id}`,
+    narrative: 'Existing corpus row that hooks must not load.',
+    facts: [],
+    filesModified: [],
+    concepts: [],
+    tokens: 8,
+    createdAt: new Date().toISOString(),
+    projectId: 'test/hook-write',
+    status: 'active',
+    source: 'agent',
+  };
+}
+
+let testDir: string;
+
+beforeEach(async () => {
+  testDir = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-hook-write-'));
+  resetObservationRuntime();
+  resetObservationStore();
+  await resetDb();
+  await initObservationStore(testDir);
+  const store = getObservationStore();
+  for (let id = 1; id <= 5; id++) {
+    await store.insert(makeObs(id));
+  }
+  await store.saveIdCounter(6);
+});
+
+afterEach(() => {
+  resetObservationRuntime();
+  resetObservationStore();
+  closeDatabase(testDir);
+  fs.rm(testDir, { recursive: true, force: true }).catch(() => {});
+});
+
+describe('hook write without corpus load', () => {
+  it('does not call loadAll when skipCorpusLoad is set', async () => {
+    const store = getObservationStore();
+    const loadAll = vi.spyOn(store, 'loadAll');
+
+    await initObservations(testDir, {
+      skipCorpusLoad: true,
+      embeddingWriteMode: 'deferred',
+    });
+
+    expect(loadAll).not.toHaveBeenCalled();
+    expect(getAllObservations()).toEqual([]);
+  });
+
+  it('persists a hook observation to SQLite without loading the existing corpus', async () => {
+    const store = getObservationStore();
+    const loadAll = vi.spyOn(store, 'loadAll');
+
+    await initObservations(testDir, {
+      skipCorpusLoad: true,
+      embeddingWriteMode: 'deferred',
+    });
+
+    const { observation } = await storeObservation({
+      entityName: 'memorix-e2e',
+      type: 'what-changed',
+      title: 'PostToolUse hook write',
+      narrative: 'Native hook capture without hydrating Orama or loadAll.',
+      projectId: 'test/hook-write',
+      sourceDetail: 'hook',
+    });
+
+    expect(loadAll).not.toHaveBeenCalled();
+    expect(observation.id).toBe(6);
+
+    const persisted = await store.getById(6);
+    expect(persisted?.title).toBe('PostToolUse hook write');
+    expect(persisted?.sourceDetail).toBe('hook');
+
+    const all = await store.loadAll();
+    expect(all).toHaveLength(6);
+  });
+});

--- a/tests/memory/prepare-search-index.test.ts
+++ b/tests/memory/prepare-search-index.test.ts
@@ -35,17 +35,20 @@ vi.mock('../../src/store/persistence.js', () => ({
   loadIdCounter: mockLoadIdCounter,
 }));
 
-vi.mock('../../src/store/obs-store.js', () => ({
-  initObservationStore: vi.fn().mockResolvedValue(undefined),
-  getObservationStore: () => ({
+vi.mock('../../src/store/obs-store.js', () => {
+  const store = {
     loadAll: mockLoadObservationsJson,
     loadIdCounter: mockLoadIdCounter,
     ensureFresh: vi.fn().mockResolvedValue(false),
     close: vi.fn(),
     getBackendName: () => 'json',
     getGeneration: () => 0,
-  }),
-}));
+  };
+  return {
+    initObservationStore: vi.fn().mockResolvedValue(undefined),
+    getObservationStore: () => store,
+  };
+});
 
 vi.mock('../../src/store/file-lock.js', () => ({
   withFileLock: async (_dir: string, fn: () => Promise<unknown>) => fn(),

--- a/tests/memory/prepare-search-index.test.ts
+++ b/tests/memory/prepare-search-index.test.ts
@@ -133,6 +133,7 @@ describe('prepareSearchIndex', () => {
         expect.objectContaining({ id: 1, title: 'Prepared startup index' }),
         expect.objectContaining({ id: 2, title: 'Resolved old note' }),
       ]),
+      { skipCachedVectors: undefined },
     );
     expect(mockBatchGenerateEmbeddings).not.toHaveBeenCalled();
     expect(getVectorMissingIds()).toEqual([1, 2]);

--- a/tests/sdk/memory-client.test.ts
+++ b/tests/sdk/memory-client.test.ts
@@ -10,7 +10,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { execSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 
 // Shared test data dir
 let testDir: string;
@@ -55,6 +55,88 @@ function createTestGitRepo(): string {
   execSync('git config user.email "tests@memorix.local"', { cwd: dir, stdio: 'ignore' });
   execSync('git commit --allow-empty -m "init"', { cwd: dir, stdio: 'ignore' });
   return dir;
+}
+
+/**
+ * Write through a child process so the parent MemoryClient cannot share a
+ * SQLite handle or mutate the in-memory observation snapshot.
+ */
+function writeExternalObservation(input: {
+  dataDir: string;
+  projectId: string;
+  id: number;
+  title: string;
+  nextId: number;
+  updateId?: number;
+  updateTitle?: string;
+}): void {
+  const result = spawnSync(
+    process.execPath,
+    ['--input-type=module', '-e', `
+      import { createRequire } from 'node:module';
+      const require = createRequire(process.cwd() + '/package.json');
+      function openDatabase(dbPath) {
+        try {
+          const Database = require('better-sqlite3');
+          return new Database(dbPath);
+        } catch {
+          // Native binding may be compiled for a different Node than this child.
+        }
+        return new (require('node:sqlite').DatabaseSync)(dbPath);
+      }
+      const db = openDatabase(process.env.MEMORIX_WRITER_DB);
+      if (process.env.MEMORIX_WRITER_UPDATE_ID) {
+        db.prepare('UPDATE observations SET title = ? WHERE id = ?').run(
+          process.env.MEMORIX_WRITER_UPDATE_TITLE,
+          Number(process.env.MEMORIX_WRITER_UPDATE_ID),
+        );
+      }
+      db.prepare(\`INSERT OR REPLACE INTO observations (
+        id, entityName, type, title, narrative, facts, filesModified, concepts,
+        tokens, createdAt, projectId, status, source, sourceDetail
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\`).run(
+        Number(process.env.MEMORIX_WRITER_ID),
+        'external-writer',
+        'discovery',
+        process.env.MEMORIX_WRITER_TITLE,
+        'Inserted after MemoryClient.close()',
+        '[]',
+        '[]',
+        '[]',
+        8,
+        new Date().toISOString(),
+        process.env.MEMORIX_WRITER_PROJECT,
+        'active',
+        'agent',
+        'external',
+      );
+      db.prepare("UPDATE meta SET value = CAST(CAST(value AS INTEGER) + 1 AS TEXT) WHERE key = 'storage_generation'").run();
+      db.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES ('next_id', ?)").run(process.env.MEMORIX_WRITER_NEXT_ID);
+      db.close();
+    `],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        MEMORIX_WRITER_DB: join(input.dataDir, 'memorix.db'),
+        MEMORIX_WRITER_ID: String(input.id),
+        MEMORIX_WRITER_TITLE: input.title,
+        MEMORIX_WRITER_PROJECT: input.projectId,
+        MEMORIX_WRITER_NEXT_ID: String(input.nextId),
+        ...(input.updateId !== undefined
+          ? {
+              MEMORIX_WRITER_UPDATE_ID: String(input.updateId),
+              MEMORIX_WRITER_UPDATE_TITLE: input.updateTitle ?? '',
+            }
+          : {}),
+      },
+      encoding: 'utf8',
+      windowsHide: true,
+    },
+  );
+  if (result.status !== 0) {
+    throw new Error(`external writer failed: ${result.stderr || result.stdout || `exit ${result.status}`}`);
+  }
 }
 
 describe('MemoryClient (unit)', () => {
@@ -310,6 +392,41 @@ describe('createMemoryClient (integration)', () => {
     const openHandle = getDatabase(isolatedDataDir);
     await client.close();
     expect(() => openHandle.prepare('SELECT 1').get()).toThrow();
+    await expect(rm(isolatedDataDir, { recursive: true, force: true })).resolves.toBeUndefined();
+  });
+
+  it('reloads SQLite after close so a later in-process client is not a stale snapshot', async () => {
+    const clientA = await createMemoryClient({ projectRoot: repoDir, silent: true });
+    const { observation } = await clientA.store({
+      entityName: 'sdk-reopen',
+      type: 'discovery',
+      title: 'client-a-original-title',
+      narrative: 'First SDK client snapshot that must not survive close + external write.',
+    });
+    expect(await clientA.count()).toBe(1);
+    const dataDir = clientA.dataDir;
+    const projectId = clientA.projectId;
+    await clientA.close();
+
+    const externalTitle = 'client-b-must-see-external-write';
+    const updatedTitle = 'client-a-title-updated-after-close';
+    writeExternalObservation({
+      dataDir,
+      projectId,
+      id: observation.id + 1,
+      title: externalTitle,
+      nextId: observation.id + 2,
+      updateId: observation.id,
+      updateTitle: updatedTitle,
+    });
+
+    const clientB = await createMemoryClient({ projectRoot: repoDir, silent: true });
+    const all = await clientB.getAll();
+    expect(await clientB.count()).toBe(2);
+    expect(all.map((row) => row.title)).toEqual(expect.arrayContaining([updatedTitle, externalTitle]));
+    expect(all.map((row) => row.title)).not.toContain('client-a-original-title');
+    await clientB.close();
+
     await expect(rm(isolatedDataDir, { recursive: true, force: true })).resolves.toBeUndefined();
   });
 

--- a/tests/sdk/memory-client.test.ts
+++ b/tests/sdk/memory-client.test.ts
@@ -3,9 +3,11 @@ import { MemoryClient, createMemoryClient } from '../../src/sdk.js';
 import { initObservationStore, resetObservationStore } from '../../src/store/obs-store.js';
 import { initObservations, prepareSearchIndex, getAllObservations, getObservation, storeObservation } from '../../src/memory/observations.js';
 import { resetDb } from '../../src/store/orama-store.js';
+import { getDatabase } from '../../src/store/sqlite-db.js';
 import { resetProvider } from '../../src/embedding/provider.js';
 import { resetConfigCache } from '../../src/config.js';
 import { mkdtempSync, rmSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
@@ -294,6 +296,21 @@ describe('createMemoryClient (integration)', () => {
     const client = await createMemoryClient({ projectRoot: repoDir, silent: true });
     expect(client.dataDir).toBe(isolatedDataDir);
     await client.close();
+  });
+
+  it('releases SQLite so the temp dataDir can be deleted after close', async () => {
+    const client = await createMemoryClient({ projectRoot: repoDir, silent: true });
+    await client.store({
+      entityName: 'close-release',
+      type: 'discovery',
+      title: 'Close must drop the SQLite lock',
+      narrative: 'Windows cannot unlink memorix.db while the handle is open.',
+    });
+    expect(client.dataDir).toBe(isolatedDataDir);
+    const openHandle = getDatabase(isolatedDataDir);
+    await client.close();
+    expect(() => openHandle.prepare('SELECT 1').get()).toThrow();
+    await expect(rm(isolatedDataDir, { recursive: true, force: true })).resolves.toBeUndefined();
   });
 
   it('should throw for non-git directory', async () => {

--- a/tests/sdk/memory-client.test.ts
+++ b/tests/sdk/memory-client.test.ts
@@ -248,17 +248,25 @@ describe('MemoryClient (unit)', () => {
 
 describe('createMemoryClient (integration)', () => {
   let repoDir: string;
+  let isolatedDataDir: string;
+  let previousDataDir: string | undefined;
 
   beforeEach(() => {
     forceEmbeddingOffForTest();
     repoDir = createTestGitRepo();
+    isolatedDataDir = mkdtempSync(join(tmpdir(), 'memorix-sdk-data-'));
+    previousDataDir = process.env.MEMORIX_DATA_DIR;
+    process.env.MEMORIX_DATA_DIR = isolatedDataDir;
   });
 
   afterEach(async () => {
     resetObservationStore();
     await resetDb();
     restoreEmbeddingEnv();
+    if (previousDataDir === undefined) delete process.env.MEMORIX_DATA_DIR;
+    else process.env.MEMORIX_DATA_DIR = previousDataDir;
     try { rmSync(repoDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    try { rmSync(isolatedDataDir, { recursive: true, force: true }); } catch { /* best effort */ }
   });
 
   it('should create a client from a Git repo path', async () => {
@@ -279,6 +287,12 @@ describe('createMemoryClient (integration)', () => {
     const results = await client.search({ query: 'SDK integration' });
     expect(results.length).toBeGreaterThan(0);
 
+    await client.close();
+  });
+
+  it('keeps createMemoryClient data under MEMORIX_DATA_DIR', async () => {
+    const client = await createMemoryClient({ projectRoot: repoDir, silent: true });
+    expect(client.dataDir).toBe(isolatedDataDir);
     await client.close();
   });
 

--- a/tests/store/hydrate-index-cache.test.ts
+++ b/tests/store/hydrate-index-cache.test.ts
@@ -166,6 +166,20 @@ describe('hydrateIndex cached vectors', () => {
     expect(embedding.getEmbeddingProvider).toHaveBeenCalledWith({ allowNetworkProbe: false });
   });
 
+  it('skips cached-vector attach entirely for one-shot CLI reads', async () => {
+    const vector = [0.1, 0.2, 0.3];
+    const provider = makeProvider([vector]);
+    embedding.getEmbeddingProvider.mockResolvedValue(provider);
+    const observation = makeObservation(7);
+
+    const inserted = await hydrateIndexForStartup([observation], { skipCachedVectors: true });
+
+    expect(inserted).toBe(1);
+    expect(provider.getCachedEmbeddings).not.toHaveBeenCalled();
+    expect(hasObservationVector(observation.projectId, observation.id)).toBe(false);
+    expect(getDeferredCachedVectorHydration()).toBeNull();
+  });
+
   it('does not attach an old cached vector after the observation changed during cache loading', async () => {
     let resolveCache!: (vectors: (number[] | null)[]) => void;
     const cachePromise = new Promise<(number[] | null)[]>((resolve) => {

--- a/tests/stress/large-store-gate.test.ts
+++ b/tests/stress/large-store-gate.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Reproducible large-store gate for the embedding-cache / control-plane PR.
+ *
+ * Always runs 1,000 records. Set MEMORIX_LARGE_STORE_40K=1 to also run 40k
+ * when the machine can spare a few minutes.
+ */
+import { execSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createMemoryClient } from '../../src/sdk.js';
+import { getEmbeddingRuntimeHealth, resetProvider } from '../../src/embedding/provider.js';
+import {
+  ensureDiskCacheLoaded,
+  resetApiEmbeddingCacheForTests,
+} from '../../src/embedding/api-provider.js';
+import { hookObservationRuntimeOptions } from '../../src/hooks/lifecycle.js';
+import {
+  initObservations,
+  resetObservationRuntime,
+  storeObservation,
+} from '../../src/memory/observations.js';
+import { initObservationStore, resetObservationStore } from '../../src/store/obs-store.js';
+import { resetDb } from '../../src/store/orama-store.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+import { resetConfigCache } from '../../src/config.js';
+
+const RUN_40K = process.env.MEMORIX_LARGE_STORE_40K === '1';
+
+function uniqueLookupToken(index: number): string {
+  let value = index;
+  let suffix = '';
+  do {
+    suffix = String.fromCharCode(97 + (value % 26)) + suffix;
+    value = Math.floor(value / 26) - 1;
+  } while (value >= 0);
+  return `lookupkey${suffix}`;
+}
+
+function percentile(samples: number[], fraction: number): number {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * fraction) - 1));
+  return sorted[index];
+}
+
+describe('large-store gate', () => {
+  let sandbox = '';
+  let previousDataDir: string | undefined;
+  let previousEmbedding: string | undefined;
+
+  beforeEach(() => {
+    sandbox = mkdtempSync(path.join(tmpdir(), 'memorix-large-store-'));
+    previousDataDir = process.env.MEMORIX_DATA_DIR;
+    previousEmbedding = process.env.MEMORIX_EMBEDDING;
+    process.env.MEMORIX_DATA_DIR = path.join(sandbox, 'data');
+    process.env.MEMORIX_EMBEDDING = 'off';
+    resetConfigCache();
+    resetProvider();
+    resetApiEmbeddingCacheForTests();
+    resetObservationRuntime();
+  });
+
+  afterEach(async () => {
+    resetObservationStore();
+    resetObservationRuntime();
+    await resetDb();
+    closeAllDatabases();
+    resetProvider();
+    resetApiEmbeddingCacheForTests();
+    if (previousDataDir === undefined) delete process.env.MEMORIX_DATA_DIR;
+    else process.env.MEMORIX_DATA_DIR = previousDataDir;
+    if (previousEmbedding === undefined) delete process.env.MEMORIX_EMBEDDING;
+    else process.env.MEMORIX_EMBEDDING = previousEmbedding;
+    resetConfigCache();
+    if (sandbox) rmSync(sandbox, { recursive: true, force: true });
+    sandbox = '';
+  });
+
+  async function runGate(records: number): Promise<void> {
+    const projectRoot = path.join(sandbox, 'project');
+    execSync('git init --quiet', { cwd: sandbox, encoding: 'utf8' });
+    execSync(`git init --quiet "${projectRoot}"`, { encoding: 'utf8' });
+
+    const client = await createMemoryClient({ projectRoot, silent: true });
+    const warmup = 20;
+    const steady: number[] = [];
+    let peakRss = process.memoryUsage().rss;
+
+    for (let index = 0; index < records; index += 1) {
+      const lookupToken = uniqueLookupToken(index);
+      const started = performance.now();
+      await client.store({
+        entityName: `module-${index % 64}`,
+        type: index % 5 === 0 ? 'decision' : 'discovery',
+        title: `Large-store gate record ${index}`,
+        narrative: `Module ${index % 64} recorded gate evidence for scenario ${index} with ${lookupToken}.`,
+        facts: [`scenario=${index}`, `module=${index % 64}`, lookupToken],
+        concepts: ['gate', 'large-store', `module-${index % 64}`, lookupToken],
+      });
+      const elapsed = performance.now() - started;
+      if (index >= warmup) steady.push(elapsed);
+      peakRss = Math.max(peakRss, process.memoryUsage().rss);
+    }
+
+    const healthStarted = performance.now();
+    const health = getEmbeddingRuntimeHealth();
+    const healthMs = performance.now() - healthStarted;
+    expect(health.status).toBe('disabled');
+    expect(healthMs).toBeLessThan(20);
+
+    const searchStarted = performance.now();
+    const hits = await client.search({
+      query: uniqueLookupToken(0),
+      quality: 'fast',
+      limit: 10,
+    });
+    const searchMs = performance.now() - searchStarted;
+    expect(hits.length).toBeGreaterThan(0);
+    // 1k stays on the fast lexical budget. 40k is a cold in-process search
+    // after seed, not the HTTP /health path — allow the larger corpus.
+    expect(searchMs).toBeLessThan(records <= 1_000 ? 250 : 1_500);
+
+    const p50 = percentile(steady, 0.5);
+    const p95 = percentile(steady, 0.95);
+    expect(p50).toBeLessThan(25);
+    expect(p95).toBeLessThan(80);
+    // 40k keeps the full lexical index in-process. That is larger than the
+    // 1k budget but must stay well below an unbounded 4096d cache.
+    expect(peakRss).toBeLessThan((records <= 1_000 ? 512 : 2048) * 1024 * 1024);
+
+    await client.close();
+    closeAllDatabases();
+    resetObservationStore();
+    resetObservationRuntime();
+    await resetDb();
+
+    const hookInitStarted = performance.now();
+    await initObservationStore(process.env.MEMORIX_DATA_DIR!);
+    await initObservations(process.env.MEMORIX_DATA_DIR!, hookObservationRuntimeOptions(projectRoot));
+    const hookInitMs = performance.now() - hookInitStarted;
+    const hookWriteStarted = performance.now();
+    const { observation } = await storeObservation({
+      entityName: 'hook-gate',
+      type: 'what-changed',
+      title: 'Hook write after large store',
+      narrative: 'PostToolUse must persist without hydrating the corpus.',
+      projectId: client.projectId,
+      sourceDetail: 'hook',
+    });
+    const hookWriteMs = performance.now() - hookWriteStarted;
+    expect(observation.id).toBeGreaterThan(records);
+    expect(hookWriteMs).toBeLessThan(200);
+    expect(hookInitMs + hookWriteMs).toBeLessThan(records <= 1_000 ? 200 : 1_000);
+
+    const jsonl = path.join(process.env.MEMORIX_DATA_DIR!, '.embedding-api-cache.jsonl');
+    writeFileSync(
+      jsonl,
+      `${JSON.stringify({ h: 'gatehash00000001', v: [0.1, 0.2, 0.3] })}\n${JSON.stringify({ h: 'gatehash00000002', v: [0.4, 0.5, 0.6] })}\n`,
+    );
+    resetApiEmbeddingCacheForTests();
+    const loaded = await ensureDiskCacheLoaded();
+    expect(loaded).toBe(2);
+    const persisted = readFileSync(jsonl, 'utf8').trim().split('\n');
+    expect(persisted).toHaveLength(2);
+  }
+
+  it('stays responsive at 1k records', { timeout: 60_000 }, async () => {
+    await runGate(1_000);
+  });
+
+  it.skipIf(!RUN_40K)('stays responsive at 40k records', { timeout: 600_000 }, async () => {
+    await runGate(40_000);
+  });
+});

--- a/tests/stress/large-store-gate.test.ts
+++ b/tests/stress/large-store-gate.test.ts
@@ -4,7 +4,7 @@
  * Always runs 1,000 records. Set MEMORIX_LARGE_STORE_40K=1 to also run 40k
  * when the machine can spare a few minutes.
  */
-import { execSync } from 'node:child_process';
+import { execSync, spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
@@ -42,6 +42,71 @@ function percentile(samples: number[], fraction: number): number {
   const sorted = [...samples].sort((a, b) => a - b);
   const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil(sorted.length * fraction) - 1));
   return sorted[index];
+}
+
+function writeExternalObservation(input: {
+  dataDir: string;
+  projectId: string;
+  id: number;
+  title: string;
+  nextId: number;
+}): void {
+  const result = spawnSync(
+    process.execPath,
+    ['--input-type=module', '-e', `
+      import { createRequire } from 'node:module';
+      const require = createRequire(process.cwd() + '/package.json');
+      function openDatabase(dbPath) {
+        try {
+          const Database = require('better-sqlite3');
+          return new Database(dbPath);
+        } catch {
+          // Native binding may be compiled for a different Node than this child.
+        }
+        return new (require('node:sqlite').DatabaseSync)(dbPath);
+      }
+      const db = openDatabase(process.env.MEMORIX_WRITER_DB);
+      db.prepare(\`INSERT OR REPLACE INTO observations (
+        id, entityName, type, title, narrative, facts, filesModified, concepts,
+        tokens, createdAt, projectId, status, source, sourceDetail
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)\`).run(
+        Number(process.env.MEMORIX_WRITER_ID),
+        'external-writer',
+        'discovery',
+        process.env.MEMORIX_WRITER_TITLE,
+        'Inserted after MemoryClient.close()',
+        '[]',
+        '[]',
+        '[]',
+        8,
+        new Date().toISOString(),
+        process.env.MEMORIX_WRITER_PROJECT,
+        'active',
+        'agent',
+        process.env.MEMORIX_WRITER_SOURCE,
+      );
+      db.prepare("UPDATE meta SET value = CAST(CAST(value AS INTEGER) + 1 AS TEXT) WHERE key = 'storage_generation'").run();
+      db.prepare("INSERT OR REPLACE INTO meta (key, value) VALUES ('next_id', ?)").run(process.env.MEMORIX_WRITER_NEXT_ID);
+      db.close();
+    `],
+    {
+      cwd: process.cwd(),
+      env: {
+        ...process.env,
+        MEMORIX_WRITER_DB: path.join(input.dataDir, 'memorix.db'),
+        MEMORIX_WRITER_ID: String(input.id),
+        MEMORIX_WRITER_TITLE: input.title,
+        MEMORIX_WRITER_PROJECT: input.projectId,
+        MEMORIX_WRITER_NEXT_ID: String(input.nextId),
+        MEMORIX_WRITER_SOURCE: input.title.includes('MCP') ? 'mcp' : 'hook',
+      },
+      encoding: 'utf8',
+      windowsHide: true,
+    },
+  );
+  if (result.status !== 0) {
+    throw new Error(`external writer failed: ${result.stderr || result.stdout || `exit ${result.status}`}`);
+  }
 }
 
 describe('large-store gate', () => {
@@ -130,6 +195,30 @@ describe('large-store gate', () => {
     expect(peakRss).toBeLessThan((records <= 1_000 ? 512 : 2048) * 1024 * 1024);
 
     await client.close();
+
+    const dataDir = process.env.MEMORIX_DATA_DIR!;
+    writeExternalObservation({
+      dataDir,
+      projectId: client.projectId,
+      id: records + 1,
+      title: 'MCP marker 1',
+      nextId: records + 2,
+    });
+    writeExternalObservation({
+      dataDir,
+      projectId: client.projectId,
+      id: records + 2,
+      title: 'Hook write after large store',
+      nextId: records + 3,
+    });
+
+    const reopened = await createMemoryClient({ projectRoot, silent: true });
+    const reopenedRows = await reopened.getAll();
+    expect(await reopened.count()).toBe(records + 2);
+    expect(reopenedRows.some((row) => row.title === 'MCP marker 1')).toBe(true);
+    expect(reopenedRows.some((row) => row.title === 'Hook write after large store')).toBe(true);
+    await reopened.close();
+
     closeAllDatabases();
     resetObservationStore();
     resetObservationRuntime();


### PR DESCRIPTION
## Summary
Rebased onto current `main` (1.6.1 / #213). This PR no longer contains the #212 rerank commit.

- Defer HTTP control-plane runtime hydration until the first real tool so `/health` and MCP initialize stay responsive on 40k+ observation hosts.
- Stream the embedding cache from JSONL with event-loop yields, convert giant JSON-array caches off-thread without posting vectors back, and refuse to overwrite a larger on-disk cache with a smaller in-memory map.
- Persist hook captures without `loadAll()` (`skipCorpusLoad` on `hookObservationRuntimeOptions`) so OpenCode per-tool hooks and `formation=active` stay enabled. Keeps the 1.6.1 bounded hook lifecycle.
- One-shot CLI search skips cached-vector attach (the previous flag was inverted).
- `memorix background start` spawns `dist/cli/index.js`, not the library `dist/index.js` stdio entry.
- Cache-only provider create does not start the 300MB JSONL parse; concurrent loads are single-flighted; Orama vector attach yields so initialize stays ~50ms.

## Issues
#215 #216 #217 #218 #219 #220 #221 #222 #223

Still open after this PR: #224 (first `session_start` 15–28s), #225 (`$HOME` / decoy db).

Owner review still wanted on this branch: bounded-memory JSONL load, atomic JSON→JSONL rename, shrink guard without a full rescan, 40k-obs stress (health / heap / hooks / cache integrity).

## Test plan
- [x] Unit tests after rebase: hook lifecycle, hook write without corpus load, JSONL cache, skipCachedVectors, background CLI entry
- [x] macbook16 live E2E 75/75
- [x] macbook13 OpenCode `mcpm_memorix connected` after attach-yield
- [x] dev-001 live E2E 75/75