### PR TITLE
feat(dashboard): add preview-first memory maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ test-smoke.txt
 .pipeline/
 .worktrees/
 .playwright-mcp/
+.playwright-cli/
 .planning/
 output/
 memory-game-*.png

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -497,7 +497,10 @@ It provides an operational view for:
 - identity health
 - sessions
 - retention state
+- preview-first cleanup, consolidation, intelligent deduplication, and retention archival
 - read-only orchestration coordination state in the standalone dashboard and live state in HTTP service mode
+
+Dashboard maintenance is not a separate business-logic implementation. CLI, MCP, background jobs, and Dashboard routes share the same cleanup, consolidation, deduplication, and retention functions. Mutation routes issue a project-bound signed preview token and reject execution when the candidate set changed after preview.
 
 This is part of Memorix's shift from a single MCP server to a broader local memory platform.
 

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -1,0 +1,54 @@
+# Dashboard
+
+The Memorix Dashboard is the local control surface for inspecting project memory and running explicit maintenance. It is available through the shared background service or as a standalone local process.
+
+## Start
+
+```bash
+memorix background start
+# dashboard: http://127.0.0.1:3211
+
+memorix dashboard
+# standalone dashboard: http://127.0.0.1:3210
+```
+
+Both modes read the same project-scoped stores. The project switcher changes the active project filter; it does not merge projects or grant access to personal memories.
+
+## Maintenance Workbench
+
+The Observations page exposes three explicit maintenance actions:
+
+| Action | Effect | Shared implementation |
+| --- | --- | --- |
+| Cleanup | Deletes low-quality activity records and exact duplicates; optionally archives test/demo noise | `analyzeCleanupObservations` and `applyCleanupMutations` |
+| Consolidate | Merges strongly similar project-visible observations while preserving facts and references | `findConsolidationCandidates` and `executeConsolidation` |
+| Deduplicate | Uses the configured memory LLM to identify redundant or superseded records and marks them resolved | `planMemoryDeduplication` and `applyDeduplicationPlan` |
+
+The Retention page exposes Archive for records already classified as archive candidates by the canonical retention projection.
+
+Every action follows the same contract:
+
+1. The Dashboard requests a project-scoped preview.
+2. The server returns the candidate records, counts, and a signed preview token.
+3. The user confirms the displayed plan.
+4. Execution verifies the token and current candidate set before mutating data.
+5. If memory changed after preview, execution fails with `409` and requires a new preview.
+
+Cleanup noise archival is opt-in. Consolidation never touches personal or team-scoped observations from an unbound Dashboard. Deduplication marks records resolved rather than deleting them. Retention changes status to archived. Manual selection and hard deletion remain separate from the maintenance workbench.
+
+## HTTP Contract
+
+Maintenance endpoints are local Dashboard APIs and are not a replacement for MCP or CLI integrations:
+
+```text
+POST /api/maintenance/cleanup/preview
+POST /api/maintenance/cleanup/execute
+POST /api/maintenance/consolidate/preview
+POST /api/maintenance/consolidate/execute
+POST /api/maintenance/deduplicate/preview
+POST /api/maintenance/deduplicate/execute
+POST /api/maintenance/retention/preview
+POST /api/maintenance/retention/execute
+```
+
+Use the CLI for scripts and remote terminals. Use MCP for agent-driven maintenance. The Dashboard is the reviewable local operator surface; all three call the same maintenance logic.

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ The public docs are organized by user intent:
 | CLI commands and MCP tools | [API_REFERENCE.md](API_REFERENCE.md) |
 | Memory Autopilot, Code State, and context packs | [API_REFERENCE.md § Memory Autopilot, Code State, and Context Packs](API_REFERENCE.md#memory-autopilot-code-state-and-context-packs), [1.2 Code State](1.2.0-CODE-STATE.md), and [1.2 Workset Retrieval](1.2.0-WORKSET-RETRIEVAL.md) |
 | Reviewed episodic, semantic, and procedural long-term memory | [1.3 Memory Architecture](1.3-MEMORY-ARCHITECTURE.md) |
+| Browse memory and run preview-first local maintenance | [Dashboard](DASHBOARD.md) |
 | Reviewable knowledge pages and workflow inheritance | [API_REFERENCE.md § Knowledge Workspace and Workflows](API_REFERENCE.md#knowledge-workspace-and-workflows), [1.2 Knowledge Workspace](1.2.0-KNOWLEDGE-WORKSPACE.md), and [1.2 Workflow Inheritance](1.2.0-WORKFLOW-INHERITANCE.md) |
 | Git-derived engineering memory | [GIT_MEMORY.md](GIT_MEMORY.md) |
 | Memory formation and quality pipeline | [MEMORY_FORMATION_PIPELINE.md](MEMORY_FORMATION_PIPELINE.md) |
@@ -51,6 +52,7 @@ The public docs are organized by user intent:
 | TOML-first configuration | [CONFIGURATION.md](CONFIGURATION.md) |
 | Docker/compose deployment | [DOCKER.md](DOCKER.md) |
 | Resource and timeout tuning | [PERFORMANCE.md](PERFORMANCE.md) |
+| Dashboard modes, maintenance actions, and safety contract | [DASHBOARD.md](DASHBOARD.md) |
 | AI-facing install and troubleshooting playbook | [Agent Playbook](AGENT_OPERATOR_PLAYBOOK.md) |
 
 ---

--- a/src/cli/commands/cleanup.ts
+++ b/src/cli/commands/cleanup.ts
@@ -17,88 +17,15 @@ import { defineCommand } from 'citty';
 import type { Observation } from '../../types.js';
 import { detectProject } from '../../project/detector.js';
 import { getProjectDataDir } from '../../store/persistence.js';
-import type { ObservationStore } from '../../store/obs-store.js';
 import { getObservationStore, initObservationStore } from '../../store/obs-store.js';
 import { filterReadableObservations } from '../../memory/visibility.js';
+import {
+    analyzeCleanupObservations,
+    applyCleanupMutations,
+    isLowQualityObservation,
+} from '../../memory/cleanup.js';
 
-/** Patterns that indicate auto-generated, low-value observations */
-const LOW_QUALITY_PATTERNS = [
-    /^Session activity/i,
-    /^Updated \S+\.\w+$/i,
-    /^Created \S+\.\w+$/i,
-    /^Deleted \S+\.\w+$/i,
-    /^Modified \S+\.\w+$/i,
-    /^Ran command:/i,
-    /^Read file:/i,
-];
-
-/** Patterns for demo/test noise — matches session.ts NOISE_PATTERNS */
-const NOISE_PATTERNS = [
-    /\[测试\]/i, /\[test\]/i, /验证/i, /兼容/i, /\bcompat(?:ibility)?\b/i,
-    /\bdemo\b/i, /展示/i, /全能力/i, /handoff/i, /交接/i,
-    /for_memmcp_test/i, /\bbenchmark\b/i, /\bsandbox\b/i, /\bplayground\b/i,
-];
-
-/** Patterns for Memorix system self-reference — should not pollute unrelated projects */
-const SYSTEM_SELF_PATTERNS = [
-    /memorix.demo/i, /memorix.*全能力/i, /memorix.*工具.*能力/i,
-    /memorix.*runtime.*mode/i, /memorix.*运行模式/i, /memorix.*control.plane/i,
-    /session.*inject(?:ion)?/i, /注入.*逻辑/i,
-    /\b22\s*(?:个|tools?).*(?:工具|能力|capabilit)/i,
-    /memorix.*(?:v\d|版本|version)/i, /memorix.*(?:兼容|compat)/i,
-    /memorix.*(?:测试|test)/i, /memmcp/i,
-];
-
-/** Check if an observation title matches low-quality patterns */
-function isLowQuality(title: string): boolean {
-    return LOW_QUALITY_PATTERNS.some(p => p.test(title.trim()));
-}
-
-/** Check if observation text matches noise/demo/test/system-self patterns */
-function isNoisePollution(obs: { title?: string; narrative?: string; entityName?: string; facts?: string[]; concepts?: string[] }): { isNoise: boolean; reason: string } {
-    const text = [obs.title, obs.narrative, obs.entityName, ...(obs.facts ?? []), ...(obs.concepts ?? [])]
-        .filter(Boolean).join('\n');
-    for (const p of SYSTEM_SELF_PATTERNS) {
-        if (p.test(text)) return { isNoise: true, reason: 'system-self' };
-    }
-    for (const p of NOISE_PATTERNS) {
-        if (p.test(text)) return { isNoise: true, reason: 'demo/test/noise' };
-    }
-    return { isNoise: false, reason: '' };
-}
-
-function requireObservationIds(observations: Observation[], action: string): number[] {
-    const ids = observations.map((observation) => observation.id);
-    if (ids.some((id) => typeof id !== 'number')) {
-        throw new Error(`Cannot ${action}: an observation has no persisted ID.`);
-    }
-    return ids as number[];
-}
-
-/**
- * Apply cleanup mutations without replacing the shared observation table.
- * Keeping lifecycle updates targeted prevents a cleanup in one project from
- * overwriting observations written concurrently by another project.
- */
-export async function applyCleanupMutations(
-    store: ObservationStore,
-    toArchive: Observation[],
-    toRemove: Observation[],
-): Promise<{ archived: number; removed: number }> {
-    const archiveIds = requireObservationIds(toArchive, 'archive');
-    const removeIds = requireObservationIds(toRemove, 'delete');
-    const removals = new Set(removeIds);
-    if (archiveIds.some((id) => removals.has(id))) {
-        throw new Error('Cleanup cannot archive and delete the same observation.');
-    }
-
-    await store.atomic(async (tx) => {
-        await Promise.all(archiveIds.map((id) => tx.setStatus(id, 'archived')));
-        await Promise.all(removeIds.map((id) => tx.remove(id)));
-    });
-
-    return { archived: archiveIds.length, removed: removeIds.length };
-}
+export { applyCleanupMutations } from '../../memory/cleanup.js';
 
 export default defineCommand({
     meta: {
@@ -170,40 +97,12 @@ export default defineCommand({
             return;
         }
 
-        // Categorize: low-quality
-        const lowQuality = projectObs.filter(o => isLowQuality(o.title ?? ''));
-        const highQuality = projectObs.filter(o => !isLowQuality(o.title ?? ''));
-
-        // Find duplicates (same title + type + entity)
-        const seen = new Set<string>();
-        const duplicates: typeof projectObs = [];
-        const unique: typeof projectObs = [];
-        for (const obs of highQuality) {
-            const key = `${obs.type}|${obs.title}|${obs.entityName}`;
-            if (seen.has(key)) {
-                duplicates.push(obs);
-            } else {
-                seen.add(key);
-                unique.push(obs);
-            }
-        }
-
-        // Find noise pollution (demo/test/system-self)
-        const noiseHits: Array<{ obs: typeof projectObs[0]; reason: string }> = [];
-        if (args.noise) {
-            for (const obs of projectObs) {
-                if (lowQuality.includes(obs) || duplicates.includes(obs)) continue;
-                const { isNoise, reason } = isNoisePollution(obs);
-                if (isNoise) noiseHits.push({ obs, reason });
-            }
-        }
-
-        const toRemove = [...lowQuality, ...duplicates];
-        const toArchive = noiseHits.map(h => h.obs);
+        const analysis = analyzeCleanupObservations(projectObs as Observation[], { includeNoise: args.noise });
+        const { lowQuality, duplicates, noise: noiseHits, toRemove, toArchive } = analysis;
 
         console.log(`Analysis (active observations for ${projectId}):`);
-        console.log(`   Total active:       ${projectObs.length}`);
-        console.log(`   High quality:       ${unique.length - toArchive.length}`);
+        console.log(`   Total active:       ${analysis.totalActive}`);
+        console.log(`   High quality:       ${analysis.highQuality}`);
         console.log(`   Low quality:        ${lowQuality.length}`);
         console.log(`   Duplicates:         ${duplicates.length}`);
         if (args.noise) {
@@ -224,7 +123,7 @@ export default defineCommand({
         if (toRemove.length > 0) {
             console.log('Items to DELETE:');
             toRemove.slice(0, 10).forEach(o => {
-                const tag = isLowQuality(o.title ?? '') ? '(low-quality)' : '(duplicate)';
+                const tag = isLowQualityObservation(o.title ?? '') ? '(low-quality)' : '(duplicate)';
                 console.log(`   ${tag} #${o.id ?? '?'} "${o.title}" [${o.type}]`);
             });
             if (toRemove.length > 10) {
@@ -236,8 +135,8 @@ export default defineCommand({
         // Preview noise archival
         if (toArchive.length > 0) {
             console.log('Items to ARCHIVE (noise pollution):');
-            noiseHits.slice(0, 15).forEach(({ obs, reason }) => {
-                console.log(`   (${reason}) #${obs.id ?? '?'} "${obs.title}" [${obs.type}] entity=${obs.entityName}`);
+            noiseHits.slice(0, 15).forEach(({ observation, reason }) => {
+                console.log(`   (${reason}) #${observation.id ?? '?'} "${observation.title}" [${observation.type}] entity=${observation.entityName}`);
             });
             if (toArchive.length > 15) {
                 console.log(`   ... and ${toArchive.length - 15} more`);

--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -3,7 +3,9 @@ import { compactDetail, compactSearch, compactTimeline } from '../../compact/eng
 import { withFreshIndex } from '../../memory/freshness.js';
 import { getAllObservations, getObservation, getProjectObservations, resolveObservations, storeObservation, suggestTopicKey } from '../../memory/observations.js';
 import { buildGraphContextPacket, formatGraphContextPrompt } from '../../memory/graph-context.js';
+import { applyDeduplicationPlan, planMemoryDeduplication } from '../../memory/deduplication.js';
 import { canManageObservation, filterReadableObservations, resolveObservationVisibility } from '../../memory/visibility.js';
+import { getObservationStore } from '../../store/obs-store.js';
 import {
   asStringArg,
   coerceObservationStatus,
@@ -288,12 +290,11 @@ export default defineCommand({
             return;
           }
 
-          const { deduplicateMemory } = await import('../../llm/memory-manager.js');
           const allObs = await withFreshIndex(() =>
             filterReadableObservations(
               getAllObservations().filter((obs) => (obs.status ?? 'active') === 'active' && obs.projectId === project.id),
               reader,
-            ),
+            ).filter((observation) => canManageObservation(observation, reader)),
           );
 
           if (allObs.length < 2) {
@@ -310,55 +311,23 @@ export default defineCommand({
             candidates = allObs.slice(-20);
           }
 
-          const byEntity = new Map<string, typeof candidates>();
-          for (const obs of candidates) {
-            const bucket = byEntity.get(obs.entityName) ?? [];
-            bucket.push(obs);
-            byEntity.set(obs.entityName, bucket);
-          }
+          const plan = await planMemoryDeduplication(candidates);
+          const actionLines = plan.actions.map((item) =>
+            `Resolve #${item.resolveId} "${item.resolveTitle}"; keep #${item.keepId} "${item.keepTitle}" (${item.reason})`,
+          );
 
-          const actions: string[] = [];
-          const toResolve: number[] = [];
-          for (const [, group] of byEntity) {
-            if (group.length < 2) continue;
-            for (let index = 0; index < group.length; index += 1) {
-              for (let compareIndex = index + 1; compareIndex < group.length; compareIndex += 1) {
-                const newer = group[compareIndex];
-                const older = group[index];
-                try {
-                  const decision = await deduplicateMemory(
-                    { title: newer.title, narrative: newer.narrative, facts: newer.facts },
-                    [{ id: older.id, title: older.title, narrative: older.narrative, facts: older.facts.join('\n') }],
-                  );
-                  if (decision && (decision.action === 'DELETE' || decision.action === 'UPDATE' || decision.action === 'NONE')) {
-                    actions.push(`Resolve #${older.id} because it duplicates newer #${newer.id}`);
-                    toResolve.push(older.id);
-                  }
-                } catch {
-                  // Ignore failed pair analysis so one bad comparison doesn't abort the batch.
-                }
-              }
-            }
-          }
-
-          if (dryRun || toResolve.length === 0) {
+          if (dryRun || plan.resolveIds.length === 0) {
             emitResult(
-              { project, actions, resolved: [], dryRun: true },
-              actions.length === 0 ? 'No duplicate candidates found.' : actions.join('\n'),
+              { project, plan, resolved: [], dryRun: true },
+              actionLines.length === 0 ? 'No duplicate candidates found.' : actionLines.join('\n'),
               asJson,
             );
             return;
           }
 
-          const result = await resolveObservations(
-            [...new Set(toResolve)].filter((id) => {
-              const observation = getObservation(id, project.id);
-              return observation ? canManageObservation(observation, reader) : false;
-            }),
-            'resolved',
-          );
+          const result = await applyDeduplicationPlan(getObservationStore(), project.id, plan.resolveIds, reader);
           emitResult(
-            { project, actions, resolved: result.resolved, notFound: result.notFound, dryRun: false },
+            { project, plan, resolved: result.resolved, skipped: result.skipped, dryRun: false },
             `Resolved ${result.resolved.length} duplicate observation(s).`,
             asJson,
           );

--- a/src/dashboard/maintenance.ts
+++ b/src/dashboard/maintenance.ts
@@ -1,0 +1,303 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+
+import { isLLMEnabled } from '../llm/provider.js';
+import { analyzeCleanupObservations, applyCleanupMutations } from '../memory/cleanup.js';
+import { findConsolidationCandidates, executeConsolidation } from '../memory/consolidation.js';
+import { applyDeduplicationPlan, planMemoryDeduplication } from '../memory/deduplication.js';
+import { archiveExpired, projectObservationRetention } from '../memory/retention.js';
+import { canManageObservation, filterReadableObservations } from '../memory/visibility.js';
+import type { ObservationStore } from '../store/obs-store.js';
+import type { Observation, ObservationReader } from '../types.js';
+
+const previewSecret = randomBytes(32);
+
+export class DashboardMaintenanceError extends Error {
+  constructor(message: string, readonly status: number) {
+    super(message);
+  }
+}
+
+export interface DashboardMaintenanceContext {
+  dataDir: string;
+  projectId: string;
+  projectRoot: string | null;
+  store: ObservationStore;
+}
+
+interface CleanupTokenPayload {
+  includeNoise: boolean;
+  removeIds: number[];
+  archiveIds: number[];
+}
+
+interface DeduplicateTokenPayload {
+  resolveIds: number[];
+}
+
+interface ConsolidateTokenPayload {
+  clusterIds: number[][];
+}
+
+interface RetentionTokenPayload {
+  archiveIds: number[];
+}
+
+function reader(projectId: string): ObservationReader {
+  return { projectId };
+}
+
+function summarize(observation: Observation) {
+  return {
+    id: observation.id,
+    title: observation.title,
+    type: observation.type,
+    entityName: observation.entityName,
+  };
+}
+
+function normalizeIds(ids: readonly number[]): number[] {
+  return [...new Set(ids)].sort((left, right) => left - right);
+}
+
+function normalizeClusters(clusters: readonly (readonly number[])[]): number[][] {
+  return clusters
+    .map((ids) => normalizeIds(ids))
+    .sort((left, right) => left.join(',').localeCompare(right.join(',')));
+}
+
+function payloadRecord(payload: unknown): Record<string, unknown> {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new DashboardMaintenanceError('The maintenance preview payload is missing.', 400);
+  }
+  return payload as Record<string, unknown>;
+}
+
+function payloadIds(value: unknown, field: string): number[] {
+  if (!Array.isArray(value) || value.some((id) => !Number.isSafeInteger(id) || Number(id) <= 0)) {
+    throw new DashboardMaintenanceError(`Invalid ${field} in maintenance preview.`, 400);
+  }
+  return normalizeIds(value as number[]);
+}
+
+function sign(action: string, projectId: string, payload: object): string {
+  return createHmac('sha256', previewSecret)
+    .update(JSON.stringify({ action, projectId, payload }))
+    .digest('hex');
+}
+
+function verify(action: string, projectId: string, payload: object, token: unknown): void {
+  if (typeof token !== 'string' || !/^[a-f0-9]{64}$/.test(token)) {
+    throw new DashboardMaintenanceError('Preview this maintenance action before executing it.', 400);
+  }
+  const expected = Buffer.from(sign(action, projectId, payload), 'hex');
+  const received = Buffer.from(token, 'hex');
+  if (!timingSafeEqual(expected, received)) {
+    throw new DashboardMaintenanceError('The maintenance preview is invalid or belongs to another project.', 409);
+  }
+}
+
+function assertCurrent(expected: readonly number[], actual: readonly number[]): void {
+  if (JSON.stringify(normalizeIds(expected)) !== JSON.stringify(normalizeIds(actual))) {
+    throw new DashboardMaintenanceError('Memory changed after the preview. Refresh the preview before executing.', 409);
+  }
+}
+
+async function manageableActiveObservations(context: DashboardMaintenanceContext): Promise<Observation[]> {
+  const scope = reader(context.projectId);
+  return filterReadableObservations(
+    await context.store.loadByProject(context.projectId, { status: 'active' }),
+    scope,
+  ).filter((observation) => canManageObservation(observation, scope));
+}
+
+function cleanupPayload(includeNoise: boolean, analysis: ReturnType<typeof analyzeCleanupObservations>): CleanupTokenPayload {
+  return {
+    includeNoise,
+    removeIds: normalizeIds(analysis.toRemove.map((observation) => observation.id)),
+    archiveIds: normalizeIds(analysis.toArchive.map((observation) => observation.id)),
+  };
+}
+
+export async function previewCleanup(context: DashboardMaintenanceContext, includeNoise: boolean) {
+  const analysis = analyzeCleanupObservations(await manageableActiveObservations(context), { includeNoise });
+  const payload = cleanupPayload(includeNoise, analysis);
+  return {
+    action: 'cleanup',
+    projectId: context.projectId,
+    includeNoise,
+    summary: {
+      totalActive: analysis.totalActive,
+      highQuality: analysis.highQuality,
+      lowQuality: analysis.lowQuality.length,
+      duplicates: analysis.duplicates.length,
+      noise: analysis.noise.length,
+      delete: analysis.toRemove.length,
+      archive: analysis.toArchive.length,
+    },
+    lowQuality: analysis.lowQuality.map(summarize),
+    duplicateGroups: analysis.duplicateGroups.map((group) => ({
+      canonical: summarize(group.canonical),
+      duplicates: group.duplicates.map(summarize),
+    })),
+    noise: analysis.noise.map((hit) => ({ ...summarize(hit.observation), reason: hit.reason })),
+    payload,
+    token: sign('cleanup', context.projectId, payload),
+  };
+}
+
+export async function executeCleanup(
+  context: DashboardMaintenanceContext,
+  payload: unknown,
+  token: unknown,
+) {
+  const record = payloadRecord(payload);
+  const normalized: CleanupTokenPayload = {
+    includeNoise: record.includeNoise === true,
+    removeIds: payloadIds(record.removeIds, 'removeIds'),
+    archiveIds: payloadIds(record.archiveIds, 'archiveIds'),
+  };
+  verify('cleanup', context.projectId, normalized, token);
+  const observations = await manageableActiveObservations(context);
+  const analysis = analyzeCleanupObservations(observations, { includeNoise: normalized.includeNoise });
+  const current = cleanupPayload(normalized.includeNoise, analysis);
+  assertCurrent(normalized.removeIds, current.removeIds);
+  assertCurrent(normalized.archiveIds, current.archiveIds);
+  const result = await applyCleanupMutations(context.store, analysis.toArchive, analysis.toRemove);
+  return { action: 'cleanup', projectId: context.projectId, ...result };
+}
+
+export async function previewDeduplicate(context: DashboardMaintenanceContext) {
+  if (!isLLMEnabled()) {
+    return {
+      action: 'deduplicate',
+      projectId: context.projectId,
+      available: false,
+      reason: 'Intelligent deduplication requires a configured memory LLM.',
+    };
+  }
+  const plan = await planMemoryDeduplication(await manageableActiveObservations(context));
+  const payload: DeduplicateTokenPayload = { resolveIds: normalizeIds(plan.resolveIds) };
+  return {
+    action: 'deduplicate',
+    projectId: context.projectId,
+    available: true,
+    summary: {
+      scanned: plan.scanned,
+      entities: plan.entities,
+      comparisons: plan.comparisons,
+      failedComparisons: plan.failedComparisons,
+      resolve: payload.resolveIds.length,
+    },
+    actions: plan.actions,
+    payload,
+    token: sign('deduplicate', context.projectId, payload),
+  };
+}
+
+export async function executeDeduplicate(
+  context: DashboardMaintenanceContext,
+  payload: unknown,
+  token: unknown,
+) {
+  const record = payloadRecord(payload);
+  const normalized: DeduplicateTokenPayload = { resolveIds: payloadIds(record.resolveIds, 'resolveIds') };
+  verify('deduplicate', context.projectId, normalized, token);
+  const result = await applyDeduplicationPlan(
+    context.store,
+    context.projectId,
+    normalized.resolveIds,
+    reader(context.projectId),
+  );
+  if (result.skipped.length > 0) {
+    throw new DashboardMaintenanceError('Memory changed after the preview. Refresh before applying deduplication.', 409);
+  }
+  return { action: 'deduplicate', projectId: context.projectId, ...result };
+}
+
+export async function previewConsolidate(context: DashboardMaintenanceContext) {
+  const clusters = await findConsolidationCandidates(
+    context.projectRoot ?? context.dataDir,
+    context.projectId,
+  );
+  const payload: ConsolidateTokenPayload = { clusterIds: normalizeClusters(clusters.map((cluster) => cluster.ids)) };
+  return {
+    action: 'consolidate',
+    projectId: context.projectId,
+    summary: {
+      clusters: clusters.length,
+      observations: normalizeIds(clusters.flatMap((cluster) => cluster.ids)).length,
+    },
+    clusters,
+    payload,
+    token: sign('consolidate', context.projectId, payload),
+  };
+}
+
+export async function executeConsolidate(
+  context: DashboardMaintenanceContext,
+  payload: unknown,
+  token: unknown,
+) {
+  const record = payloadRecord(payload);
+  if (!Array.isArray(record.clusterIds)) {
+    throw new DashboardMaintenanceError('Invalid clusterIds in maintenance preview.', 400);
+  }
+  const clusterIds = record.clusterIds.map((ids, index) => payloadIds(ids, `clusterIds[${index}]`));
+  const normalized: ConsolidateTokenPayload = { clusterIds: normalizeClusters(clusterIds) };
+  verify('consolidate', context.projectId, normalized, token);
+  const current = await findConsolidationCandidates(context.projectRoot ?? context.dataDir, context.projectId);
+  if (JSON.stringify(normalized.clusterIds) !== JSON.stringify(normalizeClusters(current.map((cluster) => cluster.ids)))) {
+    throw new DashboardMaintenanceError('Memory changed after the preview. Refresh before consolidating.', 409);
+  }
+  const result = await executeConsolidation(context.projectRoot ?? context.dataDir, context.projectId);
+  return { action: 'consolidate', projectId: context.projectId, ...result };
+}
+
+async function retentionCandidates(context: DashboardMaintenanceContext) {
+  return (await manageableActiveObservations(context))
+    .map((observation) => ({
+      observation,
+      retention: projectObservationRetention(observation),
+    }))
+    .filter((row) => row.retention.zone === 'archive-candidate');
+}
+
+export async function previewRetentionArchive(context: DashboardMaintenanceContext) {
+  const candidates = await retentionCandidates(context);
+  const payload: RetentionTokenPayload = {
+    archiveIds: normalizeIds(candidates.map((candidate) => candidate.observation.id)),
+  };
+  return {
+    action: 'retention-archive',
+    projectId: context.projectId,
+    summary: { archive: payload.archiveIds.length },
+    candidates: candidates.map(({ observation, retention }) => ({
+      ...summarize(observation),
+      score: retention.displayScore,
+      zone: retention.zone,
+      ageHours: retention.ageHours,
+    })),
+    payload,
+    token: sign('retention-archive', context.projectId, payload),
+  };
+}
+
+export async function executeRetentionArchive(
+  context: DashboardMaintenanceContext,
+  payload: unknown,
+  token: unknown,
+) {
+  const record = payloadRecord(payload);
+  const normalized: RetentionTokenPayload = { archiveIds: payloadIds(record.archiveIds, 'archiveIds') };
+  verify('retention-archive', context.projectId, normalized, token);
+  const current = await retentionCandidates(context);
+  assertCurrent(normalized.archiveIds, current.map((candidate) => candidate.observation.id));
+  const result = await archiveExpired(
+    context.dataDir,
+    undefined,
+    undefined,
+    context.projectId,
+    reader(context.projectId),
+  );
+  return { action: 'retention-archive', projectId: context.projectId, ...result };
+}

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -26,6 +26,17 @@ import { scopeKnowledgeGraphToProject } from '../memory/graph-scope.js';
 import { projectObservationRetention, summarizeRetentionProjections } from '../memory/retention.js';
 import { canManageObservation, filterReadableObservations } from '../memory/visibility.js';
 import type { Observation } from '../types.js';
+import {
+    DashboardMaintenanceError,
+    executeCleanup,
+    executeConsolidate,
+    executeDeduplicate,
+    executeRetentionArchive,
+    previewCleanup,
+    previewConsolidate,
+    previewDeduplicate,
+    previewRetentionArchive,
+} from './maintenance.js';
 
 // MIME types for static file serving
 const MIME_TYPES: Record<string, string> = {
@@ -73,6 +84,68 @@ function filterDashboardObservations(observations: Observation[], projectId: str
 
 function isActiveStatus(status?: string): boolean {
     return (status ?? 'active') === 'active';
+}
+
+async function handleMaintenanceMutation(
+    apiPath: string,
+    req: IncomingMessage,
+    res: ServerResponse,
+    context: {
+        dataDir: string;
+        projectId: string;
+        projectRoot: string | null;
+    },
+): Promise<void> {
+    if (req.method !== 'POST') {
+        throw new DashboardMaintenanceError('Maintenance actions require POST.', 405);
+    }
+
+    let body: Record<string, unknown> = {};
+    const raw = await readBody(req);
+    if (raw.trim()) {
+        try {
+            const parsed = JSON.parse(raw);
+            if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) throw new Error('object required');
+            body = parsed as Record<string, unknown>;
+        } catch {
+            throw new DashboardMaintenanceError('Invalid maintenance request body.', 400);
+        }
+    }
+
+    const maintenanceContext = {
+        ...context,
+        store: getObservationStore(),
+    };
+    let result: unknown;
+    switch (apiPath) {
+        case '/maintenance/cleanup/preview':
+            result = await previewCleanup(maintenanceContext, body.includeNoise === true);
+            break;
+        case '/maintenance/cleanup/execute':
+            result = await executeCleanup(maintenanceContext, body.payload, body.token);
+            break;
+        case '/maintenance/deduplicate/preview':
+            result = await previewDeduplicate(maintenanceContext);
+            break;
+        case '/maintenance/deduplicate/execute':
+            result = await executeDeduplicate(maintenanceContext, body.payload, body.token);
+            break;
+        case '/maintenance/consolidate/preview':
+            result = await previewConsolidate(maintenanceContext);
+            break;
+        case '/maintenance/consolidate/execute':
+            result = await executeConsolidate(maintenanceContext, body.payload, body.token);
+            break;
+        case '/maintenance/retention/preview':
+            result = await previewRetentionArchive(maintenanceContext);
+            break;
+        case '/maintenance/retention/execute':
+            result = await executeRetentionArchive(maintenanceContext, body.payload, body.token);
+            break;
+        default:
+            throw new DashboardMaintenanceError('Unknown maintenance action.', 404);
+    }
+    sendJson(res, result);
 }
 
 /**
@@ -155,6 +228,22 @@ async function handleApi(
 
     try {
         switch (apiPath) {
+            case '/maintenance/cleanup/preview':
+            case '/maintenance/cleanup/execute':
+            case '/maintenance/deduplicate/preview':
+            case '/maintenance/deduplicate/execute':
+            case '/maintenance/consolidate/preview':
+            case '/maintenance/consolidate/execute':
+            case '/maintenance/retention/preview':
+            case '/maintenance/retention/execute': {
+                await handleMaintenanceMutation(apiPath, req, res, {
+                    dataDir: effectiveDataDir,
+                    projectId: effectiveProjectId,
+                    projectRoot: effectiveProjectRoot,
+                });
+                break;
+            }
+
             case '/projects': {
                 // List all unique project IDs from observations data (flat storage)
                 // Deduplicate using alias registry – aliased IDs are merged under canonical
@@ -773,7 +862,8 @@ async function handleApi(
         }
     } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error';
-        sendError(res, message);
+        const status = err instanceof DashboardMaintenanceError ? err.status : 500;
+        sendError(res, message, status);
     }
 }
 
@@ -989,7 +1079,15 @@ async function buildTeamSnapshot(dataDir: string, projectId: string, scope: stri
 function readBody(req: IncomingMessage): Promise<string> {
     return new Promise((resolve, reject) => {
         const chunks: Buffer[] = [];
-        req.on('data', (c: Buffer) => chunks.push(c));
+        let size = 0;
+        req.on('data', (c: Buffer) => {
+            size += c.length;
+            if (size > 64 * 1024) {
+                reject(new DashboardMaintenanceError('Request body is too large.', 413));
+                return;
+            }
+            chunks.push(c);
+        });
         req.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
         req.on('error', reject);
     });

--- a/src/dashboard/static/app.js
+++ b/src/dashboard/static/app.js
@@ -49,6 +49,38 @@ const i18n = {
     deleteObs: 'Delete',
     deleteConfirm: 'Delete observation #%id%?',
     batchCleanup: 'Cleanup',
+    selectRecords: 'Select',
+    memoryMaintenance: 'Memory Maintenance',
+    previewRequired: 'Preview required',
+    cleanupAction: 'Cleanup',
+    consolidateAction: 'Consolidate',
+    deduplicateAction: 'Deduplicate',
+    archiveAction: 'Archive',
+    previewAction: 'Preview',
+    executeAction: 'Execute',
+    closeAction: 'Close',
+    cleanupNoise: 'Include test and demo noise',
+    maintenancePreview: 'Maintenance preview',
+    maintenanceEmpty: 'No candidates found',
+    maintenanceUnavailable: 'Action unavailable',
+    maintenanceChanged: 'Memory changed. Preview again before executing.',
+    maintenanceSuccess: 'Maintenance completed',
+    maintenanceFailed: 'Maintenance failed',
+    willDelete: 'Delete',
+    willArchive: 'Archive',
+    willResolve: 'Resolve',
+    willMerge: 'Merge',
+    canonicalRecord: 'Keep',
+    affectedRecords: 'Affected records',
+    cleanupLowQuality: 'Low quality',
+    cleanupDuplicates: 'Exact duplicates',
+    cleanupNoiseCount: 'Noise',
+    scannedRecords: 'Scanned',
+    comparisonFailures: 'Comparison failures',
+    confirmCleanup: 'Execute cleanup',
+    confirmConsolidate: 'Merge candidates',
+    confirmDeduplicate: 'Resolve duplicates',
+    confirmArchive: 'Archive candidates',
     selected: 'selected',
     cancel: 'Cancel',
     deleteSelected: 'Delete Selected',
@@ -481,6 +513,38 @@ const i18n = {
     deleteObs: '删除',
     deleteConfirm: '确认删除观察 #%id%？',
     batchCleanup: '清理',
+    selectRecords: '选择',
+    memoryMaintenance: '记忆维护',
+    previewRequired: '执行前需预览',
+    cleanupAction: '清理',
+    consolidateAction: '合并',
+    deduplicateAction: '智能去重',
+    archiveAction: '归档',
+    previewAction: '预览',
+    executeAction: '执行',
+    closeAction: '关闭',
+    cleanupNoise: '包含测试和演示噪声',
+    maintenancePreview: '维护预览',
+    maintenanceEmpty: '没有发现候选项',
+    maintenanceUnavailable: '当前操作不可用',
+    maintenanceChanged: '记忆已发生变化，请重新预览后再执行。',
+    maintenanceSuccess: '维护完成',
+    maintenanceFailed: '维护失败',
+    willDelete: '删除',
+    willArchive: '归档',
+    willResolve: '设为已解决',
+    willMerge: '合并',
+    canonicalRecord: '保留',
+    affectedRecords: '受影响记录',
+    cleanupLowQuality: '低质量记录',
+    cleanupDuplicates: '完全重复',
+    cleanupNoiseCount: '噪声',
+    scannedRecords: '已扫描',
+    comparisonFailures: '比较失败',
+    confirmCleanup: '执行清理',
+    confirmConsolidate: '合并候选项',
+    confirmDeduplicate: '解决重复项',
+    confirmArchive: '归档候选项',
     selected: '已选中',
     cancel: '取消',
     deleteSelected: '删除所选',
@@ -1070,6 +1134,209 @@ async function api(endpoint) {
     return null;
   }
 }
+
+// ============================================================
+// Maintenance actions
+// ============================================================
+
+let activeMaintenancePreview = null;
+
+const maintenanceMeta = {
+  cleanup: { title: 'cleanupAction', confirm: 'confirmCleanup', icon: 'lucide:eraser' },
+  consolidate: { title: 'consolidateAction', confirm: 'confirmConsolidate', icon: 'lucide:combine' },
+  deduplicate: { title: 'deduplicateAction', confirm: 'confirmDeduplicate', icon: 'lucide:copy-minus' },
+  retention: { title: 'archiveAction', confirm: 'confirmArchive', icon: 'lucide:archive' },
+};
+
+async function maintenancePost(action, phase, body = {}) {
+  const suffix = selectedProject ? `?project=${encodeURIComponent(selectedProject)}` : '';
+  const response = await fetch(`/api/maintenance/${action}/${phase}${suffix}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const data = await response.json().catch(() => ({ error: `HTTP ${response.status}` }));
+  if (!response.ok) {
+    const error = new Error(data.error || `HTTP ${response.status}`);
+    error.status = response.status;
+    throw error;
+  }
+  return data;
+}
+
+function showDashboardToast(message, tone = 'success') {
+  const toast = document.getElementById('dashboard-toast');
+  if (!toast) return;
+  toast.textContent = message;
+  toast.dataset.tone = tone;
+  toast.classList.add('visible');
+  clearTimeout(showDashboardToast.timer);
+  showDashboardToast.timer = setTimeout(() => toast.classList.remove('visible'), 3200);
+}
+
+function maintenanceSummaryEntries(action, summary = {}) {
+  const mappings = {
+    cleanup: [
+      ['delete', 'willDelete'], ['archive', 'willArchive'],
+      ['lowQuality', 'cleanupLowQuality'], ['duplicates', 'cleanupDuplicates'], ['noise', 'cleanupNoiseCount'],
+    ],
+    consolidate: [['clusters', 'willMerge'], ['observations', 'affectedRecords']],
+    deduplicate: [['resolve', 'willResolve'], ['scanned', 'scannedRecords'], ['failedComparisons', 'comparisonFailures']],
+    retention: [['archive', 'willArchive']],
+  };
+  return (mappings[action] || [])
+    .filter(([key]) => summary[key] !== undefined)
+    .map(([key, label]) => ({ label: t(label), value: summary[key] }));
+}
+
+function maintenanceRecord(record, prefix = '') {
+  return `
+    <div class="maintenance-record">
+      <span class="maintenance-record-id">#${record.id}</span>
+      <span class="maintenance-record-title">${prefix}${escapeHtml(record.title || t('untitled'))}</span>
+      <span class="maintenance-record-meta">${escapeHtml(record.entityName || '')}</span>
+    </div>`;
+}
+
+function maintenanceDetails(action, preview) {
+  if (action === 'cleanup') {
+    const lowQuality = (preview.lowQuality || []).map((item) => maintenanceRecord(item)).join('');
+    const duplicateGroups = (preview.duplicateGroups || []).map((group) => `
+      <div class="maintenance-group">
+        ${maintenanceRecord(group.canonical, `${t('canonicalRecord')}: `)}
+        ${(group.duplicates || []).map((item) => maintenanceRecord(item, `${t('willDelete')}: `)).join('')}
+      </div>`).join('');
+    const noise = (preview.noise || []).map((item) => maintenanceRecord(item, `${t('willArchive')}: `)).join('');
+    const records = `${lowQuality}${duplicateGroups}${noise}`;
+    return `
+      <label class="maintenance-toggle">
+        <input id="maintenance-noise-toggle" type="checkbox" ${preview.includeNoise ? 'checked' : ''}>
+        <span>${t('cleanupNoise')}</span>
+      </label>
+      ${records || `<div class="maintenance-empty">${t('maintenanceEmpty')}</div>`}`;
+  }
+  if (action === 'consolidate') {
+    return (preview.clusters || []).map((cluster, index) => `
+      <div class="maintenance-group">
+        <div class="maintenance-group-title">${t('willMerge')} ${index + 1} · ${escapeHtml(cluster.entityName)} · ${Math.round(cluster.similarity * 100)}%</div>
+        ${(cluster.ids || []).map((id, itemIndex) => maintenanceRecord({
+          id,
+          title: (cluster.titles || [])[itemIndex] || '',
+          entityName: cluster.type || '',
+        })).join('')}
+      </div>`).join('');
+  }
+  if (action === 'deduplicate') {
+    return (preview.actions || []).map((item) => `
+      <div class="maintenance-group">
+        ${maintenanceRecord({ id: item.keepId, title: item.keepTitle, entityName: item.entityName }, `${t('canonicalRecord')}: `)}
+        ${maintenanceRecord({ id: item.resolveId, title: item.resolveTitle, entityName: item.reason }, `${t('willResolve')}: `)}
+      </div>`).join('');
+  }
+  return (preview.candidates || []).map((item) => maintenanceRecord({
+    ...item,
+    entityName: `${item.score} · ${item.ageHours}h`,
+  })).join('');
+}
+
+function renderMaintenanceDialog(action, preview) {
+  const dialog = document.getElementById('maintenance-dialog');
+  const body = document.getElementById('maintenance-dialog-body');
+  const footer = document.getElementById('maintenance-dialog-footer');
+  const meta = maintenanceMeta[action];
+  document.getElementById('maintenance-dialog-kicker').textContent = t('maintenancePreview');
+  document.getElementById('maintenance-dialog-title').textContent = t(meta.title);
+
+  if (preview.available === false) {
+    body.innerHTML = `<div class="maintenance-empty"><strong>${t('maintenanceUnavailable')}</strong><span>${escapeHtml(preview.reason || '')}</span></div>`;
+    footer.innerHTML = `<button class="maintenance-secondary" type="button" data-maintenance-close>${t('closeAction')}</button>`;
+  } else {
+    const summary = maintenanceSummaryEntries(action, preview.summary);
+    const hasChanges = action === 'cleanup'
+      ? (preview.summary.delete + preview.summary.archive) > 0
+      : action === 'consolidate'
+        ? preview.summary.clusters > 0
+        : action === 'deduplicate'
+          ? preview.summary.resolve > 0
+          : preview.summary.archive > 0;
+    body.innerHTML = `
+      <div class="maintenance-summary">
+        ${summary.map((item) => `<div class="maintenance-metric"><span>${escapeHtml(item.label)}</span><strong>${item.value}</strong></div>`).join('')}
+      </div>
+      <div class="maintenance-records">
+        ${action === 'cleanup' || hasChanges ? maintenanceDetails(action, preview) : `<div class="maintenance-empty">${t('maintenanceEmpty')}</div>`}
+      </div>`;
+    footer.innerHTML = `
+      <button class="maintenance-secondary" type="button" data-maintenance-close>${t('cancel')}</button>
+      <button class="maintenance-primary" id="maintenance-execute" type="button" ${hasChanges ? '' : 'disabled'}>
+        <span class="iconify" data-icon="${meta.icon}"></span>${t(meta.confirm)}
+      </button>`;
+    document.getElementById('maintenance-execute')?.addEventListener('click', executeMaintenancePreview);
+    document.getElementById('maintenance-noise-toggle')?.addEventListener('change', (event) => {
+      openMaintenancePreview('cleanup', { includeNoise: event.target.checked });
+    });
+  }
+  footer.querySelector('[data-maintenance-close]')?.addEventListener('click', closeMaintenanceDialog);
+  if (!dialog.open) dialog.showModal();
+}
+
+async function openMaintenancePreview(action, options = {}) {
+  const dialog = document.getElementById('maintenance-dialog');
+  const meta = maintenanceMeta[action];
+  document.getElementById('maintenance-dialog-kicker').textContent = t('maintenancePreview');
+  document.getElementById('maintenance-dialog-title').textContent = t(meta.title);
+  document.getElementById('maintenance-dialog-body').innerHTML = '<div class="loading"><div class="spinner"></div></div>';
+  document.getElementById('maintenance-dialog-footer').innerHTML = '';
+  if (!dialog.open) dialog.showModal();
+
+  try {
+    const preview = await maintenancePost(action, 'preview', action === 'cleanup' ? { includeNoise: options.includeNoise === true } : {});
+    activeMaintenancePreview = { action, preview };
+    renderMaintenanceDialog(action, preview);
+  } catch (error) {
+    activeMaintenancePreview = null;
+    document.getElementById('maintenance-dialog-body').innerHTML = `
+      <div class="maintenance-empty"><strong>${t('maintenanceFailed')}</strong><span>${escapeHtml(error.message)}</span></div>`;
+    document.getElementById('maintenance-dialog-footer').innerHTML = `
+      <button class="maintenance-secondary" type="button" data-maintenance-close>${t('closeAction')}</button>`;
+    document.querySelector('[data-maintenance-close]')?.addEventListener('click', closeMaintenanceDialog);
+  }
+}
+
+async function executeMaintenancePreview() {
+  if (!activeMaintenancePreview) return;
+  const { action, preview } = activeMaintenancePreview;
+  const button = document.getElementById('maintenance-execute');
+  button.disabled = true;
+  button.classList.add('busy');
+  try {
+    await maintenancePost(action, 'execute', { payload: preview.payload, token: preview.token });
+    closeMaintenanceDialog();
+    showDashboardToast(t('maintenanceSuccess'));
+    if (currentPage === 'retention') await loadRetention();
+    else await loadObservations();
+  } catch (error) {
+    button.disabled = false;
+    button.classList.remove('busy');
+    const message = error.status === 409 ? t('maintenanceChanged') : `${t('maintenanceFailed')}: ${error.message}`;
+    showDashboardToast(message, 'error');
+  }
+}
+
+function closeMaintenanceDialog() {
+  activeMaintenancePreview = null;
+  document.getElementById('maintenance-dialog')?.close();
+}
+
+onDomReady(() => {
+  const dialog = document.getElementById('maintenance-dialog');
+  dialog?.querySelector('.maintenance-dialog-close')?.addEventListener('click', closeMaintenanceDialog);
+  dialog?.addEventListener('click', (event) => {
+    if (event.target === dialog) closeMaintenanceDialog();
+  });
+});
+
+window.openMaintenancePreview = openMaintenancePreview;
 
 // ============================================================
 // Project Switcher — Custom Dropdown
@@ -3214,20 +3481,6 @@ let obsTypeFilter = '';
 let batchMode = false;
 let selectedIds = new Set();
 
-// Low quality detection (same patterns as CLI cleanup)
-const LOW_QUALITY_OBS_PATTERNS = [
-  /^Session activity/i,
-  /^Updated \S+\.\w+$/i,
-  /^Created \S+\.\w+$/i,
-  /^Deleted \S+\.\w+$/i,
-  /^Modified \S+\.\w+$/i,
-  /^Ran command:/i,
-  /^Read file:/i,
-];
-function isLowQualityObs(title) {
-  return LOW_QUALITY_OBS_PATTERNS.some(p => p.test(title.trim()));
-}
-
 function renderBatchToolbar() {
   const slot = document.getElementById('batch-toolbar-slot');
   if (!slot) return;
@@ -3314,8 +3567,8 @@ async function loadObservations() {
         <p class="page-subtitle">${allObservations.length} ${t('observationsStored')}</p>
       </div>
       <div style="display:flex;gap:8px;">
-        <button class="export-btn" id="btn-batch-cleanup" title="${t('batchCleanup')}">
-          [CLEANUP] ${t('batchCleanup')}
+        <button class="export-btn" id="btn-batch-select" title="${t('selectRecords')}">
+          <span class="iconify" data-icon="lucide:list-checks"></span> ${t('selectRecords')}
         </button>
         <button class="export-btn" id="btn-export" title="${t('exportData')}">
           <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M8 2v8M4 7l4 4 4-4M2 12v2h12v-2"/></svg>
@@ -3323,6 +3576,18 @@ async function loadObservations() {
         </button>
       </div>
     </div>
+
+    <section class="maintenance-strip" aria-labelledby="memory-maintenance-title">
+      <div class="maintenance-strip-heading">
+        <span id="memory-maintenance-title">${t('memoryMaintenance')}</span>
+        <small>${t('previewRequired')}</small>
+      </div>
+      <div class="maintenance-actions">
+        <button type="button" onclick="openMaintenancePreview('cleanup')"><span class="iconify" data-icon="lucide:eraser"></span>${t('cleanupAction')}</button>
+        <button type="button" onclick="openMaintenancePreview('consolidate')"><span class="iconify" data-icon="lucide:combine"></span>${t('consolidateAction')}</button>
+        <button type="button" onclick="openMaintenancePreview('deduplicate')"><span class="iconify" data-icon="lucide:copy-minus"></span>${t('deduplicateAction')}</button>
+      </div>
+    </section>
 
     <div id="batch-toolbar-slot"></div>
 
@@ -3341,18 +3606,10 @@ async function loadObservations() {
     window.open(`/api/export${sep}`, '_blank');
   });
 
-  // Batch cleanup: enter batch mode, auto-select low-quality observations
-  document.getElementById('btn-batch-cleanup').addEventListener('click', () => {
+  // Manual selection remains separate from the shared cleanup pipeline.
+  document.getElementById('btn-batch-select').addEventListener('click', () => {
     batchMode = !batchMode;
-    if (batchMode) {
-      // Auto-select low quality ones
-      selectedIds.clear();
-      allObservations.forEach(obs => {
-        if (isLowQualityObs(obs.title || '')) selectedIds.add(obs.id);
-      });
-    } else {
-      selectedIds.clear();
-    }
+    selectedIds.clear();
     renderObsList();
     renderBatchToolbar();
   });
@@ -3405,18 +3662,16 @@ function renderObsList() {
   }
 
   list.innerHTML = filtered.map(obs => {
-    const isLow = isLowQualityObs(obs.title || '');
     const isSelected = selectedIds.has(obs.id);
     const hl = (text) => obsFilter ? escapeHtml(text).replace(new RegExp(`(${escapeHtml(obsFilter).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')})`, 'gi'), '<mark>$1</mark>') : escapeHtml(text);
     return `
-    <div class="obs-card${isLow ? ' low-quality' : ''}" data-obs-id="${obs.id}" onclick="toggleObsDetail(${obs.id})" style="cursor:pointer;">
+    <div class="obs-card" data-obs-id="${obs.id}" onclick="toggleObsDetail(${obs.id})" style="cursor:pointer;">
       <div class="obs-card-header">
         ${batchMode ? `<input type="checkbox" class="obs-checkbox" ${isSelected ? 'checked' : ''} onclick="event.stopPropagation(); toggleObsSelect(${obs.id});" />` : ''}
         <span class="obs-card-id">#${obs.id}</span>
         <span class="type-badge" data-type="${obs.type || 'unknown'}">
           ${typeIcons[obs.type] || '[UNKNOWN]'} ${obs.type || t('unknown')}
         </span>
-        ${isLow ? '<span class="low-quality-badge">' + t('lowQuality') + '</span>' : ''}
         <span class="obs-card-title">${hl(obs.title || t('untitled'))}</span>
         <span class="obs-expand-icon">▼</span>
       </div>
@@ -3461,9 +3716,14 @@ async function loadRetention() {
   const { summary, items } = data;
 
   container.innerHTML = `
-    <div class="page-header">
-      <h1 class="page-title">${t('memoryRetention')}</h1>
-      <p class="page-subtitle">${t('retentionSubtitle')}</p>
+    <div class="page-header page-header-actions">
+      <div>
+        <h1 class="page-title">${t('memoryRetention')}</h1>
+        <p class="page-subtitle">${t('retentionSubtitle')}</p>
+      </div>
+      <button class="export-btn" type="button" onclick="openMaintenancePreview('retention')" ${summary.archive > 0 ? '' : 'disabled'}>
+        <span class="iconify" data-icon="lucide:archive"></span>${t('archiveAction')}
+      </button>
     </div>
 
     <div class="retention-summary">

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -182,6 +182,23 @@
     <div id="page-team" class="page"></div>
   </main>
 
+  <dialog id="maintenance-dialog" class="maintenance-dialog" aria-labelledby="maintenance-dialog-title">
+    <div class="maintenance-dialog-shell">
+      <header class="maintenance-dialog-header">
+        <div>
+          <div class="maintenance-dialog-kicker" id="maintenance-dialog-kicker"></div>
+          <h2 id="maintenance-dialog-title"></h2>
+        </div>
+        <button class="icon-btn maintenance-dialog-close" type="button" aria-label="Close" title="Close">
+          <span class="iconify" data-icon="lucide:x"></span>
+        </button>
+      </header>
+      <div id="maintenance-dialog-body" class="maintenance-dialog-body"></div>
+      <footer id="maintenance-dialog-footer" class="maintenance-dialog-footer"></footer>
+    </div>
+  </dialog>
+  <div id="dashboard-toast" class="dashboard-toast" role="status" aria-live="polite"></div>
+
   <!-- Apache ECharts 5 — Knowledge Graph renderer -->
   <script src="https://cdn.jsdelivr.net/npm/echarts@5.5.1/dist/echarts.min.js"></script>
   <!-- Cytoscape.js + Dagre — legacy entity-graph fallback -->

--- a/src/dashboard/static/style.css
+++ b/src/dashboard/static/style.css
@@ -2148,6 +2148,316 @@ body {
   color: var(--text-primary);
 }
 
+/* Maintenance workbench */
+.maintenance-strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 0;
+  margin-bottom: 14px;
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.maintenance-strip-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.maintenance-strip-heading small {
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--text-muted);
+}
+
+.maintenance-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.maintenance-actions button,
+.maintenance-primary,
+.maintenance-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  min-height: 36px;
+  padding: 8px 12px;
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font: 500 12px var(--font-sans);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast), color var(--transition-fast);
+}
+
+.maintenance-actions button:hover,
+.maintenance-secondary:hover {
+  background: var(--bg-card-hover);
+  border-color: var(--text-muted);
+  color: var(--text-primary);
+}
+
+.maintenance-dialog {
+  width: min(680px, calc(100vw - 32px));
+  max-height: min(760px, calc(100dvh - 32px));
+  padding: 0;
+  border: 1px solid var(--border-medium);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  box-shadow: var(--elevation-3);
+  overflow: hidden;
+}
+
+.maintenance-dialog::backdrop {
+  background: rgba(5, 5, 12, 0.72);
+  backdrop-filter: blur(3px);
+}
+
+.maintenance-dialog-shell {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr) auto;
+  max-height: min(760px, calc(100dvh - 32px));
+}
+
+.maintenance-dialog-header,
+.maintenance-dialog-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 16px 18px;
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.maintenance-dialog-footer {
+  justify-content: flex-end;
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 0;
+}
+
+.maintenance-dialog-kicker {
+  margin-bottom: 3px;
+  font: 500 10px var(--font-mono);
+  color: var(--text-muted);
+  text-transform: uppercase;
+}
+
+.maintenance-dialog-header h2 {
+  font-size: 17px;
+  line-height: 1.3;
+}
+
+.maintenance-dialog-close {
+  width: 34px;
+  height: 34px;
+  flex: 0 0 34px;
+}
+
+.maintenance-dialog-body {
+  min-height: 180px;
+  overflow: auto;
+  padding: 18px;
+}
+
+.maintenance-summary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+  border-top: 1px solid var(--border-subtle);
+  border-bottom: 1px solid var(--border-subtle);
+  margin-bottom: 16px;
+}
+
+.maintenance-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 0;
+  padding: 12px;
+  border-right: 1px solid var(--border-subtle);
+}
+
+.maintenance-metric:last-child {
+  border-right: 0;
+}
+
+.maintenance-metric span {
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+.maintenance-metric strong {
+  font: 600 19px var(--font-mono);
+  color: var(--text-primary);
+}
+
+.maintenance-records,
+.maintenance-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.maintenance-group {
+  margin-bottom: 12px;
+  border-top: 1px solid var(--border-subtle);
+}
+
+.maintenance-group-title {
+  padding: 10px 8px 6px;
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.maintenance-record {
+  display: grid;
+  grid-template-columns: 52px minmax(0, 1fr) minmax(80px, auto);
+  align-items: center;
+  gap: 10px;
+  min-height: 42px;
+  padding: 8px;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 12px;
+}
+
+.maintenance-record-id,
+.maintenance-record-meta {
+  font-family: var(--font-mono);
+  color: var(--text-muted);
+}
+
+.maintenance-record-title,
+.maintenance-record-meta {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.maintenance-record-meta {
+  text-align: right;
+  font-size: 10px;
+}
+
+.maintenance-toggle {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 14px;
+  font-size: 12px;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
+.maintenance-toggle input {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent-purple);
+}
+
+.maintenance-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  min-height: 130px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.maintenance-primary {
+  border-color: var(--accent-purple);
+  background: var(--accent-purple);
+  color: var(--bg-base);
+}
+
+.maintenance-primary:hover:not(:disabled) {
+  filter: brightness(1.08);
+}
+
+.maintenance-primary:disabled,
+.export-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.dashboard-toast {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 1200;
+  max-width: min(420px, calc(100vw - 40px));
+  padding: 11px 14px;
+  border: 1px solid var(--accent-green);
+  border-radius: var(--radius-sm);
+  background: var(--bg-card);
+  color: var(--text-primary);
+  box-shadow: var(--elevation-2);
+  font-size: 12px;
+  opacity: 0;
+  transform: translateY(10px);
+  pointer-events: none;
+  transition: opacity var(--transition-fast), transform var(--transition-fast);
+}
+
+.dashboard-toast[data-tone="error"] {
+  border-color: var(--accent-red);
+}
+
+.dashboard-toast.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.page-header-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+@media (max-width: 720px) {
+  .maintenance-strip,
+  .page-header-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .maintenance-actions {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .maintenance-actions button {
+    min-width: 0;
+    padding-inline: 8px;
+  }
+
+  .maintenance-record {
+    grid-template-columns: 44px minmax(0, 1fr);
+  }
+
+  .maintenance-record-meta {
+    grid-column: 2;
+    text-align: left;
+  }
+
+  .maintenance-dialog-body {
+    padding: 14px;
+  }
+}
+
 /* Low quality indicator */
 .obs-card.low-quality {
   border-left: 3px solid var(--accent-amber);

--- a/src/memory/cleanup.ts
+++ b/src/memory/cleanup.ts
@@ -1,0 +1,143 @@
+import type { Observation } from '../types.js';
+import type { ObservationStore } from '../store/obs-store.js';
+
+const LOW_QUALITY_PATTERNS = [
+  /^Session activity/i,
+  /^Updated \S+\.\w+$/i,
+  /^Created \S+\.\w+$/i,
+  /^Deleted \S+\.\w+$/i,
+  /^Modified \S+\.\w+$/i,
+  /^Ran command:/i,
+  /^Read file:/i,
+];
+
+const EXPLICIT_NOISE_TITLE_PATTERNS = [
+  /^\s*\[(?:test|demo|benchmark|sandbox|playground|测试|演示)\]/i,
+  /^\s*(?:Used\s+(?:mcp__\S+|apply_patch)|Ran:)\s*/i,
+];
+
+const EXPLICIT_NOISE_MARKERS = new Set([
+  'test-fixture',
+  'demo-fixture',
+  'benchmark-fixture',
+  'sandbox-fixture',
+  'cleanup-noise',
+]);
+
+export interface CleanupNoiseHit {
+  observation: Observation;
+  reason: 'system-self' | 'demo/test/noise';
+}
+
+export interface CleanupDuplicateGroup {
+  canonical: Observation;
+  duplicates: Observation[];
+}
+
+export interface CleanupAnalysis {
+  totalActive: number;
+  highQuality: number;
+  lowQuality: Observation[];
+  duplicateGroups: CleanupDuplicateGroup[];
+  duplicates: Observation[];
+  noise: CleanupNoiseHit[];
+  toRemove: Observation[];
+  toArchive: Observation[];
+}
+
+export function isLowQualityObservation(title: string): boolean {
+  return LOW_QUALITY_PATTERNS.some((pattern) => pattern.test(title.trim()));
+}
+
+export function classifyNoiseObservation(
+  observation: Pick<Observation, 'title' | 'narrative' | 'entityName' | 'facts' | 'concepts'>,
+): { isNoise: boolean; reason?: CleanupNoiseHit['reason'] } {
+  const title = observation.title?.trim() ?? '';
+  const entityName = observation.entityName?.trim().toLowerCase() ?? '';
+  const concepts = (observation.concepts ?? []).map((concept) => concept.trim().toLowerCase());
+
+  if (
+    entityName === 'memorix.demo'
+    || entityName.startsWith('for_memmcp_test')
+    || concepts.some((concept) => EXPLICIT_NOISE_MARKERS.has(concept))
+  ) {
+    return { isNoise: true, reason: 'system-self' };
+  }
+  if (EXPLICIT_NOISE_TITLE_PATTERNS.some((pattern) => pattern.test(title))) {
+    return { isNoise: true, reason: 'demo/test/noise' };
+  }
+  return { isNoise: false };
+}
+
+export function analyzeCleanupObservations(
+  observations: readonly Observation[],
+  options: { includeNoise?: boolean } = {},
+): CleanupAnalysis {
+  const active = observations.filter((observation) => (observation.status ?? 'active') === 'active');
+  const lowQuality = active.filter((observation) => isLowQualityObservation(observation.title ?? ''));
+  const lowQualityIds = new Set(lowQuality.map((observation) => observation.id));
+  const highQuality = active.filter((observation) => !lowQualityIds.has(observation.id));
+
+  const groups = new Map<string, CleanupDuplicateGroup>();
+  for (const observation of highQuality) {
+    const key = `${observation.type}|${observation.title}|${observation.entityName}`;
+    const existing = groups.get(key);
+    if (existing) existing.duplicates.push(observation);
+    else groups.set(key, { canonical: observation, duplicates: [] });
+  }
+  const duplicateGroups = [...groups.values()].filter((group) => group.duplicates.length > 0);
+  const duplicates = duplicateGroups.flatMap((group) => group.duplicates);
+  const excludedIds = new Set([...lowQuality, ...duplicates].map((observation) => observation.id));
+
+  const noise: CleanupNoiseHit[] = [];
+  if (options.includeNoise) {
+    for (const observation of active) {
+      if (excludedIds.has(observation.id)) continue;
+      const classification = classifyNoiseObservation(observation);
+      if (classification.isNoise && classification.reason) {
+        noise.push({ observation, reason: classification.reason });
+      }
+    }
+  }
+
+  const toRemove = [...lowQuality, ...duplicates];
+  const toArchive = noise.map((hit) => hit.observation);
+  return {
+    totalActive: active.length,
+    highQuality: highQuality.length - duplicates.length - toArchive.length,
+    lowQuality,
+    duplicateGroups,
+    duplicates,
+    noise,
+    toRemove,
+    toArchive,
+  };
+}
+
+function requireObservationIds(observations: readonly Observation[], action: string): number[] {
+  const ids = observations.map((observation) => observation.id);
+  if (ids.some((id) => typeof id !== 'number')) {
+    throw new Error(`Cannot ${action}: an observation has no persisted ID.`);
+  }
+  return ids as number[];
+}
+
+export async function applyCleanupMutations(
+  store: ObservationStore,
+  toArchive: readonly Observation[],
+  toRemove: readonly Observation[],
+): Promise<{ archived: number; removed: number }> {
+  const archiveIds = requireObservationIds(toArchive, 'archive');
+  const removeIds = requireObservationIds(toRemove, 'delete');
+  const removals = new Set(removeIds);
+  if (archiveIds.some((id) => removals.has(id))) {
+    throw new Error('Cleanup cannot archive and delete the same observation.');
+  }
+
+  await store.atomic(async (tx) => {
+    await Promise.all(archiveIds.map((id) => tx.setStatus(id, 'archived', 'active')));
+    await Promise.all(removeIds.map((id) => tx.remove(id)));
+  });
+
+  return { archived: archiveIds.length, removed: removeIds.length };
+}

--- a/src/memory/deduplication.ts
+++ b/src/memory/deduplication.ts
@@ -1,0 +1,178 @@
+import type { CompactDecision } from '../llm/memory-manager.js';
+import { deduplicateMemory } from '../llm/memory-manager.js';
+import type { ObservationStore } from '../store/obs-store.js';
+import type { Observation, ObservationReader } from '../types.js';
+import { canManageObservation } from './visibility.js';
+
+export interface DeduplicationAction {
+  resolveId: number;
+  keepId: number;
+  entityName: string;
+  resolveTitle: string;
+  keepTitle: string;
+  reason: string;
+  decision: 'UPDATE' | 'DELETE' | 'NONE';
+  usedLLM: boolean;
+}
+
+export interface DeduplicationPlan {
+  scanned: number;
+  entities: number;
+  comparisons: number;
+  failedComparisons: number;
+  actions: DeduplicationAction[];
+  resolveIds: number[];
+}
+
+type DeduplicationDecision = (
+  newer: { title: string; narrative: string; facts: string[] },
+  existing: Array<{ id: number; title: string; narrative: string; facts: string }>,
+) => Promise<CompactDecision | null>;
+
+function chronological(left: Observation, right: Observation): number {
+  const byTime = new Date(left.createdAt).getTime() - new Date(right.createdAt).getTime();
+  return byTime || left.id - right.id;
+}
+
+function actionFromDecision(
+  older: Observation,
+  newer: Observation,
+  decision: CompactDecision,
+): DeduplicationAction | null {
+  let resolveId: number;
+  let keepId: number;
+
+  if (decision.action === 'NONE') {
+    resolveId = newer.id;
+    keepId = older.id;
+  } else if (decision.action === 'UPDATE') {
+    resolveId = decision.targetId ?? older.id;
+    keepId = resolveId === newer.id ? older.id : newer.id;
+  } else if (decision.action === 'DELETE') {
+    resolveId = decision.targetId ?? older.id;
+    keepId = resolveId === newer.id ? older.id : newer.id;
+  } else {
+    return null;
+  }
+
+  const records = new Map([[older.id, older], [newer.id, newer]]);
+  const resolved = records.get(resolveId);
+  const kept = records.get(keepId);
+  if (!resolved || !kept || resolved.id === kept.id) return null;
+
+  return {
+    resolveId,
+    keepId,
+    entityName: newer.entityName,
+    resolveTitle: resolved.title,
+    keepTitle: kept.title,
+    reason: decision.reason,
+    decision: decision.action,
+    usedLLM: decision.usedLLM,
+  };
+}
+
+/**
+ * Build one deterministic, reviewable deduplication plan. Callers own project,
+ * visibility, and optional search filtering before passing observations in.
+ */
+export async function planMemoryDeduplication(
+  observations: readonly Observation[],
+  options: { limit?: number; decide?: DeduplicationDecision } = {},
+): Promise<DeduplicationPlan> {
+  const limit = Math.min(100, Math.max(2, Math.floor(options.limit ?? 20)));
+  const candidates = observations
+    .filter((observation) => (observation.status ?? 'active') === 'active')
+    .sort(chronological)
+    .slice(-limit);
+  const byEntity = new Map<string, Observation[]>();
+  for (const observation of candidates) {
+    const group = byEntity.get(observation.entityName) ?? [];
+    group.push(observation);
+    byEntity.set(observation.entityName, group);
+  }
+
+  const decide = options.decide ?? deduplicateMemory;
+  const actions = new Map<number, DeduplicationAction>();
+  let comparisons = 0;
+  let failedComparisons = 0;
+
+  for (const group of byEntity.values()) {
+    if (group.length < 2) continue;
+    group.sort(chronological);
+    for (let index = 0; index < group.length; index += 1) {
+      for (let compareIndex = index + 1; compareIndex < group.length; compareIndex += 1) {
+        const older = group[index];
+        const newer = group[compareIndex];
+        comparisons += 1;
+        let decision: CompactDecision | null;
+        try {
+          decision = await decide(
+            { title: newer.title, narrative: newer.narrative, facts: newer.facts },
+            [{ id: older.id, title: older.title, narrative: older.narrative, facts: older.facts.join('\n') }],
+          );
+        } catch {
+          failedComparisons += 1;
+          continue;
+        }
+        if (!decision) continue;
+        const action = actionFromDecision(older, newer, decision);
+        if (action && !actions.has(action.resolveId)) actions.set(action.resolveId, action);
+      }
+    }
+  }
+
+  const planned = [...actions.values()];
+  for (const [entityName, group] of byEntity) {
+    const resolvedIds = new Set(
+      planned.filter((action) => action.entityName === entityName).map((action) => action.resolveId),
+    );
+    if (group.length > 0 && group.every((observation) => resolvedIds.has(observation.id))) {
+      const survivor = group[group.length - 1];
+      const unsafeIndex = planned.findIndex((action) => action.resolveId === survivor.id);
+      if (unsafeIndex >= 0) planned.splice(unsafeIndex, 1);
+    }
+  }
+  return {
+    scanned: candidates.length,
+    entities: byEntity.size,
+    comparisons,
+    failedComparisons,
+    actions: planned,
+    resolveIds: planned.map((action) => action.resolveId),
+  };
+}
+
+export async function applyDeduplicationPlan(
+  store: ObservationStore,
+  projectId: string,
+  resolveIds: readonly number[],
+  reader: ObservationReader = { projectId },
+): Promise<{ resolved: number[]; skipped: number[] }> {
+  const uniqueIds = [...new Set(resolveIds)];
+  const manageable: number[] = [];
+  const skipped: number[] = [];
+
+  for (const id of uniqueIds) {
+    const observation = await store.getById(id);
+    if (
+      observation
+      && observation.projectId === projectId
+      && (observation.status ?? 'active') === 'active'
+      && canManageObservation(observation, reader)
+    ) {
+      manageable.push(id);
+    } else {
+      skipped.push(id);
+    }
+  }
+
+  const resolved = skipped.length > 0 || manageable.length === 0
+    ? []
+    : await store.atomic(async (tx) => {
+      const updates = await Promise.all(manageable.map((id) => tx.setStatus(id, 'resolved', 'active')));
+      return manageable.filter((_, index) => updates[index]);
+    });
+
+  return { resolved, skipped };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,7 +46,8 @@ import {
   type ToolProfile,
 } from './server/tool-profile.js';
 import { initLLM, isLLMEnabled, getLLMConfig } from './llm/provider.js';
-import { compactOnWrite, deduplicateMemory } from './llm/memory-manager.js';
+import { compactOnWrite } from './llm/memory-manager.js';
+import { applyDeduplicationPlan, planMemoryDeduplication } from './memory/deduplication.js';
 import type { ExistingMemory } from './llm/memory-manager.js';
 import { runFormation, getMetricsSummary, getBeforeAfterMetrics } from './memory/formation/index.js';
 import type { FormationConfig, SearchHit, FormedMemory, FormationStage, FormationStageEvent } from './memory/formation/types.js';
@@ -2503,66 +2504,31 @@ export async function createMemorixServer(
         return { content: [{ type: 'text' as const, text: 'Not enough memories in scope to deduplicate.' }] };
       }
 
-      // Group by entity for focused dedup
-      const byEntity = new Map<string, typeof candidates>();
-      for (const obs of candidates) {
-        const list = byEntity.get(obs.entityName) ?? [];
-        list.push(obs);
-        byEntity.set(obs.entityName, list);
-      }
+      const manageableCandidates = candidates.filter((observation) => canManageObservation(observation, reader));
+      const plan = await planMemoryDeduplication(manageableCandidates);
+      const actionLines = plan.actions.map((item) =>
+        `Resolve #${item.resolveId} "${item.resolveTitle}"; keep #${item.keepId} "${item.keepTitle}" (${item.reason})${item.usedLLM ? ' [LLM]' : ' [heuristic]'}`,
+      );
 
-      const actions: string[] = [];
-      const toResolve: number[] = [];
-
-      for (const [entity, group] of byEntity) {
-        if (group.length < 2) continue;
-
-        // Compare each pair within entity group
-        for (let i = 0; i < group.length; i++) {
-          for (let j = i + 1; j < group.length; j++) {
-            const newer = group[j];
-            const older = group[i];
-            try {
-              const decision = await deduplicateMemory(
-                { title: newer.title, narrative: newer.narrative, facts: newer.facts },
-                [{ id: older.id, title: older.title, narrative: older.narrative, facts: older.facts.join('\n') }],
-              );
-              if (decision && decision.action === 'UPDATE' && decision.targetId) {
-                actions.push(`[UPDATED] #${older.id} "${older.title}" → superseded by #${newer.id} (${decision.reason})${decision.usedLLM ? ' [LLM]' : ' [heuristic]'}`);
-                toResolve.push(older.id);
-              } else if (decision && decision.action === 'NONE') {
-                actions.push(`[DELETE] #${newer.id} "${newer.title}" → redundant (${decision.reason})${decision.usedLLM ? ' [LLM]' : ' [heuristic]'}`);
-                toResolve.push(newer.id);
-              } else if (decision && decision.action === 'DELETE') {
-                actions.push(`[ERROR] #${decision.targetId ?? older.id} → outdated (${decision.reason})${decision.usedLLM ? ' [LLM]' : ' [heuristic]'}`);
-                toResolve.push(decision.targetId ?? older.id);
-              }
-            } catch (dedupErr) { actions.push(`[WARN] comparison failed: ${(dedupErr as Error)?.message ?? dedupErr}`); }
-          }
-        }
-      }
-
-      if (actions.length === 0) {
-        return { content: [{ type: 'text' as const, text: `[OK] Scanned ${candidates.length} memories across ${byEntity.size} entities — no duplicates found.` }] };
+      if (actionLines.length === 0) {
+        return { content: [{ type: 'text' as const, text: `[OK] Scanned ${plan.scanned} memories across ${plan.entities} entities — no duplicates found.` }] };
       }
 
       if (dryRun) {
         return {
           content: [{
             type: 'text' as const,
-            text: `[SEARCH] DRY RUN — ${actions.length} action(s) found:\n\n${actions.join('\n')}\n\nRun with dryRun=false to apply.`,
+            text: `[SEARCH] DRY RUN — ${actionLines.length} action(s) found:\n\n${actionLines.join('\n')}\n\nRun with dryRun=false to apply.`,
           }],
         };
       }
 
-      // Apply resolutions
-      const unique = [...new Set(toResolve)];
-      await resolveObservations(unique, 'resolved');
+      const result = await applyDeduplicationPlan(getObservationStore(), project.id, plan.resolveIds, reader);
 
       return {
         content: [{
           type: 'text' as const,
-          text: `[CLEANUP] Deduplicated: resolved ${unique.length} memory(ies)\n\n${actions.join('\n')}`,
+          text: `[CLEANUP] Deduplicated: resolved ${result.resolved.length} memory(ies)\n\n${actionLines.join('\n')}`,
         }],
       };
     },

--- a/tests/dashboard/maintenance-actions.test.ts
+++ b/tests/dashboard/maintenance-actions.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  DashboardMaintenanceError,
+  executeCleanup,
+  executeConsolidate,
+  executeRetentionArchive,
+  previewCleanup,
+  previewConsolidate,
+  previewDeduplicate,
+  previewRetentionArchive,
+} from '../../src/dashboard/maintenance.js';
+import { setLLMConfig } from '../../src/llm/provider.js';
+import { getObservationStore, initObservationStore, resetObservationStore } from '../../src/store/obs-store.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+import type { Observation } from '../../src/types.js';
+
+const PROJECT_ID = 'test/dashboard-maintenance';
+
+function observation(id: number, title: string, overrides: Partial<Observation> = {}): Observation {
+  return {
+    id,
+    entityName: 'auth',
+    type: 'discovery',
+    title,
+    narrative: 'Use project-scoped evidence for this durable memory.',
+    facts: ['project-scoped evidence'],
+    filesModified: [],
+    concepts: ['maintenance'],
+    tokens: 12,
+    createdAt: new Date(2026, 0, id).toISOString(),
+    projectId: PROJECT_ID,
+    status: 'active',
+    ...overrides,
+  };
+}
+
+describe('dashboard maintenance actions', () => {
+  let dataDir: string;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-dashboard-maintenance-'));
+    await initObservationStore(dataDir);
+    setLLMConfig(null);
+  });
+
+  afterEach(async () => {
+    resetObservationStore();
+    closeAllDatabases();
+    setLLMConfig(null);
+    await fs.rm(dataDir, { recursive: true, force: true });
+  });
+
+  function context() {
+    return {
+      dataDir,
+      projectId: PROJECT_ID,
+      projectRoot: null,
+      store: getObservationStore(),
+    };
+  }
+
+  it('rejects a cleanup execution when candidates changed after preview', async () => {
+    const store = getObservationStore();
+    await store.insert(observation(1, 'Updated auth.ts'));
+    const preview = await previewCleanup(context(), false);
+    await store.insert(observation(2, 'Created session.ts'));
+
+    await expect(executeCleanup(context(), preview.payload, preview.token))
+      .rejects.toMatchObject<Partial<DashboardMaintenanceError>>({ status: 409 });
+    expect(await store.getById(1)).toMatchObject({ status: 'active' });
+  });
+
+  it('previews and executes the existing consolidation engine', async () => {
+    const store = getObservationStore();
+    await store.insert(observation(1, 'Windows path separator bug', {
+      narrative: 'Use path join because string path concatenation breaks on Windows.',
+    }));
+    await store.insert(observation(2, 'Windows path separator issue', {
+      narrative: 'String path concatenation breaks on Windows so use path join.',
+    }));
+
+    const preview = await previewConsolidate(context());
+    expect(preview.summary.clusters).toBe(1);
+    expect(preview.summary.observations).toBe(2);
+
+    const result = await executeConsolidate(context(), preview.payload, preview.token);
+    expect(result.clustersFound).toBe(1);
+    expect(result.observationsMerged).toBe(1);
+  });
+
+  it('previews and archives only current retention candidates', async () => {
+    const store = getObservationStore();
+    await store.insert(observation(1, 'Old contextual note', {
+      createdAt: '2024-01-01T00:00:00.000Z',
+      source: 'agent',
+      valueCategory: 'contextual',
+    }));
+
+    const preview = await previewRetentionArchive(context());
+    expect(preview.summary.archive).toBe(1);
+    expect(preview.candidates).toMatchObject([{ id: 1, zone: 'archive-candidate' }]);
+
+    const result = await executeRetentionArchive(context(), preview.payload, preview.token);
+    expect(result.archived).toBe(1);
+    expect(await store.getById(1)).toMatchObject({ status: 'archived' });
+  });
+
+  it('reports intelligent deduplication as unavailable without a memory LLM', async () => {
+    const preview = await previewDeduplicate(context());
+    expect(preview).toMatchObject({ available: false, action: 'deduplicate' });
+  });
+});

--- a/tests/integration/dashboard-project-scope.test.ts
+++ b/tests/integration/dashboard-project-scope.test.ts
@@ -13,7 +13,7 @@ import { createServer, type Server } from 'node:http';
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { resetObservationStore } from '../../src/store/obs-store.js';
+import { getObservationStore, resetObservationStore } from '../../src/store/obs-store.js';
 import { initTeamStore, resetTeamStore } from '../../src/team/team-store.js';
 import { resetProvider } from '../../src/embedding/provider.js';
 import { resetConfigCache } from '../../src/config.js';
@@ -231,6 +231,73 @@ describe('Standalone Dashboard Project Scope', () => {
       workspaces: expect.any(Array),
       workflows: expect.any(Object),
     });
+  });
+
+  it('previews and executes real cleanup only for the selected project', async () => {
+    const store = getObservationStore();
+    await store.insert({
+      id: 8,
+      entityName: 'auth-module',
+      type: 'discovery',
+      title: 'Updated auth.ts',
+      narrative: 'Automatic activity noise',
+      facts: [],
+      filesModified: [],
+      concepts: [],
+      tokens: 5,
+      createdAt: new Date().toISOString(),
+      projectId: PROJECT_A,
+      status: 'active',
+    });
+    await store.insert({
+      id: 9,
+      entityName: 'billing-service',
+      type: 'discovery',
+      title: 'Updated billing.ts',
+      narrative: 'Other project activity noise',
+      facts: [],
+      filesModified: [],
+      concepts: [],
+      tokens: 5,
+      createdAt: new Date().toISOString(),
+      projectId: PROJECT_B,
+      status: 'active',
+    });
+
+    const preview = await fetchJson('/api/maintenance/cleanup/preview', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ includeNoise: false }),
+    });
+    expect(preview.status).toBe(200);
+    expect(preview.body.projectId).toBe(PROJECT_A);
+    expect(preview.body.summary).toMatchObject({ lowQuality: 1, delete: 1, archive: 0 });
+    expect(preview.body.lowQuality.map((item: any) => item.id)).toEqual([8]);
+
+    const invalid = await fetchJson('/api/maintenance/cleanup/execute', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ payload: preview.body.payload, token: '0'.repeat(64) }),
+    });
+    expect(invalid.status).toBe(409);
+    expect(await store.getById(8)).toMatchObject({ status: 'active' });
+
+    const execute = await fetchJson('/api/maintenance/cleanup/execute', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ payload: preview.body.payload, token: preview.body.token }),
+    });
+    expect(execute.status).toBe(200);
+    expect(execute.body).toMatchObject({ projectId: PROJECT_A, removed: 1, archived: 0 });
+    expect(await store.getById(8)).toBeUndefined();
+    expect(await store.getById(9)).toMatchObject({ projectId: PROJECT_B, status: 'active' });
+    await store.remove(9);
+  });
+
+  it('requires a POST preview for every maintenance action', async () => {
+    const { status, body } = await fetchJson('/api/maintenance/consolidate/preview');
+    expect(status).toBe(405);
+    expect(body.error).toContain('require POST');
   });
 
   it('GET /api/knowledge returns a project-scoped read-only memory overview', async () => {

--- a/tests/memory/cleanup-analysis.test.ts
+++ b/tests/memory/cleanup-analysis.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { analyzeCleanupObservations } from '../../src/memory/cleanup.js';
+import type { Observation } from '../../src/types.js';
+
+function observation(id: number, title: string, overrides: Partial<Observation> = {}): Observation {
+  return {
+    id,
+    entityName: 'auth',
+    type: 'discovery',
+    title,
+    narrative: 'Durable project information.',
+    facts: [],
+    filesModified: [],
+    concepts: [],
+    tokens: 10,
+    createdAt: new Date(2026, 0, id).toISOString(),
+    projectId: 'test/project',
+    status: 'active',
+    ...overrides,
+  };
+}
+
+describe('cleanup analysis', () => {
+  it('keeps one canonical exact duplicate and separates low-quality records', () => {
+    const canonical = observation(1, 'Stable auth decision');
+    const duplicate = observation(2, 'Stable auth decision');
+    const lowQuality = observation(3, 'Updated auth.ts');
+
+    const result = analyzeCleanupObservations([canonical, duplicate, lowQuality]);
+
+    expect(result.lowQuality.map((item) => item.id)).toEqual([3]);
+    expect(result.duplicateGroups).toEqual([{ canonical, duplicates: [duplicate] }]);
+    expect(result.toRemove.map((item) => item.id)).toEqual([3, 2]);
+    expect(result.highQuality).toBe(1);
+  });
+
+  it('archives noise only when explicitly requested', () => {
+    const noise = observation(1, '[benchmark] sandbox result');
+
+    expect(analyzeCleanupObservations([noise]).toArchive).toEqual([]);
+    const optedIn = analyzeCleanupObservations([noise], { includeNoise: true });
+    expect(optedIn.noise).toMatchObject([{ observation: { id: 1 }, reason: 'demo/test/noise' }]);
+    expect(optedIn.toArchive.map((item) => item.id)).toEqual([1]);
+  });
+
+  it('does not classify normal engineering language as cleanup noise', () => {
+    const durable = [
+      observation(1, '1.0.7 canonical storage rule set'),
+      observation(2, 'Phase tasks issued as colleague handoffs'),
+      observation(3, 'Read-only sandbox blocks local writes'),
+      observation(4, 'Memorix API compatibility contract'),
+      observation(5, 'test(stress): deterministic stress exams for the stability gate'),
+    ];
+
+    const analysis = analyzeCleanupObservations(durable, { includeNoise: true });
+    expect(analysis.noise).toEqual([]);
+    expect(analysis.toArchive).toEqual([]);
+  });
+
+  it('recognizes explicit fixture markers and tool receipts', () => {
+    const fixture = observation(1, 'Synthetic record', { concepts: ['test-fixture'] });
+    const receipt = observation(2, 'Used apply_patch');
+
+    const analysis = analyzeCleanupObservations([fixture, receipt], { includeNoise: true });
+    expect(analysis.toArchive.map((item) => item.id)).toEqual([1, 2]);
+  });
+
+  it('ignores records that are not active', () => {
+    const archived = observation(1, 'Updated old.ts', { status: 'archived' });
+    expect(analyzeCleanupObservations([archived]).totalActive).toBe(0);
+  });
+});

--- a/tests/memory/deduplication-plan.test.ts
+++ b/tests/memory/deduplication-plan.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { applyDeduplicationPlan, planMemoryDeduplication } from '../../src/memory/deduplication.js';
+import { SqliteBackend } from '../../src/store/sqlite-store.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+import type { CompactDecision } from '../../src/llm/memory-manager.js';
+import type { Observation } from '../../src/types.js';
+
+function observation(id: number, title: string, overrides: Partial<Observation> = {}): Observation {
+  return {
+    id,
+    entityName: 'auth',
+    type: 'decision',
+    title,
+    narrative: title,
+    facts: [],
+    filesModified: [],
+    concepts: [],
+    tokens: 10,
+    createdAt: new Date(2026, 0, id).toISOString(),
+    projectId: 'test/project',
+    status: 'active',
+    ...overrides,
+  };
+}
+
+describe('deduplication plan', () => {
+  let dataDir: string;
+  let store: SqliteBackend;
+
+  beforeEach(async () => {
+    dataDir = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-dedup-plan-'));
+    store = new SqliteBackend();
+    await store.init(dataDir);
+  });
+
+  afterEach(async () => {
+    store.close();
+    closeAllDatabases();
+    await fs.rm(dataDir, { recursive: true, force: true });
+  });
+
+  it.each([
+    ['UPDATE', 1, 2],
+    ['NONE', 2, 1],
+    ['DELETE', 1, 2],
+  ] as const)('maps %s decisions to the record that should resolve', async (action, resolveId, keepId) => {
+    const decide = async (): Promise<CompactDecision> => ({
+      action,
+      targetId: action === 'NONE' ? undefined : 1,
+      reason: 'same durable fact',
+      usedLLM: true,
+    });
+    const plan = await planMemoryDeduplication([
+      observation(1, 'Older'),
+      observation(2, 'Newer'),
+    ], { decide });
+
+    expect(plan.actions).toMatchObject([{ resolveId, keepId, decision: action }]);
+    expect(plan.resolveIds).toEqual([resolveId]);
+  });
+
+  it('continues when one LLM comparison fails', async () => {
+    const plan = await planMemoryDeduplication(
+      [observation(1, 'Older'), observation(2, 'Newer')],
+      { decide: async () => { throw new Error('provider timeout'); } },
+    );
+    expect(plan).toMatchObject({ comparisons: 1, failedComparisons: 1, actions: [] });
+  });
+
+  it('keeps at least one active survivor when mixed decisions form a cycle', async () => {
+    const decisions: CompactDecision[] = [
+      { action: 'NONE', reason: 'keep first', usedLLM: true },
+      { action: 'DELETE', targetId: 1, reason: 'drop first', usedLLM: true },
+      { action: 'NONE', reason: 'keep second', usedLLM: true },
+    ];
+    const plan = await planMemoryDeduplication([
+      observation(1, 'First'),
+      observation(2, 'Second'),
+      observation(3, 'Third'),
+    ], { decide: async () => decisions.shift() ?? null });
+
+    expect(plan.resolveIds).not.toContain(3);
+    expect(new Set(plan.resolveIds).size).toBeLessThan(3);
+  });
+
+  it('applies only active manageable records from the selected project', async () => {
+    await store.insert(observation(1, 'Resolve me'));
+    await store.insert(observation(2, 'Other project', { projectId: 'other/project' }));
+    await store.insert(observation(3, 'Private', { visibility: 'personal', createdByAgentId: 'owner' }));
+
+    const result = await applyDeduplicationPlan(store, 'test/project', [1, 2, 3], { projectId: 'test/project' });
+
+    expect(result).toEqual({ resolved: [], skipped: [2, 3] });
+    expect(await store.getById(1)).toMatchObject({ status: 'active' });
+    expect(await store.getById(2)).toMatchObject({ status: 'active' });
+    expect(await store.getById(3)).toMatchObject({ status: 'active' });
+  });
+});


### PR DESCRIPTION
## Summary
- add preview-first Cleanup, Consolidate, Deduplicate, and Retention Archive actions to the local Dashboard
- share cleanup and deduplication planning/execution across Dashboard, CLI, and MCP
- bind execution to signed project-scoped previews and reject stale candidate sets
- tighten cleanup noise detection after validating against a real 232-record project store
- document the Dashboard maintenance and safety contract

## Verification
- `npm run lint`
- `npm test` (294 files, 2904 passed, 4 skipped)
- focused Dashboard/cleanup/dedup integration tests (39 passed before final dedup invariant; 34 passed after final invariant)
- `npm run build`
- Playwright desktop and 390x844 mobile smoke against the built standalone Dashboard

Closes #226
Closes #227
Closes #228
Closes #229