### PR TITLE
perf(retrieval): harden large-store cold start for 1.7.2

### DIFF
--- a/ACTIVE_WORK.md
+++ b/ACTIVE_WORK.md
@@ -4,29 +4,21 @@
 > before resuming substantial work, update it after a material decision or
 > milestone, and do not create parallel progress logs.
 
-**Last updated:** 2026-08-17
+**Last updated:** 2026-08-19
 
 ## Current Product State
 
-- `1.5.1` is the current published release (2026-08-16) on npm, the
-  official MCP Registry, and GitHub Releases. It is the reliability patch for
-  bounded formation cancellation and provider-error handling. A separate
-  Registry-only publish path now keeps the official MCP Registry current when
-  npm was already published manually.
-- `1.6.0` is the release candidate for bounded context receipts, explicit
-  optional local CodeGraph lifecycle, and task-scoped Agent loadouts. It keeps
-  detailed diagnostic JSON backward-compatible while generated guidance uses
-  the bounded CLI form. External CodeGraph is never installed or configured by
-  Memorix; an explicit sync that remains stale falls back to Lite evidence.
-- `1.5.0` is the underlying stability release: the deterministic stress-exam matrix
-  (corpus, concurrency, session churn, long-term scale, CLI repeat) runs in
-  the normal suite, the OpenRouter embedding lane was verified live
-  (`qwen/qwen3-embedding-8b`, 4096d), and the embedding default is now
-  provider-aware. Everything from the 1.4.6 memory-native line carries
-  forward.
-- Contributor PR #206 remains independently reviewed and attributed. It is a
-  distinct hook process-lifecycle fix for issue #205; its author needs to
-  update one stale static test before it can merge.
+- `1.7.1` is the current published release (2026-08-19) on npm, the official
+  MCP Registry, and GitHub Releases. It contains preview-first Dashboard
+  maintenance plus the graph overflow and dialog-centering fixes.
+- `1.7.2` is the active reliability patch. It strengthens the existing 40,000
+  record release gate so the public SDK, HTTP MCP context/search/store paths,
+  hooks, and reopen behavior are measured together with hard timeouts.
+- SDK, CLI, hooks, and HTTP MCP share SQLite as the canonical flat data store.
+  Large-store startup hydration uses bounded Orama batches so health remains
+  responsive without rebalancing the index once per row.
+- Open contributor PRs #212 (HTTP rerank) and #204 (WorkBuddy) remain separate
+  feature work. They are not part of this patch release.
 
 ## Agent-Memory Landscape Decision (2026-08-17)
 
@@ -58,7 +50,7 @@ provider when the operator chooses one.
   freshness, and queue bounded sync). It must never run an upstream installer
   that edits the user's Agent configuration.
 
-## 1.5.0 Stability Main Line (stress-tested, measured)
+## Historical Stability Baseline (1.5.0, stress-tested and measured)
 
 - Stress exams live in `tests/stress/` and run in the normal suite:
   - Corpus: 2,000 observations, 25 real searches, planted needles all hit,
@@ -83,7 +75,7 @@ provider when the operator chooses one.
 - Live embedding exams stay env-gated (`MEMORIX_RUN_LIVE_EMBEDDING_TESTS=1`)
   and never run in CI.
 
-## Memory Hygiene Main Line (1.4.x, measured)
+## Historical Memory Hygiene Baseline (1.4.x, measured)
 
 - Session dedup: `memorix_search` demotes rows already shown in the same
   session and remembers the surfaced set. Session-replay exam: duplicate
@@ -128,6 +120,8 @@ provider when the operator chooses one.
    it overlaps a planned product direction.
 4. Make every bounded foreground path cancel the network work it starts, and
    make non-retryable provider failures fail once with a useful diagnostic.
+5. Keep the 40,000-record gate fail-closed across SDK, HTTP MCP, hooks, and
+   canonical persistence before every release that changes retrieval/storage.
 
 ## Completed Contribution Decisions
 
@@ -158,12 +152,14 @@ provider when the operator chooses one.
 
 ## Immediate Next Step
 
