### PR TITLE
fix: make coordination status truthful for 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.8.1] - 2026-08-24
+
 ### Changed
-- **Coordination truth in Dashboard** -- the Dashboard Coordination Status page
-  is a read-only project-scoped view backed by the persistent SQLite `TeamStore`
-  for agents, tasks, messages, locks, handoffs, and poll state. It no longer
-  falls back to an in-memory team snapshot or presents coordination read errors
-  as a healthy empty result.
+- **Truthful coordination status** -- the persistent SQLite `TeamStore` is the
+  sole coordination truth for agents, tasks, messages, locks, handoffs, and poll
+  state. The Dashboard exposes read-only `Coordination Status` and `Task Status`
+  views, and `/api/team` reports explicit `error` or `degraded` status instead of
+  presenting a failed coordination read as a healthy empty result.
 
 ## [1.8.0] - 2026-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- **Coordination truth in Dashboard** -- the Dashboard Coordination Status page
+  is a read-only project-scoped view backed by the persistent SQLite `TeamStore`
+  for agents, tasks, messages, locks, handoffs, and poll state. It no longer
+  falls back to an in-memory team snapshot or presents coordination read errors
+  as a healthy empty result.
+
 ## [1.8.0] - 2026-08-23
 
 ### Added

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -864,6 +864,8 @@ Important inputs:
 
 When using HTTP mode, the main dashboard is usually served from the same port as `serve-http`.
 
+The Dashboard's Coordination Status page is read-only. It reads the selected project's agents, tasks, locks, handoffs, messages, and poll state from the persistent SQLite `TeamStore`; it does not expose team/task write endpoints or replace task execution and orchestration tools. A coordination read failure is returned as an explicit degraded/error response rather than an empty healthy snapshot.
+
 ---
 
 ## 12. Optional Graph Compatibility Tools

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -498,7 +498,9 @@ It provides an operational view for:
 - sessions
 - retention state
 - preview-first cleanup, consolidation, intelligent deduplication, and retention archival
-- read-only orchestration coordination state in the standalone dashboard and live state in HTTP service mode
+- read-only Coordination Status derived from the project-scoped SQLite `TeamStore`; the page is a projection, not a task execution surface
+
+`TeamStore` is the real persistent coordination layer for agents, tasks, messages, locks, handoffs, and poll state. Dashboard coordination reads use that same SQLite state and return an explicit degraded/error status when it cannot be read; they must not substitute a normal-looking empty snapshot.
 
 Dashboard maintenance is not a separate business-logic implementation. CLI, MCP, background jobs, and Dashboard routes share the same cleanup, consolidation, deduplication, and retention functions. Mutation routes issue a project-bound signed preview token and reject execution when the candidate set changed after preview.
 

--- a/docs/DASHBOARD.md
+++ b/docs/DASHBOARD.md
@@ -19,6 +19,12 @@ memorix dashboard
 
 Both modes read the same project-scoped stores. The project switcher changes the active project filter; it does not merge projects or grant access to personal memories.
 
+## Coordination Status
+
+The Coordination Status page is a read-only projection of the selected project's persistent coordination state. `TeamStore` is the canonical SQLite layer for agents, tasks, messages, locks, handoffs, and poll state; the Dashboard does not keep a second in-memory coordination registry.
+
+The page reports agents, task status, file locks, and handoffs for the selected project. It exposes no team or task write endpoints and is not a task execution or full orchestration platform. If the SQLite read fails, the API returns an explicit degraded/error status and the page shows that the status is unavailable instead of presenting an empty result as healthy.
+
 ## Maintenance Workbench
 
 The Observations page exposes three explicit maintenance actions:

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -13,8 +13,8 @@ Memorix is a TypeScript project built around:
 
 ## Current Development Baseline
 
