### PR TITLE
fix(serve-http): serve stateless MCP requests without a project handle

### DIFF
--- a/src/cli/commands/serve-http.ts
+++ b/src/cli/commands/serve-http.ts
@@ -433,11 +433,6 @@ export default defineCommand({
         ? req.headers['mcp-project-root']
         : undefined;
       const root = persisted?.projectRoot ?? requestedRoot ?? projectRoot;
-      if (!persisted && !isInitializeRequest(body) && !isServerDiscoverRequest(body)) {
-        res.writeHead(400, { 'Content-Type': 'application/json' });
-        res.end(JSON.stringify({ jsonrpc: '2.0', error: { code: -32000, message: 'Stateless MCP requests require Mcp-Project-Handle; initialize first.' }, id: null }));
-        return;
-      }
 
       const { createMemorixServer } = await import('../../server.js');
       const { createProjectBindingController } = await import('../../server/request-context.js');
@@ -465,7 +460,7 @@ export default defineCommand({
       try {
         await server.connect(transport);
         let effectiveHandle = persisted;
-        if (!effectiveHandle && projectId !== '__unresolved__') {
+        if (!effectiveHandle && projectId !== '__unresolved__' && isInitializeRequest(body)) {
           effectiveHandle = statelessBindingStore.create({
             projectId,
             projectRoot: root,

--- a/tests/cli/serve-mode.test.ts
+++ b/tests/cli/serve-mode.test.ts
@@ -57,7 +57,9 @@ vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({
         jsonrpc: '2.0',
-        result: { protocolVersion: '2024-11-05', capabilities: { tools: {} } },
+        result: body?.method === 'tools/list'
+          ? { tools: [{ name: 'memorix_store' }] }
+          : { protocolVersion: '2024-11-05', capabilities: { tools: {} } },
         id: body?.id ?? 1,
       }));
     }
@@ -412,6 +414,44 @@ describe('serve-http command mode support', () => {
     expect(createMemorixServerMock.mock.calls[0]?.[3]).toMatchObject({ toolProfile: 'full' });
     expect(createControlPlaneMaintenanceWorkerMock).toHaveBeenCalledWith('E:/memorix-data', { pollIntervalMs: 2_000 });
     expect(maintenanceWorkerStartMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('serves current-protocol tools/list without a project handle', async () => {
+    const run = serveHttpCommand.run as ((input: any) => Promise<void>) | undefined;
+
+    await run?.({
+      args: {
+        cwd: project.rootPath,
+        host: '127.0.0.1',
+        port: '3211',
+      },
+    } as any);
+
+    expect(capturedHttpHandler).toBeTypeOf('function');
+
+    const initializeReq = createFakeRequest({
+      jsonrpc: '2.0',
+      method: 'initialize',
+      params: {
+        protocolVersion: '2026-07-28',
+        capabilities: {},
+        clientInfo: { name: 'vitest', version: '1.0.0' },
+      },
+      id: 1,
+    });
+    initializeReq.headers['mcp-protocol-version'] = '2026-07-28';
+    initializeReq.rawHeaders = ['mcp-protocol-version', '2026-07-28'];
+    await capturedHttpHandler!(initializeReq, createFakeResponse() as any);
+
+    const listReq = createFakeRequest({ jsonrpc: '2.0', method: 'tools/list', id: 2 });
+    listReq.headers['mcp-protocol-version'] = '2026-07-28';
+    listReq.rawHeaders = ['mcp-protocol-version', '2026-07-28'];
+    const listRes = createFakeResponse();
+
+    await capturedHttpHandler!(listReq, listRes as any);
+
+    expect(listRes.statusCode).toBe(200);
+    expect(JSON.parse(listRes.getBody()).result.tools).toContainEqual({ name: 'memorix_store' });
   });
 
   it('uses MEMORIX_MODE as the HTTP fallback when mode is omitted', async () => {


### PR DESCRIPTION
Fixes #255

Fixes the HTTP transport for clients that send `mcp-protocol-version:
2026-07-28` on every request (Claude Code 2.1.245), which currently makes every
`tools/list` fail with `-32000 Stateless MCP requests require
Mcp-Project-Handle`.

## Change

- `serve-http.ts`: a handle-less stateless request is now served as a one-shot
  call against the already-resolved `root` instead of being rejected with 400.
- `serve-http.ts:462-469`: the durable project handle is created only for
  `initialize`, not for every handle-less request (creating it on each request
  produced a 500).

Routing (`serve-http.ts:507-515`) is left untouched — the 1.8.0 stateless
feature keeps working, and a client that does send a handle still gets the
bound project.

## Tests

- New regression test in `tests/cli/serve-mode.test.ts`: `initialize` +
  `tools/list`, both with `mcp-protocol-version: 2026-07-28` and no handle,
  expects `200` and a non-empty tool list.
- `npm test`: `Test Files 1 failed | 307 passed | 2 skipped (310)`. The single
  failing file is `tests/hooks/handler-e2e.test.ts` (`:348`, `:393`), which
  fails identically on a clean tree — verified with `git stash`.
- Verified at the HTTP level: `tools/list` with the 2026-07-28 header and no
  handle returns `200` and a full tool list.

## Note

This fix alone does not yet make Claude Code usable: once the 400 is gone, a
second, independent problem surfaces — the server advertises protocol revision
`2026-07-28` while the pinned SDK does not implement it, so the client rejects
`tools/list` with `missing required resultType`. That is filed separately as #257.