-- Release the completed bounded-context and semantic-CodeGraph UX slice after
-  the full verification suite and package smoke pass. Do not turn it into a
-  giant memory-hub rewrite or a broad new MCP tool surface.
-- Keep contributor PR #206 separate: its hook deadline, stdin release,
-  deferred embeddings, and smaller hook heap are valuable, but the author
-  should update the failing static test and rerun CI before review/merge.
+- Finish the `1.7.2` full suite, package smoke, and 40,000-record acceptance
+  run, then publish the same verified version to npm, GitHub Releases, and the
+  official MCP Registry.
+- After the patch, review #212 only after it is rebased onto current `main` and
+  re-verified. Validate #204 against current official WorkBuddy behavior before
+  considering it for a feature release.
+
+## Historical Release Notes
 
 The #174 controlled audio derivations, #175 governed one-hop graph evidence,
 #185 CodeBuddy integration, and #184 Star History CI verification are merged

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.7.2] - 2026-08-19
+
+### Changed
+- **Faster large-store cold retrieval** -- startup hydration now inserts
+  persisted observations into Orama in bounded batches. This avoids rebuilding
+  index balance once per row while continuing to yield to HTTP health traffic.
+- **Fail-closed large-store evidence** -- the reproducible 40,000-record gate
+  now exercises and times HTTP readiness, MCP initialize/bind/context/search/
+  store, hook capture, and SDK reopen behavior with hard request and release
+  budgets instead of checking persistence alone.
+- **Isolated index tests** -- startup hydration tests explicitly disable the
+  embedding lane and restore the caller environment instead of reading an
+  operator's provider configuration or local vector cache.
+- **Current public guidance** -- README and canonical development/status docs
+  now describe preview-first Dashboard maintenance and the 1.7 product line.
+
 ## [1.7.1] - 2026-08-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Memorix is more than a memory store. It also installs agent integrations, keeps 
 | Agent setup | One setup path for MCP, rules, hooks, skills, plugins, bundles, or extensions depending on the agent | `memorix setup --agent <agent>` |
 | Agent doctor | Checks whether agent MCP config and guidance are current, then repairs Memorix-owned entries when needed | `memorix doctor agents`, `memorix repair agents` |
 | Hooks and skills | Optional capture from supported agents, plus reusable project skills promoted from durable knowledge | `memorix hooks`, `memorix skills` |
-| Dashboard and HTTP | A local web UI and shared MCP endpoint for browsing memory, project state, teams, and diagnostics | `memorix dashboard`, `memorix background start` |
+| Dashboard and HTTP | A local web UI and shared MCP endpoint for browsing memory, project state, teams, diagnostics, and preview-first cleanup, consolidation, deduplication, and retention actions | `memorix dashboard`, `memorix background start` |
 | Orchestration and team work | Task planning, worker handoffs, file locks, messages, verification gates, and review loops | `memorix orchestrate`, `memorix team`, `memorix lock` |
 | memcode | A bundled terminal coding agent that already reads and writes the same project memory | `memorix`, `memcode` |
 | CLI and SDK | Scriptable access for automation, imports/exports, diagnostics, and custom integrations | `memorix ...`, `createMemoryClient()` |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -79,7 +79,7 @@ Memorix 不只是一个记忆库。它还负责安装 Agent 接入、保留有�
 | Agent setup | 按目标 Agent 写入 MCP、rules、hooks、skills、plugin、bundle 或 extension | `memorix setup --agent <agent>` |
 | Agent doctor | 检查 Agent 的 MCP 配置和规则是否是当前版本，并修复 Memorix 自己管理的条目 | `memorix doctor agents`、`memorix repair agents` |
 | Hooks 和 skills | 在支持的 Agent 中可选捕获工作事件，并把稳定知识提升成可复用项目技能 | `memorix hooks`、`memorix skills` |
-| Dashboard 和 HTTP | 本地 Web UI 与共享 MCP endpoint，用于浏览记忆、项目状态、团队和诊断信息 | `memorix dashboard`、`memorix background start` |
+| Dashboard 和 HTTP | 本地 Web UI 与共享 MCP endpoint，用于浏览记忆、项目状态、团队和诊断，并在预览确认后执行清理、合并、去重和保留归档 | `memorix dashboard`、`memorix background start` |
 | Orchestration 和团队协作 | 任务规划、worker 交接、文件锁、消息、验证门和 review loop | `memorix orchestrate`、`memorix team`、`memorix lock` |
 | memcode | 内置终端 Coding Agent，默认读写同一套项目记忆 | `memorix`、`memcode` |
 | CLI 和 SDK | 给自动化、导入导出、诊断和自定义集成使用的本地接口 | `memorix ...`、`createMemoryClient()` |

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -13,9 +13,10 @@ Memorix is a TypeScript project built around:
 
 ## Current Development Baseline
 
