### PR TITLE
fix: harden MCP discovery and provider fallbacks for 1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.8.2] - 2026-08-25
+
+### Fixed
+- **Dashboard deduplication initialization (#248)** -- standalone and HTTP
+  maintenance previews now idempotently resolve the selected project's memory
+  LLM from TOML and `.env`, clear stale cross-project configuration, and keep
+  credentials out of responses.
+- **CodeGraph capability fallback (#250)** -- a failed or invalid `context`
+  probe now tries the official `explore` CLI with bounded, shell-free spawning.
+  Only validated paths, symbols, and relationships can select the external
+  provider; separate context/explore diagnostics explain Lite fallback.
+
+### MCP Compatibility
+- **Discovery adapter (#249)** -- the stdio server registers a real low-level
+  `server/discover` handler that returns the required 2026-07-28
+  `DiscoverResult` before `initialize`. Legacy 2025 initialize and versionless
+  `tools/list`/`tools/call` remain supported through the SDK's legacy envelopes.
+  Tasks, subscriptions, and list-response caching remain unsupported and are
+  not advertised.
+
 ## [1.8.1] - 2026-08-24
 
 ### Changed

--- a/docs/1.2.0-PROVIDER-QUALITY.md
+++ b/docs/1.2.0-PROVIDER-QUALITY.md
@@ -58,8 +58,9 @@ Memorix only considers the external provider when all of these are true:
    root;
 4. the index has no reported pending changes or worktree mismatch;
 5. the bounded command completes before its configured timeout; and
-6. the returned JSON passes Memorix's schema, path, count, and output-size
-   validation.
+6. the returned context JSON, or the official v1.5.0 `explore` output after a
+   context-command failure, passes Memorix's schema, path, relation, count,
+   and output-size validation.
 
 Memorix never runs `codegraph init`, `index`, or `sync` on the user's behalf.
 It does not transmit the repository to a remote service. Its default request is
@@ -90,7 +91,7 @@ external_context = "auto"
 # external_command = "C:\\tools\\codegraph.cmd"
 
 # A bounded local query. Values outside the safe range are clamped.
-external_timeout_ms = 1200
+external_timeout_ms = 3000
 ~~~
 
 The equivalent YAML keys are `externalContext`, `externalCommand`, and
@@ -114,12 +115,19 @@ The status is visible through `memorix codegraph status --json`, `memorix
 doctor --json`, and Project Context JSON. Prompt output keeps it compact: it
 adds semantic start points only when a valid external outline is available, and
 adds one caution when a requested external outline was not safe to use.
+An external status of `ready` means only that the index is initialized and
+current; it does not prove that the installed CLI exposes `context`. The task
+diagnostics therefore record `context` and `explore` independently.
 
 ## Validation and Fallback
 
 The external adapter executes without a shell, pins the working directory to
-the actual project root, uses a bounded timeout and stdout limit, and accepts
-JSON only. It rejects a result when:
+the actual project root, uses a bounded timeout and stdout limit, and tries
+`context` first. CodeGraph v1.5.0 does not register that command, so a failed
+or invalid context result triggers the official `explore --path <root>
+--max-files 4 <task>` command. JSON context output and the stable explore
+outline/relationship markers are accepted only after the same strict path and
+relation validation. It rejects a result when:
 
 - the status belongs to another project root;
 - the index is uninitialized, has pending changes, or reports a worktree
@@ -145,7 +153,8 @@ runner. It verifies:
 3. Stale, mismatched, malformed, timed-out, and oversized external output
    safely falls back to Lite.
 4. Raw code blocks and credentials do not enter the default Workset.
-5. `codegraph status` and `doctor` identify the active/fallback provider.
+5. `codegraph status` and `doctor` identify the active/fallback provider, and
+   distinguish a healthy index from a usable task-query command.
 
 The optional real smoke can be run on a Windows project that already has an
 indexed CodeGraph installation:

--- a/docs/1.3.3-MULTIMODAL-MEDIA-AND-MCP-COMPAT.md
+++ b/docs/1.3.3-MULTIMODAL-MEDIA-AND-MCP-COMPAT.md
@@ -158,15 +158,16 @@ layer, not Memorix product identity.
 - Product operations receive a resolved project/workspace binding and explicit
   actor metadata; they do not read an HTTP session map directly.
 - The old `Mcp-Session-Id` map remains isolated in `serve-http` as a legacy
-  adapter until the current SDK has a stable released implementation of the
-  2026-07-28 protocol.
+  adapter. A low-level `server/discover` adapter now covers the required
+  2026-07-28 discovery result without upgrading the pinned v1 SDK.
 - Asset IDs, media job IDs, project IDs, and attachment targets are explicit
   durable identifiers. They are never inferred from a live MCP connection.
 - New media tools work through stdio, legacy streamable HTTP, and direct CLI
   invocation with identical project binding behavior.
-- No release depends on an unreleased MCP SDK 2.x alpha. The current server
-  remains compatible with existing Codex, Claude Code, OpenCode, and other
-  configured clients.
+- No release depends on the MCP TypeScript SDK v2. The current server remains
+  compatible with existing legacy clients and supports versionless list/call
+  through the v1 SDK's legacy envelopes. The adapter does not claim modern
+  result caching, Tasks, subscriptions, or complete 2026 conformance.
 
 ## Non-goals
 
@@ -177,7 +178,7 @@ layer, not Memorix product identity.
 - No automatic audio/video transcription, frame extraction, or arbitrary media
   understanding in 1.3.3. The asset model makes those future derivations safe.
 - No forced migration to a protocol version that the published MCP TypeScript
-  SDK does not yet support.
+  SDK does not yet support; discovery is a narrow compatibility adapter.
 - No additional swarm of low-level MCP tools; CLI is the complete management
   surface and MCP exposes only small agent-facing operations.
 

--- a/docs/1.8.0-RELEASE-CANDIDATE-SPEC.md
+++ b/docs/1.8.0-RELEASE-CANDIDATE-SPEC.md
@@ -17,14 +17,16 @@ Status: accepted implementation contract for Memorix 1.8.0.
 
 ## Compatibility Contract
 
-The MCP 2026-07-28 protocol is the external stateless request contract.
-Memorix also accepts the legacy stateful Streamable HTTP contract with
-`Mcp-Session-Id`. Stateless requests carry an explicit `Mcp-Project-Handle`
-that is persisted in SQLite and survives service restart; the handle, rather
-than a transport session id, owns project routing. The pinned SDK's accepted
-wire version is normalized internally at the HTTP boundary, while responses
-continue to advertise current protocol metadata. Unsupported Tasks/polling is
-reported by capability diagnostics rather than simulated.
+Memorix preserves the legacy 2025-era initialize contract, including stdio and
+stateful Streamable HTTP with `Mcp-Session-Id`. Memorix 1.8.2 also registers a
+low-level `server/discover` compatibility adapter for the 2026-07-28 request.
+Its `DiscoverResult` is complete for the required identity, versions,
+capabilities, and private zero-TTL cache hint. Versionless `tools/list` and
+`tools/call` are accepted by the pinned v1 SDK and retain its legacy result
+envelopes. HTTP stateless project handles remain a compatibility adapter: they
+own project routing, but do not turn the v1 SDK into a complete 2026 runtime.
+Tasks, subscriptions, and list-response caching are unsupported and are not
+advertised or simulated.
 
 Antigravity is the primary setup target. Gemini CLI remains a compatibility and
 migration path. GitHub issue #204 (WorkBuddy) is intentionally not merged or

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -150,14 +150,16 @@ feedback projection.
 ### HTTP MCP Compatibility
 
 Legacy clients use stateful Streamable HTTP with `Mcp-Session-Id`. Current
-stateless clients send `Mcp-Protocol-Version: 2026-07-28` and receive a durable
-`Mcp-Project-Handle`. Send that handle on subsequent requests; it is persisted
-in SQLite and remains valid across service restart until its TTL expires.
-`/protocol-diagnostics` reports the current/legacy contract and explicitly
-reports Tasks and polling as unsupported when the pinned SDK cannot provide a
-durable implementation. When MCP discovery is unavailable, use one bounded
-`memorix context --fallback` request for a task; repeated fallback probing is
-rejected by the local budget.
+Legacy clients use the 2025-era `initialize` handshake and stateful
+`Mcp-Session-Id`. The stdio server also accepts the 2026-07-28
+`server/discover` request before `initialize` and returns the required
+`DiscoverResult`. Versionless `tools/list` and `tools/call` use the pinned
+SDK's legacy result envelopes. HTTP stateless clients may use a durable
+`Mcp-Project-Handle`; `/protocol-diagnostics` labels this as compatibility-only.
+Modern result metadata is discovery-only with a private zero-TTL hint. Tasks,
+subscriptions, and list-response caching are unsupported. When MCP discovery
+is unavailable, use one bounded `memorix context --fallback` request for a
+task; repeated fallback probing is rejected by the local budget.
 
 The built-in Lite provider indexes common code files with lightweight file, symbol, and import facts. It is a structural fallback, not a language-server-quality graph. When a project already has a healthy local CodeGraph index, `[codegraph].external_context = "auto"` may add a validated, bounded semantic outline to the Workset. Memorix never initializes, syncs, or exports that external index, and never stores its raw source output. `memorix codegraph status --json`, `memorix doctor --json`, and Project Context JSON identify the actual provider quality.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -74,7 +74,7 @@ max_file_bytes = 2097152
 # Optional: use an already-indexed local CodeGraph only when it is healthy.
 external_context = "auto"
 # external_command = "C:\\tools\\codegraph.cmd"
-external_timeout_ms = 1200
+external_timeout_ms = 3000
 
 [server]
 transport = "stdio"
@@ -334,7 +334,7 @@ Common keys:
 - `max_file_bytes = 2097152` (2 MiB per source file by default)
 - `external_context = "auto"` (`"off"` keeps the built-in Lite provider only)
 - `external_command = "C:\\tools\\codegraph.cmd"` (optional path when CodeGraph is not on `PATH`)
-- `external_timeout_ms = 1200` (bounded local semantic-query timeout)
+- `external_timeout_ms = 3000` (bounded local semantic-query timeout; values are clamped to 5 seconds)
 
 Legacy YAML uses `codegraph.excludePatterns`, `codegraph.maxFileBytes`,
 `codegraph.externalContext`, `codegraph.externalCommand`, and

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -13,8 +13,8 @@ Memorix is a TypeScript project built around:
 
 ## Current Development Baseline
 
-The current release work targets the **1.8.1 release line** and package metadata
-is kept at `1.8.1` for this release commit.
+The current release work targets the **1.8.2 release line** and package metadata
+is kept at `1.8.2` for this release commit.
 
 Contributors should assume the following areas are part of the current release line:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -63,6 +63,7 @@ The public docs are organized by user intent:
 | Topic | Document |
 | --- | --- |
 | MCP / CLI commands | [API_REFERENCE.md](API_REFERENCE.md) |
+| MCP protocol discovery and compatibility boundaries | [API_REFERENCE.md](API_REFERENCE.md), [1.3.3 MCP Compatibility](1.3.3-MULTIMODAL-MEDIA-AND-MCP-COMPAT.md), and [1.8.0 Release Specification](1.8.0-RELEASE-CANDIDATE-SPEC.md) |
 | Plugin, rules, hooks, skills, and MCP support matrix | [INTEGRATIONS.md](INTEGRATIONS.md) |
 | TypeScript SDK | [../README.md#sdk](../README.md#sdk) |
 | Workspace and rules sync | [API_REFERENCE.md § Workspace and Rules](API_REFERENCE.md#8-workspace-and-rules-tools) |
@@ -93,7 +94,7 @@ The public docs are organized by user intent:
 | 1.2 honest Lite and optional semantic CodeGraph provider contract | [1.2 Provider Quality](1.2.0-PROVIDER-QUALITY.md) |
 | 1.3 long-term memory model, source boundary, and lifecycle | [1.3 Memory Architecture](1.3-MEMORY-ARCHITECTURE.md) |
 | Active context-control work | [1.2.2 Memory Control Plane](1.2.2-MEMORY-CONTROL-PLANE.md) |
-| 1.8 context-control acceptance contract | [1.8.0 Release Specification](1.8.0-RELEASE-CANDIDATE-SPEC.md) |
+| 1.8.2 context-control and compatibility acceptance contract | [1.8.0 Release Specification](1.8.0-RELEASE-CANDIDATE-SPEC.md) |
 | Historical cloud sync and multi-agent research | [CLOUD_SYNC_AND_MULTI_AGENT_RESEARCH.md](CLOUD_SYNC_AND_MULTI_AGENT_RESEARCH.md) |
 | Known issues and old roadmap notes | [KNOWN_ISSUES_AND_ROADMAP.md](KNOWN_ISSUES_AND_ROADMAP.md) |
 
@@ -121,7 +122,7 @@ Historical/deep-reference documents may describe older designs. If they conflict
 
 ## Current Product Line
 
-The current product line is **1.8.1**. The authoritative acceptance contract is
+The current product line is **1.8.2**. The authoritative acceptance contract is
 [1.8.0 Release Specification](1.8.0-RELEASE-CANDIDATE-SPEC.md).
 The current baseline has:
 
@@ -140,8 +141,10 @@ The current baseline has:
 - `~/.memorix/config.toml` and project `memorix.toml` are the user-facing configuration model
 - legacy `memorix.yml`, `.env`, and `config.json` files are still read for compatibility, but new setups should use TOML
 
-For MCP compatibility, 1.8 preserves legacy stateful Streamable HTTP and
-supports 2026-07-28 stateless requests with durable project handles. Tasks and
-polling are reported as unsupported when the pinned SDK cannot provide a real
-durable implementation. Antigravity is the primary setup target; Gemini CLI is
-the compatibility path. See the release specification for the exact contract.
+For MCP compatibility, 1.8.2 preserves legacy 2025-era initialize and
+stateful Streamable HTTP behavior, and adds a tested 2026-07-28
+`server/discover` adapter. Versionless `tools/list` and `tools/call` continue
+through the SDK's legacy result envelopes. Modern result metadata is limited to
+the discovery response (`ttlMs: 0`, private cache scope); Tasks, subscriptions,
+and list-response caching are unsupported. Stateless HTTP project handles are
+a compatibility adapter, not a claim of complete 2026 conformance.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memorix",
   "mcpName": "io.github.AVIDS2/memorix",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/plugins/antigravity/memorix/plugin.json
+++ b/plugins/antigravity/memorix/plugin.json
@@ -1,3 +1,4 @@
 {
-  "name": "memorix"
+  "name": "memorix",
+  "version": "1.8.2"
 }

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
+++ b/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Local-first project memory for CodeBuddy Code and other coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/hermes/memorix/plugin.yaml
+++ b/plugins/hermes/memorix/plugin.yaml
@@ -1,5 +1,5 @@
 name: memorix
-version: "1.1.1"
+version: "1.8.2"
 description: Shared workspace memory bridge for Hermes Agent.
 author: AVIDS2
 license: Apache-2.0

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -2,12 +2,12 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.AVIDS2/memorix",
   "title": "Memorix",
-  "description": "Local-first persistent project memory for AI coding agents across MCP clients and sessions.",
+  "description": "Local-first project memory with legacy MCP and 2026 discovery compatibility.",
   "repository": {
     "url": "https://github.com/AVIDS2/memorix",
     "source": "github"
   },
-  "version": "1.8.1",
+  "version": "1.8.2",
   "websiteUrl": "https://github.com/AVIDS2/memorix#readme",
   "icons": [
     {
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "memorix",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "runtimeHint": "npx",
       "packageArguments": [
         {

--- a/src/cli/commands/serve-http.ts
+++ b/src/cli/commands/serve-http.ts
@@ -40,6 +40,12 @@ export const EXPIRED_SESSION_TTL_MS = 10 * 60 * 1000;
 /** Pinned SDK protocol accepted internally while the HTTP boundary speaks the current stateless contract. */
 export const MCP_SDK_COMPAT_PROTOCOL_VERSION = '2025-11-25';
 
+/** Modern discovery is allowed before a durable project handle exists. */
+export function isServerDiscoverRequest(body: unknown): boolean {
+  return Boolean(body && typeof body === 'object' && !Array.isArray(body)
+    && (body as { method?: unknown }).method === 'server/discover');
+}
+
 export function parseSessionTimeoutMs(raw: string | undefined): number {
   const value = raw?.trim();
   if (!value) return DEFAULT_SESSION_TIMEOUT_MS;
@@ -427,7 +433,7 @@ export default defineCommand({
         ? req.headers['mcp-project-root']
         : undefined;
       const root = persisted?.projectRoot ?? requestedRoot ?? projectRoot;
-      if (!persisted && !isInitializeRequest(body)) {
+      if (!persisted && !isInitializeRequest(body) && !isServerDiscoverRequest(body)) {
         res.writeHead(400, { 'Content-Type': 'application/json' });
         res.end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32000, message: 'Stateless MCP requests require Mcp-Project-Handle; initialize first.' }, id: null }));
         return;
@@ -505,7 +511,9 @@ export default defineCommand({
 
       const requestedProtocol = req.headers['mcp-protocol-version'];
       const statelessRequested = req.headers['mcp-stateless'] === 'true'
-        || requestedProtocol === CURRENT_MCP_PROTOCOL_VERSION;
+        || requestedProtocol === CURRENT_MCP_PROTOCOL_VERSION
+        || typeof req.headers['mcp-project-handle'] === 'string'
+        || isServerDiscoverRequest(body);
       if (!sessionId && statelessRequested) {
         await handleStatelessPost(req, res, body);
         return;

--- a/src/codegraph/external-provider.ts
+++ b/src/codegraph/external-provider.ts
@@ -14,8 +14,8 @@ import type {
 } from './types.js';
 
 // The bundled Windows CodeGraph CLI takes roughly 600 ms just to start cold.
-// Keep the default useful in real sessions while still bounding a local call.
-export const DEFAULT_EXTERNAL_CODEGRAPH_TIMEOUT_MS = 1_200;
+// Leave room for a cold project read while keeping each probe bounded.
+export const DEFAULT_EXTERNAL_CODEGRAPH_TIMEOUT_MS = 3_000;
 export const MAX_EXTERNAL_CODEGRAPH_TIMEOUT_MS = 5_000;
 /** Explicit index maintenance is opt-in and may legitimately take longer. */
 export const EXTERNAL_CODEGRAPH_LIFECYCLE_TIMEOUT_MS = 30_000;
@@ -85,6 +85,28 @@ export interface ExternalCodeGraphContextResult extends InspectExternalCodeGraph
   outline?: ExternalCodeGraphOutline;
   /** Only present when a detected external graph could not safely contribute. */
   caution?: string;
+  diagnostics?: ExternalCodeGraphQueryDiagnostics;
+}
+
+export type ExternalCodeGraphQueryOutcome =
+  | 'not-attempted'
+  | 'success'
+  | 'failed'
+  | 'timed-out'
+  | 'output-limited'
+  | 'invalid-output';
+
+export interface ExternalCodeGraphQueryDiagnostic {
+  command: 'context' | 'explore';
+  attempted: boolean;
+  outcome: ExternalCodeGraphQueryOutcome;
+  exitCode?: number;
+  reason?: string;
+}
+
+export interface ExternalCodeGraphQueryDiagnostics {
+  context: ExternalCodeGraphQueryDiagnostic;
+  explore: ExternalCodeGraphQueryDiagnostic;
 }
 
 /** Explicit lifecycle operations. Memorix never calls CodeGraph's `install`. */
@@ -410,6 +432,42 @@ function unavailableHealth(result: ExternalCodeGraphCommandResult): ExternalCode
   return { state: 'unavailable', reason: 'A local CodeGraph command did not complete.' };
 }
 
+function notAttemptedDiagnostic(command: 'context' | 'explore'): ExternalCodeGraphQueryDiagnostic {
+  return { command, attempted: false, outcome: 'not-attempted' };
+}
+
+function commandDiagnostic(
+  command: 'context' | 'explore',
+  result: ExternalCodeGraphCommandResult,
+  outcome: ExternalCodeGraphQueryOutcome,
+  reason?: string,
+): ExternalCodeGraphQueryDiagnostic {
+  return {
+    command,
+    attempted: true,
+    outcome,
+    ...(typeof result.exitCode === 'number' ? { exitCode: result.exitCode } : {}),
+    ...(reason ? { reason: sanitizeCredentials(reason).slice(0, 240) } : {}),
+  };
+}
+
+function failedCommandDiagnostic(
+  command: 'context' | 'explore',
+  result: ExternalCodeGraphCommandResult,
+): ExternalCodeGraphQueryDiagnostic {
+  const outcome: ExternalCodeGraphQueryOutcome = result.timedOut
+    ? 'timed-out'
+    : result.outputLimited
+      ? 'output-limited'
+      : 'failed';
+  return commandDiagnostic(
+    command,
+    result,
+    outcome,
+    result.error || result.stderr || 'CodeGraph command did not complete.',
+  );
+}
+
 async function runSafely(
   runner: ExternalCodeGraphRunner,
   input: ExternalCodeGraphCommandInput,
@@ -590,6 +648,7 @@ function parseOutline(value: unknown, projectRoot: string, exclude?: string[]): 
   if (nodes.some(node => !node)) return undefined;
   const byId = new Map<string, ExternalCodeGraphSymbol>();
   for (const node of nodes as RawExternalNode[]) {
+    if (byId.has(node.id)) return undefined;
     byId.set(node.id, externalSymbol(node));
   }
   const entryPoints = value.entryPoints
@@ -609,7 +668,7 @@ function parseOutline(value: unknown, projectRoot: string, exclude?: string[]): 
     if (!source || !target || !kind || (rawEdge.line !== undefined && (!line || line < 1))) return undefined;
     const from = byId.get(source);
     const to = byId.get(target);
-    if (!from || !to) continue;
+    if (!from || !to) return undefined;
     relations.push({ from, to, kind, ...(line ? { line } : {}) });
   }
 
@@ -629,10 +688,200 @@ function parseOutline(value: unknown, projectRoot: string, exclude?: string[]): 
   };
 }
 
+function parseTextLocation(value: string): { filePath: string; line?: number } | undefined {
+  const match = value.trim().match(/^(.*?)(?::([1-9]\d*))?$/);
+  if (!match?.[1]) return undefined;
+  return {
+    filePath: match[1].trim(),
+    ...(match[2] ? { line: Number(match[2]) } : {}),
+  };
+}
+
+function parseExploreText(value: string, projectRoot: string, exclude?: string[]): ExternalCodeGraphOutline | undefined {
+  if (!value.trim() || Buffer.byteLength(value, 'utf8') > MAX_EXTERNAL_CODEGRAPH_OUTPUT_BYTES) return undefined;
+
+  const entryPoints: RawExternalNode[] = [];
+  const nodes: RawExternalNode[] = [];
+  const relatedFiles = new Set<string>();
+  const byName = new Map<string, RawExternalNode>();
+  let section: 'entry' | 'related' | 'relationships' | null = null;
+  let relationKind = 'references';
+
+  const addNode = (node: RawExternalNode, entry: boolean): void => {
+    const key = `${node.filePath}\0${node.name}`;
+    const existing = byName.get(key);
+    if (existing) return;
+    byName.set(key, node);
+    relatedFiles.add(node.filePath);
+    (entry ? entryPoints : nodes).push(node);
+  };
+
+  for (const rawLine of value.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    const fileHeader = line.match(/^\*\*`([^`]+)`\*\*\s+(?:—|-)\s+(.+)$/);
+    if (fileHeader) {
+      const filePath = safeRelativePath(projectRoot, fileHeader[1], exclude);
+      if (!filePath) return undefined;
+      const symbolText = fileHeader[2].split(/\s+·\s+/, 1)[0] ?? '';
+      const symbols = [...symbolText.matchAll(/([^,]+?)\(([^()]+)\)/g)];
+      if (symbols.length === 0) return undefined;
+      const isFirstFile = entryPoints.length === 0 && nodes.length === 0;
+      for (const symbol of symbols.slice(0, MAX_EXTERNAL_NODE_COUNT)) {
+        const name = symbol[1]?.trim();
+        const kind = symbol[2]?.trim();
+        if (!name || !kind) return undefined;
+        addNode({
+          id: `explore:${filePath}:${name}`,
+          kind,
+          name,
+          filePath,
+        }, isFirstFile);
+      }
+      section = null;
+      continue;
+    }
+    if (/^#{2,3}\s+Entry Points?\b/i.test(line)) {
+      section = 'entry';
+      continue;
+    }
+    if (/^#{2,3}\s+Related Symbols?\b/i.test(line)) {
+      section = 'related';
+      continue;
+    }
+    if (/^\*\*Relationships\*\*$/i.test(line)) {
+      section = 'relationships';
+      continue;
+    }
+    if (/^\*\*(?:Source Code|Code)\*\*$/i.test(line) || /^#{2,3}\s+/i.test(line)) {
+      section = null;
+      continue;
+    }
+
+    if (section === 'entry') {
+      const match = line.match(/^-\s+\*\*(.+?)\*\*\s+\(([^)]+)\)\s+-\s+(.+)$/);
+      if (!match) continue;
+      const location = parseTextLocation(match[3]);
+      if (!location) return undefined;
+      const filePath = safeRelativePath(projectRoot, location.filePath, exclude);
+      if (!filePath) return undefined;
+      addNode({
+        id: `explore:${filePath}:${match[1]}`,
+        kind: match[2],
+        name: match[1],
+        filePath,
+        ...(location.line ? { startLine: location.line, endLine: location.line } : {}),
+      }, true);
+      continue;
+    }
+
+    if (section === 'related') {
+      const match = line.match(/^-\s+([^:]+):\s+(.+)$/);
+      if (!match) continue;
+      const filePath = safeRelativePath(projectRoot, match[1], exclude);
+      if (!filePath) return undefined;
+      relatedFiles.add(filePath);
+      for (const rawSymbol of match[2].split(',')) {
+        const symbol = rawSymbol.trim().match(/^(.+?)(?::([1-9]\d*))?$/);
+        if (!symbol?.[1]) return undefined;
+        addNode({
+          id: `explore:${filePath}:${symbol[1].trim()}`,
+          kind: 'unknown',
+          name: symbol[1].trim(),
+          filePath,
+          ...(symbol[2] ? { startLine: Number(symbol[2]), endLine: Number(symbol[2]) } : {}),
+        }, false);
+      }
+      continue;
+    }
+
+    if (section === 'relationships') {
+      const kind = line.match(/^\*\*([^*]+):\*\*$/);
+      if (kind?.[1]) {
+        relationKind = kind[1].trim();
+        continue;
+      }
+    }
+  }
+
+  const bySymbolName = new Map<string, RawExternalNode>();
+  for (const node of [...entryPoints, ...nodes]) {
+    if (!bySymbolName.has(node.name)) bySymbolName.set(node.name, node);
+  }
+  const relations: ExternalCodeGraphRelation[] = [];
+  if (section === 'relationships') {
+    for (const rawLine of value.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      const match = line.match(/^-\s+(.+?)\s+(?:\u2192|->)\s+(.+)$/);
+      if (!match) continue;
+      const from = bySymbolName.get(match[1].trim());
+      const to = bySymbolName.get(match[2].trim());
+      if (!from || !to) continue;
+      relations.push({
+        from: externalSymbol(from),
+        to: externalSymbol(to),
+        kind: relationKind,
+      });
+    }
+  } else {
+    // The relationship section may be followed by source sections. Re-scan
+    // its bounded region so relation parsing does not depend on the final
+    // section value after the loop.
+    const relationshipStart = value.split(/\r?\n/).findIndex((line) => /^\s*\*\*Relationships\*\*\s*$/i.test(line));
+    if (relationshipStart >= 0) {
+      const relationshipLines = value.split(/\r?\n/).slice(relationshipStart + 1);
+      for (const rawLine of relationshipLines) {
+        const line = rawLine.trim();
+        if (/^\*\*(?:Source Code|Code)\*\*$/i.test(line) || /^#{2,3}\s+/i.test(line)) break;
+        const kind = line.match(/^\*\*([^*]+):\*\*$/);
+        if (kind?.[1]) {
+          relationKind = kind[1].trim();
+          continue;
+        }
+        const match = line.match(/^-\s+(.+?)\s+(?:\u2192|->)\s+(.+)$/);
+        if (!match) continue;
+        const from = bySymbolName.get(match[1].trim());
+        const to = bySymbolName.get(match[2].trim());
+        if (from && to) relations.push({ from: externalSymbol(from), to: externalSymbol(to), kind: relationKind });
+      }
+    }
+  }
+
+  const allNodes = [...entryPoints, ...nodes];
+  if (allNodes.length === 0) return undefined;
+  return {
+    provider: 'external',
+    entryPoints: entryPoints.map(externalSymbol).slice(0, 5),
+    relations: relations.slice(0, 6),
+    relatedFiles: [...relatedFiles].slice(0, 5),
+    stats: {
+      nodes: allNodes.length,
+      edges: relations.length,
+      files: relatedFiles.size,
+    },
+  };
+}
+
+function parseExplorePayload(value: unknown, projectRoot: string, exclude?: string[]): ExternalCodeGraphOutline | undefined {
+  if (typeof value === 'string') return parseExploreText(value, projectRoot, exclude);
+  if (isRecord(value) && isRecord(value.result)) value = value.result;
+  if (isRecord(value) && Array.isArray(value.content)) {
+    const text = value.content
+      .filter((item): item is Record<string, unknown> => isRecord(item) && item.type === 'text' && typeof item.text === 'string')
+      .map(item => item.text as string)
+      .join('\n');
+    return parseExploreText(text, projectRoot, exclude);
+  }
+  return parseOutline(value, projectRoot, exclude);
+}
+
 function fallbackCaution(health: ExternalCodeGraphHealth): string | undefined {
   if (health.state === 'disabled' || health.state === 'not-detected'
     || health.state === 'not-initialized' || health.state === 'ready') return undefined;
   return 'External semantic CodeGraph is ' + health.state + '; using Lite structural evidence for this brief.';
+}
+
+function queryFallbackCaution(diagnostics: ExternalCodeGraphQueryDiagnostics): string {
+  return `External semantic CodeGraph context was unavailable (context: ${diagnostics.context.outcome}; explore: ${diagnostics.explore.outcome}); using Lite structural evidence.`;
 }
 
 export async function getExternalCodeGraphContext(input: ExternalCodeGraphContextInput): Promise<ExternalCodeGraphContextResult> {
@@ -642,34 +891,65 @@ export async function getExternalCodeGraphContext(input: ExternalCodeGraphContex
   }
 
   const mode = input.mode ?? 'auto';
-  const result = await runSafely(input.runner ?? defaultRunner, {
+  const runner = input.runner ?? defaultRunner;
+  const contextResult = await runSafely(runner, {
     command: input.command,
     args: ['context', '--path', input.projectRoot, '--format', 'json', '--max-nodes', '8', '--no-code', input.task],
     cwd: input.projectRoot,
     timeoutMs: boundedTimeout(input.timeoutMs),
     maxOutputBytes: MAX_EXTERNAL_CODEGRAPH_OUTPUT_BYTES,
   });
-  if (!result.ok) {
-    const health = unavailableHealth(result);
+  const diagnostics: ExternalCodeGraphQueryDiagnostics = {
+    context: contextResult.ok
+      ? commandDiagnostic('context', contextResult, 'success')
+      : failedCommandDiagnostic('context', contextResult),
+    explore: notAttemptedDiagnostic('explore'),
+  };
+
+  const contextOutline = contextResult.ok
+    ? parseOutline(parseJson(contextResult.stdout), input.projectRoot, input.exclude)
+    : undefined;
+  if (contextOutline && (contextOutline.entryPoints.length > 0 || contextOutline.relations.length > 0 || contextOutline.relatedFiles.length > 0)) {
     return {
-      health,
-      quality: providerQuality({ mode, health }),
-      caution: fallbackCaution(health),
+      ...inspected,
+      outline: contextOutline,
+      diagnostics,
+      quality: providerQuality({ mode, health: inspected.health, selected: 'external' }),
     };
   }
-  const outline = parseOutline(parseJson(result.stdout), input.projectRoot, input.exclude);
-  if (!outline) {
-    const health: ExternalCodeGraphHealth = { state: 'invalid', reason: 'The local CodeGraph context payload failed validation.' };
+  if (contextResult.ok) diagnostics.context = commandDiagnostic('context', contextResult, 'invalid-output', 'The context payload failed validation or contained no safe outline.');
+
+  const exploreResult = await runSafely(runner, {
+    command: input.command,
+    args: ['explore', '--path', input.projectRoot, '--max-files', '4', input.task],
+    cwd: input.projectRoot,
+    timeoutMs: boundedTimeout(input.timeoutMs),
+    maxOutputBytes: MAX_EXTERNAL_CODEGRAPH_OUTPUT_BYTES,
+  });
+  diagnostics.explore = exploreResult.ok
+    ? commandDiagnostic('explore', exploreResult, 'success')
+    : failedCommandDiagnostic('explore', exploreResult);
+
+  const exploreOutline = exploreResult.ok
+    ? parseExplorePayload(parseJson(exploreResult.stdout) ?? exploreResult.stdout, input.projectRoot, input.exclude)
+    : undefined;
+  if (exploreOutline && (exploreOutline.entryPoints.length > 0 || exploreOutline.relations.length > 0 || exploreOutline.relatedFiles.length > 0)) {
     return {
-      health,
-      quality: providerQuality({ mode, health }),
-      caution: fallbackCaution(health),
+      ...inspected,
+      outline: exploreOutline,
+      diagnostics,
+      quality: providerQuality({ mode, health: inspected.health, selected: 'external' }),
     };
   }
-  const contributes = outline.entryPoints.length > 0 || outline.relations.length > 0 || outline.relatedFiles.length > 0;
+  if (exploreResult.ok) diagnostics.explore = commandDiagnostic('explore', exploreResult, 'invalid-output', 'The explore payload failed validation or contained no safe outline.');
+
+  const health = exploreResult.ok
+    ? { state: 'invalid' as const, reason: 'The local CodeGraph context and explore payloads failed validation.' }
+    : unavailableHealth(exploreResult);
   return {
-    ...inspected,
-    ...(contributes ? { outline } : {}),
-    quality: providerQuality({ mode, health: inspected.health, ...(contributes ? { selected: 'external' as const } : {}) }),
+    health,
+    quality: providerQuality({ mode, health }),
+    diagnostics,
+    caution: queryFallbackCaution(diagnostics),
   };
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -23,13 +23,13 @@ export { loadFileConfig, resetConfigCache, type MemorixConfig } from './config/l
 // ─── Resolved Getters ────────────────────────────────────────────────
 
 /** Memory/background LLM API key: env > memorix.yml > config.json > provider env fallbacks */
-export function getLLMApiKey(): string | undefined {
-  return getResolvedMemoryLane().llm.apiKey;
+export function getLLMApiKey(options: ResolvedLaneOptions = {}): string | undefined {
+  return getResolvedMemoryLane(options).llm.apiKey;
 }
 
 /** LLM provider: env > memorix.yml > config.json > auto-detect */
-export function getLLMProvider(): string {
-  const provider = getResolvedMemoryLane().llm.provider;
+export function getLLMProvider(options: ResolvedLaneOptions = {}): string {
+  const provider = getResolvedMemoryLane(options).llm.provider;
   if (provider) return provider;
   // Auto-detect from env var names
   if (process.env.ANTHROPIC_API_KEY && !process.env.OPENAI_API_KEY) return 'anthropic';
@@ -38,33 +38,33 @@ export function getLLMProvider(): string {
 }
 
 /** LLM model: env > memorix.yml > config.json > provider default */
-export function getLLMModel(providerDefault: string): string {
-  return getResolvedMemoryLane().llm.model || providerDefault;
+export function getLLMModel(providerDefault: string, options: ResolvedLaneOptions = {}): string {
+  return getResolvedMemoryLane(options).llm.model || providerDefault;
 }
 
 /** LLM base URL: env > memorix.yml > config.json > provider default */
-export function getLLMBaseUrl(providerDefault: string): string {
-  return getResolvedMemoryLane().llm.baseUrl || providerDefault;
+export function getLLMBaseUrl(providerDefault: string, options: ResolvedLaneOptions = {}): string {
+  return getResolvedMemoryLane(options).llm.baseUrl || providerDefault;
 }
 
 /** TUI/chat agent API key: agent env > agent config > memory LLM fallback */
-export function getAgentLLMApiKey(): string | undefined {
-  return getResolvedAgentLane().apiKey;
+export function getAgentLLMApiKey(options: ResolvedLaneOptions = {}): string | undefined {
+  return getResolvedAgentLane(options).apiKey;
 }
 
 /** TUI/chat agent provider: agent env > agent config > memory LLM fallback */
-export function getAgentLLMProvider(): string {
-  return getResolvedAgentLane().provider || getLLMProvider();
+export function getAgentLLMProvider(options: ResolvedLaneOptions = {}): string {
+  return getResolvedAgentLane(options).provider || getLLMProvider(options);
 }
 
 /** TUI/chat agent model: agent env > agent config > memory LLM fallback */
-export function getAgentLLMModel(providerDefault: string): string {
-  return getResolvedAgentLane().model || getLLMModel(providerDefault);
+export function getAgentLLMModel(providerDefault: string, options: ResolvedLaneOptions = {}): string {
+  return getResolvedAgentLane(options).model || getLLMModel(providerDefault, options);
 }
 
 /** TUI/chat agent base URL: agent env > agent config > memory LLM fallback */
-export function getAgentLLMBaseUrl(providerDefault: string): string {
-  return getResolvedAgentLane().baseUrl || getLLMBaseUrl(providerDefault);
+export function getAgentLLMBaseUrl(providerDefault: string, options: ResolvedLaneOptions = {}): string {
+  return getResolvedAgentLane(options).baseUrl || getLLMBaseUrl(providerDefault, options);
 }
 
 /** Embedding mode: env > memorix.yml > config.json > 'off' */

--- a/src/config/dotenv-loader.ts
+++ b/src/config/dotenv-loader.ts
@@ -28,6 +28,7 @@ import { getGlobalDotenvPath, getProjectDotenvPath } from './config-paths.js';
 
 let dotenvLoaded = false;
 let dotenvProjectRoot: string | null = null;
+let dotenvHomeDir: string | null = null;
 
 /** Track which .env files were loaded (for diagnostics) */
 const loadedEnvFiles: string[] = [];
@@ -65,9 +66,11 @@ interface DotenvLoadOptions {
  * @param projectRoot - Project root directory (for project-level .env)
  */
 export function loadDotenv(projectRoot?: string, options: DotenvLoadOptions = {}): void {
-  if (dotenvLoaded && dotenvProjectRoot === (projectRoot ?? null)) return;
+  const userHomeDir = options.userHomeDir ?? homedir();
+  const normalizedProjectRoot = projectRoot ?? null;
+  if (dotenvLoaded && dotenvProjectRoot === normalizedProjectRoot && dotenvHomeDir === userHomeDir) return;
 
-  if (dotenvLoaded && dotenvProjectRoot !== (projectRoot ?? null)) {
+  if (dotenvLoaded && (dotenvProjectRoot !== normalizedProjectRoot || dotenvHomeDir !== userHomeDir)) {
     resetDotenv();
   }
 
@@ -85,10 +88,11 @@ export function loadDotenv(projectRoot?: string, options: DotenvLoadOptions = {}
 
   // 2. User-level .env (~/.memorix/.env) — lowest .env priority, load second
   //    (override: false means it only fills in keys not already set)
-  loadEnvFile(getGlobalDotenvPath(options.userHomeDir ?? homedir()));
+  loadEnvFile(getGlobalDotenvPath(userHomeDir));
 
   dotenvLoaded = true;
-  dotenvProjectRoot = projectRoot ?? null;
+  dotenvProjectRoot = normalizedProjectRoot;
+  dotenvHomeDir = userHomeDir;
 }
 
 /**
@@ -101,6 +105,7 @@ export function resetDotenv(): void {
   injectedKeys.clear();
   dotenvLoaded = false;
   dotenvProjectRoot = null;
+  dotenvHomeDir = null;
   loadedEnvFiles.length = 0;
   loadedEnvKeys.clear();
 }

--- a/src/dashboard/maintenance.ts
+++ b/src/dashboard/maintenance.ts
@@ -1,6 +1,6 @@
 import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
 
-import { isLLMEnabled } from '../llm/provider.js';
+import { initLLM, isLLMEnabled } from '../llm/provider.js';
 import { analyzeCleanupObservations, applyCleanupMutations } from '../memory/cleanup.js';
 import { findConsolidationCandidates, executeConsolidation } from '../memory/consolidation.js';
 import { applyDeduplicationPlan, planMemoryDeduplication } from '../memory/deduplication.js';
@@ -167,6 +167,9 @@ export async function executeCleanup(
 }
 
 export async function previewDeduplicate(context: DashboardMaintenanceContext) {
+  // Dashboard callers do not share the CLI/server bootstrap path. Resolve the
+  // memory lane here so standalone and HTTP previews use the selected project.
+  initLLM({ scope: 'memory', projectRoot: context.projectRoot });
   if (!isLLMEnabled()) {
     return {
       action: 'deduplicate',

--- a/src/llm/provider.ts
+++ b/src/llm/provider.ts
@@ -210,6 +210,10 @@ export type LLMConfigScope = 'memory' | 'agent';
 
 export interface InitLLMOptions {
   scope?: LLMConfigScope;
+  /** Resolve project TOML/.env instead of relying on process.cwd(). */
+  projectRoot?: string | null;
+  /** Override the home directory used for global TOML/.env resolution. */
+  homeDir?: string;
 }
 
 /**
@@ -218,20 +222,29 @@ export interface InitLLMOptions {
  */
 export function initLLM(options: InitLLMOptions = {}): LLMConfig | null {
   const scope = options.scope ?? 'memory';
-  const apiKey = scope === 'agent' ? getAgentLLMApiKey() : getLLMApiKey();
+  const configOptions = { projectRoot: options.projectRoot, homeDir: options.homeDir };
+  const apiKey = scope === 'agent'
+    ? getAgentLLMApiKey(configOptions)
+    : getLLMApiKey(configOptions);
   if (!apiKey) {
     currentConfig = null;
     return null;
   }
 
-  const provider = (scope === 'agent' ? getAgentLLMProvider() : getLLMProvider()) as LLMConfig['provider'];
+  const provider = (scope === 'agent'
+    ? getAgentLLMProvider(configOptions)
+    : getLLMProvider(configOptions)) as LLMConfig['provider'];
   const defaults = PROVIDER_DEFAULTS[provider] ?? PROVIDER_DEFAULTS.openai;
 
   currentConfig = {
     provider,
     apiKey,
-    model: scope === 'agent' ? getAgentLLMModel(defaults.model) : getLLMModel(defaults.model),
-    baseUrl: scope === 'agent' ? getAgentLLMBaseUrl(defaults.baseUrl) : getLLMBaseUrl(defaults.baseUrl),
+    model: scope === 'agent'
+      ? getAgentLLMModel(defaults.model, configOptions)
+      : getLLMModel(defaults.model, configOptions),
+    baseUrl: scope === 'agent'
+      ? getAgentLLMBaseUrl(defaults.baseUrl, configOptions)
+      : getLLMBaseUrl(defaults.baseUrl, configOptions),
   };
 
   return currentConfig;

--- a/src/server.ts
+++ b/src/server.ts
@@ -62,6 +62,7 @@ import {
   type ProjectBindingController,
   type ProjectBindingSource,
 } from './server/request-context.js';
+import { registerMcpDiscovery } from './server/mcp-compat.js';
 
 // ── Timeout budgets for LLM-heavy paths ──────────────────────────
 const FORMATION_TIMEOUT_MS = parseFormationTimeoutMs(process.env.MEMORIX_FORMATION_TIMEOUT_MS); // Formation pipeline (extract+resolve+evaluate)
@@ -593,10 +594,12 @@ export async function createMemorixServer(
   };
 
   // Create MCP server (or use existing one from roots-aware flow)
-  const server = existingServer ?? new McpServer({
+  const serverInfo = {
     name: 'memorix',
     version: typeof __MEMORIX_VERSION__ !== 'undefined' ? __MEMORIX_VERSION__ : '1.0.1',
-  });
+  };
+  const server = existingServer ?? new McpServer(serverInfo);
+  registerMcpDiscovery(server, serverInfo);
 
   const originalRegisterTool = server.registerTool.bind(server);
   server.registerTool = ((name: string, ...args: unknown[]) => {

--- a/src/server/mcp-compat.ts
+++ b/src/server/mcp-compat.ts
@@ -1,0 +1,82 @@
+/**
+ * Small MCP 2026-07-28 discovery adapter for the pinned v1 SDK.
+ *
+ * The v1 SDK can route an extension request through its low-level Server, but
+ * it does not implement the modern discovery/cache negotiation itself. Keep
+ * this adapter deliberately narrow: advertise discovery and the existing
+ * legacy tool handlers, while leaving unsupported extensions unadvertised.
+ */
+
+import { RequestSchema, type ServerCapabilities } from '@modelcontextprotocol/sdk/types.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod/v4';
+
+export const MCP_MODERN_PROTOCOL_VERSION = '2026-07-28';
+export const MCP_LEGACY_PROTOCOL_VERSION = '2025-11-25';
+export const MCP_OLDEST_LEGACY_PROTOCOL_VERSION = '2024-11-05';
+export const MCP_SERVER_DISCOVER_METHOD = 'server/discover';
+export const MCP_SERVER_INFO_META_KEY = 'io.modelcontextprotocol/serverInfo';
+
+const ServerDiscoverRequestSchema = RequestSchema.extend({
+  method: z.literal(MCP_SERVER_DISCOVER_METHOD),
+  params: z.looseObject({}).optional(),
+});
+
+export interface McpServerInfo {
+  name: string;
+  version: string;
+}
+
+export interface McpDiscoverResult {
+  resultType: 'complete';
+  supportedVersions: string[];
+  capabilities: ServerCapabilities;
+  _meta: {
+    [MCP_SERVER_INFO_META_KEY]: McpServerInfo;
+  };
+  ttlMs: number;
+  cacheScope: 'public' | 'private';
+}
+
+const registeredServers = new WeakSet<McpServer>();
+
+/** Build the wire result without exposing unsupported cache/task features. */
+export function buildMcpDiscoverResult(server: McpServer, serverInfo: McpServerInfo): McpDiscoverResult {
+  // SDK 1.30 exposes this method at runtime but marks it private in its
+  // declaration file. The discovery response must reflect the capabilities
+  // already registered on this exact low-level Server instance.
+  const getCapabilities = (server.server as unknown as {
+    getCapabilities: () => ServerCapabilities;
+  }).getCapabilities.bind(server.server);
+  return {
+    resultType: 'complete',
+    supportedVersions: [
+      MCP_MODERN_PROTOCOL_VERSION,
+      MCP_LEGACY_PROTOCOL_VERSION,
+      MCP_OLDEST_LEGACY_PROTOCOL_VERSION,
+    ],
+    capabilities: getCapabilities(),
+    _meta: {
+      [MCP_SERVER_INFO_META_KEY]: { ...serverInfo },
+    },
+    // v1 has no response-cache negotiation. A zero private TTL is the
+    // conservative result and prevents clients from inventing a shared cache.
+    ttlMs: 0,
+    cacheScope: 'private',
+  };
+}
+
+/**
+ * Register `server/discover` on the v1 low-level Server.
+ *
+ * This is idempotent for a single McpServer instance because HTTP/session
+ * setup can revisit the registration boundary while reusing an object.
+ */
+export function registerMcpDiscovery(server: McpServer, serverInfo: McpServerInfo): void {
+  if (registeredServers.has(server)) return;
+
+  server.server.setRequestHandler(ServerDiscoverRequestSchema, async () => (
+    buildMcpDiscoverResult(server, serverInfo)
+  ));
+  registeredServers.add(server);
+}

--- a/src/server/mcp-diagnostics.ts
+++ b/src/server/mcp-diagnostics.ts
@@ -1,7 +1,8 @@
 /** MCP compatibility diagnostics shared by HTTP and CLI-facing checks. */
 
 export const CURRENT_MCP_PROTOCOL_VERSION = '2026-07-28';
-export const LEGACY_MCP_PROTOCOL_VERSION = '2024-11-05';
+export const LEGACY_MCP_PROTOCOL_VERSION = '2025-11-25';
+export const OLDEST_LEGACY_MCP_PROTOCOL_VERSION = '2024-11-05';
 export const MCP_SERVER_NAME = 'io.github.AVIDS2/memorix';
 
 export interface McpDiagnostics {
@@ -9,13 +10,17 @@ export interface McpDiagnostics {
   protocol: {
     current: string;
     legacy: string;
+    discovery: 'supported';
+    versionlessRequests: 'legacy-compatible';
+    modernResultMetadata: 'discovery-only';
     statelessRequests: 'supported' | 'compatibility-only' | 'unsupported';
     statefulStreamableHttp: 'supported';
   };
   capabilities: {
     tasks: 'supported' | 'unsupported';
     polling: 'supported' | 'unsupported';
-    listCache: 'supported';
+    subscriptions: 'supported' | 'unsupported';
+    listCache: 'supported' | 'unsupported';
     explicitProjectHandle: 'supported';
   };
 }
@@ -27,13 +32,17 @@ export function getMcpDiagnostics(): McpDiagnostics {
     protocol: {
       current: CURRENT_MCP_PROTOCOL_VERSION,
       legacy: LEGACY_MCP_PROTOCOL_VERSION,
-    statelessRequests: 'supported',
+      discovery: 'supported',
+      versionlessRequests: 'legacy-compatible',
+      modernResultMetadata: 'discovery-only',
+      statelessRequests: 'compatibility-only',
       statefulStreamableHttp: 'supported',
     },
     capabilities: {
       tasks: 'unsupported',
       polling: 'unsupported',
-      listCache: 'supported',
+      subscriptions: 'unsupported',
+      listCache: 'unsupported',
       explicitProjectHandle: 'supported',
     },
   };

--- a/tests/codegraph/external-provider.test.ts
+++ b/tests/codegraph/external-provider.test.ts
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  DEFAULT_EXTERNAL_CODEGRAPH_TIMEOUT_MS,
   MAX_EXTERNAL_CODEGRAPH_OUTPUT_BYTES,
   EXTERNAL_CODEGRAPH_LIFECYCLE_TIMEOUT_MS,
   getExternalCodeGraphContext,
@@ -73,6 +74,25 @@ function outline(): string {
   });
 }
 
+function exploreText(): string {
+  return [
+    '## Code Context',
+    '',
+    '### Entry Points',
+    '',
+    '- **requireAuthenticatedUser** (function) - src/auth.ts:2',
+    '',
+    '### Related Symbols',
+    '',
+    '- src/auth.ts: validateToken:1',
+    '',
+    '**Relationships**',
+    '',
+    '**calls:**',
+    '- requireAuthenticatedUser \u2192 validateToken',
+  ].join('\n');
+}
+
 function runnerFor(projectRoot: string, context = outline(), statusPayload = status(projectRoot)): ExternalCodeGraphRunner & { run: ReturnType<typeof vi.fn> } {
   return {
     run: vi.fn(async ({ args }: { args: string[] }) => ({
@@ -114,6 +134,113 @@ describe('external CodeGraph provider', () => {
       'context', '--path', projectRoot, '--format', 'json', '--max-nodes', '8', '--no-code',
       'trace authenticated user validation',
     ]);
+  });
+
+  it('falls back from an unknown context command to the official explore command', async () => {
+    const projectRoot = makeProject();
+    const runner: ExternalCodeGraphRunner & { run: ReturnType<typeof vi.fn> } = {
+      run: vi.fn(async ({ args }: { args: string[] }) => {
+        if (args[0] === 'status') return { ok: true, stdout: status(projectRoot) };
+        if (args[0] === 'context') return { ok: false, stdout: '', stderr: 'unknown command: context', exitCode: 1 };
+        return { ok: true, stdout: exploreText() };
+      }),
+    };
+
+    const result = await getExternalCodeGraphContext({
+      projectRoot,
+      task: 'trace authenticated user validation',
+      runner,
+    });
+
+    expect(result.quality).toMatchObject({ selected: 'external', selectedQuality: 'semantic' });
+    expect(result.outline).toMatchObject({
+      provider: 'external',
+      relatedFiles: ['src/auth.ts'],
+      relations: [{ kind: 'calls' }],
+    });
+    expect(result.diagnostics).toMatchObject({
+      context: { outcome: 'failed' },
+      explore: { outcome: 'success' },
+    });
+    expect(runner.run.mock.calls[2][0]).toMatchObject({
+      args: ['explore', '--path', projectRoot, '--max-files', '4', 'trace authenticated user validation'],
+      cwd: projectRoot,
+    });
+  });
+
+  it('reports separate context and explore failures without claiming external readiness', async () => {
+    const projectRoot = makeProject();
+    const runner: ExternalCodeGraphRunner = {
+      run: vi.fn(async ({ args }: { args: string[] }) => {
+        if (args[0] === 'status') return { ok: true, stdout: status(projectRoot) };
+        return { ok: false, stdout: '', stderr: `failed ${args[0]}`, exitCode: 1 };
+      }),
+    };
+
+    const result = await getExternalCodeGraphContext({ projectRoot, task: 'trace auth', runner });
+
+    expect(result.quality).toMatchObject({ selected: 'lite', external: { state: 'unavailable' } });
+    expect(result.outline).toBeUndefined();
+    expect(result.diagnostics).toMatchObject({
+      context: { outcome: 'failed' },
+      explore: { outcome: 'failed' },
+    });
+    expect(result.caution).toContain('context');
+    expect(result.caution).toContain('explore');
+  });
+
+  it('keeps timeout and output-limit diagnostics bounded for both context paths', async () => {
+    const projectRoot = makeProject();
+    const timeout: ExternalCodeGraphRunner = {
+      run: vi.fn(async ({ args }: { args: string[] }) => args[0] === 'status'
+        ? { ok: true, stdout: status(projectRoot) }
+        : { ok: false, stdout: '', timedOut: true }),
+    };
+    const timeoutResult = await getExternalCodeGraphContext({ projectRoot, task: 'trace auth', runner: timeout });
+    expect(timeoutResult.diagnostics).toMatchObject({
+      context: { outcome: 'timed-out' },
+      explore: { outcome: 'timed-out' },
+    });
+    expect(timeoutResult.quality.external.state).toBe('timed-out');
+
+    const outputLimited: ExternalCodeGraphRunner = {
+      run: vi.fn(async ({ args }: { args: string[] }) => args[0] === 'status'
+        ? { ok: true, stdout: status(projectRoot) }
+        : { ok: false, stdout: '', outputLimited: true }),
+    };
+    const limitedResult = await getExternalCodeGraphContext({ projectRoot, task: 'trace auth', runner: outputLimited });
+    expect(limitedResult.diagnostics).toMatchObject({
+      context: { outcome: 'output-limited' },
+      explore: { outcome: 'output-limited' },
+    });
+    expect(limitedResult.quality.external.state).toBe('invalid');
+    expect(DEFAULT_EXTERNAL_CODEGRAPH_TIMEOUT_MS).toBeGreaterThan(1_200);
+    expect(DEFAULT_EXTERNAL_CODEGRAPH_TIMEOUT_MS).toBeLessThanOrEqual(5_000);
+  });
+
+  it('rejects unsafe paths and relations from an explore fallback', async () => {
+    const projectRoot = makeProject();
+    const unsafe = JSON.stringify({
+      ...JSON.parse(outline()),
+      entryPoints: [{
+        ...JSON.parse(outline()).entryPoints[0],
+        filePath: '../outside.ts',
+      }],
+    });
+    const runner: ExternalCodeGraphRunner = {
+      run: vi.fn(async ({ args }: { args: string[] }) => {
+        if (args[0] === 'status') return { ok: true, stdout: status(projectRoot) };
+        if (args[0] === 'context') return { ok: false, stdout: '', stderr: 'unknown command', exitCode: 1 };
+        return { ok: true, stdout: unsafe };
+      }),
+    };
+
+    const result = await getExternalCodeGraphContext({ projectRoot, task: 'trace auth', runner });
+
+    expect(result.outline).toBeUndefined();
+    expect(result.quality).toMatchObject({ selected: 'lite', external: { state: 'invalid' } });
+    expect(result.diagnostics).toMatchObject({ explore: { outcome: 'invalid-output' } });
+    expect(result.caution).toContain('Lite structural evidence');
   });
 
   it('stays quiet when a project has not opted into a local CodeGraph index', async () => {

--- a/tests/config/dotenv-loader.test.ts
+++ b/tests/config/dotenv-loader.test.ts
@@ -131,6 +131,20 @@ describe('loadDotenv', () => {
     loadDotenv(TEST_DIR_B, { userHomeDir: TEST_HOME });
     expect(process.env.MEMORIX_TEST_SWITCH_VAR).toBeUndefined();
   });
+
+  it('should reload the user .env when only the configured home changes', () => {
+    const homeA = join(TEST_DIR, 'home-a');
+    const homeB = join(TEST_DIR, 'home-b');
+    mkdirSync(join(homeA, '.memorix'), { recursive: true });
+    mkdirSync(join(homeB, '.memorix'), { recursive: true });
+    writeFileSync(join(homeA, '.memorix', '.env'), 'MEMORIX_TEST_SWITCH_VAR=from_home_a\n');
+    writeFileSync(join(homeB, '.memorix', '.env'), 'MEMORIX_TEST_SWITCH_VAR=from_home_b\n');
+
+    loadDotenv(undefined, { userHomeDir: homeA });
+    expect(process.env.MEMORIX_TEST_SWITCH_VAR).toBe('from_home_a');
+    loadDotenv(undefined, { userHomeDir: homeB });
+    expect(process.env.MEMORIX_TEST_SWITCH_VAR).toBe('from_home_b');
+  });
 });
 
 describe('getLoadedEnvFiles', () => {

--- a/tests/dashboard/maintenance-actions.test.ts
+++ b/tests/dashboard/maintenance-actions.test.ts
@@ -1,7 +1,16 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { promises as fs } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+
+vi.mock('../../src/llm/provider.js', async () => {
+  const actual = await vi.importActual<typeof import('../../src/llm/provider.js')>('../../src/llm/provider.js');
+  return {
+    ...actual,
+    initLLM: vi.fn(() => null),
+    isLLMEnabled: vi.fn(() => false),
+  };
+});
 
 import {
   DashboardMaintenanceError,

--- a/tests/integration/dashboard-coordination-truth.test.ts
+++ b/tests/integration/dashboard-coordination-truth.test.ts
@@ -165,10 +165,10 @@ describe('Dashboard coordination truth', () => {
     const packageLock = JSON.parse(await fs.readFile(path.join(process.cwd(), 'package-lock.json'), 'utf8'));
     const serverManifest = JSON.parse(await fs.readFile(path.join(process.cwd(), 'server.json'), 'utf8'));
 
-    expect(packageJson.version).toBe('1.8.1');
-    expect(packageLock.version).toBe('1.8.1');
-    expect(packageLock.packages[''].version).toBe('1.8.1');
-    expect(serverManifest.version).toBe('1.8.1');
+    expect(packageJson.version).toBe('1.8.2');
+    expect(packageLock.version).toBe('1.8.2');
+    expect(packageLock.packages[''].version).toBe('1.8.2');
+    expect(serverManifest.version).toBe('1.8.2');
     expect(app).toContain("teamTaskStatus: 'Task Status'");
     expect(app).toContain("teamTaskStatus: '任务状态'");
     expect(app).toContain("teamTitle: 'Coordination Status'");

--- a/tests/integration/dashboard-deduplicate-llm.test.ts
+++ b/tests/integration/dashboard-deduplicate-llm.test.ts
@@ -1,0 +1,170 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resetConfigCache } from '../../src/config.js';
+import { resetDotenv } from '../../src/config/dotenv-loader.js';
+import { resetTomlConfigCache } from '../../src/config/toml-loader.js';
+import { resetYamlConfigCache } from '../../src/config/yaml-loader.js';
+import {
+  previewDeduplicate,
+  type DashboardMaintenanceContext,
+} from '../../src/dashboard/maintenance.js';
+import { startDashboard } from '../../src/dashboard/server.js';
+import { getLLMConfig, setLLMConfig } from '../../src/llm/provider.js';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+import { getObservationStore, initObservationStore, resetObservationStore } from '../../src/store/obs-store.js';
+import type { Observation } from '../../src/types.js';
+
+const DASHBOARD_PORT = 14212;
+const PROJECT_ID = 'test/dashboard-deduplicate-llm';
+
+let tempRoot = '';
+let projectRoot = '';
+let dataDir = '';
+let homeDir = '';
+let originalHome: string | undefined;
+let originalUserProfile: string | undefined;
+let originalFetch: typeof fetch;
+
+function makeObservation(id: number, title: string): Observation {
+  return {
+    id,
+    entityName: 'auth',
+    type: 'discovery',
+    title,
+    narrative: 'The authentication memory is project scoped and should be deduplicated.',
+    facts: ['project scoped'],
+    filesModified: [],
+    concepts: ['dashboard'],
+    tokens: 12,
+    createdAt: new Date(2026, 0, id).toISOString(),
+    projectId: PROJECT_ID,
+    status: 'active',
+  };
+}
+
+function context(): DashboardMaintenanceContext {
+  return {
+    dataDir,
+    projectId: PROJECT_ID,
+    projectRoot,
+    store: getObservationStore(),
+  };
+}
+
+function resetConfigState(): void {
+  resetDotenv();
+  resetTomlConfigCache();
+  resetYamlConfigCache();
+  resetConfigCache();
+  setLLMConfig(null);
+}
+
+describe('dashboard deduplicate memory LLM initialization', () => {
+  beforeAll(async () => {
+    originalHome = process.env.HOME;
+    originalUserProfile = process.env.USERPROFILE;
+    originalFetch = globalThis.fetch;
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-dashboard-deduplicate-llm-'));
+    homeDir = path.join(tempRoot, 'home');
+    projectRoot = path.join(tempRoot, 'project');
+    dataDir = path.join(tempRoot, 'data');
+    await fs.mkdir(path.join(homeDir, '.memorix'), { recursive: true });
+    await fs.mkdir(projectRoot, { recursive: true });
+    await fs.mkdir(dataDir, { recursive: true });
+    await fs.writeFile(
+      path.join(projectRoot, 'memorix.toml'),
+      '[memory.llm]\nprovider = "openai"\nmodel = "dashboard-test-model"\nbase_url = "http://127.0.0.1:14213/v1"\n',
+      'utf8',
+    );
+    await fs.writeFile(path.join(projectRoot, '.env'), 'MEMORIX_LLM_API_KEY=dashboard-project-secret\n', 'utf8');
+
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
+    for (const key of [
+      'MEMORIX_LLM_API_KEY',
+      'MEMORIX_LLM_PROVIDER',
+      'MEMORIX_LLM_MODEL',
+      'MEMORIX_LLM_BASE_URL',
+      'MEMORIX_API_KEY',
+      'OPENAI_API_KEY',
+      'ANTHROPIC_API_KEY',
+      'OPENROUTER_API_KEY',
+    ]) delete process.env[key];
+    resetConfigState();
+
+    await initObservationStore(dataDir);
+    const store = getObservationStore();
+    await store.insert(makeObservation(1, 'Auth memory')); 
+    await store.insert(makeObservation(2, 'Auth memory duplicate'));
+
+    globalThis.fetch = vi.fn(async (input, init) => {
+      if (!String(input).startsWith('http://127.0.0.1:14213')) {
+        return originalFetch(input, init);
+      }
+      const body = JSON.parse(String(init?.body));
+      expect(body.model).toBe('dashboard-test-model');
+      return new Response(JSON.stringify({
+        choices: [{ message: { content: JSON.stringify({ action: 'NONE', targetId: 1, reason: 'duplicate' }) } }],
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as typeof fetch;
+
+    await startDashboard(dataDir, DASHBOARD_PORT, path.join(tempRoot, 'static'), PROJECT_ID, 'project', false, projectRoot, true);
+  }, 15_000);
+
+  beforeEach(() => {
+    resetConfigState();
+  });
+
+  afterAll(async () => {
+    globalThis.fetch = originalFetch;
+    resetObservationStore();
+    closeAllDatabases();
+    resetConfigState();
+    process.env.HOME = originalHome;
+    process.env.USERPROFILE = originalUserProfile;
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it('initializes the project memory LLM for the standalone maintenance call', async () => {
+    const first = await previewDeduplicate(context());
+    const second = await previewDeduplicate(context());
+
+    expect(first.available).toBe(true);
+    expect(second.available).toBe(true);
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(first)).not.toContain('dashboard-project-secret');
+    expect(getLLMConfig()).toMatchObject({ model: 'dashboard-test-model' });
+  });
+
+  it('does not leak one project memory LLM into another project', async () => {
+    const otherProjectRoot = path.join(tempRoot, 'other-project');
+    await fs.mkdir(otherProjectRoot, { recursive: true });
+
+    const result = await previewDeduplicate({
+      dataDir,
+      projectId: 'test/other-project',
+      projectRoot: otherProjectRoot,
+      store: getObservationStore(),
+    });
+
+    expect(result).toMatchObject({ available: false, action: 'deduplicate' });
+    expect(getLLMConfig()).toBeNull();
+  });
+
+  it('initializes the same project-scoped LLM through the HTTP dashboard API', async () => {
+    const response = await fetch(`http://127.0.0.1:${DASHBOARD_PORT}/api/maintenance/deduplicate/preview`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toMatchObject({ available: true, action: 'deduplicate', projectId: PROJECT_ID });
+    expect(JSON.stringify(body)).not.toContain('dashboard-project-secret');
+    expect(getLLMConfig()).toMatchObject({ model: 'dashboard-test-model' });
+  });
+});

--- a/tests/integration/serve-http.test.ts
+++ b/tests/integration/serve-http.test.ts
@@ -20,8 +20,14 @@ describe('MCP protocol diagnostics', () => {
     expect(diagnostics.protocol.current).toBe(CURRENT_MCP_PROTOCOL_VERSION);
     expect(diagnostics.protocol.legacy).toBe(LEGACY_MCP_PROTOCOL_VERSION);
     expect(diagnostics.protocol.statefulStreamableHttp).toBe('supported');
+    expect(diagnostics.protocol.discovery).toBe('supported');
+    expect(diagnostics.protocol.versionlessRequests).toBe('legacy-compatible');
+    expect(diagnostics.protocol.modernResultMetadata).toBe('discovery-only');
+    expect(diagnostics.protocol.statelessRequests).toBe('compatibility-only');
     expect(diagnostics.capabilities.tasks).toBe('unsupported');
     expect(diagnostics.capabilities.polling).toBe('unsupported');
+    expect(diagnostics.capabilities.subscriptions).toBe('unsupported');
+    expect(diagnostics.capabilities.listCache).toBe('unsupported');
   });
 });
 

--- a/tests/rerank/neural-rerank.test.ts
+++ b/tests/rerank/neural-rerank.test.ts
@@ -2,12 +2,13 @@
  * HTTP rerank lane: configured /rerank endpoint. Failures keep original order.
  */
 
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { resetTomlConfigCache } from '../../src/config/toml-loader.js';
 import { resetYamlConfigCache } from '../../src/config/yaml-loader.js';
 import { resetResolvedConfigCache } from '../../src/config/resolved-config.js';
+import { resetDotenv } from '../../src/config/dotenv-loader.js';
 
 const TMP = join(process.cwd(), '.tmp-neural-rerank-test');
 const HOME = join(TMP, 'home');
@@ -19,7 +20,12 @@ const ENV_KEYS = [
   'MEMORIX_RERANK_API_KEY',
   'MEMORIX_LLM_BASE_URL',
   'MEMORIX_LLM_API_KEY',
+  'MEMORIX_API_KEY',
+  'OPENAI_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'OPENROUTER_API_KEY',
 ];
+const ORIGINAL_ENV = Object.fromEntries(ENV_KEYS.map((key) => [key, process.env[key]]));
 
 async function loadLane() {
   const { isNeuralRerankEnabled, neuralRerankCandidates } = await import('../../src/rerank/index.js');
@@ -27,12 +33,22 @@ async function loadLane() {
 }
 
 describe('neural rerank lane', () => {
+  beforeEach(() => {
+    resetDotenv();
+    for (const key of ENV_KEYS) delete process.env[key];
+  });
+
   afterEach(() => {
     rmSync(TMP, { recursive: true, force: true });
+    resetDotenv();
     resetTomlConfigCache();
     resetYamlConfigCache();
     resetResolvedConfigCache();
-    for (const key of ENV_KEYS) delete process.env[key];
+    for (const key of ENV_KEYS) {
+      const value = ORIGINAL_ENV[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
     vi.resetModules();
   });
 

--- a/tests/sdk/memory-client.test.ts
+++ b/tests/sdk/memory-client.test.ts
@@ -3,7 +3,7 @@ import { MemoryClient, createMemoryClient } from '../../src/sdk.js';
 import { initObservationStore, resetObservationStore } from '../../src/store/obs-store.js';
 import { initObservations, prepareSearchIndex, getAllObservations, getObservation, storeObservation } from '../../src/memory/observations.js';
 import { resetDb } from '../../src/store/orama-store.js';
-import { getDatabase } from '../../src/store/sqlite-db.js';
+import { closeAllDatabases, getDatabase } from '../../src/store/sqlite-db.js';
 import { resetProvider } from '../../src/embedding/provider.js';
 import { resetConfigCache } from '../../src/config.js';
 import { mkdtempSync, rmSync } from 'node:fs';
@@ -154,6 +154,7 @@ describe('MemoryClient (unit)', () => {
   afterEach(async () => {
     resetObservationStore();
     await resetDb();
+    closeAllDatabases();
     restoreEmbeddingEnv();
     try { rmSync(testDir, { recursive: true, force: true }); } catch { /* best effort */ }
   });

--- a/tests/server/mcp-discovery.test.ts
+++ b/tests/server/mcp-discovery.test.ts
@@ -1,0 +1,164 @@
+import { PassThrough } from 'node:stream';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+import { resetDb } from '../../src/store/orama-store.js';
+import { resetObservationStore } from '../../src/store/obs-store.js';
+import { createMemorixServer } from '../../src/server.js';
+import {
+  MCP_LEGACY_PROTOCOL_VERSION,
+  MCP_MODERN_PROTOCOL_VERSION,
+} from '../../src/server/mcp-compat.js';
+
+type JsonRpcMessage = Record<string, unknown>;
+
+let tempRoot = '';
+let projectRoot = '';
+let previousHome: string | undefined;
+let previousUserProfile: string | undefined;
+let previousDataDir: string | undefined;
+let server: Awaited<ReturnType<typeof createMemorixServer>>['server'] | undefined;
+let handleTransportClose: (() => void) | undefined;
+let transport: StdioServerTransport | undefined;
+
+function readMessage(output: PassThrough): Promise<JsonRpcMessage> {
+  return new Promise((resolve, reject) => {
+    let buffer = '';
+    const onData = (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      const newline = buffer.indexOf('\n');
+      if (newline < 0) return;
+      output.off('data', onData);
+      try {
+        resolve(JSON.parse(buffer.slice(0, newline)) as JsonRpcMessage);
+      } catch (error) {
+        reject(error);
+      }
+    };
+    output.on('data', onData);
+  });
+}
+
+async function sendMessage(input: PassThrough, output: PassThrough, message: JsonRpcMessage): Promise<JsonRpcMessage> {
+  const response = readMessage(output);
+  input.write(`${JSON.stringify(message)}\n`);
+  return response;
+}
+
+async function createFakeGitRepo(root: string): Promise<void> {
+  await fs.mkdir(path.join(root, '.git'), { recursive: true });
+  await fs.writeFile(path.join(root, '.git', 'config'), '', 'utf8');
+}
+
+beforeEach(async () => {
+  previousHome = process.env.HOME;
+  previousUserProfile = process.env.USERPROFILE;
+  previousDataDir = process.env.MEMORIX_DATA_DIR;
+  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'memorix-mcp-discovery-'));
+  projectRoot = path.join(tempRoot, 'project');
+  await fs.mkdir(projectRoot, { recursive: true });
+  await createFakeGitRepo(projectRoot);
+  process.env.HOME = path.join(tempRoot, 'home');
+  process.env.USERPROFILE = process.env.HOME;
+  process.env.MEMORIX_DATA_DIR = path.join(tempRoot, 'data');
+  resetObservationStore();
+  await resetDb();
+
+  const created = await createMemorixServer(projectRoot, undefined, undefined, {
+    toolProfile: 'micro',
+    deferProjectRuntimeInit: true,
+  });
+  server = created.server;
+  handleTransportClose = created.handleTransportClose;
+});
+
+afterEach(async () => {
+  await server?.close().catch(() => undefined);
+  await transport?.close().catch(() => undefined);
+  handleTransportClose?.();
+  transport = undefined;
+  server = undefined;
+  handleTransportClose = undefined;
+  resetObservationStore();
+  closeAllDatabases();
+  await resetDb();
+  process.env.HOME = previousHome;
+  process.env.USERPROFILE = previousUserProfile;
+  if (previousDataDir === undefined) delete process.env.MEMORIX_DATA_DIR;
+  else process.env.MEMORIX_DATA_DIR = previousDataDir;
+  await fs.rm(tempRoot, { recursive: true, force: true });
+});
+
+describe('MCP discovery compatibility at the production server entry', () => {
+  it('handles discover before initialize, then serves versionless tools/list and tools/call', async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    transport = new StdioServerTransport(input, output);
+    await server!.connect(transport);
+
+    const discovery = await sendMessage(input, output, {
+      jsonrpc: '2.0',
+      id: 'discover-1',
+      method: 'server/discover',
+      params: { _meta: { 'io.modelcontextprotocol/protocolVersion': MCP_MODERN_PROTOCOL_VERSION } },
+    });
+    const result = discovery.result as Record<string, any>;
+
+    expect(result).toMatchObject({
+      resultType: 'complete',
+      supportedVersions: expect.arrayContaining([MCP_MODERN_PROTOCOL_VERSION, MCP_LEGACY_PROTOCOL_VERSION]),
+      capabilities: { tools: { listChanged: true } },
+      ttlMs: 0,
+      cacheScope: 'private',
+      _meta: {
+        'io.modelcontextprotocol/serverInfo': { name: 'memorix' },
+      },
+    });
+
+    const list = await sendMessage(input, output, {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/list',
+    });
+    expect((list.result as Record<string, any>).tools).toEqual(expect.arrayContaining([
+      expect.objectContaining({ name: 'memorix_codegraph_status' }),
+    ]));
+
+    const call = await sendMessage(input, output, {
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: { name: 'memorix_codegraph_status', arguments: {} },
+    });
+    expect(call.error).toBeUndefined();
+    expect(call.result).toMatchObject({ content: [{ type: 'text' }] });
+  });
+
+  it('keeps legacy initialize working on the production server', async () => {
+    const input = new PassThrough();
+    const output = new PassThrough();
+    transport = new StdioServerTransport(input, output);
+    await server!.connect(transport);
+
+    const response = await sendMessage(input, output, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: MCP_LEGACY_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: { name: 'legacy-test', version: '1.0.0' },
+      },
+    });
+
+    expect(response.error).toBeUndefined();
+    expect(response.result).toMatchObject({
+      protocolVersion: MCP_LEGACY_PROTOCOL_VERSION,
+      serverInfo: { name: 'memorix' },
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,6 +38,8 @@ export default defineConfig({
             'tests/cli/uninstall.test.ts',
             // Mutates process.cwd/env and tears down git+sqlite sandboxes.
             'tests/cli/codegraph-command.test.ts',
+            // SDK tests mutate process-wide stores/config and SQLite handles.
+            'tests/sdk/memory-client.test.ts',
           ],
         },
       },
@@ -62,6 +64,8 @@ export default defineConfig({
             'tests/cli/operator-surface.test.ts',
             'tests/cli/uninstall.test.ts',
             'tests/cli/codegraph-command.test.ts',
+            // SDK tests mutate process-wide stores/config and SQLite handles.
+            'tests/sdk/memory-client.test.ts',
           ],
           testTimeout: 15_000,
           hookTimeout: 30_000,


### PR DESCRIPTION
## Summary

This release hardens the three compatibility paths for 1.8.2:

- #248: fixes Dashboard deduplication initialization for standalone and HTTP maintenance previews. The selected project's memory LLM now resolves idempotently from project TOML and `.env`, stale dotenv state is cleared across project/home switches, missing configuration remains unavailable, and credentials are never returned.
- #250: keeps the CodeGraph `context` compatibility path and falls back to the official `explore` CLI when `context` is unavailable or its output is invalid. The fallback uses shell-free bounded spawning, separate command diagnostics, strict output/path/relation validation, and an explicit Lite caution.
- #249: adds a low-level `server/discover` adapter on the pinned MCP SDK. Discovery works before `initialize`; versionless `tools/list` and `tools/call` remain available through the SDK legacy result envelopes, and legacy initialize continues to work.

MCP 2026-07-28 support is intentionally partial. Discovery returns the required identity, version, capability, and private zero-TTL cache fields, but modern result metadata outside discovery, Tasks, subscriptions, and list-response caching are not implemented or advertised. This is not a claim of complete modern MCP conformance. #249 remains open.

## Verification

- Full test suite: 307 files passed, 2 skipped; 2987 tests passed, 4 skipped.
- `npm run lint`
- `npm run build`
- `npm pack --dry-run --json`
- MCP Registry and plugin metadata checks
- Built stdio discovery before initialize, versionless tools/list and tools/call, and legacy initialize smoke
- Built HTTP discovery, versionless tools/list and tools/call, and legacy initialize smoke
- Secret and private-path scan

Fixes #248
Fixes #250
Related to #249