### PR TITLE
fix(llm): preserve explicit OpenAI-compatible API versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ All notable changes to this project will be documented in this file.
   when HTTP rerank is off.
 
 ### Fixed
+- **OpenAI-compatible provider base URLs** -- preserve explicit versioned paths
+  such as Volcano Ark's `/api/v3` for ordinary chat, tool calling, streaming,
+  and vision requests instead of appending an incorrect `/v1` segment.
 - HTTP rerank honors `MEMORIX_RERANK_TIMEOUT_MS` on the inner fetch
   (default 30s) instead of aborting at 5s.
 - HTTP rerank no longer inherits or transmits the memory LLM credential

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -145,6 +145,9 @@ Common keys:
 
 For OpenAI-compatible providers such as DashScope, DeepSeek-compatible gateways,
 or internal model gateways, use `provider = "openai"` and set `base_url`.
+Memorix uses an explicit provider path as-is: for example,
+`https://ark.cn-beijing.volces.com/api/v3` remains `/api/v3`. Only a bare host
+without a versioned path receives the convenience suffix `/v1`.
 
 ### `[embedding]`
 

--- a/src/llm/provider.ts
+++ b/src/llm/provider.ts
@@ -31,6 +31,36 @@ const LLM_TIMEOUT_MIN_MS = 1_000;
 const LLM_TIMEOUT_MAX_MS = 300_000;
 const MAX_LLM_RESPONSE_BYTES = 2 * 1024 * 1024;
 