-The current release work targets the **1.4 line** while package metadata may still show the last published version until the release commit is cut.
+The current release work targets the **1.7 line** while package metadata may
+still show the last published version until the release commit is cut.
 
-Contributors should assume the following areas are part of the 1.4 release line:
+Contributors should assume the following areas are part of the current release line:
 
 - shared memory across MCP clients, CLI, SDK, dashboard, hooks, and memcode
 - memcode uses Memorix project memory, hooks, `/memory` commands, resumable sessions, and model switching as the bundled terminal agent
@@ -27,6 +28,9 @@ Contributors should assume the following areas are part of the 1.4 release line:
 - dashboard config loading aligned with CLI/TUI status surfaces
 - the existing layered retrieval, retention, attribution, and compact output model
 - source-backed long-term memory with candidate, qualification, approval, archival, supersession, and explicit portable user scope
+- preview-first project maintenance shared across Dashboard, CLI, and MCP
+- the reproducible large-store gate for SDK, HTTP MCP, hooks, persistence, and
+  cold-start retrieval budgets
 
 ---
 

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -103,9 +103,16 @@ On the release development machine used for this check, the healthy HTTP service
 temporary Git project with an isolated data directory. It runs with embeddings
 disabled, so it does not use provider credentials or make paid network calls.
 The gate measures steady-state writes, first lexical search, process memory,
-HTTP MCP and hook persistence, and an SDK close/reopen cycle. It also verifies
-that the personal hook candidate remains durable on disk without becoming
-visible to an unbound SDK reader.
+HTTP readiness, MCP initialize/bind/context/search/store, hook capture, and an
+SDK close/reopen cycle. Every network request has a hard timeout, and the
+report fails when an interactive path exceeds its release budget. It also
+verifies that the personal hook candidate remains durable on disk without
+becoming visible to an unbound SDK reader.
+
+Startup hydration uses bounded Orama batches. This keeps HTTP health responsive
+while avoiding a full index rebalance for every persisted observation. The MCP
+search number is intentionally a cold control-plane measurement: it includes
+any lexical hydration the fresh service still owes before its first search.
 
 Results are machine-specific and should be compared on the same OS and Node
 version. The release gate is an integrity and regression check, not a public

--- a/docs/README.md
+++ b/docs/README.md
@@ -119,11 +119,13 @@ Historical/deep-reference documents may describe older designs. If they conflict
 
 ## Current Product Line
 
-The released product is on the **1.6 line**. The current baseline has:
+The released product is on the **1.7 line**. The current baseline has:
 
 - `memorix setup --agent <agent> --global` is the default agent integration command
 - `memorix serve` is the manual stdio MCP server for external agents
 - `memorix background start` runs the shared HTTP MCP service and dashboard
+- Dashboard maintenance is preview-first, project-scoped, and uses the same
+  cleanup and deduplication planners as CLI and MCP
 - context and CodeGraph commands return bounded task receipts before detailed diagnostics
 - HTTP MCP sessions have a bounded, explicit lifecycle and fail with a reinitialize hint after expiry
 - `memorix integrate --agent <agent>` and `memorix hooks install --agent <agent>` remain manual/fallback generation commands

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memorix",
   "mcpName": "io.github.AVIDS2/memorix",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
+++ b/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Local-first project memory for CodeBuddy Code and other coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/scripts/large-store-gate.mjs
+++ b/scripts/large-store-gate.mjs
@@ -50,6 +50,15 @@ function percentile(samples, fraction) {
   return samples[index];
 }
 
