### PR TITLE
fix: stabilize stdio MCP discovery startup for 1.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.8.3] - 2026-08-25
+
+### Fixed
+- **Stdio MCP startup gate** -- `memorix serve` now reads and bounds
+  newline-delimited JSON-RPC input before project initialization completes.
+  Early `server/discover` requests receive the complete discovery result, while
+  initialize, notifications, responses, and versionless tool requests replay
+  through the pinned SDK transport in input order without duplicate handling.
+
+### MCP Compatibility
+- **Stable cold-start discovery** -- real stdio CLI startup now supports
+  pre-initialize discovery within the startup window and preserves legacy
+  initialize plus versionless `tools/list`/`tools/call` behavior. Tasks,
+  subscriptions, list-response caching, and modern non-discovery result
+  metadata remain unsupported or partial.
+
 ## [1.8.2] - 2026-08-25
 
 ### Fixed

--- a/docs/1.8.0-RELEASE-CANDIDATE-SPEC.md
+++ b/docs/1.8.0-RELEASE-CANDIDATE-SPEC.md
@@ -18,12 +18,15 @@ Status: accepted implementation contract for Memorix 1.8.0.
 ## Compatibility Contract
 
 Memorix preserves the legacy 2025-era initialize contract, including stdio and
-stateful Streamable HTTP with `Mcp-Session-Id`. Memorix 1.8.2 also registers a
+stateful Streamable HTTP with `Mcp-Session-Id`. Memorix 1.8.3 also registers a
 low-level `server/discover` compatibility adapter for the 2026-07-28 request.
 Its `DiscoverResult` is complete for the required identity, versions,
 capabilities, and private zero-TTL cache hint. Versionless `tools/list` and
 `tools/call` are accepted by the pinned v1 SDK and retain its legacy result
-envelopes. HTTP stateless project handles remain a compatibility adapter: they
+envelopes. The stdio startup gate reads bounded newline-delimited input before
+project initialization, answers discovery immediately, and replays all other
+messages in order; EOF is deferred until the queued input is released. HTTP
+stateless project handles remain a compatibility adapter: they
 own project routing, but do not turn the v1 SDK into a complete 2026 runtime.
 Tasks, subscriptions, and list-response caching are unsupported and are not
 advertised or simulated.

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -147,14 +147,15 @@ preserved. A memory without explicit feedback keeps the legacy relevance and
 retention score. The first feedback event opts that candidate into the
 feedback projection.
 
-### HTTP MCP Compatibility
+### MCP Compatibility
 
-Legacy clients use stateful Streamable HTTP with `Mcp-Session-Id`. Current
-Legacy clients use the 2025-era `initialize` handshake and stateful
-`Mcp-Session-Id`. The stdio server also accepts the 2026-07-28
-`server/discover` request before `initialize` and returns the required
-`DiscoverResult`. Versionless `tools/list` and `tools/call` use the pinned
-SDK's legacy result envelopes. HTTP stateless clients may use a durable
+Legacy clients use stateful Streamable HTTP with `Mcp-Session-Id` and the
+2025-era `initialize` handshake. The 1.8.3 stdio server starts a bounded
+newline-delimited JSON-RPC gate before project initialization: it answers the
+2026-07-28 `server/discover` request before `initialize`, then replays other
+requests, notifications, and responses in order into the pinned SDK transport.
+Versionless `tools/list` and `tools/call` use the SDK's legacy result envelopes.
+HTTP stateless clients may use a durable
 `Mcp-Project-Handle`; `/protocol-diagnostics` labels this as compatibility-only.
 Modern result metadata is discovery-only with a private zero-TTL hint. Tasks,
 subscriptions, and list-response caching are unsupported. When MCP discovery

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -13,8 +13,8 @@ Memorix is a TypeScript project built around:
 
 ## Current Development Baseline
 
-The current release work targets the **1.8.2 release line** and package metadata
-is kept at `1.8.2` for this release commit.
+The current release work targets the **1.8.3 release line** and package metadata
+is kept at `1.8.3` for this release commit.
 
 Contributors should assume the following areas are part of the current release line:
 