+const OPENAI_API_VERSION_SEGMENT = /^v\d+(?:[a-z][a-z0-9-]*)?$/i;
+
+/**
+ * Normalize an OpenAI-compatible API root without rewriting an explicit
+ * provider version such as `/api/v3` or `/v1beta`.
+ *
+ * Bare hosts keep the historical convenience of receiving `/v1`. Once a
+ * caller supplies a versioned path, that path is authoritative.
+ */
+export function normalizeOpenAICompatibleBaseUrl(baseUrl: string): string {
+  const base = baseUrl.trim().replace(/\/+$/, '');
+  if (!base) return base;
+
+  let pathname = '';
+  try {
+    pathname = new URL(base).pathname.replace(/\/+$/, '');
+  } catch {
+    pathname = base.split(/[?#]/, 1)[0].replace(/\/+$/, '');
+  }
+
+  const lastSegment = pathname.split('/').filter(Boolean).at(-1);
+  if (lastSegment && OPENAI_API_VERSION_SEGMENT.test(lastSegment)) {
+    return base;
+  }
+
+  const queryOrHash = base.match(/[?#].*$/)?.[0] ?? '';
+  const pathWithoutQuery = base.slice(0, base.length - queryOrHash.length).replace(/\/+$/, '');
+  return `${pathWithoutQuery}/v1${queryOrHash}`;
+}
+
 /**
  * Parse and validate MEMORIX_LLM_TIMEOUT_MS environment variable.
  * - Must be a valid integer in the range 1000–300000ms.
@@ -259,9 +289,7 @@ async function callOpenAICompatible(
   signal?: AbortSignal,
 ): Promise<LLMResponse> {
   const config = currentConfig!;
-  // Auto-fix: append /v1 if baseUrl doesn't end with it (common user mistake)
-  let base = config.baseUrl!.replace(/\/+$/, '');
-  if (!base.endsWith('/v1')) base += '/v1';
+  const base = normalizeOpenAICompatibleBaseUrl(config.baseUrl!);
   const url = `${base}/chat/completions`;
 
   const fetchSignal = signal
@@ -387,8 +415,7 @@ async function callOpenAIWithTools(
   signal?: AbortSignal,
 ): Promise<LLMToolResponse> {
   const config = currentConfig!;
-  let base = config.baseUrl!.replace(/\/+$/, '');
-  if (!base.endsWith('/v1')) base += '/v1';
+  const base = normalizeOpenAICompatibleBaseUrl(config.baseUrl!);
   const url = `${base}/chat/completions`;
 
   // Convert ChatMessage[] to OpenAI format
@@ -603,8 +630,7 @@ async function* callOpenAIWithToolsStream(
   tools: ToolDefinition[],
 ): AsyncGenerator<LLMStreamEvent, void, undefined> {
   const config = currentConfig!;
-  let base = config.baseUrl!.replace(/\/+$/, '');
-  if (!base.endsWith('/v1')) base += '/v1';
+  const base = normalizeOpenAICompatibleBaseUrl(config.baseUrl!);
   const url = `${base}/chat/completions`;
 
   const openaiMessages: Array<Record<string, unknown>> = messages.map((msg) => {

--- a/src/multimodal/image-loader.ts
+++ b/src/multimodal/image-loader.ts
@@ -6,7 +6,11 @@
  */
 
 import { getLLMApiKey, getLLMBaseUrl, getLLMModel } from '../config.js';
-import { isLLMEnabled, getLLMConfig } from '../llm/provider.js';
+import {
+  isLLMEnabled,
+  getLLMConfig,
+  normalizeOpenAICompatibleBaseUrl,
+} from '../llm/provider.js';
 import { sanitizeCredentials } from '../memory/secret-filter.js';
 import {
   decodeBase64ImagePayload,
@@ -55,8 +59,7 @@ async function callVisionLLM(
     throw new Error('No LLM API key configured for image analysis.');
   }
 
-  let baseUrl = getLLMBaseUrl('https://api.openai.com/v1').replace(/\/+$/, '');
-  if (!baseUrl.endsWith('/v1')) baseUrl += '/v1';
+  const baseUrl = normalizeOpenAICompatibleBaseUrl(getLLMBaseUrl('https://api.openai.com/v1'));
   const model = getLLMModel('gpt-4o');
 
   const response = await fetch(`${baseUrl}/chat/completions`, {

--- a/tests/llm/provider.test.ts
+++ b/tests/llm/provider.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { callLLMWithTools, initLLM, parseLLMTimeoutMs, setLLMConfig } from '../../src/llm/provider.ts';
+import {
+  callLLM,
+  callLLMWithTools,
+  callLLMWithToolsStream,
+  initLLM,
+  normalizeOpenAICompatibleBaseUrl,
+  parseLLMTimeoutMs,
+  setLLMConfig,
+} from '../../src/llm/provider.ts';
 
 const LLM_ENV_KEYS = [
   'MEMORIX_AGENT_API_KEY',
@@ -155,6 +163,23 @@ describe('parseLLMTimeoutMs', () => {
   });
 });
 
+describe('normalizeOpenAICompatibleBaseUrl', () => {
+  it('adds /v1 only to a bare API host', () => {
+    expect(normalizeOpenAICompatibleBaseUrl('http://localhost:11434')).toBe('http://localhost:11434/v1');
+  });
+
+  it('preserves explicit v1 through v4 API paths', () => {
+    expect(normalizeOpenAICompatibleBaseUrl('https://api.example.com/v1')).toBe('https://api.example.com/v1');
+    expect(normalizeOpenAICompatibleBaseUrl('https://api.example.com/v2/')).toBe('https://api.example.com/v2');
+    expect(normalizeOpenAICompatibleBaseUrl('https://ark.cn-beijing.volces.com/api/v3')).toBe('https://ark.cn-beijing.volces.com/api/v3');
+    expect(normalizeOpenAICompatibleBaseUrl('https://api.example.com/v4')).toBe('https://api.example.com/v4');
+  });
+
+  it('preserves provider version variants such as v1beta', () => {
+    expect(normalizeOpenAICompatibleBaseUrl('https://generativelanguage.googleapis.com/v1beta')).toBe('https://generativelanguage.googleapis.com/v1beta');
+  });
+});
+
 describe('callLLMWithTools', () => {
   const originalFetch = globalThis.fetch;
 
@@ -229,5 +254,81 @@ describe('callLLMWithTools', () => {
     await expect(callLLMWithTools([
       { role: 'user', content: 'Hello?' },
     ], [])).rejects.toThrow(/too large/i);
+  });
+
+  it('uses a provider-supplied /api/v3 root without appending /v1', async () => {
+    setLLMConfig({
+      provider: 'openai',
+      apiKey: 'test-key',
+      model: 'deepseek-v4-flash-ga-260731',
+      baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
+    });
+    let requestedUrl = '';
+    globalThis.fetch = vi.fn(async (input) => {
+      requestedUrl = String(input);
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as typeof fetch;
+
+    await callLLMWithTools([{ role: 'user', content: 'Hello?' }], []);
+
+    expect(requestedUrl).toBe('https://ark.cn-beijing.volces.com/api/v3/chat/completions');
+  });
+});
+
+describe('OpenAI-compatible ordinary and streaming calls', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    setLLMConfig(null);
+    vi.restoreAllMocks();
+  });
+
+  it('uses a provider-supplied /api/v3 root for ordinary chat calls', async () => {
+    setLLMConfig({
+      provider: 'openai',
+      apiKey: 'test-key',
+      model: 'deepseek-v4-flash-ga-260731',
+      baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
+    });
+    let requestedUrl = '';
+    globalThis.fetch = vi.fn(async (input) => {
+      requestedUrl = String(input);
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: 'ok' } }],
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as typeof fetch;
+
+    await callLLM('system', 'user');
+
+    expect(requestedUrl).toBe('https://ark.cn-beijing.volces.com/api/v3/chat/completions');
+  });
+
+  it('uses a provider-supplied /api/v3 root for streaming tool calls', async () => {
+    setLLMConfig({
+      provider: 'openai',
+      apiKey: 'test-key',
+      model: 'deepseek-v4-flash-ga-260731',
+      baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
+    });
+    let requestedUrl = '';
+    globalThis.fetch = vi.fn(async (input) => {
+      requestedUrl = String(input);
+      return new Response(
+        'data: {"choices":[{"delta":{"content":"ok"},"finish_reason":"stop"}]}\n\n' +
+        'data: [DONE]\n\n',
+        { status: 200, headers: { 'content-type': 'text/event-stream' } },
+      );
+    }) as typeof fetch;
+
+    const events = [];
+    for await (const event of callLLMWithToolsStream([{ role: 'user', content: 'Hello?' }], [])) {
+      events.push(event);
+    }
+
+    expect(requestedUrl).toBe('https://ark.cn-beijing.volces.com/api/v3/chat/completions');
+    expect(events.some((event) => event.type === 'text' && event.content === 'ok')).toBe(true);
   });
 });

--- a/tests/multimodal/image-loader.test.ts
+++ b/tests/multimodal/image-loader.test.ts
@@ -19,6 +19,7 @@ describe('image-loader', () => {
     globalThis.fetch = originalFetch;
     delete process.env.OPENAI_API_KEY;
     delete process.env.MEMORIX_LLM_API_KEY;
+    delete process.env.MEMORIX_LLM_BASE_URL;
     delete process.env.MEMORIX_API_KEY;
     setLLMConfig(null);
     resetConfigCache();
@@ -138,6 +139,28 @@ describe('image-loader', () => {
     expect(content[0].type).toBe('text');
     expect(content[1].type).toBe('image_url');
     expect(content[1].image_url.url).toContain('data:image/jpeg;base64,');
+  });
+
+  it('preserves a provider-supplied /api/v3 root for Vision requests', async () => {
+    process.env.OPENAI_API_KEY = 'test-key';
+    process.env.MEMORIX_LLM_BASE_URL = 'https://ark.cn-beijing.volces.com/api/v3';
+    setLLMConfig({
+      provider: 'openai',
+      apiKey: 'test-key',
+      model: 'deepseek-v4-flash-ga-260731',
+      baseUrl: 'https://ark.cn-beijing.volces.com/api/v3',
+    });
+    let requestedUrl = '';
+    globalThis.fetch = (async (input) => {
+      requestedUrl = String(input);
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: '{"description":"test","tags":[],"entities":[]}' } }],
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as typeof fetch;
+
+    await analyzeImage({ base64: 'dGVzdA==', mimeType: 'image/png' });
+
+    expect(requestedUrl).toBe('https://ark.cn-beijing.volces.com/api/v3/chat/completions');
   });
 
   it('handles Vision LLM API errors', async () => {


### PR DESCRIPTION
## Summary

Fixes #240. OpenAI-compatible provider roots are now treated as authoritative when they contain an explicit API version path.

- Preserve Volcano Ark `https://ark.cn-beijing.volces.com/api/v3`
- Preserve `/v1`, `/v2`, `/v4`, and variants such as `/v1beta`
- Keep the existing `/v1` convenience only for bare hosts such as `http://localhost:11434`
- Apply the same rule to ordinary chat, tool calling, streaming, and vision

## Verification

- Official Volcano Ark OpenAI SDK documentation verified
- Focused tests: 54/54 passed
- `npm run build` passed
- `npm run lint` passed
- Clean-environment full suite: 298 files passed, 2953 tests passed, 2 live test files skipped by design

The fix is based on current `main` and contains no credentials or user configuration.