### PR TITLE
fix(dashboard): contain long text and center maintenance dialog

### DIFF
--- a/src/dashboard/static/app.js
+++ b/src/dashboard/static/app.js
@@ -2377,20 +2377,21 @@ function renderSemanticGraph(kg) {
       backgroundColor: 'transparent',
       tooltip: {
         trigger: 'item',
+        confine: true,
         backgroundColor: tooltipBg,
         borderColor: tooltipBorder,
         borderWidth: 1,
         textStyle: { color: labelColor, fontSize: 12, fontFamily: 'Inter, system-ui, sans-serif' },
-        extraCssText: 'box-shadow: 0 4px 16px rgba(0,0,0,0.18); border-radius: 8px; padding: 10px 12px; max-width: 320px;',
+        extraCssText: 'box-shadow: 0 4px 16px rgba(0,0,0,0.18); border-radius: 8px; padding: 10px 12px; width: min(320px, calc(100vw - 32px)); max-width: calc(100vw - 32px); box-sizing: border-box; white-space: normal; overflow-wrap: anywhere; word-break: break-word;',
         formatter: (params) => {
           if (params.dataType === 'node') {
             const d = params.data;
             const summary = d.summary ? String(d.summary).slice(0, 160) : '';
             return (
-              `<div style="font-weight:600;font-size:13px;margin-bottom:4px;line-height:1.35;">${wrap(d.fullLabel || d.name)}</div>` +
+              `<div style="font-weight:600;font-size:13px;margin-bottom:4px;line-height:1.35;white-space:normal;overflow-wrap:anywhere;word-break:break-word;">${wrap(d.fullLabel || d.name)}</div>` +
               `<div style="font-size:11px;color:${labelMutedColor};margin-bottom:6px;">${wrap(d.nodeType || '')}${d.entityName ? ' \u00b7 ' + wrap(d.entityName) : ''}</div>` +
-              `<div style="font-size:11px;color:${labelMutedColor};">${d.evidenceCount || 0} ${wrap(t('kgInspectorEvidence'))}</div>` +
-              (summary ? `<div style="font-size:11.5px;line-height:1.5;margin-top:8px;color:${labelColor};opacity:0.85;">${wrap(summary)}\u2026</div>` : '')
+              `<div style="font-size:11px;color:${labelMutedColor};white-space:normal;overflow-wrap:anywhere;word-break:break-word;">${d.evidenceCount || 0} ${wrap(t('kgInspectorEvidence'))}</div>` +
+              (summary ? `<div style="font-size:11.5px;line-height:1.5;margin-top:8px;color:${labelColor};opacity:0.85;white-space:normal;overflow-wrap:anywhere;word-break:break-word;">${wrap(summary)}\u2026</div>` : '')
             );
           }
           if (params.dataType === 'edge') {

--- a/src/dashboard/static/style.css
+++ b/src/dashboard/static/style.css
@@ -937,6 +937,7 @@ body {
 .graph-inspector {
   width: 280px;
   flex-shrink: 0;
+  min-width: 0;
   background: var(--bg-card);
   border-left: 1px solid var(--border-subtle);
   overflow-y: auto;
@@ -973,6 +974,7 @@ body {
   color: var(--text-primary);
   margin-bottom: 4px;
   word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .gi-type {
@@ -1049,6 +1051,7 @@ body {
   background: var(--bg-surface);
   border-left: 2px solid var(--accent-purple);
   word-break: break-word;
+  overflow-wrap: anywhere;
 }
 
 .gi-rel-item {
@@ -1058,6 +1061,7 @@ body {
   display: flex;
   align-items: center;
   gap: 6px;
+  min-width: 0;
 }
 
 .gi-rel-arrow {
@@ -1080,6 +1084,9 @@ body {
   font-weight: 500;
   color: var(--text-primary);
   cursor: pointer;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
   transition: color var(--transition-fast);
 }
 
@@ -1142,6 +1149,10 @@ body {
   transition: opacity var(--transition-fast);
   z-index: 100;
   max-width: 260px;
+  box-sizing: border-box;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
   box-shadow: var(--elevation-2);
 }
 
@@ -1530,6 +1541,10 @@ body {
   transition: opacity var(--transition-fast);
   z-index: 100;
   max-width: 300px;
+  box-sizing: border-box;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
   box-shadow: 0 8px 32px rgba(0, 0, 0, 0.6);
 }
 
@@ -2209,6 +2224,9 @@ body {
 }
 
 .maintenance-dialog {
+  position: fixed;
+  inset: 0;
+  margin: auto;
   width: min(680px, calc(100vw - 32px));
   max-height: min(760px, calc(100dvh - 32px));
   padding: 0;


### PR DESCRIPTION
## Summary\n- Keep semantic graph tooltip text inside a responsive bounded box, including long identifiers and summaries.\n- Allow graph inspector labels and relation targets to wrap safely.\n- Restore native modal centering for the maintenance preview dialog after the global reset.\n\n## Verification\n- 
pm run build\n- 
pm run lint\n- 
px vitest run tests/dashboard/maintenance-actions.test.ts tests/integration/dashboard-project-scope.test.ts --no-file-parallelism --maxWorkers=1 --minWorkers=1\n- Real Playwright smoke at 2048x962 and 390x844: dialog centered in the available layout area, no horizontal overflow, long graph tooltip contained.