-The current release work targets the **1.8.0 release line** and package metadata
-is kept at `1.8.0` for this release commit.
+The current release work targets the **1.8.1 release line** and package metadata
+is kept at `1.8.1` for this release commit.
 
 Contributors should assume the following areas are part of the current release line:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,7 +33,7 @@ The public docs are organized by user intent:
 | CLI commands and MCP tools | [API_REFERENCE.md](API_REFERENCE.md) |
 | Memory Autopilot, Code State, and context packs | [API_REFERENCE.md § Memory Autopilot, Code State, and Context Packs](API_REFERENCE.md#memory-autopilot-code-state-and-context-packs), [1.2 Code State](1.2.0-CODE-STATE.md), and [1.2 Workset Retrieval](1.2.0-WORKSET-RETRIEVAL.md) |
 | Reviewed episodic, semantic, and procedural long-term memory | [1.3 Memory Architecture](1.3-MEMORY-ARCHITECTURE.md) |
-| Browse memory and run preview-first local maintenance | [Dashboard](DASHBOARD.md) |
+| Browse memory, maintenance, and read-only Coordination Status | [Dashboard](DASHBOARD.md) |
 | Reviewable knowledge pages and workflow inheritance | [API_REFERENCE.md § Knowledge Workspace and Workflows](API_REFERENCE.md#knowledge-workspace-and-workflows), [1.2 Knowledge Workspace](1.2.0-KNOWLEDGE-WORKSPACE.md), and [1.2 Workflow Inheritance](1.2.0-WORKFLOW-INHERITANCE.md) |
 | Git-derived engineering memory | [GIT_MEMORY.md](GIT_MEMORY.md) |
 | Memory formation and quality pipeline | [MEMORY_FORMATION_PIPELINE.md](MEMORY_FORMATION_PIPELINE.md) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -121,7 +121,7 @@ Historical/deep-reference documents may describe older designs. If they conflict
 
 ## Current Product Line
 
-The current product line is **1.8.0**. The authoritative acceptance contract is
+The current product line is **1.8.1**. The authoritative acceptance contract is
 [1.8.0 Release Specification](1.8.0-RELEASE-CANDIDATE-SPEC.md).
 The current baseline has:
 
@@ -130,6 +130,9 @@ The current baseline has:
 - `memorix background start` runs the shared HTTP MCP service and dashboard
 - Dashboard maintenance is preview-first, project-scoped, and uses the same
   cleanup and deduplication planners as CLI and MCP
+- Dashboard Coordination Status is read-only and projects the persistent SQLite
+  `TeamStore` truth; its task section is `Task Status` and failed reads are
+  explicit `error`/`degraded` states
 - context and CodeGraph commands return bounded task receipts before detailed diagnostics
 - HTTP MCP sessions have a bounded, explicit lifecycle and fail with a reinitialize hint after expiry
 - `memorix integrate --agent <agent>` and `memorix hooks install --agent <agent>` remain manual/fallback generation commands

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memorix",
   "mcpName": "io.github.AVIDS2/memorix",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
+++ b/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Local-first project memory for CodeBuddy Code and other coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AVIDS2/memorix",
     "source": "github"
   },
-  "version": "1.8.0",
+  "version": "1.8.1",
   "websiteUrl": "https://github.com/AVIDS2/memorix#readme",
   "icons": [
     {
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "memorix",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "runtimeHint": "npx",
       "packageArguments": [
         {

--- a/src/cli/commands/dashboard.ts
+++ b/src/cli/commands/dashboard.ts
@@ -59,7 +59,7 @@ export default defineCommand({
         const cliDir = path.dirname(fileURLToPath(import.meta.url));
         const staticDir = path.join(cliDir, '..', 'dashboard', 'static');
 
-        await startDashboard(dataDir, port, staticDir, project.id, project.name, true, undefined, project.rootPath, true);
+        await startDashboard(dataDir, port, staticDir, project.id, project.name, true, project.rootPath, true);
 
         // Keep alive
         await new Promise(() => { });

--- a/src/cli/commands/serve-http.ts
+++ b/src/cli/commands/serve-http.ts
@@ -889,6 +889,15 @@ export default defineCommand({
         }
 
         if (apiPath === '/team') {
+          if (req.method !== 'GET') {
+            sendJson({
+              status: 'error',
+              readOnly: true,
+              error: 'Coordination status is read-only',
+              errorCode: 'COORDINATION_STATUS_READ_ONLY',
+            }, 405);
+            return;
+          }
           // Phase 4a: All team state is in SQLite via TeamStore
           const { projectId: teamProjectId, dataDir: teamDataDir } = await resolveRequestProject(url);
           const ts = await getTeamStore(teamDataDir);
@@ -967,8 +976,9 @@ export default defineCommand({
           const openHandoffs = handoffs.filter((handoff: any) => handoff.status !== 'completed').length;
 
           sendJson({
+            status: 'ok',
             mode: 'control-plane',
-            readOnly: false,
+            readOnly: true,
             scope,
             agents: withTier,
             // Primary headline number
@@ -1650,6 +1660,23 @@ export default defineCommand({
 
         sendJson({ error: 'Not found' }, 404);
       } catch (err) {
+        if (apiPath === '/team') {
+          const scope = url.searchParams.get('scope') === 'global' ? 'global' : 'project';
+          console.error('[memorix] coordination snapshot unavailable', { status: 'error', scope });
+          sendJson({
+            status: 'error',
+            mode: 'control-plane',
+            readOnly: true,
+            scope,
+            agents: [],
+            locks: [],
+            tasks: [],
+            handoffs: [],
+            error: 'Coordination state unavailable',
+            errorCode: 'COORDINATION_STATE_UNAVAILABLE',
+          }, 503);
+          return;
+        }
         sendJson({ error: err instanceof Error ? err.message : 'Unknown error' }, 500);
       }
     }

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -958,16 +958,8 @@ interface DashboardState {
     dataDir: string;
     projectRoot: string | null;
     projectResolved: boolean;
-    mode: 'standalone' | 'control-plane';
+    mode: 'standalone';
     port: number;
-}
-
-/** Optional coordination instances passed from MCP server */
-export interface TeamInstances {
-    registry: { listAgents: (filter?: any) => any[]; getActiveCount: () => number; getAgent: (id: string) => any };
-    fileLocks: { listLocks: (agentId?: string) => any[]; cleanExpired: () => void };
-    taskManager: { list: (filter?: any) => any[]; getAvailable: () => any[] };
-    messageBus: { getUnreadCount: (agentId: string) => number };
 }
 
 function parseJsonField(value: unknown, fallback: unknown): unknown {
@@ -1027,7 +1019,72 @@ function normalizeDashboardTask(task: any) {
     };
 }
 
-async function buildTeamSnapshot(dataDir: string, projectId: string, scope: string, mode: DashboardState['mode']) {
+type TeamSnapshotStatus = 'ok' | 'degraded' | 'error';
+
+interface TeamSnapshot {
+    status: TeamSnapshotStatus;
+    mode: DashboardState['mode'];
+    readOnly: true;
+    scope: string;
+    agents: any[];
+    activeCount: number;
+    recentCount: number;
+    historicalCount: number;
+    totalAgents: number;
+    recentWindowDays: number;
+    locks: any[];
+    tasks: any[];
+    availableTasks: number;
+    sessions: number;
+    roles: any[];
+    roleOccupancy: any[];
+    handoffs: any[];
+    openTasks: number;
+    openHandoffs: number;
+    totalUnread: number;
+    activeSessions: number;
+    error?: string;
+    errorCode?: string;
+}
+
+function emptyTeamSnapshot(
+    mode: DashboardState['mode'],
+    scope: string,
+    status: Exclude<TeamSnapshotStatus, 'ok'>,
+): TeamSnapshot {
+    return {
+        status,
+        mode,
+        readOnly: true,
+        scope,
+        agents: [],
+        activeCount: 0,
+        recentCount: 0,
+        historicalCount: 0,
+        totalAgents: 0,
+        recentWindowDays: 7,
+        locks: [],
+        tasks: [],
+        availableTasks: 0,
+        sessions: 0,
+        roles: [],
+        roleOccupancy: [],
+        handoffs: [],
+        openTasks: 0,
+        openHandoffs: 0,
+        totalUnread: 0,
+        activeSessions: 0,
+        error: status === 'error' ? 'Coordination state unavailable' : 'Coordination state is incomplete',
+        errorCode: status === 'error' ? 'COORDINATION_STATE_UNAVAILABLE' : 'COORDINATION_STATE_DEGRADED',
+    };
+}
+
+function logTeamSnapshotFailure(scope: string, status: Exclude<TeamSnapshotStatus, 'ok'>): void {
+    const safeScope = scope === 'global' ? 'global' : 'project';
+    console.error('[dashboard] coordination snapshot unavailable', { status, scope: safeScope });
+}
+
+async function buildTeamSnapshot(dataDir: string, projectId: string, scope: string, mode: DashboardState['mode']): Promise<TeamSnapshot> {
     try {
         const { initTeamStore } = await import('../team/team-store.js');
         const teamStore = await initTeamStore(dataDir);
@@ -1053,8 +1110,9 @@ async function buildTeamSnapshot(dataDir: string, projectId: string, scope: stri
         const roleOccupancy = effectiveProjectId ? teamStore.getRoleOccupancy(effectiveProjectId) : [];
         const handoffs = effectiveProjectId ? teamStore.listHandoffs(effectiveProjectId) : [];
         return {
+            status: 'ok',
             mode,
-            readOnly: mode === 'standalone',
+            readOnly: true,
             scope,
             agents: withTier,
             activeCount,
@@ -1075,28 +1133,8 @@ async function buildTeamSnapshot(dataDir: string, projectId: string, scope: stri
             activeSessions: activeCount,
         };
     } catch {
-        return {
-            mode,
-            readOnly: mode === 'standalone',
-            scope,
-            agents: [],
-            activeCount: 0,
-            recentCount: 0,
-            historicalCount: 0,
-            totalAgents: 0,
-            recentWindowDays: 7,
-            locks: [],
-            tasks: [],
-            availableTasks: 0,
-            sessions: 0,
-            roles: [],
-            roleOccupancy: [],
-            handoffs: [],
-            openTasks: 0,
-            openHandoffs: 0,
-            totalUnread: 0,
-            activeSessions: 0,
-        };
+        logTeamSnapshotFailure(scope, 'error');
+        return emptyTeamSnapshot(mode, scope, 'error');
     }
 }
 
@@ -1125,7 +1163,6 @@ export async function startDashboard(
     projectId: string,
     projectName: string,
     autoOpen = true,
-    teamInstances?: TeamInstances,
     projectRoot: string | null = null,
     projectResolved = true,
 ): Promise<void> {
@@ -1136,8 +1173,7 @@ export async function startDashboard(
     const baseDir = getBaseDataDir();
 
     // Mutable state — can be updated via /api/set-current-project
-    const isControlPlane = !!teamInstances;
-    const state: DashboardState = { projectId, projectName, dataDir, projectRoot, projectResolved, mode: isControlPlane ? 'control-plane' : 'standalone', port };
+    const state: DashboardState = { projectId, projectName, dataDir, projectRoot, projectResolved, mode: 'standalone', port };
 
     const server = createServer(async (req, res) => {
         const url = req.url || '/';
@@ -1164,56 +1200,20 @@ export async function startDashboard(
             return;
         }
 
-        if (url.startsWith('/api/team')) {
-            if (!teamInstances) {
-                const parsedUrl = new URL(url, `http://127.0.0.1:${port}`);
-                const scope = parsedUrl.searchParams.get('scope') || 'project';
-                sendJson(res, await buildTeamSnapshot(state.dataDir, state.projectId, scope, state.mode));
+        const parsedUrl = new URL(url, `http://127.0.0.1:${port}`);
+        if (parsedUrl.pathname === '/api/team') {
+            if (req.method !== 'GET') {
+                sendJson(res, {
+                    status: 'error',
+                    readOnly: true,
+                    error: 'Coordination status is read-only',
+                    errorCode: 'COORDINATION_STATUS_READ_ONLY',
+                }, 405);
                 return;
             }
-            try {
-                teamInstances.fileLocks.cleanExpired();
-                const agents = teamInstances.registry.listAgents();
-                const locks = teamInstances.fileLocks.listLocks();
-                const tasks = teamInstances.taskManager.list();
-                const available = teamInstances.taskManager.getAvailable();
-
-                // Role occupancy and handoffs from TeamStore (if available)
-                let roles: any[] = [];
-                let roleOccupancy: any[] = [];
-                let handoffs: any[] = [];
-                try {
-                    const { getTeamStore, isTeamStoreInitialized } = await import('../team/team-store.js');
-                    if (isTeamStoreInitialized()) {
-                        const teamStore = getTeamStore();
-                        const projectId = state.projectId;
-                        roles = teamStore.listRoles(projectId);
-                        roleOccupancy = teamStore.getRoleOccupancy(projectId);
-                        handoffs = teamStore.listHandoffs(projectId);
-                    }
-                } catch { /* team store not available in standalone mode */ }
-
-                sendJson(res, {
-                    agents: agents.map((a: any) => ({
-                        ...a,
-                        unread: teamInstances!.messageBus.getUnreadCount(a.id),
-                    })),
-                    activeCount: teamInstances.registry.getActiveCount(),
-                    locks,
-                    tasks,
-                    availableTasks: available.length,
-                    roles,
-                    roleOccupancy,
-                    handoffs,
-                    // Resume data for "Continue this project" area
-                    openTasks: tasks.filter((t: any) => t.status === 'pending' || t.status === 'in_progress').length,
-                    openHandoffs: handoffs.filter((h: any) => h.handoff_status === 'open' || h.handoffStatus === 'open').length,
-                    totalUnread: agents.reduce((sum: number, a: any) => sum + teamInstances!.messageBus.getUnreadCount(a.id), 0),
-                    activeSessions: agents.filter((a: any) => a.status === 'active').length,
-                });
-            } catch {
-                sendJson(res, { agents: [], activeCount: 0, locks: [], tasks: [], availableTasks: 0, roles: [], roleOccupancy: [], handoffs: [] });
-            }
+            const scope = parsedUrl.searchParams.get('scope') || 'project';
+            const snapshot = await buildTeamSnapshot(state.dataDir, state.projectId, scope, state.mode);
+            sendJson(res, snapshot, snapshot.status === 'error' ? 503 : 200);
             return;
         }
 
@@ -1237,13 +1237,12 @@ export async function startDashboard(
         server.listen(port, '127.0.0.1', () => {
             const url = `http://127.0.0.1:${port}`;
             const resolvedLabel = projectResolved ? 'resolved' : 'unresolved';
-            const modeLabel = isControlPlane ? 'Control Plane' : 'Standalone';
+            const modeLabel = 'Standalone';
             console.error(`  Memorix Dashboard [${modeLabel}]`);
             console.error(`  ───────────────────────`);
             console.error(`  Mode:     ${modeLabel}`);
             console.error(`  Project:  ${projectName} (${projectId}) [${resolvedLabel}]`);
             console.error(`  Local:    ${url}`);
-            if (isControlPlane) console.error(`  MCP:      ${url}/mcp`);
             console.error(`  Data dir: ${dataDir}`);
             console.error(`\n  Press Ctrl+C to stop\n`);
             if (autoOpen) openBrowser(url);

--- a/src/dashboard/static/app.js
+++ b/src/dashboard/static/app.js
@@ -142,17 +142,21 @@ const i18n = {
     noRetentionDesc: 'Store observations to see memory retention scores',
 
     // Team -> Coordination
-    teamTitle: 'Coordination',
-    teamSubtitle: 'Coordinated agents, tasks, locks, and handoffs',
-    teamNoData: 'No coordination workflow activity yet',
-    teamNoDataHint: 'Use the CLI orchestrator or inspect coordination state.',
+    teamTitle: 'Coordination Status',
+    teamSubtitle: 'Read-only project coordination status',
+    teamNoData: 'No coordination status is available',
+    teamNoDataHint: 'Coordination state is read-only and comes from the project SQLite store.',
+    teamStatusError: 'Coordination status unavailable',
+    teamStatusDegraded: 'Coordination status degraded',
+    teamStatusErrorDesc: 'The persistent coordination state could not be read. This view has no write actions.',
+    teamStatusDegradedDesc: 'Some persistent coordination state could not be read. Values may be incomplete.',
     teamActiveAgents: 'Active Agents',
     teamLockedFiles: 'Locked Files',
     teamTasks: 'Tasks',
     teamAvailable: 'Available',
     teamAgents: 'Agents',
     teamLocks: 'File Locks',
-    teamTaskBoard: 'Task Board',
+    teamTaskStatus: 'Task Status',
     // Resume area
     resumeTitle: 'Continue This Project',
     resumeDesc: 'What needs attention right now',
@@ -282,7 +286,7 @@ const i18n = {
     projectUnresolved: 'Unresolved',
     projectUnresolvedDesc: 'No project bound — select a project from the switcher',
     projectResolved: 'Resolved',
-    projectScopeProject: 'Project Coordination',
+    projectScopeProject: 'Project Coordination Status',
     projectScopeGlobal: 'All Projects',
     projectScopeProjectDesc: 'Agents and tasks coordinated for this project',
     projectScopeGlobalDesc: 'Agents and tasks coordinated across projects',
@@ -469,8 +473,8 @@ const i18n = {
     // Mode banner
     modeStandalone: 'Standalone',
     modeControlPlane: 'Control Plane',
-    modeStandaloneHint: 'Standalone dashboard - memory and read-only coordination state',
-    modeControlPlaneHint: 'HTTP control plane - shared MCP access and live dashboard',
+    modeStandaloneHint: 'Standalone dashboard - memory and read-only coordination status',
+    modeControlPlaneHint: 'HTTP control plane - shared MCP access and read-only coordination status',
     modeBannerProject: 'Project',
     modeBannerMcp: 'MCP',
 
@@ -621,17 +625,21 @@ const i18n = {
     noRetentionDesc: '存储观察记录以查看记忆衰减分数',
 
     // Team -> 编排协作
-    teamTitle: '编排协作',
-    teamSubtitle: 'agents、任务、文件锁和交接状态',
-    teamNoData: '暂无编排协作活动',
-    teamNoDataHint: '使用 CLI 编排任务，或查看协调状态。',
+    teamTitle: '协作状态',
+    teamSubtitle: '只读项目协作状态',
+    teamNoData: '暂无可用的协作状态',
+    teamNoDataHint: '协作状态为只读，并来自项目 SQLite 存储。',
+    teamStatusError: '协作状态不可用',
+    teamStatusDegraded: '协作状态已降级',
+    teamStatusErrorDesc: '无法读取持久协作状态。此视图不提供写入操作。',
+    teamStatusDegradedDesc: '部分持久协作状态无法读取，当前数据可能不完整。',
     teamActiveAgents: '活跃 Agent',
     teamLockedFiles: '锁定文件',
     teamTasks: '任务',
     teamAvailable: '可领取',
     teamAgents: 'Agent',
     teamLocks: '文件锁',
-    teamTaskBoard: '任务看板',
+    teamTaskStatus: '任务状态',
     // Resume area
     resumeTitle: '继续这个项目',
     resumeDesc: '当前需要关注的事项',
@@ -761,7 +769,7 @@ const i18n = {
     projectUnresolved: '未绑定',
     projectUnresolvedDesc: '无项目绑定 — 请从切换器选择项目',
     projectResolved: '已绑定',
-    projectScopeProject: '项目编排协作',
+    projectScopeProject: '项目协作状态',
     projectScopeGlobal: '所有项目',
     projectScopeProjectDesc: '当前项目中的 agents 和任务',
     projectScopeGlobalDesc: '所有项目中的 agents 和任务',
@@ -953,8 +961,8 @@ const i18n = {
     // Mode banner
     modeStandalone: '独立模式',
     modeControlPlane: '控制平面',
-    modeStandaloneHint: '独立看板 - 记忆与只读协调状态',
-    modeControlPlaneHint: 'HTTP 控制平面 - 共享 MCP 接入与实时看板',
+    modeStandaloneHint: '独立视图 - 记忆与只读协作状态',
+    modeControlPlaneHint: 'HTTP 控制平面 - 共享 MCP 接入与只读协作状态',
     modeBannerProject: '项目',
     modeBannerMcp: 'MCP',
 
@@ -1157,8 +1165,12 @@ async function api(endpoint) {
       ? `/api/${endpoint}${sep}project=${encodeURIComponent(selectedProject)}`
       : `/api/${endpoint}`;
     const res = await fetch(url);
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
-    return await res.json();
+    const payload = await res.json().catch(() => null);
+    if (!res.ok) {
+      if (endpoint.startsWith('team') && payload?.status) return payload;
+      throw new Error(`HTTP ${res.status}`);
+    }
+    return payload;
   } catch (err) {
     console.error(`API error (${endpoint}):`, err);
     return null;
@@ -4492,7 +4504,10 @@ async function loadTeam() {
   }
 
   const data = await api('team?scope=' + teamScope);
-  if (!data || data.unavailable) {
+  if (!data || data.unavailable || data.status === 'error' || data.status === 'degraded') {
+    const isDegraded = data?.status === 'degraded';
+    const statusTitle = isDegraded ? t('teamStatusDegraded') : (data?.status === 'error' ? t('teamStatusError') : t('teamNoData'));
+    const statusDescription = isDegraded ? t('teamStatusDegradedDesc') : (data?.status === 'error' ? t('teamStatusErrorDesc') : t('teamNoDataHint'));
     container.innerHTML = `
       <div class="page-header">
         <h1 class="page-title">${t('teamTitle')}</h1>
@@ -4501,10 +4516,9 @@ async function loadTeam() {
       <div class="panel">
         <div class="panel-body" style="text-align:center;padding:48px;">
           <div style="font-size:36px;margin-bottom:12px;"><span class="iconify" data-icon="lucide:users" style="font-size:36px;"></span></div>
-          <div style="font-size:16px;font-weight:600;color:var(--text-primary);margin-bottom:8px;">${t('teamNoData')}</div>
+          <div style="font-size:16px;font-weight:600;color:var(--text-primary);margin-bottom:8px;">${statusTitle}</div>
           <div style="font-size:13px;color:var(--text-muted);max-width:480px;margin:0 auto;line-height:1.6;">
-            ${t('teamNoDataHint')}<br>
-            <code style="background:var(--bg-surface);padding:4px 10px;border-radius:6px;margin-top:8px;display:inline-block;font-size:12px;">memorix orchestrate · memorix team status · memorix task list</code>
+            ${statusDescription}<br>
           </div>
         </div>
       </div>
@@ -4763,7 +4777,7 @@ async function loadTeam() {
 
     <div class="panel">
       <div class="panel-header">
-        <span class="panel-title">${t('teamTaskBoard')}</span>
+        <span class="panel-title">${t('teamTaskStatus')}</span>
         <span class="team-panel-count">${data.availableTasks || 0} ${t('teamAvailableToClaim')}</span>
       </div>
       <div class="panel-body">

--- a/src/dashboard/static/index.html
+++ b/src/dashboard/static/index.html
@@ -135,7 +135,7 @@
         </svg>
         <span class="nav-label">Sessions</span>
       </button>
-      <button class="nav-btn" data-page="team" title="Coordination" aria-label="Coordination">
+      <button class="nav-btn" data-page="team" title="Coordination Status" aria-label="Coordination Status">
         <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
           <circle cx="9" cy="7" r="4"/>

--- a/src/server.ts
+++ b/src/server.ts
@@ -198,7 +198,7 @@ function createDeterministicInstanceId(projectId: string, agentType: string, age
  * Create and configure the Memorix MCP Server.
  */
 /** Optional shared TeamStore — passed by serve-http so all sessions share state */
-export interface SharedTeamInstances {
+export interface SharedTeamStore {
   teamStore: import('./team/team-store.js').TeamStore;
 }
 
@@ -245,7 +245,7 @@ export function shouldAwaitProjectRuntime(toolName: string): boolean {
 export async function createMemorixServer(
   cwd?: string,
   existingServer?: McpServer,
-  sharedTeam?: SharedTeamInstances,
+  sharedTeam?: SharedTeamStore,
   options: CreateMemorixServerOptions = {},
 ): Promise<{
   server: McpServer;
@@ -4420,7 +4420,7 @@ export async function createMemorixServer(
         console.error(`[memorix] Dashboard staticDir: ${staticDir}`);
 
         // Start in background (non-blocking), disable auto-open (we'll open it ourselves)
-        startDashboard(projectDir, portNum, staticDir, project.id, project.name, false, undefined, project.rootPath, projectResolved)
+        startDashboard(projectDir, portNum, staticDir, project.id, project.name, false, project.rootPath, projectResolved)
           .then(() => { dashboardRunning = true; })
           .catch((err) => { console.error('[memorix] Dashboard error:', err); dashboardRunning = false; });
 
@@ -4786,7 +4786,7 @@ export async function createMemorixServer(
   server.registerTool(
     'team_task',
     {
-      title: 'Task Board',
+      title: 'Task Status',
       description:
         'Create, claim, complete, or list tasks in the team task board. Supports dependencies. ' +
         'Action "create": create a task. Action "claim": assign to yourself (atomic, race-safe). ' +

--- a/tests/integration/dashboard-coordination-truth.test.ts
+++ b/tests/integration/dashboard-coordination-truth.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { initTeamStore, resetTeamStore } from '../../src/team/team-store.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+
+const PORT_A = 14212;
+const PORT_B = 14213;
+const BASE_A = `http://127.0.0.1:${PORT_A}`;
+const BASE_B = `http://127.0.0.1:${PORT_B}`;
+
+let tempDir: string;
+let dataDir: string;
+
+async function getJson(baseUrl: string, urlPath: string, init?: RequestInit): Promise<{ status: number; body: any }> {
+  const response = await fetch(`${baseUrl}${urlPath}`, init);
+  return { status: response.status, body: await response.json() };
+}
+
+describe('Dashboard coordination truth', () => {
+  beforeAll(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-coordination-truth-'));
+    dataDir = path.join(tempDir, 'data');
+    await fs.mkdir(dataDir, { recursive: true });
+
+    const teamStore = await initTeamStore(dataDir);
+    const agentA = teamStore.registerAgent({
+      projectId: 'project-a',
+      agentType: 'codex',
+      instanceId: 'a-1',
+      name: 'agent-a',
+      role: 'engineer',
+    });
+    const agentA2 = teamStore.registerAgent({
+      projectId: 'project-a',
+      agentType: 'windsurf',
+      instanceId: 'a-2',
+      name: 'agent-a-2',
+      role: 'reviewer',
+    });
+    const agentB = teamStore.registerAgent({
+      projectId: 'project-b',
+      agentType: 'claude-code',
+      instanceId: 'b-1',
+      name: 'agent-b',
+      role: 'engineer',
+    });
+
+    teamStore.createTask({
+      projectId: 'project-a',
+      description: 'Project A task',
+      createdBy: agentA.agent_id,
+      requiredRole: 'engineer',
+    });
+    teamStore.createTask({
+      projectId: 'project-b',
+      description: 'Project B task',
+      createdBy: agentB.agent_id,
+      requiredRole: 'engineer',
+    });
+    teamStore.acquireLock('project-a', 'src/a.ts', agentA.agent_id);
+    teamStore.acquireLock('project-b', 'src/b.ts', agentB.agent_id);
+    teamStore.sendMessage({
+      projectId: 'project-a',
+      senderAgentId: agentA.agent_id,
+      recipientAgentId: agentA2.agent_id,
+      type: 'handoff',
+      content: 'Project A handoff',
+      toRole: 'reviewer',
+      handoffStatus: 'open',
+    });
+
+    resetTeamStore();
+
+    const { startDashboard } = await import('../../src/dashboard/server.js');
+    const staticDir = path.join(process.cwd(), 'src', 'dashboard', 'static');
+    await startDashboard(dataDir, PORT_A, staticDir, 'project-a', 'project-a', false);
+
+    resetTeamStore();
+    await startDashboard(dataDir, PORT_B, staticDir, 'project-b', 'project-b', false);
+  }, 15_000);
+
+  afterAll(async () => {
+    resetTeamStore();
+    closeAllDatabases();
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('reads agents, tasks, locks, and handoffs from project-scoped SQLite', async () => {
+    const { status, body } = await getJson(BASE_A, '/api/team');
+
+    expect(status).toBe(200);
+    expect(body.status).toBe('ok');
+    expect(body.readOnly).toBe(true);
+    expect(body.mode).toBe('standalone');
+    expect(body.agents.map((agent: any) => agent.name)).toEqual(['agent-a-2', 'agent-a']);
+    expect(body.tasks).toHaveLength(1);
+    expect(body.tasks[0].description).toBe('Project A task');
+    expect(body.locks).toHaveLength(1);
+    expect(body.locks[0].file).toBe('src/a.ts');
+    expect(body.handoffs).toHaveLength(1);
+    expect(body.handoffs[0].content).toBe('Project A handoff');
+    expect(body.totalUnread).toBe(1);
+  });
+
+  it('keeps SQLite data visible after the TeamStore singleton is reopened', async () => {
+    resetTeamStore();
+    closeAllDatabases();
+
+    const { status, body } = await getJson(BASE_A, '/api/team');
+
+    expect(status).toBe(200);
+    expect(body.status).toBe('ok');
+    expect(body.tasks[0].description).toBe('Project A task');
+    expect(body.locks[0].file).toBe('src/a.ts');
+  });
+
+  it('reports SQLite read failures without leaking local details', async () => {
+    const teamStore = await initTeamStore(dataDir);
+    const originalListAgents = teamStore.listAgents;
+    teamStore.listAgents = (() => {
+      throw new Error(`simulated failure at ${dataDir}`);
+    }) as typeof teamStore.listAgents;
+    const logSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    try {
+      const { status, body } = await getJson(BASE_A, '/api/team');
+
+      expect(status).toBe(503);
+      expect(body.status).toBe('error');
+      expect(body.errorCode).toBe('COORDINATION_STATE_UNAVAILABLE');
+      expect(body.error).toBe('Coordination state unavailable');
+      expect(JSON.stringify(logSpy.mock.calls)).not.toContain(dataDir);
+    } finally {
+      teamStore.listAgents = originalListAgents;
+      logSpy.mockRestore();
+    }
+  });
+
+  it('isolates project A and project B coordination snapshots', async () => {
+    const projectA = await getJson(BASE_A, '/api/team');
+    const projectB = await getJson(BASE_B, '/api/team');
+
+    expect(projectA.body.tasks.map((task: any) => task.description)).toEqual(['Project A task']);
+    expect(projectA.body.locks.map((lock: any) => lock.file)).toEqual(['src/a.ts']);
+    expect(projectB.body.tasks.map((task: any) => task.description)).toEqual(['Project B task']);
+    expect(projectB.body.locks.map((lock: any) => lock.file)).toEqual(['src/b.ts']);
+    expect(projectB.body.handoffs).toEqual([]);
+  });
+
+  it('does not expose successful team or task write paths', async () => {
+    for (const method of ['POST', 'PATCH', 'DELETE']) {
+      for (const urlPath of ['/api/team', '/api/team/task', '/api/task']) {
+        const { status } = await getJson(BASE_A, urlPath, { method });
+        expect(status, `${method} ${urlPath}`).toBeGreaterThanOrEqual(400);
+      }
+    }
+  });
+
+  it('keeps the dashboard coordination surface read-only and accurately named', async () => {
+    const app = await fs.readFile(path.join(process.cwd(), 'src', 'dashboard', 'static', 'app.js'), 'utf8');
+    const server = await fs.readFile(path.join(process.cwd(), 'src', 'dashboard', 'server.ts'), 'utf8');
+
+    expect(app).toContain("teamTaskStatus: 'Task Status'");
+    expect(app).toContain("teamTaskStatus: '任务状态'");
+    expect(app).toContain("teamTitle: 'Coordination Status'");
+    expect(app).toContain("teamTitle: '协作状态'");
+    expect(app).not.toContain(['Task', 'Board'].join(' '));
+    expect(app).not.toContain(['任务', '看板'].join(''));
+    const legacyInstanceTypes = [['Team', 'Instances'], ['team', 'Instances']].map(parts => parts.join(''));
+    for (const legacyInstanceType of legacyInstanceTypes) {
+      expect(server).not.toContain(legacyInstanceType);
+    }
+  });
+});

--- a/tests/integration/dashboard-coordination-truth.test.ts
+++ b/tests/integration/dashboard-coordination-truth.test.ts
@@ -94,7 +94,7 @@ describe('Dashboard coordination truth', () => {
     expect(body.status).toBe('ok');
     expect(body.readOnly).toBe(true);
     expect(body.mode).toBe('standalone');
-    expect(body.agents.map((agent: any) => agent.name)).toEqual(['agent-a-2', 'agent-a']);
+    expect(body.agents.map((agent: any) => agent.name).sort()).toEqual(['agent-a', 'agent-a-2']);
     expect(body.tasks).toHaveLength(1);
     expect(body.tasks[0].description).toBe('Project A task');
     expect(body.locks).toHaveLength(1);
@@ -161,11 +161,20 @@ describe('Dashboard coordination truth', () => {
   it('keeps the dashboard coordination surface read-only and accurately named', async () => {
     const app = await fs.readFile(path.join(process.cwd(), 'src', 'dashboard', 'static', 'app.js'), 'utf8');
     const server = await fs.readFile(path.join(process.cwd(), 'src', 'dashboard', 'server.ts'), 'utf8');
+    const packageJson = JSON.parse(await fs.readFile(path.join(process.cwd(), 'package.json'), 'utf8'));
+    const packageLock = JSON.parse(await fs.readFile(path.join(process.cwd(), 'package-lock.json'), 'utf8'));
+    const serverManifest = JSON.parse(await fs.readFile(path.join(process.cwd(), 'server.json'), 'utf8'));
 
+    expect(packageJson.version).toBe('1.8.1');
+    expect(packageLock.version).toBe('1.8.1');
+    expect(packageLock.packages[''].version).toBe('1.8.1');
+    expect(serverManifest.version).toBe('1.8.1');
     expect(app).toContain("teamTaskStatus: 'Task Status'");
     expect(app).toContain("teamTaskStatus: '任务状态'");
     expect(app).toContain("teamTitle: 'Coordination Status'");
     expect(app).toContain("teamTitle: '协作状态'");
+    expect(app).toContain("modeControlPlane: 'Control Plane'");
+    expect(app).toContain("dashboardMode === 'control-plane'");
     expect(app).not.toContain(['Task', 'Board'].join(' '));
     expect(app).not.toContain(['任务', '看板'].join(''));
     const legacyInstanceTypes = [['Team', 'Instances'], ['team', 'Instances']].map(parts => parts.join(''));

--- a/tests/integration/dashboard-project-scope.test.ts
+++ b/tests/integration/dashboard-project-scope.test.ts
@@ -582,7 +582,6 @@ describe('Embedded serve-http /api/config project scope', () => {
       '__unresolved__',
       'unbound',
       false,
-      undefined,
       null,
       false,
     );


### PR DESCRIPTION
## Summary
- TeamStore SQLite remains the single coordination truth for real team/task/message/lock/handoff/poll state.
- Removed the unreachable in-memory TeamInstances branch.
- Dashboard coordination is read-only and named Coordination Status / Task Status.
- `/api/team` is project-isolated, survives reopen, and returns explicit errors instead of healthy empty data.
- Updated documentation, version, plugin metadata, and Registry metadata.

## Verification
- 111 focused tests
- `npm run lint`
- `npm run build`
- `npm pack --dry-run`