### PR TITLE
chore(release): 1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.6.2] - 2026-08-18
+
+### Changed
+- **Responsive large-store control plane** -- HTTP health and MCP initialize
+  no longer wait for full observation or embedding-cache hydration. Hook writes
+  persist directly without loading the full corpus, one-shot CLI paths avoid
+  cached-vector attachment, and ordinary embedding-disabled writes stay off
+  the provider/configuration hot path. Contributed by
+  [@RaviTharuma](https://github.com/RaviTharuma) in #214.
+- **Bounded and crash-safe embedding cache** -- JSONL cache loading is bounded
+  by a 256 MiB raw-vector payload budget, legacy JSON migration publishes via
+  temporary-file rename, concurrent loads are single-flighted, and sidecar
+  metadata avoids rescanning a large cache on every save.
+
+### Fixed
+- **SDK lifecycle and persistence parity** -- `MemoryClient.close()` releases
+  its SQLite handle on Windows, reopening the same directory reloads a fresh
+  store snapshot, and SDK clients use the same flat data directory as CLI,
+  hooks, and HTTP MCP instead of the retired per-project directory layout.
+- **Correct background entrypoint** -- `memorix background start` launches the
+  built HTTP CLI entrypoint rather than the stdio library entry.
+
 ## [1.6.1] - 2026-08-17
 
 ### Fixed

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -78,6 +78,7 @@ On the release development machine used for this check, the healthy HTTP service
 | `MEMORIX_RERANK_TIMEOUT_MS` | provider default | Bound slow LLM rerank calls |
 | `memorix memory search --quality fast` | n/a | Force a fully local retrieval path for a latency-sensitive call |
 | `npm run benchmark:retrieval -- --records 1000 --runs 100` | n/a | Reproduce hot in-process lexical retrieval latency; not an end-to-end claim |
+| `npm run gate:large-store -- --records 40000` | n/a | Exercise SDK, HTTP MCP, hook persistence, cache integrity, and reopen behavior against a large isolated store |
 | `[codegraph].max_file_bytes` | `2097152` | Raise only when a large file is intentional source that should enter Code Memory |
 | `memorix retention status` | report only | Inspect whether memory growth needs cleanup |
 | `memorix retention archive` | explicit | Archive expired memories when the project gets noisy |
@@ -95,6 +96,20 @@ On the release development machine used for this check, the healthy HTTP service
 - When Dashboard shows queued or failed maintenance work, inspect
   `/api/maintenance` on that local dashboard before assuming a Code Memory scan
   or lifecycle task completed.
+
+## Large-Store Release Gate
+
+`npm run gate:large-store -- --records 40000` builds Memorix and creates a
+temporary Git project with an isolated data directory. It runs with embeddings
+disabled, so it does not use provider credentials or make paid network calls.
+The gate measures steady-state writes, first lexical search, process memory,
+HTTP MCP and hook persistence, and an SDK close/reopen cycle. It also verifies
+that the personal hook candidate remains durable on disk without becoming
+visible to an unbound SDK reader.
+
+Results are machine-specific and should be compared on the same OS and Node
+version. The release gate is an integrity and regression check, not a public
+latency guarantee.
 
 ## Current Optimization Opportunities
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memorix",
   "mcpName": "io.github.AVIDS2/memorix",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
+++ b/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Local-first project memory for CodeBuddy Code and other coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AVIDS2/memorix",
     "source": "github"
   },