+async function measure(operation) {
+  const startedAt = performance.now();
+  const value = await operation();
+  return {
+    value,
+    elapsedMs: Number((performance.now() - startedAt).toFixed(3)),
+  };
+}
+
 function allocatePort() {
   return new Promise((resolve, reject) => {
     const server = createServer();
@@ -110,7 +119,7 @@ function waitForExit(child, timeoutMs = 10_000) {
   });
 }
 
-async function mcpPost(port, body, sessionId) {
+async function mcpPost(port, body, sessionId, timeoutMs = 30_000) {
   const headers = {
     'Content-Type': 'application/json',
     Accept: 'application/json, text/event-stream',
@@ -120,6 +129,7 @@ async function mcpPost(port, body, sessionId) {
     method: 'POST',
     headers,
     body: JSON.stringify(body),
+    signal: AbortSignal.timeout(timeoutMs),
   });
   const text = await response.text();
   let json;
@@ -147,8 +157,15 @@ function toolText(result) {
   return content.map((part) => part.text ?? '').join('\n');
 }
 
-async function storeViaHttpMcp(port, projectRoot) {
-  const init = await mcpPost(port, {
+function requireMcpSuccess(label, result) {
+  if (result.status < 200 || result.status >= 300 || result.json?.error || result.json?.result?.isError) {
+    const detail = result.json?.error?.message ?? toolText(result) ?? result.text;
+    throw new Error(`${label} failed (${result.status}): ${String(detail).slice(0, 1_000)}`);
+  }
+}
+
+async function exerciseHttpMcp(port, projectRoot, lookupToken) {
+  const initialized = await measure(() => mcpPost(port, {
     jsonrpc: '2.0',
     method: 'initialize',
     params: {
@@ -157,12 +174,14 @@ async function storeViaHttpMcp(port, projectRoot) {
       clientInfo: { name: 'large-store-gate', version: '1.0' },
     },
     id: 1,
-  });
+  }));
+  const init = initialized.value;
+  requireMcpSuccess('HTTP MCP initialize', init);
   const sessionId = init.headers.get('mcp-session-id');
   if (!sessionId) {
     throw new Error(`HTTP MCP initialize returned no session id: ${init.text}`);
   }
-  await fetch(`http://127.0.0.1:${port}/mcp`, {
+  const notification = await fetch(`http://127.0.0.1:${port}/mcp`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -170,9 +189,13 @@ async function storeViaHttpMcp(port, projectRoot) {
       'Mcp-Session-Id': sessionId,
     },
     body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+    signal: AbortSignal.timeout(30_000),
   });
+  if (!notification.ok) {
+    throw new Error(`HTTP MCP initialized notification failed (${notification.status})`);
+  }
 
-  const started = await mcpPost(port, {
+  const bound = await measure(() => mcpPost(port, {
     jsonrpc: '2.0',
     method: 'tools/call',
     params: {
@@ -180,12 +203,40 @@ async function storeViaHttpMcp(port, projectRoot) {
       arguments: { agent: 'large-store-gate', projectRoot },
     },
     id: 2,
-  }, sessionId);
-  if (started.json?.result?.isError) {
-    throw new Error(`HTTP MCP session_start failed: ${toolText(started)}`);
+  }, sessionId));
+  requireMcpSuccess('HTTP MCP session_start', bound.value);
+
+  const context = await measure(() => mcpPost(port, {
+    jsonrpc: '2.0',
+    method: 'tools/call',
+    params: {
+      name: 'memorix_project_context',
+      arguments: { task: 'Verify large-store persistence, retrieval, and release readiness.' },
+    },
+    id: 3,
+  }, sessionId, 120_000));
+  requireMcpSuccess('HTTP MCP project_context', context.value);
+
+  const searched = await measure(() => mcpPost(port, {
+    jsonrpc: '2.0',
+    method: 'tools/call',
+    params: {
+      name: 'memorix_search',
+      arguments: {
+        query: lookupToken,
+        quality: 'fast',
+        limit: 5,
+        purpose: 'Verify a planted record through the public HTTP MCP search path.',
+      },
+    },
+    id: 4,
+  }, sessionId, 120_000));
+  requireMcpSuccess('HTTP MCP search', searched.value);
+  if (!toolText(searched.value).includes(lookupToken)) {
+    throw new Error(`HTTP MCP search did not return planted token ${lookupToken}`);
   }
 
-  const stored = await mcpPost(port, {
+  const stored = await measure(() => mcpPost(port, {
     jsonrpc: '2.0',
     method: 'tools/call',
     params: {
@@ -197,11 +248,17 @@ async function storeViaHttpMcp(port, projectRoot) {
         narrative: 'HTTP MCP write after the SDK client closed. The next SDK open must see this row.',
       },
     },
-    id: 3,
-  }, sessionId);
-  if (stored.json?.result?.isError) {
-    throw new Error(`HTTP MCP memorix_store failed: ${toolText(stored)}`);
-  }
+    id: 5,
+  }, sessionId));
+  requireMcpSuccess('HTTP MCP store', stored.value);
+
+  return {
+    initializeMs: initialized.elapsedMs,
+    bindMs: bound.elapsedMs,
+    contextMs: context.elapsedMs,
+    searchMs: searched.elapsedMs,
+    storeMs: stored.elapsedMs,
+  };
 }
 
 function storeViaHook(projectRoot, dataDir, childHome) {
@@ -225,6 +282,7 @@ function storeViaHook(projectRoot, dataDir, childHome) {
     },
     tool_response: 'File written successfully',
   };
+  const startedAt = performance.now();
   const result = spawnSync(process.execPath, [cliEntry, 'hook', '--agent', 'claude'], {
     cwd: projectRoot,
     input: JSON.stringify(payload),
@@ -243,6 +301,7 @@ function storeViaHook(projectRoot, dataDir, childHome) {
   if (result.status !== 0) {
     throw new Error(`memorix hook failed: ${result.stderr || result.stdout || `exit ${result.status}`}`);
   }
+  return Number((performance.now() - startedAt).toFixed(3));
 }
 
 function listDiskObservations(dataDir) {
@@ -264,7 +323,7 @@ function listDiskObservations(dataDir) {
   }
 }
 
-async function writeAcrossTransports(projectRoot, dataDir, sandbox) {
+async function writeAcrossTransports(projectRoot, dataDir, sandbox, lookupToken) {
   const childHome = path.join(sandbox, 'home');
   await mkdir(path.join(projectRoot, 'src'), { recursive: true });
   await mkdir(childHome, { recursive: true });
@@ -290,15 +349,25 @@ async function writeAcrossTransports(projectRoot, dataDir, sandbox) {
     windowsHide: true,
   });
 
+  let http;
+  const serverStartedAt = performance.now();
   try {
     await waitForListening(server);
-    await storeViaHttpMcp(port, projectRoot);
+    const health = await fetch(`http://127.0.0.1:${port}/health`, {
+      signal: AbortSignal.timeout(5_000),
+    });
+    if (!health.ok) throw new Error(`HTTP health failed (${health.status})`);
+    http = {
+      readyMs: Number((performance.now() - serverStartedAt).toFixed(3)),
+      ...await exerciseHttpMcp(port, projectRoot, lookupToken),
+    };
   } finally {
     try { server.kill('SIGKILL'); } catch { /* already gone */ }
     await waitForExit(server);
   }
 
-  storeViaHook(projectRoot, dataDir, childHome);
+  const hookMs = storeViaHook(projectRoot, dataDir, childHome);
+  return { http, hookMs };
 }
 
 async function main() {
@@ -345,10 +414,17 @@ async function main() {
     await client.close();
     client = undefined;
 
-    await writeAcrossTransports(projectRoot, dataDir, sandbox);
+    const transport = await writeAcrossTransports(
+      projectRoot,
+      dataDir,
+      sandbox,
+      uniqueLookupToken(records - 1),
+    );
     const diskRows = listDiskObservations(dataDir);
     const diskCount = diskRows.length;
+    const reopenStartedAt = performance.now();
     client = await createMemoryClient({ projectRoot, silent: true });
+    const reopenMs = performance.now() - reopenStartedAt;
     const reopenedCount = await client.count();
     const reopened = await client.getAll();
     await client.close();
@@ -373,6 +449,9 @@ async function main() {
       },
       searchMs: Number(searchMs.toFixed(3)),
       searchHits: hits.length,
+      httpMcp: transport.http,
+      hookMs: transport.hookMs,
+      sdkReopenMs: Number(reopenMs.toFixed(3)),
       peakRssMb: Number((peakRss / (1024 * 1024)).toFixed(1)),
       cacheLines: cacheLines.length,
       diskCount,
@@ -387,6 +466,14 @@ async function main() {
     if (report.peakRssMb > rssBudgetMb) failed.push(`peak RSS ${report.peakRssMb}MB > ${rssBudgetMb}MB`);
     if (report.cacheLines !== 2) failed.push(`cache lines ${report.cacheLines} !== 2`);
     if (hits.length < 1) failed.push('search returned no hits');
+    if (report.httpMcp.readyMs > 30_000) failed.push(`HTTP ready ${report.httpMcp.readyMs}ms > 30000ms`);
+    if (report.httpMcp.initializeMs > 5_000) failed.push(`MCP initialize ${report.httpMcp.initializeMs}ms > 5000ms`);
+    if (report.httpMcp.bindMs > 5_000) failed.push(`MCP bind ${report.httpMcp.bindMs}ms > 5000ms`);
+    if (report.httpMcp.contextMs > 5_000) failed.push(`MCP context ${report.httpMcp.contextMs}ms > 5000ms`);
+    if (report.httpMcp.searchMs > 15_000) failed.push(`MCP cold search ${report.httpMcp.searchMs}ms > 15000ms`);
+    if (report.httpMcp.storeMs > 5_000) failed.push(`MCP store ${report.httpMcp.storeMs}ms > 5000ms`);
+    if (report.hookMs > 20_000) failed.push(`hook ${report.hookMs}ms > 20000ms`);
+    if (report.sdkReopenMs > 15_000) failed.push(`SDK reopen ${report.sdkReopenMs}ms > 15000ms`);
     if (diskCount < records + 2) failed.push(`SQLite count ${diskCount} < ${records + 2} after MCP/hook writes`);
     if (!diskRows.some((row) => row.title === 'MCP marker 1')) {
       failed.push('SQLite missed the HTTP MCP marker');

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AVIDS2/memorix",
     "source": "github"
   },
-  "version": "1.7.1",
+  "version": "1.7.2",
   "websiteUrl": "https://github.com/AVIDS2/memorix#readme",
   "icons": [
     {
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "memorix",
-      "version": "1.7.1",
+      "version": "1.7.2",
       "runtimeHint": "npx",
       "packageArguments": [
         {

--- a/src/store/orama-store.ts
+++ b/src/store/orama-store.ts
@@ -8,7 +8,7 @@
  * Vector search (embeddings) will be added in P1 phase.
  */
 
-import { create, insert, search, remove, update, count, getByID, type AnyOrama } from '@orama/orama';
+import { create, insert, insertMultiple, search, remove, update, count, getByID, type AnyOrama } from '@orama/orama';
 import type { MemorixDocument, SearchOptions, IndexEntry, KnowledgeLayer, ObservationReader } from '../types.js';
 import { OBSERVATION_ICONS, type ObservationType } from '../types.js';
 import { resolveKnowledgeLayer } from '../skills/mini-skills.js';
@@ -405,7 +405,7 @@ export async function hydrateIndex(
     ? candidates.map(() => null)
     : await getCachedEmbeddings(candidates.map(({ observation }) => observationEmbeddingText(observation)));
 
-  let inserted = 0;
+  const documents: MemorixDocument[] = [];
   for (let index = 0; index < candidates.length; index++) {
     const { observation: obs, id } = candidates[index];
     try {
@@ -439,17 +439,37 @@ export async function hydrateIndex(
         knowledgeLayer: resolveKnowledgeLayer('observation', obs.sourceDetail, obs.source),
         ...(compatibleVector ? { embedding: compatibleVector } : {}),
       };
-      await insert(database, doc);
-      rememberObservationDoc(doc);
-      inserted++;
-      // Keep the HTTP event loop alive on large corpora so /health still answers.
-      if (inserted % 50 === 0) {
-        await new Promise<void>((resolve) => setImmediate(resolve));
-      }
-      if (inserted % 200 === 0) {
-        await new Promise<void>((resolve) => setTimeout(resolve, 0));
-      }
+      documents.push(doc);
     } catch { /* skip malformed entries */ }
+  }
+
+  let inserted = 0;
+  const hydrationBatchSize = 200;
+  for (let start = 0; start < documents.length; start += hydrationBatchSize) {
+    const batch = documents.slice(start, start + hydrationBatchSize);
+    try {
+      // Orama can rebalance its indexes once per batch instead of once per
+      // document. Keep batches bounded so HTTP health remains responsive.
+      await insertMultiple(database, batch, batch.length);
+      for (const doc of batch) rememberObservationDoc(doc);
+      inserted += batch.length;
+    } catch {
+      // A concurrent write or malformed document can partially complete a
+      // batch. Preserve the old best-effort behavior without double-inserting.
+      for (const doc of batch) {
+        if (getByID(database, doc.id)) {
+          rememberObservationDoc(doc);
+          inserted++;
+          continue;
+        }
+        try {
+          await insert(database, doc);
+          rememberObservationDoc(doc);
+          inserted++;
+        } catch { /* skip malformed or concurrently inserted entries */ }
+      }
+    }
+    await new Promise<void>((resolve) => setImmediate(resolve));
   }
 
   deferredCachedVectorHydration = options.skipCachedVectors

--- a/tests/store/hydrate-index.test.ts
+++ b/tests/store/hydrate-index.test.ts
@@ -1,6 +1,10 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from 'vitest';
 import { resetDb, hydrateIndex, makeOramaObservationId } from '../../src/store/orama-store.js';
 import { getByID, insert, search } from '@orama/orama';
+import { resetProvider } from '../../src/embedding/provider.js';
+import { resetConfigCache } from '../../src/config.js';
+
+const previousEmbedding = process.env.MEMORIX_EMBEDDING;
 
 // Minimal observation shape matching what hydrateIndex expects
 function makeObs(id: number, status: string, title: string) {
@@ -24,8 +28,23 @@ function makeObs(id: number, status: string, title: string) {
 }
 
 describe('hydrateIndex – status handling', () => {
+  beforeAll(() => {
+    process.env.MEMORIX_EMBEDDING = 'off';
+    resetConfigCache();
+    resetProvider();
+  });
+
   beforeEach(async () => {
     await resetDb();
+    resetConfigCache();
+    resetProvider();
+  });
+
+  afterAll(() => {
+    if (previousEmbedding === undefined) delete process.env.MEMORIX_EMBEDDING;
+    else process.env.MEMORIX_EMBEDDING = previousEmbedding;
+    resetConfigCache();
+    resetProvider();
   });
 
   it('indexes active, resolved, AND archived observations', async () => {
@@ -73,6 +92,20 @@ describe('hydrateIndex – status handling', () => {
 
     const inserted = await hydrateIndex(observations as any[]);
     expect(inserted).toBe(2);
+  });
+
+  it('hydrates every document across bounded startup batches', async () => {
+    const observations = Array.from({ length: 450 }, (_, index) =>
+      makeObs(index + 100, 'active', `Batched hydration ${index}`),
+    );
+
+    const inserted = await hydrateIndex(observations);
+    expect(inserted).toBe(observations.length);
+
+    const { getDb } = await import('../../src/store/orama-store.js');
+    const db = await getDb();
+    expect(getByID(db, makeOramaObservationId('test/hydrate-project', 100))).toBeDefined();
+    expect(getByID(db, makeOramaObservationId('test/hydrate-project', 549))).toBeDefined();
   });
 
   it('hydrates missing observations when a mini-skill already populated the index', async () => {


### PR DESCRIPTION
## Summary
- hydrate the Orama startup index in bounded batches to reduce large-store cold-search cost while preserving HTTP responsiveness
- extend the reproducible large-store gate across HTTP readiness, MCP initialize/bind/context/search/store, hook capture, and SDK reopen with hard budgets
- update README and canonical status/development/performance docs for the 1.7 product line

## Verification
- npm run lint
- npm test (294 files, 2906 passed, 4 skipped)
- npm run gate:large-store -- --records 40000
- npm pack + isolated tarball install; version and Codex setup dry-run
- npm audit --omit=dev (0 vulnerabilities)
- npm run check:mcp-registry
- npm run check:plugin-release

## 40k Windows evidence
- seed/index: 29.28s
- HTTP ready: 1.38s
- MCP context: 603ms
- MCP cold search: 5.70s
- MCP store: 2.17s
- hook: 1.93s
- SDK reopen: 4.52s
- peak RSS: 770MiB
- persistence and planted retrieval: passed