@@ -96,6 +96,7 @@ npm run test:watch
 
 ```bash
 memorix serve
+node scripts/mcp-stdio-smoke.mjs
 memorix background start
 memorix status
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,7 +94,7 @@ The public docs are organized by user intent:
 | 1.2 honest Lite and optional semantic CodeGraph provider contract | [1.2 Provider Quality](1.2.0-PROVIDER-QUALITY.md) |
 | 1.3 long-term memory model, source boundary, and lifecycle | [1.3 Memory Architecture](1.3-MEMORY-ARCHITECTURE.md) |
 | Active context-control work | [1.2.2 Memory Control Plane](1.2.2-MEMORY-CONTROL-PLANE.md) |
-| 1.8.2 context-control and compatibility acceptance contract | [1.8.0 Release Specification](1.8.0-RELEASE-CANDIDATE-SPEC.md) |
+| 1.8.3 stdio discovery startup and compatibility acceptance contract | [1.8.0 Release Specification](1.8.0-RELEASE-CANDIDATE-SPEC.md) |
 | Historical cloud sync and multi-agent research | [CLOUD_SYNC_AND_MULTI_AGENT_RESEARCH.md](CLOUD_SYNC_AND_MULTI_AGENT_RESEARCH.md) |
 | Known issues and old roadmap notes | [KNOWN_ISSUES_AND_ROADMAP.md](KNOWN_ISSUES_AND_ROADMAP.md) |
 
@@ -122,7 +122,7 @@ Historical/deep-reference documents may describe older designs. If they conflict
 
 ## Current Product Line
 
-The current product line is **1.8.2**. The authoritative acceptance contract is
+The current product line is **1.8.3**. The authoritative acceptance contract is
 [1.8.0 Release Specification](1.8.0-RELEASE-CANDIDATE-SPEC.md).
 The current baseline has:
 
@@ -141,10 +141,13 @@ The current baseline has:
 - `~/.memorix/config.toml` and project `memorix.toml` are the user-facing configuration model
 - legacy `memorix.yml`, `.env`, and `config.json` files are still read for compatibility, but new setups should use TOML
 
-For MCP compatibility, 1.8.2 preserves legacy 2025-era initialize and
-stateful Streamable HTTP behavior, and adds a tested 2026-07-28
-`server/discover` adapter. Versionless `tools/list` and `tools/call` continue
-through the SDK's legacy result envelopes. Modern result metadata is limited to
-the discovery response (`ttlMs: 0`, private cache scope); Tasks, subscriptions,
-and list-response caching are unsupported. Stateless HTTP project handles are
-a compatibility adapter, not a claim of complete 2026 conformance.
+For MCP compatibility, 1.8.3 preserves legacy 2025-era initialize and
+stateful Streamable HTTP behavior. `memorix serve` starts a bounded stdio
+startup gate: pre-initialize 2026-07-28 `server/discover` is answered with a
+complete discovery result, and other early JSON-RPC messages replay in order
+through the pinned SDK transport. Versionless `tools/list` and `tools/call`
+continue through the SDK's legacy result envelopes. Modern result metadata is
+limited to the discovery response (`ttlMs: 0`, private cache scope); Tasks,
+subscriptions, and list-response caching are unsupported. Stateless HTTP
+project handles are a compatibility adapter, not a claim of complete 2026
+conformance.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memorix",
   "mcpName": "io.github.AVIDS2/memorix",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,
@@ -62,6 +62,7 @@
     "update-models": "npm --workspace @memorix/ai run update-models",
     "start": "node dist/index.js",
     "test": "vitest run --no-file-parallelism --maxWorkers=1 --minWorkers=1",
+    "test:mcp-stdio-smoke": "node scripts/mcp-stdio-smoke.mjs",
     "test:watch": "vitest",
     "test:llm-live": "MEMORIX_RUN_LIVE_LLM_TESTS=1 vitest run tests/integration/formation-llm-quality.test.ts",
     "test:e2e": "vitest run tests/e2e/",

--- a/plugins/antigravity/memorix/plugin.json
+++ b/plugins/antigravity/memorix/plugin.json
@@ -1,4 +1,4 @@
 {
   "name": "memorix",
-  "version": "1.8.2"
+  "version": "1.8.3"
 }

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
+++ b/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Local-first project memory for CodeBuddy Code and other coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/hermes/memorix/plugin.yaml
+++ b/plugins/hermes/memorix/plugin.yaml
@@ -1,5 +1,5 @@
 name: memorix
-version: "1.8.2"
+version: "1.8.3"
 description: Shared workspace memory bridge for Hermes Agent.
 author: AVIDS2
 license: Apache-2.0

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/scripts/mcp-stdio-smoke.mjs
+++ b/scripts/mcp-stdio-smoke.mjs
@@ -1,0 +1,194 @@
+import { execFileSync, spawn } from 'node:child_process'
+import { mkdtemp, mkdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { performance } from 'node:perf_hooks'
+import path from 'node:path'
+import process from 'node:process'
+import assert from 'node:assert/strict'
+
+const root = process.cwd()
+const distCli = path.resolve(root, 'dist', 'cli', 'index.js')
+const timeoutMs = 10_000
+
+function terminate(child) {
+  if (!child.pid) return
+  if (process.platform === 'win32') {
+    try {
+      execFileSync('taskkill', ['/pid', String(child.pid), '/t', '/f'], {
+        stdio: 'ignore',
+        windowsHide: true,
+      })
+    } catch {
+      // The process may already have exited.
+    }
+    return
+  }
+  child.kill('SIGTERM')
+}
+
+function waitForMessage(messages, id, timeout = timeoutMs) {
+  if (messages.has(id)) return Promise.resolve(messages.get(id))
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      messages.waiters.delete(id)
+      reject(new Error(`timed out waiting for JSON-RPC response ${id}`))
+    }, timeout)
+    messages.waiters.set(id, (message) => {
+      clearTimeout(timer)
+      resolve(message)
+    })
+  })
+}
+
+function startServer(projectRoot, dataDir) {
+  const start = performance.now()
+  const child = spawn(process.execPath, [distCli, 'serve', '--cwd', projectRoot, '--mode', 'micro'], {
+    cwd: root,
+    env: {
+      ...process.env,
+      HOME: path.dirname(dataDir),
+      USERPROFILE: path.dirname(dataDir),
+      MEMORIX_DATA_DIR: dataDir,
+      MEMORIX_EMBEDDING: 'off',
+      MEMORIX_LLM_API_KEY: '',
+      OPENAI_API_KEY: '',
+      MEMORIX_LLM_PROVIDER: '',
+      MEMORIX_LLM_MODEL: '',
+      NO_COLOR: '1',
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+    windowsHide: true,
+  })
+
+  const messages = new Map()
+  messages.waiters = new Map()
+  let stdout = ''
+  let stderr = ''
+  let protocolNoise = ''
+  let buffer = ''
+  child.stdout.setEncoding('utf8')
+  child.stderr.setEncoding('utf8')
+  child.stdout.on('data', (chunk) => {
+    stdout += chunk
+    buffer += chunk
+    let newline = buffer.indexOf('\n')
+    while (newline >= 0) {
+      const line = buffer.slice(0, newline).replace(/\r$/, '')
+      buffer = buffer.slice(newline + 1)
+      if (line.trim()) {
+        try {
+          const message = JSON.parse(line)
+          messages.set(String(message.id), message)
+          const waiter = messages.waiters.get(String(message.id))
+          if (waiter) {
+            messages.waiters.delete(String(message.id))
+            waiter(message)
+          }
+        } catch {
+          protocolNoise += line
+        }
+      }
+      newline = buffer.indexOf('\n')
+    }
+  })
+  child.stderr.on('data', (chunk) => { stderr += chunk })
+
+  const send = (message) => {
+    child.stdin.write(`${JSON.stringify(message)}\n`)
+  }
+  const wait = (id) => waitForMessage(messages, id)
+  const closeInput = () => child.stdin.end()
+  const waitForExit = (timeout = 5_000) => new Promise((resolve, reject) => {
+    if (child.exitCode !== null) {
+      resolve(child.exitCode)
+      return
+    }
+    const timer = setTimeout(() => reject(new Error('stdio child did not exit after stdin EOF')), timeout)
+    child.once('exit', (code) => {
+      clearTimeout(timer)
+      resolve(code)
+    })
+  })
+  const close = () => terminate(child)
+  const elapsed = () => Math.round(performance.now() - start)
+  return { child, send, wait, closeInput, waitForExit, close, elapsed, getOutput: () => ({ stdout, stderr, protocolNoise }) }
+}
+
+async function main() {
+  assert.equal(await import('node:fs/promises').then(() => true), true)
+  const tempRoot = await mkdtemp(path.join(tmpdir(), 'memorix-mcp-stdio-smoke-'))
+  const projectRoot = path.join(tempRoot, 'project')
+  const dataDir = path.join(tempRoot, 'data')
+  await mkdir(projectRoot, { recursive: true })
+  await mkdir(dataDir, { recursive: true })
+  execFileSync('git', ['init'], { cwd: projectRoot, stdio: 'ignore', windowsHide: true })
+
+  if (!process.env.CI && !process.env.MEMORIX_SMOKE_SKIP_BUILD_CHECK && !await import('node:fs').then(({ existsSync }) => existsSync(distCli))) {
+    throw new Error(`built CLI not found at ${distCli}; run npm run build first`)
+  }
+
+  const server = startServer(projectRoot, dataDir)
+  try {
+    const discoverId = 'smoke-discover'
+    server.send({ jsonrpc: '2.0', id: discoverId, method: 'server/discover' })
+    const discovery = await server.wait(discoverId)
+    assert.ok(server.elapsed() <= timeoutMs, `discover responded after ${server.elapsed()}ms`)
+    assert.equal(discovery.error, undefined)
+    assert.equal(discovery.result.resultType, 'complete')
+    assert.deepEqual(discovery.result._meta['io.modelcontextprotocol/serverInfo'].name, 'memorix')
+    assert.ok(discovery.result.supportedVersions.includes('2026-07-28'))
+
+    const listId = 'smoke-list'
+    const callId = 'smoke-call'
+    const initializeId = 'smoke-initialize'
+    server.send({ jsonrpc: '2.0', id: listId, method: 'tools/list' })
+    server.send({
+      jsonrpc: '2.0',
+      id: callId,
+      method: 'tools/call',
+      params: { name: 'memorix_codegraph_status', arguments: {} },
+    })
+    server.send({
+      jsonrpc: '2.0',
+      id: initializeId,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-11-25',
+        capabilities: {},
+        clientInfo: { name: 'memorix-stdio-smoke', version: '1' },
+      },
+    })
+
+    const [list, call, initialize] = await Promise.all([
+      server.wait(listId),
+      server.wait(callId),
+      server.wait(initializeId),
+    ])
+    assert.equal(list.error, undefined)
+    assert.ok(list.result.tools.some((tool) => tool.name === 'memorix_codegraph_status'))
+    assert.equal(call.error, undefined)
+    assert.equal(call.result.content[0].type, 'text')
+    assert.equal(initialize.error, undefined)
+    assert.equal(initialize.result.protocolVersion, '2025-11-25')
+    assert.equal(server.getOutput().protocolNoise, '')
+    server.closeInput()
+    const exitCode = await server.waitForExit()
+    assert.equal(exitCode, 0)
+    console.log(JSON.stringify({
+      smoke: 'passed',
+      discoverMs: server.elapsed(),
+      toolCount: list.result.tools.length,
+      exitCode,
+      stderrBytes: server.getOutput().stderr.length,
+      stdoutBytes: server.getOutput().stdout.length,
+    }))
+  } finally {
+    server.close()
+    await rm(tempRoot, { recursive: true, force: true })
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack : String(error))
+  process.exitCode = 1
+})

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AVIDS2/memorix",
     "source": "github"
   },
-  "version": "1.8.2",
+  "version": "1.8.3",
   "websiteUrl": "https://github.com/AVIDS2/memorix#readme",
   "icons": [
     {
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "memorix",
-      "version": "1.8.2",
+      "version": "1.8.3",
       "runtimeHint": "npx",
       "packageArguments": [
         {

--- a/src/cli/commands/serve.ts
+++ b/src/cli/commands/serve.ts
@@ -4,6 +4,8 @@
 
 import { defineCommand } from 'citty';
 import { resolveToolProfile } from '../../server/tool-profile.js';
+import { getMcpServerInfo } from '../../server/mcp-discovery.js';
+import { StdioStartupGate } from '../../server/stdio-startup-gate.js';
 import { mcpFileUriToPath } from '../mcp-root-path.js';
 
 export default defineCommand({
@@ -29,6 +31,28 @@ export default defineCommand({
     },
   },
   run: async ({ args }) => {
+    // Take ownership of stdin before project/config/runtime initialization. The
+    // gate answers handshake-free discovery and queues every other JSON-RPC line
+    // until the SDK transport is connected, so cold starts cannot lose requests.
+    const startupGate = new StdioStartupGate({
+      stdin: process.stdin,
+      stdout: process.stdout,
+      serverInfo: getMcpServerInfo(),
+      onError: (error) => {
+        console.error(`[memorix] stdio startup gate error: ${error.message}`);
+        // The stream is no longer safe to replay after an input-limit or I/O
+        // failure. Exit instead of leaving a half-connected MCP process alive.
+        process.exit(1);
+      },
+      onEnd: () => {
+        console.error('[memorix] stdin closed — exiting');
+        // The gate has already ended the transport input when ready. Set the
+        // exit code and let pending JSON-RPC stdout writes drain naturally.
+        process.exitCode = 0;
+      },
+    });
+    startupGate.start();
+
     const { StdioServerTransport } = await import(
       '@modelcontextprotocol/sdk/server/stdio.js'
     );
@@ -36,12 +60,6 @@ export default defineCommand({
     const { detectProject, findGitInSubdirs, isSystemDirectory } = await import('../../project/detector.js');
     const { homedir } = await import('node:os');
     const { resolveServeProject } = await import('./serve-shared.js');
-
-    // Auto-exit when stdio pipe breaks (IDE closed) to prevent orphaned processes
-    process.stdin.on('end', () => {
-      console.error('[memorix] stdin closed — exiting');
-      process.exit(0);
-    });
 
     // Priority: explicit --cwd arg > MEMORIX_PROJECT_ROOT env > INIT_CWD (npm lifecycle) > process.cwd()
     let safeCwd: string;
@@ -85,8 +103,9 @@ export default defineCommand({
       ? { toolProfile, deferProjectRuntimeInit: true }
       : { allowUntrackedFallback: allowUntracked, deferProjectInitUntilBound: !allowUntracked, deferProjectRuntimeInit: true, toolProfile };
     const { server, projectId, deferredInit, switchProject } = await createMemorixServer(projectRoot, undefined, undefined, serverOptions);
-    const transport = new StdioServerTransport();
+    const transport = new StdioServerTransport(startupGate.input, process.stdout);
     await server.connect(transport);
+    startupGate.markReady();
 
     console.error(`[memorix] MCP Server running on stdio (project: ${projectId})`);
     console.error(`[memorix] Project root: ${detected?.rootPath ?? projectRoot}`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -62,7 +62,7 @@ import {
   type ProjectBindingController,
   type ProjectBindingSource,
 } from './server/request-context.js';
-import { registerMcpDiscovery } from './server/mcp-compat.js';
+import { getMcpServerInfo, registerMcpDiscovery } from './server/mcp-compat.js';
 
 // ── Timeout budgets for LLM-heavy paths ──────────────────────────
 const FORMATION_TIMEOUT_MS = parseFormationTimeoutMs(process.env.MEMORIX_FORMATION_TIMEOUT_MS); // Formation pipeline (extract+resolve+evaluate)
@@ -594,10 +594,7 @@ export async function createMemorixServer(
   };
 
   // Create MCP server (or use existing one from roots-aware flow)
-  const serverInfo = {
-    name: 'memorix',
-    version: typeof __MEMORIX_VERSION__ !== 'undefined' ? __MEMORIX_VERSION__ : '1.0.1',
-  };
+  const serverInfo = getMcpServerInfo();
   const server = existingServer ?? new McpServer(serverInfo);
   registerMcpDiscovery(server, serverInfo);
 

--- a/src/server/mcp-compat.ts
+++ b/src/server/mcp-compat.ts
@@ -11,32 +11,28 @@ import { RequestSchema, type ServerCapabilities } from '@modelcontextprotocol/sd
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod/v4';
 
-export const MCP_MODERN_PROTOCOL_VERSION = '2026-07-28';
-export const MCP_LEGACY_PROTOCOL_VERSION = '2025-11-25';
-export const MCP_OLDEST_LEGACY_PROTOCOL_VERSION = '2024-11-05';
-export const MCP_SERVER_DISCOVER_METHOD = 'server/discover';
-export const MCP_SERVER_INFO_META_KEY = 'io.modelcontextprotocol/serverInfo';
+import {
+  createMcpDiscoverResult,
+  MCP_SERVER_DISCOVER_METHOD,
+  type McpDiscoverResult,
+  type McpServerInfo,
+} from './mcp-discovery.js';
+
+export {
+  createMcpDiscoverResult,
+  getMcpServerInfo,
+  MCP_LEGACY_PROTOCOL_VERSION,
+  MCP_MODERN_PROTOCOL_VERSION,
+  MCP_OLDEST_LEGACY_PROTOCOL_VERSION,
+  MCP_SERVER_DISCOVER_METHOD,
+  MCP_SERVER_INFO_META_KEY,
+} from './mcp-discovery.js';
+export type { McpDiscoverResult, McpServerInfo } from './mcp-discovery.js';
 
 const ServerDiscoverRequestSchema = RequestSchema.extend({
   method: z.literal(MCP_SERVER_DISCOVER_METHOD),
   params: z.looseObject({}).optional(),
 });
-
-export interface McpServerInfo {
-  name: string;
-  version: string;
-}
-
-export interface McpDiscoverResult {
-  resultType: 'complete';
-  supportedVersions: string[];
-  capabilities: ServerCapabilities;
-  _meta: {
-    [MCP_SERVER_INFO_META_KEY]: McpServerInfo;
-  };
-  ttlMs: number;
-  cacheScope: 'public' | 'private';
-}
 
 const registeredServers = new WeakSet<McpServer>();
 
@@ -48,22 +44,7 @@ export function buildMcpDiscoverResult(server: McpServer, serverInfo: McpServerI
   const getCapabilities = (server.server as unknown as {
     getCapabilities: () => ServerCapabilities;
   }).getCapabilities.bind(server.server);
-  return {
-    resultType: 'complete',
-    supportedVersions: [
-      MCP_MODERN_PROTOCOL_VERSION,
-      MCP_LEGACY_PROTOCOL_VERSION,
-      MCP_OLDEST_LEGACY_PROTOCOL_VERSION,
-    ],
-    capabilities: getCapabilities(),
-    _meta: {
-      [MCP_SERVER_INFO_META_KEY]: { ...serverInfo },
-    },
-    // v1 has no response-cache negotiation. A zero private TTL is the
-    // conservative result and prevents clients from inventing a shared cache.
-    ttlMs: 0,
-    cacheScope: 'private',
-  };
+  return createMcpDiscoverResult(getCapabilities(), serverInfo);
 }
 
 /**

--- a/src/server/mcp-discovery.ts
+++ b/src/server/mcp-discovery.ts
@@ -1,0 +1,61 @@
+import type { ServerCapabilities } from '@modelcontextprotocol/sdk/types.js';
+
+export const MCP_MODERN_PROTOCOL_VERSION = '2026-07-28';
+export const MCP_LEGACY_PROTOCOL_VERSION = '2025-11-25';
+export const MCP_OLDEST_LEGACY_PROTOCOL_VERSION = '2024-11-05';
+export const MCP_SERVER_DISCOVER_METHOD = 'server/discover';
+export const MCP_SERVER_INFO_META_KEY = 'io.modelcontextprotocol/serverInfo';
+
+export interface McpServerInfo {
+  name: string;
+  version: string;
+}
+
+export interface McpDiscoverResult {
+  resultType: 'complete';
+  supportedVersions: string[];
+  capabilities: ServerCapabilities;
+  _meta: {
+    [MCP_SERVER_INFO_META_KEY]: McpServerInfo;
+  };
+  ttlMs: number;
+  cacheScope: 'public' | 'private';
+}
+
+export function getMcpServerInfo(): McpServerInfo {
+  return {
+    name: 'memorix',
+    version: typeof __MEMORIX_VERSION__ !== 'undefined' ? __MEMORIX_VERSION__ : '1.0.1',
+  };
+}
+
+/** Build the deliberately partial modern-discovery result shared by all stdio paths. */
+export function createMcpDiscoverResult(
+  capabilities: ServerCapabilities,
+  serverInfo: McpServerInfo,
+): McpDiscoverResult {
+  return {
+    resultType: 'complete',
+    supportedVersions: [
+      MCP_MODERN_PROTOCOL_VERSION,
+      MCP_LEGACY_PROTOCOL_VERSION,
+      MCP_OLDEST_LEGACY_PROTOCOL_VERSION,
+    ],
+    capabilities,
+    _meta: {
+      [MCP_SERVER_INFO_META_KEY]: { ...serverInfo },
+    },
+    // v1 has no response-cache negotiation. A zero private TTL prevents clients
+    // from inventing a shared cache for an implementation that cannot invalidate it.
+    ttlMs: 0,
+    cacheScope: 'private',
+  };
+}
+
+/**
+ * The startup gate can answer discovery before McpServer exists. These are the
+ * only capabilities the production stdio profile advertises at that boundary.
+ */
+export function createMcpStartupDiscoverResult(serverInfo: McpServerInfo): McpDiscoverResult {
+  return createMcpDiscoverResult({ tools: { listChanged: true } }, serverInfo);
+}

--- a/src/server/stdio-startup-gate.ts
+++ b/src/server/stdio-startup-gate.ts
@@ -1,0 +1,263 @@
+import { PassThrough, type Readable, type Writable } from 'node:stream';
+
+import {
+  createMcpStartupDiscoverResult,
+  MCP_SERVER_DISCOVER_METHOD,
+  type McpServerInfo,
+} from './mcp-discovery.js';
+
+/** Keep the gate aligned with @modelcontextprotocol/sdk's stdio ReadBuffer limit. */
+export const STDIO_STARTUP_GATE_MAX_BUFFER_SIZE = 10 * 1024 * 1024;
+
+export interface StdioStartupGateOptions {
+  stdin: Readable;
+  stdout: Writable;
+  serverInfo: McpServerInfo;
+  maxBufferSize?: number;
+  onError?: (error: Error) => void;
+  onEnd?: () => void;
+}
+
+type JsonRpcEnvelope = Record<string, unknown>;
+type ParsedLine = { message: JsonRpcEnvelope } | { error: { code: number; message: string } } | null;
+
+/**
+ * Reads stdio before the server's expensive project setup finishes.
+ *
+ * Only the handshake-free discovery request is answered at the front door. All
+ * other complete JSON-RPC lines, including notifications and responses, stay in
+ * an ordered queue and are replayed through the SDK transport once it is ready.
+ */
+export class StdioStartupGate {
+  readonly input = new PassThrough();
+
+  private readonly stdin: Readable;
+  private readonly stdout: Writable;
+  private readonly serverInfo: McpServerInfo;
+  private readonly maxBufferSize: number;
+  private readonly onError?: (error: Error) => void;
+  private readonly onEnd?: () => void;
+  private readonly queuedMessages: string[] = [];
+  private pendingInput = '';
+  private queuedBytes = 0;
+  private started = false;
+  private ready = false;
+  private stopped = false;
+  private stdinEnded = false;
+  private endNotified = false;
+
+  private readonly onData = (chunk: Buffer | string): void => {
+    if (this.stopped) return;
+
+    if (this.ready) {
+      if (Buffer.byteLength(chunk, 'utf8') > this.maxBufferSize) {
+        this.fail(new Error(`stdio input chunk exceeded ${this.maxBufferSize} bytes`));
+        return;
+      }
+      this.input.write(chunk);
+      return;
+    }
+
+    const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+    if (
+      this.queuedBytes
+      + Buffer.byteLength(this.pendingInput, 'utf8')
+      + Buffer.byteLength(text, 'utf8')
+      > this.maxBufferSize
+    ) {
+      this.fail(new Error(`stdio startup input exceeded ${this.maxBufferSize} bytes before a complete JSON-RPC line`));
+      return;
+    }
+
+    this.pendingInput += text;
+    let newline = this.pendingInput.indexOf('\n');
+    while (newline >= 0 && !this.stopped) {
+      const line = this.pendingInput.slice(0, newline + 1);
+      this.pendingInput = this.pendingInput.slice(newline + 1);
+      this.handleLine(line);
+      newline = this.pendingInput.indexOf('\n');
+    }
+
+    if (!this.stopped && Buffer.byteLength(this.pendingInput, 'utf8') > this.maxBufferSize) {
+      this.fail(new Error(`stdio startup input exceeded ${this.maxBufferSize} bytes`));
+    }
+  };
+
+  private readonly onStdinError = (error: Error): void => {
+    this.fail(error);
+  };
+
+  private readonly onStdinEnd = (): void => {
+    this.stdinEnded = true;
+    if (this.ready) this.finishInput();
+  };
+
+  constructor(options: StdioStartupGateOptions) {
+    this.stdin = options.stdin;
+    this.stdout = options.stdout;
+    this.serverInfo = { ...options.serverInfo };
+    this.maxBufferSize = options.maxBufferSize ?? STDIO_STARTUP_GATE_MAX_BUFFER_SIZE;
+    this.onError = options.onError;
+    this.onEnd = options.onEnd;
+  }
+
+  start(): void {
+    if (this.started || this.stopped) return;
+    this.started = true;
+    this.stdin.on('data', this.onData);
+    this.stdin.on('error', this.onStdinError);
+    this.stdin.on('end', this.onStdinEnd);
+  }
+
+  /** Release queued messages only after StdioServerTransport has installed its listener. */
+  markReady(): void {
+    if (this.stopped || this.ready) return;
+    this.ready = true;
+    for (const message of this.queuedMessages) this.input.write(message);
+    this.queuedMessages.length = 0;
+    this.queuedBytes = 0;
+    if (this.pendingInput) {
+      this.input.write(this.pendingInput);
+      this.pendingInput = '';
+    }
+    if (this.stdinEnded) this.finishInput();
+  }
+
+  stop(): void {
+    if (this.stopped) return;
+    this.stopped = true;
+    this.stdin.off('data', this.onData);
+    this.stdin.off('error', this.onStdinError);
+    this.stdin.off('end', this.onStdinEnd);
+    this.queuedMessages.length = 0;
+    this.pendingInput = '';
+    this.queuedBytes = 0;
+    if (!this.input.destroyed) this.input.end();
+  }
+
+  private handleLine(line: string): void {
+    const parsed = this.parseLine(line);
+    if (!parsed) return;
+    if ('error' in parsed) {
+      this.writeJsonRpcError(null, parsed.error.code, parsed.error.message);
+      return;
+    }
+
+    if (!this.ready && this.isDiscoveryRequest(parsed.message)) {
+      const response = {
+        jsonrpc: '2.0',
+        id: parsed.message.id,
+        result: createMcpStartupDiscoverResult(this.serverInfo),
+      };
+      try {
+        this.stdout.write(`${JSON.stringify(response)}\n`);
+      } catch (error) {
+        this.fail(error instanceof Error ? error : new Error(String(error)));
+      }
+      return;
+    }
+
+    if (this.ready) {
+      this.input.write(line);
+      return;
+    }
+
+    const bytes = Buffer.byteLength(line, 'utf8');
+    if (this.queuedBytes + bytes > this.maxBufferSize) {
+      this.fail(new Error(`stdio startup queue exceeded ${this.maxBufferSize} bytes`));
+      return;
+    }
+    this.queuedMessages.push(line);
+    this.queuedBytes += bytes;
+  }
+
+  private parseLine(line: string): ParsedLine {
+    const trimmed = line.endsWith('\n') ? line.slice(0, -1).replace(/\r$/, '') : line;
+    if (!trimmed.trim()) return null;
+
+    let value: unknown;
+    try {
+      value = JSON.parse(trimmed);
+    } catch {
+      return { error: { code: -32700, message: 'Parse error' } };
+    }
+
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return { error: { code: -32600, message: 'Invalid Request' } };
+    }
+    const message = value as JsonRpcEnvelope;
+    if (message.jsonrpc !== '2.0') {
+      return { error: { code: -32600, message: 'Invalid Request' } };
+    }
+
+    const hasId = Object.prototype.hasOwnProperty.call(message, 'id');
+    const hasMethod = typeof message.method === 'string';
+    const hasResult = Object.prototype.hasOwnProperty.call(message, 'result');
+    const hasError = Object.prototype.hasOwnProperty.call(message, 'error');
+    if (hasMethod && (hasResult || hasError)) {
+      return { error: { code: -32600, message: 'Invalid Request' } };
+    }
+    if (!hasMethod && !hasResult && !hasError) {
+      return { error: { code: -32600, message: 'Invalid Request' } };
+    }
+    if (hasId && !this.isValidRequestId(message.id)) {
+      return { error: { code: -32600, message: 'Invalid Request' } };
+    }
+    if (!hasMethod && !hasId) {
+      return { error: { code: -32600, message: 'Invalid Request' } };
+    }
+    return { message };
+  }
+
+  private isDiscoveryRequest(message: JsonRpcEnvelope): boolean {
+    if (message.method !== MCP_SERVER_DISCOVER_METHOD) return false;
+    if (!Object.prototype.hasOwnProperty.call(message, 'id')) return false;
+    const params = message.params;
+    return params === undefined || (typeof params === 'object' && params !== null && !Array.isArray(params));
+  }
+
+  private isValidRequestId(id: unknown): id is string | number | null {
+    return id === null
+      || typeof id === 'string'
+      || (typeof id === 'number' && Number.isFinite(id));
+  }
+
+  private writeJsonRpcError(id: string | number | null, code: number, message: string): void {
+    try {
+      this.stdout.write(`${JSON.stringify({
+        jsonrpc: '2.0',
+        id,
+        error: { code, message },
+      })}\n`);
+    } catch (error) {
+      this.fail(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+
+  private finishInput(): void {
+    if (!this.ready || this.input.destroyed || this.input.writableEnded) return;
+    this.input.end();
+    this.input.once('end', () => this.notifyEnd());
+  }
+
+  private notifyEnd(): void {
+    if (this.endNotified) return;
+    this.endNotified = true;
+    this.onEnd?.();
+  }
+
+  private fail(error: Error): void {
+    if (this.stopped) return;
+    this.stopped = true;
+    this.stdin.off('data', this.onData);
+    this.stdin.off('error', this.onStdinError);
+    this.stdin.off('end', this.onStdinEnd);
+    this.queuedMessages.length = 0;
+    this.pendingInput = '';
+    this.queuedBytes = 0;
+    // Destroy without an error argument so a not-yet-connected SDK transport
+    // cannot turn the gate failure into an unhandled EventEmitter error.
+    if (!this.input.destroyed) this.input.destroy();
+    this.onError?.(error);
+  }
+}

--- a/tests/integration/dashboard-coordination-truth.test.ts
+++ b/tests/integration/dashboard-coordination-truth.test.ts
@@ -165,10 +165,10 @@ describe('Dashboard coordination truth', () => {
     const packageLock = JSON.parse(await fs.readFile(path.join(process.cwd(), 'package-lock.json'), 'utf8'));
     const serverManifest = JSON.parse(await fs.readFile(path.join(process.cwd(), 'server.json'), 'utf8'));
 
-    expect(packageJson.version).toBe('1.8.2');
-    expect(packageLock.version).toBe('1.8.2');
-    expect(packageLock.packages[''].version).toBe('1.8.2');
-    expect(serverManifest.version).toBe('1.8.2');
+    expect(packageJson.version).toBe('1.8.3');
+    expect(packageLock.version).toBe('1.8.3');
+    expect(packageLock.packages[''].version).toBe('1.8.3');
+    expect(serverManifest.version).toBe('1.8.3');
     expect(app).toContain("teamTaskStatus: 'Task Status'");
     expect(app).toContain("teamTaskStatus: '任务状态'");
     expect(app).toContain("teamTitle: 'Coordination Status'");

--- a/tests/server/stdio-startup-gate.test.ts
+++ b/tests/server/stdio-startup-gate.test.ts
@@ -1,0 +1,248 @@
+import { PassThrough } from 'node:stream';
+import { describe, expect, it } from 'vitest';
+
+import { getMcpServerInfo } from '../../src/server/mcp-compat.js';
+import { StdioStartupGate } from '../../src/server/stdio-startup-gate.js';
+
+type JsonRpcMessage = Record<string, unknown>;
+
+function readLines(stream: PassThrough): Promise<JsonRpcMessage[]> {
+  return new Promise((resolve) => {
+    let buffer = '';
+    const messages: JsonRpcMessage[] = [];
+    const onData = (chunk: Buffer) => {
+      buffer += chunk.toString('utf8');
+      let newline: number;
+      while ((newline = buffer.indexOf('\n')) >= 0) {
+        const line = buffer.slice(0, newline).trim();
+        buffer = buffer.slice(newline + 1);
+        if (line) messages.push(JSON.parse(line) as JsonRpcMessage);
+      }
+      if (messages.length > 0) {
+        stream.off('data', onData);
+        resolve(messages);
+      }
+    };
+    stream.on('data', onData);
+  });
+}
+
+describe('stdio startup gate', () => {
+  it('answers early discovery with complete static capabilities and queues other requests', async () => {
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const gate = new StdioStartupGate({
+      stdin,
+      stdout,
+      serverInfo: getMcpServerInfo(),
+    });
+    gate.start();
+
+    const forwarded: string[] = [];
+    gate.input.on('data', (chunk: Buffer) => forwarded.push(chunk.toString('utf8')));
+
+    const discoveryOutput = readLines(stdout);
+    stdin.write(JSON.stringify({
+      jsonrpc: '2.0',
+      id: 'early-discover',
+      method: 'server/discover',
+    }) + '\n');
+    stdin.write(JSON.stringify({
+      jsonrpc: '2.0',
+      id: 'early-list',
+      method: 'tools/list',
+    }) + '\n');
+
+    const [discovery] = await discoveryOutput;
+    expect(discovery).toMatchObject({
+      jsonrpc: '2.0',
+      id: 'early-discover',
+      result: {
+        resultType: 'complete',
+        supportedVersions: expect.arrayContaining(['2026-07-28', '2025-11-25']),
+        capabilities: { tools: { listChanged: true } },
+        ttlMs: 0,
+        cacheScope: 'private',
+        _meta: {
+          'io.modelcontextprotocol/serverInfo': { name: 'memorix' },
+        },
+      },
+    });
+    expect(forwarded).toEqual([]);
+
+    gate.markReady();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(forwarded.join('')).toBe(JSON.stringify({
+      jsonrpc: '2.0',
+      id: 'early-list',
+      method: 'tools/list',
+    }) + '\n');
+
+    gate.stop();
+  });
+
+  it('forwards initialize, versionless calls, and later discovery exactly once after ready', async () => {
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const gate = new StdioStartupGate({
+      stdin,
+      stdout,
+      serverInfo: getMcpServerInfo(),
+    });
+    gate.start();
+
+    const forwarded: string[] = [];
+    gate.input.on('data', (chunk: Buffer) => forwarded.push(chunk.toString('utf8')));
+    stdin.write(JSON.stringify({
+      jsonrpc: '2.0',
+      id: 'initialize',
+      method: 'initialize',
+      params: { protocolVersion: '2025-11-25' },
+    }) + '\n');
+    stdin.write(JSON.stringify({
+      jsonrpc: '2.0',
+      id: 'call',
+      method: 'tools/call',
+      params: { name: 'memorix_codegraph_status', arguments: {} },
+    }) + '\n');
+
+    gate.markReady();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    stdin.write(JSON.stringify({
+      jsonrpc: '2.0',
+      id: 'late-discover',
+      method: 'server/discover',
+    }) + '\n');
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    expect(forwarded.join('')).toBe([
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'initialize',
+        method: 'initialize',
+        params: { protocolVersion: '2025-11-25' },
+      }),
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'call',
+        method: 'tools/call',
+        params: { name: 'memorix_codegraph_status', arguments: {} },
+      }),
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'late-discover',
+        method: 'server/discover',
+      }),
+    ].map((line) => line + '\n').join(''));
+
+    gate.stop();
+  });
+
+  it('preserves fragmented notifications/responses, reports parse errors, and fails safely at the input limit', async () => {
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    const errors: Error[] = [];
+    const gate = new StdioStartupGate({
+      stdin,
+      stdout,
+      serverInfo: getMcpServerInfo(),
+      maxBufferSize: 256,
+      onError: (error) => errors.push(error),
+    });
+    gate.start();
+
+    let forwarded = '';
+    gate.input.on('data', (chunk: Buffer) => { forwarded += chunk.toString('utf8'); });
+    const parseError = readLines(stdout);
+    stdin.write('{"jsonrpc":"2.0","id":"response","result":');
+    stdin.write('{} }\n{"jsonrpc":"2.0","method":"notifications/initialized"}\n');
+    stdin.write('not-json\n');
+
+    await expect(parseError).resolves.toEqual([{
+      jsonrpc: '2.0',
+      id: null,
+      error: { code: -32700, message: 'Parse error' },
+    }]);
+    gate.markReady();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(forwarded).toBe([
+      '{"jsonrpc":"2.0","id":"response","result":{} }\n',
+      '{"jsonrpc":"2.0","method":"notifications/initialized"}\n',
+    ].join(''));
+    expect(errors).toEqual([]);
+    gate.stop();
+
+    const limitedStdin = new PassThrough();
+    const limitedStdout = new PassThrough();
+    const limitedErrors: Error[] = [];
+    const limitedGate = new StdioStartupGate({
+      stdin: limitedStdin,
+      stdout: limitedStdout,
+      serverInfo: getMcpServerInfo(),
+      maxBufferSize: 8,
+      onError: (error) => limitedErrors.push(error),
+    });
+    limitedGate.start();
+    limitedStdin.write('123456789');
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(limitedErrors[0]?.message).toContain('exceeded 8 bytes');
+    expect(limitedGate.input.destroyed).toBe(true);
+    limitedGate.stop();
+  });
+
+  it('replays queued messages before ending the SDK input when stdin closes during startup', async () => {
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    let ended = 0;
+    const gate = new StdioStartupGate({
+      stdin,
+      stdout,
+      serverInfo: getMcpServerInfo(),
+      onEnd: () => { ended += 1; },
+    });
+    gate.start();
+
+    const forwarded: string[] = [];
+    let inputEnded = false;
+    gate.input.on('data', (chunk: Buffer) => forwarded.push(chunk.toString('utf8')));
+    gate.input.on('end', () => { inputEnded = true; });
+    const queued = JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }) + '\n';
+    stdin.write(queued);
+    stdin.end();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(ended).toBe(0);
+    const inputEnd = new Promise<void>((resolve) => gate.input.once('end', resolve));
+    gate.markReady();
+    await inputEnd;
+
+    expect(forwarded).toEqual([queued]);
+    expect(inputEnded).toBe(true);
+    expect(ended).toBe(1);
+    gate.stop();
+  });
+
+  it('hands EOF to the transport input after the gate is ready', async () => {
+    const stdin = new PassThrough();
+    const stdout = new PassThrough();
+    let ended = 0;
+    const gate = new StdioStartupGate({
+      stdin,
+      stdout,
+      serverInfo: getMcpServerInfo(),
+      onEnd: () => { ended += 1; },
+    });
+    gate.start();
+    gate.markReady();
+
+    let inputEnded = false;
+    gate.input.on('data', () => {});
+    gate.input.on('end', () => { inputEnded = true; });
+    const inputEnd = new Promise<void>((resolve) => gate.input.once('end', resolve));
+    stdin.end();
+    await inputEnd;
+
+    expect(inputEnded).toBe(true);
+    expect(ended).toBe(1);
+    gate.stop();
+  });
+});


### PR DESCRIPTION
## Summary

`memorix serve` performed the full `createMemorixServer()` startup before attaching `StdioServerTransport`. During that window stdin was not consumed, so a real stdio client could send `server/discover` before transport setup and hit the 10-second conformance timeout.

This patch adds a bounded stdio startup gate that:

- starts reading newline-delimited JSON-RPC immediately;
- answers early `server/discover` with the complete supported discovery result;
- queues requests, notifications, and responses in order without duplicate delivery;
- hands queued input and later stdin to the pinned SDK transport after server readiness;
- preserves EOF handling, 10 MiB input limits, JSON-RPC parse errors, legacy `initialize`, and versionless `tools/list`/`tools/call`;
- adds a real `child_process` dist smoke with Windows `windowsHide`, checking discovery latency, list/call, initialize, stdout protocol purity, and EOF exit.

## Verification

- Full npm test: 308 files passed, 2 skipped; 2992 tests passed, 4 skipped.
- Local dist child smoke: discovery in 5.389s, 9 tools, versionless call and legacy initialize passed, stdout contained only JSON-RPC.
- Docker HasMCP conformance using a locally packed 1.8.3 tarball installed globally (no npx Memorix download): 22 passed, 5 failed, 9 not verified.
- The three original startup failures are gone. The remaining failures are the declared partial modern compatibility boundary: non-discovery `resultType`/cache metadata, unsupported-version rejection, and server identity metadata on legacy list/call envelopes. Tasks, subscriptions, and list-response caching remain unsupported.

Related to #249