### PR TITLE
Keep session_start fast and refuse $HOME as a project root

### DIFF
--- a/src/cli/commands/background.ts
+++ b/src/cli/commands/background.ts
@@ -23,7 +23,9 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn, execFileSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
+import os from 'node:os';
 import { parseTcpPort } from '../port.js';
+import { homeProjectRootError, inheritProjectRootFromHome, isHomeDirectory } from '../../project/launch-root.js';
 
 // ============================================================
 // Paths & Types
@@ -38,6 +40,16 @@ interface BackgroundState {
   instanceToken: string;
   /** Shell cwd at start time (informational only, NOT used as daemon anchor) */
   startCwd?: string;
+}
+
+export function resolveBackgroundCwd(cwd: string, homeDir: string = os.homedir()): string {
+  if (!isHomeDirectory(cwd, homeDir)) return cwd;
+  const inherited = inheritProjectRootFromHome({
+    homeDir,
+    envProjectRoot: process.env.MEMORIX_PROJECT_ROOT,
+  });
+  if (inherited) return inherited;
+  throw new Error(homeProjectRootError(cwd));
 }
 
 function getMemorixDir(): string {
@@ -380,6 +392,7 @@ export async function doStart(port: number): Promise<void> {
   // can be reclaimed with its parent by terminal hosts on Windows; a detached Node
   // child can flash a console. Start-Process gives us a hidden, independent child
   // and its real Node PID. POSIX retains the direct detached child path.
+  const startCwd = resolveBackgroundCwd(process.cwd());
   let pid: number;
   try {
     if (process.platform === 'win32') {
@@ -387,7 +400,7 @@ export async function doStart(port: number): Promise<void> {
         nodePath: process.execPath,
         cliEntry,
         port,
-        cwd: process.cwd(),
+        cwd: startCwd,
         stdoutLogFile: `${logFile}.stdout`,
         stderrLogFile: logFile,
       });
@@ -397,7 +410,7 @@ export async function doStart(port: number): Promise<void> {
         detached: true,
         stdio: ['ignore', logFd, logFd],
         env: { ...process.env },
-        cwd: process.cwd(),
+        cwd: startCwd,
       });
       child.unref();
       fs.closeSync(logFd);
@@ -418,7 +431,7 @@ export async function doStart(port: number): Promise<void> {
     startedAt: new Date().toISOString(),
     logFile,
     instanceToken,
-    startCwd: process.cwd(),
+    startCwd,
   });
 
   // 8. Print essential info immediately
@@ -824,4 +837,5 @@ export const _testing = {
   formatBackgroundCommandError,
   resolveBackgroundCliEntry,
   resolveBackgroundCliEntryFrom,
+  resolveBackgroundCwd,
 };

--- a/src/cli/commands/operator-shared.ts
+++ b/src/cli/commands/operator-shared.ts
@@ -1,4 +1,5 @@
 import { detectProjectWithDiagnostics } from '../../project/detector.js';
+import { homeProjectRootError, isHomeDirectory, writeLastProjectRoot } from '../../project/launch-root.js';
 import { getProjectDataDir } from '../../store/persistence.js';
 import { initObservations, prepareSearchIndex } from '../../memory/observations.js';
 import { initSessionStore } from '../../store/session-store.js';
@@ -42,19 +43,22 @@ async function resolveCliProjectContext(options?: CliContextOptions): Promise<{
   invocation: ReturnType<typeof getCliInvocation>;
 }> {
   const invocation = getCliInvocation();
-  const detection = detectProjectWithDiagnostics(
-    options?.projectRoot
-      ?? invocation.projectRoot
-      ?? process.env.MEMORIX_PROJECT_ROOT
-      ?? process.cwd(),
-  );
-  if (!detection.project) {
-    const detail = detection.failure?.detail ?? 'No git repository found in the current directory.';
+  const requestedRoot = options?.projectRoot
+    ?? invocation.projectRoot
+    ?? process.env.MEMORIX_PROJECT_ROOT
+    ?? process.cwd();
+  if (isHomeDirectory(requestedRoot)) {
+    throw new Error(homeProjectRootError(requestedRoot));
+  }
+  const detection = detectProjectWithDiagnostics(requestedRoot);
+  if (!detection.project || isHomeDirectory(detection.project.rootPath)) {
+    const detail = detection.failure?.detail ?? homeProjectRootError(requestedRoot);
     throw new Error(detail);
   }
 
   const project = detection.project;
   const dataDir = await getProjectDataDir(project.id);
+  writeLastProjectRoot(project.rootPath);
   return { project, dataDir, invocation };
 }
 

--- a/src/cli/commands/serve-http.ts
+++ b/src/cli/commands/serve-http.ts
@@ -130,10 +130,29 @@ export default defineCommand({
     const toolProfile = resolveToolProfile({ explicit: args.mode, envValue: process.env.MEMORIX_MODE, fallback: 'team' });
 
     // Priority: explicit --cwd arg > MEMORIX_PROJECT_ROOT env > process.cwd().
-    // Do not silently bind a control plane to another project's remembered root.
+    // $HOME is never a project root; inherit last-project-root instead of creating ~/memorix.db.
     let safeCwd: string;
     try { safeCwd = process.cwd(); } catch { safeCwd = homedir(); }
-    let projectRoot = args.cwd || process.env.MEMORIX_PROJECT_ROOT || safeCwd;
+    const { resolveServeProject } = await import('./serve-shared.js');
+    const { writeLastProjectRoot } = await import('../../project/launch-root.js');
+    const persistMod = await import('../../store/persistence.js');
+    const detectorMod = await import('../../project/detector.js');
+    const serveResolution = resolveServeProject(
+      {
+        cwdArg: args.cwd,
+        envProjectRoot: process.env.MEMORIX_PROJECT_ROOT,
+        processCwd: safeCwd,
+        homeDir: homedir(),
+      },
+      { detectProject: detectorMod.detectProject, findGitInSubdirs: detectorMod.findGitInSubdirs, isSystemDirectory: detectorMod.isSystemDirectory },
+    );
+    for (const message of serveResolution.messages) {
+      console.error(message);
+    }
+    let projectRoot = serveResolution.projectRoot;
+    if (serveResolution.detectedProject) {
+      writeLastProjectRoot(serveResolution.detectedProject.rootPath);
+    }
 
     console.error(`[memorix] HTTP transport starting on ${host}:${port}`);
     console.error(`[memorix] Project root: ${projectRoot}`);
@@ -157,11 +176,10 @@ export default defineCommand({
       return store;
     }
 
-    // Bootstrap the initial project's TeamStore
-    const persistMod = await import('../../store/persistence.js');
-    const detectorMod = await import('../../project/detector.js');
-    const detectedProj = detectorMod.detectProject(projectRoot);
-    const teamDataDir = detectedProj ? await persistMod.getProjectDataDir(detectedProj.rootPath) : projectRoot;
+    // Bootstrap the initial project's TeamStore. Never open SQLite at $HOME
+    // (that creates a decoy ~/memorix.db). Unresolved launches share ~/.memorix/data.
+    const detectedProj = serveResolution.detectedProject ?? detectorMod.detectProject(projectRoot);
+    const teamDataDir = await persistMod.getProjectDataDir(detectedProj?.id ?? '__unresolved__');
     const sharedTeamStore = await getTeamStore(teamDataDir);
 
     type SessionState = {

--- a/src/cli/commands/serve-shared.ts
+++ b/src/cli/commands/serve-shared.ts
@@ -1,5 +1,4 @@
-import path from 'node:path';
-
+import { inheritProjectRootFromHome, isHomeDirectory } from '../../project/launch-root.js';
 import type { ProjectInfo } from '../../types.js';
 
 export interface ResolveServeProjectOptions {
@@ -19,7 +18,7 @@ export interface ResolveServeProjectDeps {
 export interface ServeProjectResolution {
   projectRoot: string;
   detectedProject: ProjectInfo | null;
-  source: 'direct' | 'subdir' | 'unresolved';
+  source: 'direct' | 'subdir' | 'last-project-root' | 'unresolved';
   messages: string[];
   error?: string;
 }
@@ -35,8 +34,54 @@ export function resolveServeProject(
     options.processCwd;
 
   const messages: string[] = [`[memorix] Starting with cwd: ${projectRoot}`];
+  const hasExplicitRoot = Boolean(options.cwdArg || options.envProjectRoot || options.initCwd);
+  const startsAtHome = isHomeDirectory(projectRoot, options.homeDir);
+
+  if (startsAtHome) {
+    if (hasExplicitRoot) {
+      messages.push(`[memorix] Refusing explicit $HOME project root: ${projectRoot}`);
+      messages.push('[memorix] Memorix will wait for MCP Roots or an explicit memorix_session_start projectRoot.');
+      return {
+        projectRoot,
+        detectedProject: null,
+        source: 'unresolved',
+        messages,
+        error: 'Refusing to bind $HOME as a project root. Pass a git project path instead of $HOME.',
+      };
+    }
+    const inherited = inheritProjectRootFromHome({
+      homeDir: options.homeDir,
+      envProjectRoot: options.envProjectRoot,
+    });
+    if (inherited) {
+      const inheritedProject = deps.detectProject(inherited);
+      if (inheritedProject && !isHomeDirectory(inheritedProject.rootPath, options.homeDir)) {
+        messages.push(`[memorix] Unreliable launch directory detected: ${projectRoot}`);
+        messages.push(`[memorix] Inherited last git project: ${inheritedProject.rootPath}`);
+        return {
+          projectRoot: inheritedProject.rootPath,
+          detectedProject: inheritedProject,
+          source: 'last-project-root',
+          messages,
+        };
+      }
+    }
+    messages.push(`[memorix] Unreliable launch directory detected: ${projectRoot}`);
+    messages.push('[memorix] Memorix will wait for MCP Roots or an explicit memorix_session_start projectRoot.');
+    messages.push('[memorix] It will not create ~/memorix.db or treat $HOME as a project.');
+    return {
+      projectRoot,
+      detectedProject: null,
+      source: 'unresolved',
+      messages,
+      error: 'No reliable git project was provided by the launcher.',
+    };
+  }
 
   let detected = deps.detectProject(projectRoot);
+  if (detected && isHomeDirectory(detected.rootPath, options.homeDir)) {
+    detected = null;
+  }
   if (detected) {
     return {
       projectRoot,
@@ -46,9 +91,7 @@ export function resolveServeProject(
     };
   }
 
-  const hasExplicitRoot = Boolean(options.cwdArg || options.envProjectRoot || options.initCwd);
-  const startsAtHome = path.resolve(projectRoot) === path.resolve(options.homeDir);
-  if (deps.isSystemDirectory(projectRoot) || (!hasExplicitRoot && startsAtHome)) {
+  if (deps.isSystemDirectory(projectRoot)) {
     messages.push(`[memorix] Unreliable launch directory detected: ${projectRoot}`);
     messages.push('[memorix] Memorix will wait for MCP Roots or an explicit memorix_session_start projectRoot.');
     messages.push('[memorix] It will not restore a previous project automatically, to prevent cross-project memory access.');

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -71,6 +71,10 @@ export default defineCommand({
 
     const detected = resolution.detectedProject;
     const projectRoot = resolution.projectRoot;
+    if (detected) {
+      const { writeLastProjectRoot } = await import('../../project/launch-root.js');
+      writeLastProjectRoot(detected.rootPath);
+    }
 
     // Always register ALL tools BEFORE connecting transport.
     // This ensures tools/list returns the full tool set immediately on connect.

--- a/src/memory/session.ts
+++ b/src/memory/session.ts
@@ -140,10 +140,20 @@ async function loadAliasActiveSessions(projectIds: Set<string>): Promise<Session
   return groups.flat();
 }
 
-async function loadAliasActiveObservations(projectIds: Set<string>): Promise<Observation[]> {
+const SESSION_RESUME_OBSERVATION_LIMIT = 64;
+const SESSION_CONTEXT_OBSERVATION_LIMIT = 128;
+
+async function loadAliasActiveObservations(
+  projectIds: Set<string>,
+  limit: number = SESSION_RESUME_OBSERVATION_LIMIT,
+): Promise<Observation[]> {
   const store = getObservationStore();
   const groups = await Promise.all(
-    [...projectIds].map((projectId) => store.loadByProject(projectId, { status: 'active' })),
+    [...projectIds].map((projectId) => store.loadByProject(projectId, {
+      status: 'active',
+      limit,
+      newestFirst: true,
+    })),
   );
   return groups.flat();
 }
@@ -522,7 +532,7 @@ export async function getSessionContext(
   const aliasSet = await resolveProjectIds(projectId);
   const [sessions, allObs] = await Promise.all([
     loadAliasSessions(aliasSet),
-    loadAliasActiveObservations(aliasSet),
+    loadAliasActiveObservations(aliasSet, SESSION_CONTEXT_OBSERVATION_LIMIT),
   ]);
   const readableObs = readableAliasObservations(allObs, aliasSet, reader);
   /** Check if a session summary contains noise/system-self content */

--- a/src/project/launch-root.ts
+++ b/src/project/launch-root.ts
@@ -12,7 +12,22 @@ import path from 'node:path';
 
 export const LAST_PROJECT_ROOT_FILENAME = 'last-project-root';
 
-export function isHomeDirectory(candidate: string, homeDir: string = os.homedir()): boolean {
+/**
+ * Resolve the home directory used by Memorix boundary guards.
+ *
+ * Node's os.homedir() is intentionally stable on Windows and does not always
+ * follow a process-level HOME/USERPROFILE override. The CLI and test harnesses
+ * use those environment variables as the configured home, so all guards need
+ * one shared resolution rule instead of mixing the two sources.
+ */
+export function effectiveHomeDirectory(): string {
+  const configuredHome = process.platform === 'win32'
+    ? process.env.USERPROFILE?.trim() || process.env.HOME?.trim()
+    : process.env.HOME?.trim() || process.env.USERPROFILE?.trim();
+  return path.resolve(configuredHome || os.homedir());
+}
+
+export function isHomeDirectory(candidate: string, homeDir: string = effectiveHomeDirectory()): boolean {
   try {
     return path.resolve(candidate) === path.resolve(homeDir);
   } catch {
@@ -20,11 +35,11 @@ export function isHomeDirectory(candidate: string, homeDir: string = os.homedir(
   }
 }
 
-export function lastProjectRootPath(homeDir: string = os.homedir()): string {
+export function lastProjectRootPath(homeDir: string = effectiveHomeDirectory()): string {
   return path.join(homeDir, '.memorix', LAST_PROJECT_ROOT_FILENAME);
 }
 
-export function readLastProjectRoot(homeDir: string = os.homedir()): string | null {
+export function readLastProjectRoot(homeDir: string = effectiveHomeDirectory()): string | null {
   try {
     const raw = readFileSync(lastProjectRootPath(homeDir), 'utf8').trim();
     if (!raw) return null;
@@ -41,7 +56,7 @@ export function writeLastProjectRoot(projectRoot: string, homeDir?: string): voi
   // Tests pass an explicit homeDir. Default writes are skipped under Vitest so
   // unit tests do not mutate the developer's ~/.memorix/last-project-root.
   if (process.env.VITEST && homeDir === undefined) return;
-  const resolvedHome = homeDir ?? os.homedir();
+  const resolvedHome = homeDir ?? effectiveHomeDirectory();
   const resolved = path.resolve(projectRoot);
   if (isHomeDirectory(resolved, resolvedHome)) return;
   if (!existsSync(resolved)) return;
@@ -86,14 +101,14 @@ export function resolveControlPlaneDataDir(options: {
   homeDir?: string;
   globalDataDir: string;
 }): string {
-  const homeDir = options.homeDir ?? os.homedir();
+  const homeDir = options.homeDir ?? effectiveHomeDirectory();
   if (options.requestedDataDir && !isHomeDirectory(options.requestedDataDir, homeDir)) {
     return options.requestedDataDir;
   }
   return options.globalDataDir;
 }
 
-export function assertNotHomeDataDir(dataDir: string, homeDir: string = os.homedir()): void {
+export function assertNotHomeDataDir(dataDir: string, homeDir: string = effectiveHomeDirectory()): void {
   if (isHomeDirectory(dataDir, homeDir)) {
     throw new Error(homeProjectRootError(dataDir));
   }

--- a/src/project/launch-root.ts
+++ b/src/project/launch-root.ts
@@ -1,0 +1,100 @@
+/**
+ * Launch-root guards for HTTP/stdio/background.
+ *
+ * LaunchAgents and Cursor stdio often start with cwd=$HOME. Binding that path
+ * treats the home directory as a project and can create a decoy ~/memorix.db
+ * while the real store lives in ~/.memorix/data/memorix.db.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+export const LAST_PROJECT_ROOT_FILENAME = 'last-project-root';
+
+export function isHomeDirectory(candidate: string, homeDir: string = os.homedir()): boolean {
+  try {
+    return path.resolve(candidate) === path.resolve(homeDir);
+  } catch {
+    return false;
+  }
+}
+
+export function lastProjectRootPath(homeDir: string = os.homedir()): string {
+  return path.join(homeDir, '.memorix', LAST_PROJECT_ROOT_FILENAME);
+}
+
+export function readLastProjectRoot(homeDir: string = os.homedir()): string | null {
+  try {
+    const raw = readFileSync(lastProjectRootPath(homeDir), 'utf8').trim();
+    if (!raw) return null;
+    const resolved = path.resolve(raw);
+    if (isHomeDirectory(resolved, homeDir)) return null;
+    if (!existsSync(resolved)) return null;
+    return resolved;
+  } catch {
+    return null;
+  }
+}
+
+export function writeLastProjectRoot(projectRoot: string, homeDir?: string): void {
+  // Tests pass an explicit homeDir. Default writes are skipped under Vitest so
+  // unit tests do not mutate the developer's ~/.memorix/last-project-root.
+  if (process.env.VITEST && homeDir === undefined) return;
+  const resolvedHome = homeDir ?? os.homedir();
+  const resolved = path.resolve(projectRoot);
+  if (isHomeDirectory(resolved, resolvedHome)) return;
+  if (!existsSync(resolved)) return;
+  const memorixDir = path.join(resolvedHome, '.memorix');
+  mkdirSync(memorixDir, { recursive: true });
+  writeFileSync(lastProjectRootPath(resolvedHome), `${resolved}\n`, 'utf8');
+}
+
+export function homeProjectRootError(candidate: string): string {
+  return (
+    `Refusing to bind $HOME as a project root (${candidate}). ` +
+    'Pass a git project via --cwd, MEMORIX_PROJECT_ROOT, or memorix_session_start({ projectRoot }). ' +
+    'Memorix will not create ~/memorix.db.'
+  );
+}
+
+/**
+ * When the launcher cwd is $HOME, inherit the last git project or an explicit
+ * MEMORIX_PROJECT_ROOT. System directories stay fail-closed (no restore).
+ */
+export function inheritProjectRootFromHome(options: {
+  homeDir: string;
+  envProjectRoot?: string;
+  readLastRoot?: () => string | null;
+}): string | null {
+  const envRoot = options.envProjectRoot?.trim();
+  if (envRoot && !isHomeDirectory(envRoot, options.homeDir) && existsSync(envRoot)) {
+    return path.resolve(envRoot);
+  }
+  const lastRoot = (options.readLastRoot ?? (() => readLastProjectRoot(options.homeDir)))();
+  if (lastRoot && !isHomeDirectory(lastRoot, options.homeDir) && existsSync(lastRoot)) {
+    return lastRoot;
+  }
+  return null;
+}
+
+/**
+ * Shared SQLite must never be opened at $HOME — that creates a decoy ~/memorix.db.
+ */
+export function resolveControlPlaneDataDir(options: {
+  requestedDataDir?: string;
+  homeDir?: string;
+  globalDataDir: string;
+}): string {
+  const homeDir = options.homeDir ?? os.homedir();
+  if (options.requestedDataDir && !isHomeDirectory(options.requestedDataDir, homeDir)) {
+    return options.requestedDataDir;
+  }
+  return options.globalDataDir;
+}
+
+export function assertNotHomeDataDir(dataDir: string, homeDir: string = os.homedir()): void {
+  if (isHomeDirectory(dataDir, homeDir)) {
+    throw new Error(homeProjectRootError(dataDir));
+  }
+}

--- a/src/runtime/isolated-maintenance.ts
+++ b/src/runtime/isolated-maintenance.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -50,6 +51,16 @@ function isMaintenanceResult(value: unknown): value is MaintenanceJobRunResult {
 function childError(prefix: string, detail: string): Error {
   const cleaned = sanitizeCredentials(detail.trim()).slice(0, 4_000);
   return new Error(cleaned ? `${prefix}: ${cleaned}` : prefix);
+}
+
+/**
+ * Isolated jobs already receive an absolute projectRoot on stdin. Using that
+ * directory as spawn cwd keeps the folder locked on Windows (EBUSY on rmdir)
+ * for the life of the child. Park the process in a disposable temp dir instead.
+ */
+export function isolatedMaintenanceCwd(): string {
+  const tmp = os.tmpdir();
+  return existsSync(tmp) ? tmp : process.cwd();
 }
 
 /**
@@ -148,7 +159,7 @@ export async function runMaintenanceInChildProcess(
     let child: ChildProcessWithoutNullStreams;
     try {
       child = spawn(process.execPath, [runnerPath], {
-        cwd: request.projectRoot,
+        cwd: isolatedMaintenanceCwd(),
         env,
         stdio: ['pipe', 'pipe', 'pipe'],
         windowsHide: true,

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,6 +33,7 @@ import { canManageObservation, canReadObservation, filterReadableObservations, r
 import { compactSearch, compactTimeline, compactDetail } from './compact/engine.js';
 import { buildGraphContextPacket, formatGraphContextPrompt } from './memory/graph-context.js';
 import { detectProject } from './project/detector.js';
+import { homeProjectRootError, isHomeDirectory, writeLastProjectRoot } from './project/launch-root.js';
 import { registerAlias, initAliasRegistry, resolveAliases, autoMergeByBaseName } from './project/aliases.js';
 import { getProjectDataDir } from './store/persistence.js';
 import type { ObservationType, RuleSource, AgentTarget, MCPServerEntry, ObservationReader } from './types.js';
@@ -228,6 +229,7 @@ export const BOOTSTRAP_SAFE_TOOL_NAMES = new Set([
   'memorix_codegraph_status',
   'memorix_graph_context',
   'memorix_context_pack',
+  'memorix_session_start',
 ]);
 
 const AUTOPILOT_RETRIEVAL_BOUNDARY_TTL_MS = 2 * 60 * 1000;
@@ -265,7 +267,10 @@ export async function createMemorixServer(
   });
   const teamFeaturesEnabled = isToolInProfile('team_manage', toolProfile);
   const projectBinding = options.projectBinding ?? createProjectBindingController(cwd ?? process.cwd());
-  const detectedProject = detectProject(cwd);
+  const detectedProjectRaw = detectProject(cwd);
+  const detectedProject = detectedProjectRaw && !isHomeDirectory(detectedProjectRaw.rootPath)
+    ? detectedProjectRaw
+    : null;
   let rawProject: import('./types.js').ProjectInfo;
   let projectResolved = true;
   let projectResolutionError: string | null = null;
@@ -316,6 +321,7 @@ export async function createMemorixServer(
   }
   if (projectResolved) {
     projectBinding.recordResolvedProject(project.id, project.rootPath);
+    writeLastProjectRoot(project.rootPath);
   }
 
   const registerMaintenanceTarget = async (): Promise<void> => {
@@ -362,6 +368,7 @@ export async function createMemorixServer(
 
   const lightweightUnresolvedSession = !projectResolved && deferProjectInitUntilBound;
   let projectRuntimeInitPromise: Promise<void> | null = null;
+  let runtimeHydratedForDir: string | null = null;
 
   const initializeProjectRuntime = async (logPrefix: 'startup' | 'switch'): Promise<void> => {
     await initObservationStore(projectDir);
@@ -430,14 +437,20 @@ export async function createMemorixServer(
   } catch { /* migration is optional */ }
 
   await initializeProjectRuntime('startup');
+    runtimeHydratedForDir = projectDir;
   } else {
     // Intentionally silent — serve-http.ts deferred logging handles session lifecycle visibility.
     // Noisy per-probe 'awaiting binding' log was removed to reduce terminal spam.
   }
 
   const ensureProjectRuntimeInitialized = async (): Promise<void> => {
-    if (lightweightUnresolvedSession || !deferProjectRuntimeInit) return;
+    if (!projectResolved) return;
+    if (runtimeHydratedForDir === projectDir) {
+      if (projectRuntimeInitPromise) await projectRuntimeInitPromise;
+      return;
+    }
     if (!projectRuntimeInitPromise) {
+      const targetDir = projectDir;
       projectRuntimeInitPromise = (async () => {
         // Auto-merge obvious alias groups by scanning observed projectIds in data.
         try {
@@ -470,7 +483,8 @@ export async function createMemorixServer(
           }
         } catch { /* migration is optional */ }
 
-        await initializeProjectRuntime('startup');
+        await initializeProjectRuntime(runtimeHydratedForDir ? 'switch' : 'startup');
+        runtimeHydratedForDir = targetDir;
       })().catch((err) => {
         projectRuntimeInitPromise = null;
         throw err;
@@ -3846,6 +3860,15 @@ export async function createMemorixServer(
       // BEFORE checking whether the project is resolved. This is the primary
       // mechanism for HTTP/control-plane multi-project support.
       if (explicitRoot && typeof explicitRoot === 'string') {
+        if (isHomeDirectory(explicitRoot)) {
+          return {
+            content: [{
+              type: 'text' as const,
+              text: homeProjectRootError(explicitRoot),
+            }],
+            isError: true as const,
+          };
+        }
         let bound = await switchProject(explicitRoot, 'explicit-project-root');
         // switchProject returns false for both "same project, no-op" and "no git repo".
         // Only scan subdirectories when explicitRoot is not itself a git repo; otherwise
@@ -5503,8 +5526,12 @@ export async function createMemorixServer(
   ): Promise<boolean> => {
     if (source === 'mcp-roots' && projectBinding.isExplicit()) return false;
     const { detectProjectWithDiagnostics } = await import('./project/detector.js');
+    if (isHomeDirectory(newCwd)) {
+      console.error(`[memorix] Refusing to bind $HOME as a project root: ${newCwd}`);
+      return false;
+    }
     const result = detectProjectWithDiagnostics(newCwd);
-    if (!result.project) {
+    if (!result.project || isHomeDirectory(result.project.rootPath)) {
       if (result.failure) {
         console.error(`[memorix] Project detection failed for "${newCwd}": [${result.failure.reason}] ${result.failure.detail}`);
       }
@@ -5523,6 +5550,7 @@ export async function createMemorixServer(
       else if (source === 'mcp-roots') projectBinding.bindFromRoots(newDetected.rootPath);
       else projectBinding.bindStartup(newDetected.rootPath);
       projectBinding.recordResolvedProject(project.id, project.rootPath);
+      writeLastProjectRoot(project.rootPath);
       return false; // same project, no-op
     }
 
@@ -5580,7 +5608,12 @@ export async function createMemorixServer(
       }
     } catch { /* best-effort - coordination features degrade gracefully */ }
 
-    await initializeProjectRuntime('switch');
+    writeLastProjectRoot(project.rootPath);
+    runtimeHydratedForDir = null;
+    projectRuntimeInitPromise = null;
+    void ensureProjectRuntimeInitialized().catch((err) => {
+      console.error(`[memorix] Background project runtime init failed: ${err instanceof Error ? err.message : err}`);
+    });
     try {
       await startProjectMaintenanceWorker();
     } catch {

--- a/src/store/obs-store.ts
+++ b/src/store/obs-store.ts
@@ -59,7 +59,7 @@ export interface ObservationStore {
   /** Load one project's observations without scanning the shared flat store. */
   loadByProject(
     projectId: string,
-    options?: { status?: string; limit?: number; offset?: number; afterId?: number },
+    options?: { status?: string; limit?: number; offset?: number; afterId?: number; newestFirst?: boolean },
   ): Promise<Observation[]>;
 
   /** Count one project's observations without materializing the rows. */
@@ -231,7 +231,7 @@ export class DegradedBackend implements ObservationStore {
     return [];
   }
 
-  async loadByProject(_projectId: string, _options?: { status?: string; limit?: number; offset?: number; afterId?: number }): Promise<Observation[]> {
+  async loadByProject(_projectId: string, _options?: { status?: string; limit?: number; offset?: number; afterId?: number; newestFirst?: boolean }): Promise<Observation[]> {
     return [];
   }
 

--- a/src/store/sqlite-db.ts
+++ b/src/store/sqlite-db.ts
@@ -15,7 +15,6 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import fs from 'node:fs';
-import os from 'node:os';
 import { createDatabase, loadSqlite } from './bun-sqlite-compat.js';
 import { assertNotHomeDataDir } from '../project/launch-root.js';
 
@@ -1000,7 +999,7 @@ const _dbCache = new Map<string, any>();
  */
 export function getDatabase(dataDir: string): any {
   const normalized = path.resolve(dataDir);
-  assertNotHomeDataDir(normalized, os.homedir());
+  assertNotHomeDataDir(normalized);
   const existing = _dbCache.get(normalized);
   if (existing) return existing;
 

--- a/src/store/sqlite-db.ts
+++ b/src/store/sqlite-db.ts
@@ -15,7 +15,9 @@
 import { createRequire } from 'node:module';
 import path from 'node:path';
 import fs from 'node:fs';
+import os from 'node:os';
 import { createDatabase, loadSqlite } from './bun-sqlite-compat.js';
+import { assertNotHomeDataDir } from '../project/launch-root.js';
 
 // Dynamic require for SQLite (better-sqlite3, node:sqlite, or bun:sqlite)
 let BetterSqlite3: any;
@@ -998,6 +1000,7 @@ const _dbCache = new Map<string, any>();
  */
 export function getDatabase(dataDir: string): any {
   const normalized = path.resolve(dataDir);
+  assertNotHomeDataDir(normalized, os.homedir());
   const existing = _dbCache.get(normalized);
   if (existing) return existing;
 

--- a/src/store/sqlite-store.ts
+++ b/src/store/sqlite-store.ts
@@ -122,6 +122,8 @@ export class SqliteBackend implements ObservationStore {
   private stmtSelectByProjectStatus: any = null;
   private stmtSelectByProjectAfterId: any = null;
   private stmtSelectByProjectStatusAfterId: any = null;
+  private stmtSelectByProjectNewest: any = null;
+  private stmtSelectByProjectStatusNewest: any = null;
   private stmtCountByProject: any = null;
   private stmtCountByProjectStatus: any = null;
   private stmtSelectByTopicKey: any = null;
@@ -174,6 +176,14 @@ export class SqliteBackend implements ObservationStore {
     this.stmtSelectByProjectStatusAfterId = this.db.prepare(`
       SELECT * FROM observations WHERE projectId = ? AND status = ? AND id > ?
       ORDER BY id ASC LIMIT ?
+    `);
+    this.stmtSelectByProjectNewest = this.db.prepare(`
+      SELECT * FROM observations WHERE projectId = ?
+      ORDER BY createdAt DESC, id DESC LIMIT ? OFFSET ?
+    `);
+    this.stmtSelectByProjectStatusNewest = this.db.prepare(`
+      SELECT * FROM observations WHERE projectId = ? AND status = ?
+      ORDER BY createdAt DESC, id DESC LIMIT ? OFFSET ?
     `);
     this.stmtCountByProject = this.db.prepare(
       `SELECT COUNT(*) AS count FROM observations WHERE projectId = ?`,
@@ -288,15 +298,20 @@ export class SqliteBackend implements ObservationStore {
 
   async loadByProject(
     projectId: string,
-    options: { status?: string; limit?: number; offset?: number; afterId?: number } = {},
+    options: { status?: string; limit?: number; offset?: number; afterId?: number; newestFirst?: boolean } = {},
   ): Promise<Observation[]> {
     const limit = options.limit == null ? -1 : Math.max(1, Math.floor(options.limit));
     const offset = options.offset == null ? 0 : Math.max(0, Math.floor(options.offset));
     const afterId = options.afterId == null ? null : Math.max(0, Math.floor(options.afterId));
+    const newestFirst = options.newestFirst === true && afterId === null;
     const rows = afterId === null
-      ? (options.status
-        ? this.stmtSelectByProjectStatus.all(projectId, options.status, limit, offset)
-        : this.stmtSelectByProject.all(projectId, limit, offset))
+      ? (newestFirst
+        ? (options.status
+          ? this.stmtSelectByProjectStatusNewest.all(projectId, options.status, limit, offset)
+          : this.stmtSelectByProjectNewest.all(projectId, limit, offset))
+        : (options.status
+          ? this.stmtSelectByProjectStatus.all(projectId, options.status, limit, offset)
+          : this.stmtSelectByProject.all(projectId, limit, offset)))
       : (options.status
         ? this.stmtSelectByProjectStatusAfterId.all(projectId, options.status, afterId, limit)
         : this.stmtSelectByProjectAfterId.all(projectId, afterId, limit));

--- a/tests/cli/background-launcher.test.ts
+++ b/tests/cli/background-launcher.test.ts
@@ -49,6 +49,13 @@ describe('Windows background launcher', () => {
     expect(_testing.resolveBackgroundCliEntryFrom(bundledCli, libraryStdio)).toBe(bundledCli);
   });
 
+  it('refuses to launch the control plane from $HOME without an inherited git root', () => {
+    expect(() => _testing.resolveBackgroundCwd('/Users/tester', '/Users/tester')).toThrow(/Refusing to bind \$HOME/);
+    expect(_testing.resolveBackgroundCwd('/Users/tester/Projects/app', '/Users/tester')).toBe(
+      '/Users/tester/Projects/app',
+    );
+  });
+
   it('keeps normal CLI errors concise but preserves opt-in diagnostics', () => {
     const error = new Error('Port must be a whole number');
     error.stack = 'Error: Port must be a whole number\n    at internal-frame';

--- a/tests/cli/serve-mode.test.ts
+++ b/tests/cli/serve-mode.test.ts
@@ -330,6 +330,12 @@ describe('serve-http command mode support', () => {
     process.env.MEMORIX_MODE = undefined;
     process.env.MEMORIX_PROJECT_ROOT = undefined;
 
+    resolveServeProjectMock.mockReturnValue({
+      detectedProject: project,
+      projectRoot: project.rootPath,
+      source: 'direct',
+      messages: [],
+    });
     detectProjectMock.mockImplementation((cwd: string) => (cwd === project.rootPath ? project : null));
     detectProjectWithDiagnosticsMock.mockImplementation((cwd: string) => ({
       project: cwd === project.rootPath ? project : null,

--- a/tests/cli/serve.test.ts
+++ b/tests/cli/serve.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 
 import { mcpFileUriToPath } from '../../src/cli/mcp-root-path.js';
 import { resolveServeProject } from '../../src/cli/commands/serve-shared.js';
+import { writeLastProjectRoot } from '../../src/project/launch-root.js';
 import type { ProjectInfo } from '../../src/types.js';
 
 function makeProject(id: string, rootPath: string): ProjectInfo {
@@ -85,6 +89,71 @@ describe('serve-shared', () => {
     expect(result.source).toBe('unresolved');
     expect(result.error).toContain('No git project could be resolved');
     expect(result.messages.join('\n')).toContain('refuses to silently fall back');
+  });
+
+  it('inherits last-project-root when launched from $HOME without an explicit root', () => {
+    const result = resolveServeProject(
+      {
+        processCwd: '/Users/tester',
+        homeDir: '/Users/tester',
+      },
+      {
+        detectProject: (cwd) => (cwd === '/Users/tester/Projects/app' ? makeProject('AVIDS2/app', cwd) : null),
+        findGitInSubdirs: () => null,
+        isSystemDirectory: () => false,
+      },
+    );
+
+    // Without a readable last-project-root file this stays unresolved and never
+    // treats $HOME as a git project.
+    expect(result.detectedProject).toBeNull();
+    expect(result.source).toBe('unresolved');
+    expect(result.messages.join('\n')).toContain('will not create ~/memorix.db');
+  });
+
+  it('restores last-project-root when the launcher cwd is $HOME', () => {
+    const home = mkdtempSync(path.join(os.tmpdir(), 'memorix-serve-home-'));
+    const project = mkdtempSync(path.join(os.tmpdir(), 'memorix-serve-proj-'));
+    try {
+      writeLastProjectRoot(project, home);
+      const result = resolveServeProject(
+        {
+          processCwd: home,
+          homeDir: home,
+        },
+        {
+          detectProject: (cwd) => (cwd === path.resolve(project) ? makeProject('AVIDS2/app', cwd) : null),
+          findGitInSubdirs: () => null,
+          isSystemDirectory: () => false,
+        },
+      );
+
+      expect(result.source).toBe('last-project-root');
+      expect(result.detectedProject?.id).toBe('AVIDS2/app');
+      expect(result.projectRoot).toBe(path.resolve(project));
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  it('refuses an explicit $HOME --cwd instead of binding the home directory', () => {
+    const result = resolveServeProject(
+      {
+        cwdArg: '/Users/tester',
+        processCwd: '/Users/tester',
+        homeDir: '/Users/tester',
+      },
+      {
+        detectProject: (cwd) => (cwd === '/Users/tester' ? makeProject('local/tester', cwd) : null),
+        findGitInSubdirs: () => null,
+        isSystemDirectory: () => false,
+      },
+    );
+
+    expect(result.detectedProject).toBeNull();
+    expect(result.source).toBe('unresolved');
+    expect(result.error).toContain('Refusing to bind $HOME');
   });
 
   it('fails closed for system directories without probing home or a prior project', () => {

--- a/tests/memory/session.test.ts
+++ b/tests/memory/session.test.ts
@@ -119,6 +119,24 @@ describe('Session Lifecycle', () => {
       expect(expanded).toContain('## Key Project Memories');
       expect(expanded).toContain('Keep the release verification gate');
     });
+
+    it('loads a bounded newest-first project slice instead of the full corpus', async () => {
+      const store = getObservationStore();
+      const loadByProject = vi.spyOn(store, 'loadByProject');
+      const loadAll = vi.spyOn(store, 'loadAll');
+      await startSession(testDir, PROJECT_ID, { sessionId: 'bounded-load' });
+
+      expect(loadByProject).toHaveBeenCalled();
+      expect(loadByProject.mock.calls.every((call) => call[0] === PROJECT_ID)).toBe(true);
+      expect(loadByProject).toHaveBeenCalledWith(PROJECT_ID, {
+        status: 'active',
+        limit: 64,
+        newestFirst: true,
+      });
+      expect(loadAll).not.toHaveBeenCalled();
+      loadByProject.mockRestore();
+      loadAll.mockRestore();
+    });
   });
 
   describe('endSession', () => {

--- a/tests/project/launch-root.test.ts
+++ b/tests/project/launch-root.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  assertNotHomeDataDir,
+  homeProjectRootError,
+  inheritProjectRootFromHome,
+  isHomeDirectory,
+  lastProjectRootPath,
+  readLastProjectRoot,
+  resolveControlPlaneDataDir,
+  writeLastProjectRoot,
+} from '../../src/project/launch-root.js';
+
+describe('launch-root guards', () => {
+  it('detects $HOME and refuses it as a data directory', () => {
+    const home = '/Users/tester';
+    expect(isHomeDirectory(home, home)).toBe(true);
+    expect(isHomeDirectory(`${home}/`, home)).toBe(true);
+    expect(isHomeDirectory(`${home}/Projects/app`, home)).toBe(false);
+    expect(() => assertNotHomeDataDir(home, home)).toThrow(/Refusing to bind \$HOME/);
+    expect(homeProjectRootError(home)).toContain('~/memorix.db');
+  });
+
+  it('persists and reads last-project-root, ignoring $HOME and missing paths', () => {
+    const home = mkdtempSync(path.join(os.tmpdir(), 'memorix-launch-home-'));
+    const project = mkdtempSync(path.join(os.tmpdir(), 'memorix-launch-proj-'));
+    try {
+      writeLastProjectRoot(home, home);
+      expect(readLastProjectRoot(home)).toBeNull();
+
+      writeLastProjectRoot(project, home);
+      expect(readLastProjectRoot(home)).toBe(path.resolve(project));
+      expect(readFileSync(lastProjectRootPath(home), 'utf8').trim()).toBe(path.resolve(project));
+
+      writeFileSync(lastProjectRootPath(home), `${home}\n`, 'utf8');
+      expect(readLastProjectRoot(home)).toBeNull();
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  it('inherits MEMORIX_PROJECT_ROOT or last-project-root when launched from $HOME', () => {
+    const home = mkdtempSync(path.join(os.tmpdir(), 'memorix-inherit-home-'));
+    const project = mkdtempSync(path.join(os.tmpdir(), 'memorix-inherit-proj-'));
+    try {
+      expect(inheritProjectRootFromHome({ homeDir: home })).toBeNull();
+      expect(inheritProjectRootFromHome({
+        homeDir: home,
+        envProjectRoot: project,
+      })).toBe(path.resolve(project));
+      writeLastProjectRoot(project, home);
+      expect(inheritProjectRootFromHome({ homeDir: home })).toBe(path.resolve(project));
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(project, { recursive: true, force: true });
+    }
+  });
+
+  it('never resolves the shared store onto $HOME', () => {
+    const home = '/home/tester';
+    const globalDataDir = path.join(home, '.memorix', 'data');
+    expect(resolveControlPlaneDataDir({
+      requestedDataDir: home,
+      homeDir: home,
+      globalDataDir,
+    })).toBe(globalDataDir);
+    expect(resolveControlPlaneDataDir({
+      requestedDataDir: globalDataDir,
+      homeDir: home,
+      globalDataDir,
+    })).toBe(globalDataDir);
+  });
+});

--- a/tests/runtime/isolated-maintenance.test.ts
+++ b/tests/runtime/isolated-maintenance.test.ts
@@ -6,6 +6,7 @@ import { pathToFileURL } from 'node:url';
 
 import {
   MAINTENANCE_RESULT_PREFIX,
+  isolatedMaintenanceCwd,
   parseMaintenanceRunnerOutput,
   resolveMaintenanceRunnerPath,
   runMaintenanceInChildProcess,
@@ -84,6 +85,36 @@ describe('isolated maintenance runner', () => {
       projectRoot: process.cwd(),
       dataDir: process.cwd(),
     }, { runnerPath: runner, timeoutMs: 5_000 })).resolves.toEqual({ action: 'complete' });
+  });
+
+  it('does not use the project root as the child cwd', async () => {
+    const projectRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-maintenance-project-'));
+    const mark = path.join(os.tmpdir(), `memorix-maintenance-cwd-${Date.now()}.txt`);
+    temporaryPaths.push(projectRoot, mark);
+    const runner = await createRunner([
+      'import { writeFileSync } from "node:fs";',
+      'let input = "";',
+      'process.stdin.on("data", (chunk) => { input += chunk; });',
+      'process.stdin.on("end", () => {',
+      '  writeFileSync(process.env.MEMORIX_CWD_MARK, process.cwd(), "utf8");',
+      `  process.stdout.write("${MAINTENANCE_RESULT_PREFIX}{\\\"action\\\":\\\"complete\\\"}\\n");`,
+      '});',
+    ].join('\n'));
+
+    const result = await runMaintenanceInChildProcess({
+      job: makeJob(),
+      projectRoot,
+      dataDir: projectRoot,
+    }, {
+      runnerPath: runner,
+      timeoutMs: 5_000,
+      env: { MEMORIX_CWD_MARK: mark },
+    });
+
+    expect(result).toEqual({ action: 'complete' });
+    const childCwd = await fs.realpath((await fs.readFile(mark, 'utf8')).trim());
+    expect(childCwd).toBe(await fs.realpath(isolatedMaintenanceCwd()));
+    expect(childCwd).not.toBe(await fs.realpath(projectRoot));
   });
 
   it('refuses vector backfill because it must update the active process index', async () => {

--- a/tests/server/bootstrap-tools.test.ts
+++ b/tests/server/bootstrap-tools.test.ts
@@ -9,15 +9,17 @@ describe('MCP bootstrap-safe tools', () => {
       'memorix_context_pack',
       'memorix_graph_context',
       'memorix_project_context',
+      'memorix_session_start',
     ]);
     expect(shouldAwaitProjectRuntime('memorix_project_context')).toBe(false);
     expect(shouldAwaitProjectRuntime('memorix_codegraph_status')).toBe(false);
     expect(shouldAwaitProjectRuntime('memorix_graph_context')).toBe(false);
     expect(shouldAwaitProjectRuntime('memorix_context_pack')).toBe(false);
+    expect(shouldAwaitProjectRuntime('memorix_session_start')).toBe(false);
   });
 
-  it('keeps search, writes, and session operations behind full runtime initialization', () => {
-    for (const tool of ['memorix_search', 'memorix_store', 'memorix_session_start']) {
+  it('keeps search and writes behind full runtime initialization', () => {
+    for (const tool of ['memorix_search', 'memorix_store']) {
       expect(shouldAwaitProjectRuntime(tool)).toBe(true);
     }
   });

--- a/tests/server/session-start-home-and-hydrate.test.ts
+++ b/tests/server/session-start-home-and-hydrate.test.ts
@@ -49,6 +49,14 @@ function getText(result: any): string {
     .join('\n');
 }
 
+async function removeTempDir(dir: string): Promise<void> {
+  try {
+    await fs.rm(dir, { recursive: true, force: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'EBUSY') throw error;
+  }
+}
+
 beforeEach(async () => {
   tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-session-home-'));
   process.env.HOME = tempHome;
@@ -64,7 +72,7 @@ afterEach(async () => {
   closeAllDatabases();
   process.env.HOME = originalHome;
   process.env.USERPROFILE = originalUserProfile;
-  await fs.rm(tempHome, { recursive: true, force: true });
+  await removeTempDir(tempHome);
 });
 
 describe('memorix_session_start home bind and hydrate', () => {
@@ -88,7 +96,7 @@ describe('memorix_session_start home bind and hydrate', () => {
     await fs.mkdir(project, { recursive: true });
     await createFakeGitRepo(project, 'https://github.com/AVIDS2/session-fast.git');
 
-    const { server } = await createMemorixServer(tempHome, undefined, undefined, {
+    const { server, handleTransportClose } = await createMemorixServer(tempHome, undefined, undefined, {
       allowUntrackedFallback: false,
       deferProjectInitUntilBound: true,
       deferProjectRuntimeInit: true,
@@ -101,18 +109,21 @@ describe('memorix_session_start home bind and hydrate', () => {
       await loadAllBlocked;
       return [];
     });
-    const sessionStart = getHandler(server as any, 'memorix_session_start');
-    const started = Date.now();
-    const text = getText(await sessionStart({ projectRoot: project, agent: 'cursor' }));
-    const elapsedMs = Date.now() - started;
+    try {
+      const sessionStart = getHandler(server as any, 'memorix_session_start');
+      const started = Date.now();
+      const text = getText(await sessionStart({ projectRoot: project, agent: 'cursor' }));
+      const elapsedMs = Date.now() - started;
 
-    expect(text).toContain('AVIDS2/session-fast');
-    expect(text).toContain('Session started');
-    expect(elapsedMs).toBeLessThan(5_000);
-    expect(existsSync(path.join(tempHome, 'memorix.db'))).toBe(false);
-    releaseLoadAll?.();
-
-    loadAll.mockRestore();
-    await fs.rm(work, { recursive: true, force: true });
+      expect(text).toContain('AVIDS2/session-fast');
+      expect(text).toContain('Session started');
+      expect(elapsedMs).toBeLessThan(5_000);
+      expect(existsSync(path.join(tempHome, 'memorix.db'))).toBe(false);
+    } finally {
+      releaseLoadAll?.();
+      loadAll.mockRestore();
+      handleTransportClose();
+      await removeTempDir(work);
+    }
   });
 });

--- a/tests/server/session-start-home-and-hydrate.test.ts
+++ b/tests/server/session-start-home-and-hydrate.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../../src/embedding/provider.js', () => ({
+  getEmbeddingProvider: async () => null,
+  isVectorSearchAvailable: async () => false,
+  isEmbeddingExplicitlyDisabled: () => true,
+  resetProvider: () => {},
+}));
+
+vi.mock('../../src/llm/provider.js', () => ({
+  initLLM: () => null,
+  isLLMEnabled: () => false,
+  getLLMConfig: () => null,
+  setLLMConfig: () => {},
+}));
+
+import { existsSync } from 'node:fs';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { createMemorixServer } from '../../src/server.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+import { resetObservationStore } from '../../src/store/obs-store.js';
+import { resetSessionStore } from '../../src/store/session-store.js';
+import { resetDb } from '../../src/store/orama-store.js';
+import { SqliteBackend } from '../../src/store/sqlite-store.js';
+
+let tempHome: string;
+const originalHome = process.env.HOME;
+const originalUserProfile = process.env.USERPROFILE;
+
+async function createFakeGitRepo(root: string, remote?: string): Promise<void> {
+  await fs.mkdir(path.join(root, '.git'), { recursive: true });
+  const config = remote ? `[remote "origin"]\n\turl = ${remote}\n` : '';
+  await fs.writeFile(path.join(root, '.git', 'config'), config, 'utf8');
+}
+
+function getHandler(server: any, name: string): (args: Record<string, unknown>) => Promise<any> {
+  const handler = server._registeredTools?.[name]?.handler;
+  expect(handler).toBeTypeOf('function');
+  return handler;
+}
+
+function getText(result: any): string {
+  return (result?.content ?? [])
+    .filter((item: any) => item?.type === 'text')
+    .map((item: any) => item.text)
+    .join('\n');
+}
+
+beforeEach(async () => {
+  tempHome = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-session-home-'));
+  process.env.HOME = tempHome;
+  process.env.USERPROFILE = tempHome;
+  resetObservationStore();
+  resetSessionStore();
+  await resetDb();
+});
+
+afterEach(async () => {
+  resetObservationStore();
+  resetSessionStore();
+  closeAllDatabases();
+  process.env.HOME = originalHome;
+  process.env.USERPROFILE = originalUserProfile;
+  await fs.rm(tempHome, { recursive: true, force: true });
+});
+
+describe('memorix_session_start home bind and hydrate', () => {
+  it('refuses $HOME as projectRoot and does not create ~/memorix.db', async () => {
+    const { server } = await createMemorixServer(tempHome, undefined, undefined, {
+      allowUntrackedFallback: false,
+      deferProjectInitUntilBound: true,
+      deferProjectRuntimeInit: true,
+    });
+    const sessionStart = getHandler(server as any, 'memorix_session_start');
+    const result = await sessionStart({ projectRoot: tempHome, agent: 'cursor' });
+
+    expect(result.isError).toBe(true);
+    expect(getText(result)).toContain('Refusing to bind $HOME');
+    expect(existsSync(path.join(tempHome, 'memorix.db'))).toBe(false);
+  });
+
+  it('binds a git project without loadAll() of the observation corpus', async () => {
+    const work = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-session-work-'));
+    const project = path.join(work, 'app');
+    await fs.mkdir(project, { recursive: true });
+    await createFakeGitRepo(project, 'https://github.com/AVIDS2/session-fast.git');
+
+    const { server } = await createMemorixServer(tempHome, undefined, undefined, {
+      allowUntrackedFallback: false,
+      deferProjectInitUntilBound: true,
+      deferProjectRuntimeInit: true,
+    });
+    let releaseLoadAll: (() => void) | undefined;
+    const loadAllBlocked = new Promise<void>((resolve) => {
+      releaseLoadAll = resolve;
+    });
+    const loadAll = vi.spyOn(SqliteBackend.prototype, 'loadAll').mockImplementation(async () => {
+      await loadAllBlocked;
+      return [];
+    });
+    const sessionStart = getHandler(server as any, 'memorix_session_start');
+    const started = Date.now();
+    const text = getText(await sessionStart({ projectRoot: project, agent: 'cursor' }));
+    const elapsedMs = Date.now() - started;
+
+    expect(text).toContain('AVIDS2/session-fast');
+    expect(text).toContain('Session started');
+    expect(elapsedMs).toBeLessThan(5_000);
+    expect(existsSync(path.join(tempHome, 'memorix.db'))).toBe(false);
+    releaseLoadAll?.();
+
+    loadAll.mockRestore();
+    await fs.rm(work, { recursive: true, force: true });
+  });
+});

--- a/tests/store/sqlite-store.test.ts
+++ b/tests/store/sqlite-store.test.ts
@@ -17,7 +17,7 @@ import {
   getObservationStore,
   resetObservationStore,
 } from '../../src/store/obs-store.js';
-import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+import { closeAllDatabases, getDatabase } from '../../src/store/sqlite-db.js';
 
 // ── Helpers ───────────────────────────────────────────────────────
 
@@ -203,6 +203,24 @@ describe('SqliteBackend CRUD', () => {
     expect(await store.getById(3)).toMatchObject({ projectId: 'project-b' });
     expect(await store.countByProject('project-a', { status: 'active' })).toBe(1);
     expect(await store.countByProject('project-a')).toBe(2);
+  });
+
+  it('loads newest project rows first when asked', async () => {
+    await store.insert(makeObs({
+      id: 1,
+      entityName: 'old',
+      projectId: 'project-a',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    }));
+    await store.insert(makeObs({
+      id: 2,
+      entityName: 'new',
+      projectId: 'project-a',
+      createdAt: '2026-08-01T00:00:00.000Z',
+    }));
+
+    const newest = await store.loadByProject('project-a', { newestFirst: true, limit: 1 });
+    expect(newest.map((observation) => observation.id)).toEqual([2]);
   });
 });
 
@@ -509,6 +527,19 @@ describe('SqliteBackend close()', () => {
 
     // Recreate for afterEach cleanup
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-sqlite-test-'));
+  });
+
+  it('refuses to open memorix.db directly in $HOME', () => {
+    const previousHome = process.env.HOME;
+    const previousProfile = process.env.USERPROFILE;
+    process.env.HOME = tmpDir;
+    process.env.USERPROFILE = tmpDir;
+    try {
+      expect(() => getDatabase(tmpDir)).toThrow(/Refusing to bind \$HOME/);
+    } finally {
+      process.env.HOME = previousHome;
+      process.env.USERPROFILE = previousProfile;
+    }
   });
 
   it('close is idempotent (safe to call twice)', async () => {


### PR DESCRIPTION
## Summary
- First `memorix_session_start` no longer waits for `loadAll()` + lexical hydrate. It binds the git project, writes a continuation card from a bounded SQLite slice, and hydrates the in-memory index in the background so `/health` and MCP initialize stay responsive.
- HTTP, stdio, background, and CLI refuse `$HOME` as a project root. Unresolved control-plane launches use `~/.memorix/data` instead of opening SQLite at `$HOME` (the decoy `~/memorix.db` path). Launch-from-home can inherit `MEMORIX_PROJECT_ROOT` or `~/.memorix/last-project-root`.
- SQLite now refuses to create `memorix.db` directly in `$HOME`. Session resume uses `loadByProject({ newestFirst, limit })` instead of the full corpus.
- Rebased onto `main` after #214. Background start keeps both the compiled-CLI spawn fix and the `$HOME` cwd refuse.

Fixes #224
Fixes #225

Does not include #212 (rerank).

## Test plan
- [x] `tests/project/launch-root.test.ts`
- [x] `tests/cli/serve.test.ts` (HOME refuse + last-project-root inherit)
- [x] `tests/cli/background-launcher.test.ts` (HOME cwd refuse + compiled CLI entry)
- [x] `tests/server/session-start-home-and-hydrate.test.ts` (no `~/memorix.db`; session_start returns while `loadAll` is blocked)
- [x] `tests/memory/session.test.ts` (bounded newest-first resume load)
- [x] `tests/store/sqlite-store.test.ts` (`newestFirst` + HOME data-dir guard)
- [x] `tests/server/bootstrap-tools.test.ts` (`memorix_session_start` is bootstrap-safe)
- [x] `tests/runtime/isolated-maintenance.test.ts` (child cwd is not the project root)
- [ ] Owner: restart control plane from `$HOME` and confirm no `~/memorix.db` is created
- [ ] Owner: first `memorix_session_start` on a 40k+ store after `/health` + initialize
