### PR TITLE
chore(release): prepare 1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-08-18
+
+### Added
+- **Preview-first Dashboard maintenance** -- the Observations page now offers
+  project-scoped Cleanup, Consolidate, and Deduplicate previews, while the
+  Retention page can preview and archive canonical retention candidates. Every
+  mutation shows its candidate set before confirmation.
+- **Shared maintenance execution** -- Dashboard, CLI, and MCP use the same
+  cleanup and deduplication planners/executors instead of maintaining separate
+  mutation logic.
+
+### Changed
+- **Fail-closed maintenance actions** -- execution requires a signed,
+  project-bound preview and rejects stale candidate sets with a refreshable
+  conflict instead of applying a partial plan.
+- **Conservative cleanup noise detection** -- normal engineering terms such as
+  compatibility, handoff, sandbox, and version are no longer treated as noise;
+  only explicit fixture markers and tool receipts are opt-in archive candidates.
+- **Dashboard documentation** -- added the canonical Dashboard maintenance,
+  scope, and safety contract to the public documentation map.
+
 ## [1.6.3] - 2026-08-18
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.6.3",
+      "version": "1.7.0",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memorix",
   "mcpName": "io.github.AVIDS2/memorix",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
+++ b/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "description": "Local-first project memory for CodeBuddy Code and other coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AVIDS2/memorix",
     "source": "github"
   },
-  "version": "1.6.3",
+  "version": "1.7.0",
   "websiteUrl": "https://github.com/AVIDS2/memorix#readme",
   "icons": [
     {
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "memorix",
-      "version": "1.6.3",
+      "version": "1.7.0",
       "runtimeHint": "npx",
       "packageArguments": [
         {


### PR DESCRIPTION
## Release checklist
- bump root package to `1.7.0`
- sync `server.json` for the official MCP Registry
- sync all published plugin manifests
- document Dashboard preview-first maintenance and safety behavior

## Verification
- `npm run build`
- `npm pack --dry-run` (`memorix@1.7.0`, 546 files)
- `npm run check:mcp-registry`
- `npm run check:plugin-release`
- PR #233 CI passed on Ubuntu, Windows, macOS, Node 26 SQLite, Docker, and typecheck