-  "version": "1.6.1",
+  "version": "1.6.2",
   "websiteUrl": "https://github.com/AVIDS2/memorix#readme",
   "icons": [
     {
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "memorix",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "runtimeHint": "npx",
       "packageArguments": [
         {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -354,16 +354,10 @@ export async function createMemoryClient(options: MemoryClientOptions): Promise<
     );
   }
 
-  // Honor MEMORIX_DATA_DIR so isolated benchmarks and tests do not write
-  // into ~/.memorix/data. Unset, keep the per-project home path.
-  const path = await import('node:path');
-  const os = await import('node:os');
-  const dataDir = process.env.MEMORIX_DATA_DIR
-    || path.join(os.homedir(), '.memorix', 'data', project.id.replace(/\//g, path.sep));
-
-  // Ensure data directory exists
-  const fs = await import('node:fs');
-  fs.mkdirSync(dataDir, { recursive: true });
+  // SDK, CLI, hooks, and HTTP MCP must share the same flat data directory.
+  // Project identity is stored in each row, not encoded in the directory.
+  const { getProjectDataDir } = await import('./store/persistence.js');
+  const dataDir = await getProjectDataDir(project.id);
 
   const client = new MemoryClient(project.id, projectRoot, dataDir);
   await client._init(silent);

--- a/tests/sdk/client-default-data-dir.test.ts
+++ b/tests/sdk/client-default-data-dir.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+
+const mockedOs = vi.hoisted(() => ({ home: '' }));
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  const homedir = () => mockedOs.home;
+  return {
+    ...actual,
+    homedir,
+    default: { ...actual.default, homedir },
+  };
+});
+
+import { createMemoryClient } from '../../src/sdk.js';
+import { resetConfigCache } from '../../src/config.js';
+import { resetProvider } from '../../src/embedding/provider.js';
+import { resetObservationRuntime } from '../../src/memory/observations.js';
+import { resetObservationStore } from '../../src/store/obs-store.js';
+import { resetDb } from '../../src/store/orama-store.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+
+describe('SDK default data-directory contract', () => {
+  const originalDataDir = process.env.MEMORIX_DATA_DIR;
+  const originalEmbedding = process.env.MEMORIX_EMBEDDING;
+  let sandbox = '';
+  let client: Awaited<ReturnType<typeof createMemoryClient>> | undefined;
+
+  beforeEach(() => {
+    sandbox = mkdtempSync(path.join(tmpdir(), 'memorix-sdk-default-data-'));
+    mockedOs.home = path.join(sandbox, 'home');
+    delete process.env.MEMORIX_DATA_DIR;
+    process.env.MEMORIX_EMBEDDING = 'off';
+    resetConfigCache();
+    resetProvider();
+
+    const projectRoot = path.join(sandbox, 'project');
+    execFileSync('git', ['init', '--quiet', projectRoot], { windowsHide: true });
+  });
+
+  afterEach(async () => {
+    await client?.close();
+    client = undefined;
+    resetObservationStore();
+    resetObservationRuntime();
+    await resetDb();
+    closeAllDatabases();
+    resetProvider();
+    resetConfigCache();
+    if (originalDataDir === undefined) delete process.env.MEMORIX_DATA_DIR;
+    else process.env.MEMORIX_DATA_DIR = originalDataDir;
+    if (originalEmbedding === undefined) delete process.env.MEMORIX_EMBEDDING;
+    else process.env.MEMORIX_EMBEDDING = originalEmbedding;
+    if (sandbox) rmSync(sandbox, { recursive: true, force: true });
+  });
+
+  it('uses the same flat default directory as CLI, hooks, and MCP', async () => {
+    const projectRoot = path.join(sandbox, 'project');
+    const expected = path.join(mockedOs.home, '.memorix', 'data');
+
+    client = await createMemoryClient({ projectRoot, silent: true });
+
+    expect(client.dataDir).toBe(expected);
+    expect(client.dataDir).not.toContain(`${path.sep}local${path.sep}`);
+  });
+});


### PR DESCRIPTION
## Summary
- release the responsive large-store control-plane work from #214 with contributor credit
- keep SDK, CLI, hooks, and HTTP MCP on the same flat persistence directory
- publish synchronized MCP Registry and agent plugin metadata for 1.6.2

## Verification
- main CI after #214 merge: Windows, macOS, Ubuntu, Docker, typecheck, native SQLite, registry metadata all passed
- `npm run lint`
- `npm run build`
- `npm test` (289 files passed, 2874 tests passed, 4 explicitly skipped)
- SDK persistence tests (15 passed)
- `npm run check:mcp-registry`
- `npm run check:plugin-release`
- `npm pack --dry-run --json` (541 files; no worktree, env, attachment, or internal workspace package leakage)
- 40k-record Windows large-store gate passed during #214 acceptance