### PR TITLE
chore(release): memorix 1.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.6.3] - 2026-08-18
+
+### Fixed
+- **Safe home-directory boundaries** -- project binding and SQLite now share
+  the same effective `HOME`/`USERPROFILE` resolution on Windows, so an agent
+  launched from a user directory is rejected consistently and cannot create a
+  decoy `~/memorix.db`. Contributed by
+  [@RaviTharuma](https://github.com/RaviTharuma) in #230, with a maintainer
+  compatibility follow-up for Windows environment resolution.
+- **Fast first session on large stores** -- `memorix_session_start` uses a
+  bounded newest-first slice while the remaining hydration work continues in
+  the background, keeping first contact responsive on large projects.
+
 ## [1.6.2] - 2026-08-18
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memorix",
   "mcpName": "io.github.AVIDS2/memorix",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
+++ b/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Local-first project memory for CodeBuddy Code and other coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AVIDS2/memorix",
     "source": "github"
   },
-  "version": "1.6.2",
+  "version": "1.6.3",
   "websiteUrl": "https://github.com/AVIDS2/memorix#readme",
   "icons": [
     {
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "memorix",
-      "version": "1.6.2",
+      "version": "1.6.3",
       "runtimeHint": "npx",
       "packageArguments": [
         {

--- a/tests/cli/purge-command.test.ts
+++ b/tests/cli/purge-command.test.ts
@@ -99,7 +99,7 @@ describe('purge command exam', () => {
     expect(await activeObservationCount(projectA)).toBe(1);
   });
 
-  it('purges the current project but leaves other projects intact', async () => {
+  it('purges the current project but leaves other projects intact', { timeout: 30_000 }, async () => {
     const stored = await runCommand(memoryCommand, {
       _: ['store'],
       title: 'Purge target observation',

--- a/tests/stress/large-store-gate.test.ts
+++ b/tests/stress/large-store-gate.test.ts
@@ -254,7 +254,9 @@ describe('large-store gate', () => {
     expect(persisted).toHaveLength(2);
   }
 
-  it('stays responsive at 1k records', { timeout: 60_000 }, async () => {
+  // Keep the outer hang guard generous for contended Windows CI runners. The
+  // assertions inside runGate remain the actual latency and memory budgets.
+  it('stays responsive at 1k records', { timeout: 180_000 }, async () => {
     await runGate(1_000);
   });
 


### PR DESCRIPTION
## Summary

- release the bounded large-store session-start and HOME project-root protections from #230
- keep Windows HOME/USERPROFILE and SQLite boundary checks consistent
- synchronize npm, MCP Registry, and agent plugin release metadata

## Verification

- npm run lint
- npm run check:mcp-registry
- npm run check:plugin-release
- npm run build
- npm test (291 files, 2,888 tests passed; 4 live tests skipped by design)
- npm run gate:large-store -- --records 40000 (ok; p95 write 0.782 ms; search 1.357 s)
- real Windows background start from isolated HOME: /health 200, no ~/memorix.db, clean stop
- isolated CLI store -> search -> detail smoke
- npm pack --dry-run --json (memorix@1.6.3, 542 files)

Contributed by @RaviTharuma in #230, with the Windows environment-resolution follow-up added by the maintainer.