### PR TITLE
test: stabilize Windows full-suite timeout for 1.8.3

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -14,6 +14,10 @@ export default defineConfig({
           name: 'main',
           globals: true,
           environment: 'node',
+          // Windows hosted runners are materially slower under the full
+          // multi-project suite; keep the default tests from failing only
+          // because a filesystem-backed hook needs more than five seconds.
+          testTimeout: process.platform === 'win32' ? 15_000 : 5_000,
           include: ['tests/**/*.test.ts', 'tests/**/*.test.tsx'],
           exclude: [
             'tests/e2e/**',


### PR DESCRIPTION
The merged 1.8.3 change passed Linux, macOS, Docker, typecheck, registry, and the first Windows run. The Windows full-suite runner then exposed two unrelated 5-second timeouts in hook E2E tests, and a rerun exposed the same class of timeout in the fallback-budget test.

The affected tests pass locally when run with the full-suite command. Raise the `main` Vitest project timeout to 15 seconds on Windows hosted runners only; production code and non-Windows defaults are unchanged.

This is required to make the merged 1.8.3 main CI reproducibly green before publishing.

Related to #252