### PR TITLE
fix(mcp): advertise only protocol revisions the SDK implements

### DIFF
--- a/src/cli/commands/serve-http.ts
+++ b/src/cli/commands/serve-http.ts
@@ -413,7 +413,7 @@ export default defineCommand({
       res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
       res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Accept, Mcp-Session-Id, Mcp-Project-Handle, Mcp-Project-Root, Mcp-Stateless, Last-Event-Id');
       res.setHeader('Access-Control-Expose-Headers', 'Mcp-Session-Id, Mcp-Project-Handle, Mcp-Protocol-Version, Mcp-Method, Mcp-Name');
-      res.setHeader('Mcp-Protocol-Version', req.headers['mcp-protocol-version'] || CURRENT_MCP_PROTOCOL_VERSION);
+      res.setHeader('Mcp-Protocol-Version', MCP_SDK_COMPAT_PROTOCOL_VERSION);
       res.setHeader('Mcp-Method', req.method || 'UNKNOWN');
       res.setHeader('Mcp-Name', MCP_SERVER_NAME);
     }

--- a/src/server/mcp-discovery.ts
+++ b/src/server/mcp-discovery.ts
@@ -37,7 +37,6 @@ export function createMcpDiscoverResult(
   return {
     resultType: 'complete',
     supportedVersions: [
-      MCP_MODERN_PROTOCOL_VERSION,
       MCP_LEGACY_PROTOCOL_VERSION,
       MCP_OLDEST_LEGACY_PROTOCOL_VERSION,
     ],

--- a/tests/server/mcp-discovery.test.ts
+++ b/tests/server/mcp-discovery.test.ts
@@ -110,7 +110,7 @@ describe('MCP discovery compatibility at the production server entry', () => {
 
     expect(result).toMatchObject({
       resultType: 'complete',
-      supportedVersions: expect.arrayContaining([MCP_MODERN_PROTOCOL_VERSION, MCP_LEGACY_PROTOCOL_VERSION]),
+      supportedVersions: [MCP_LEGACY_PROTOCOL_VERSION, '2024-11-05'],
       capabilities: { tools: { listChanged: true } },
       ttlMs: 0,
       cacheScope: 'private',

--- a/tests/server/stdio-startup-gate.test.ts
+++ b/tests/server/stdio-startup-gate.test.ts
@@ -59,7 +59,7 @@ describe('stdio startup gate', () => {
       id: 'early-discover',
       result: {
         resultType: 'complete',
-        supportedVersions: expect.arrayContaining(['2026-07-28', '2025-11-25']),
+        supportedVersions: ['2025-11-25', '2024-11-05'],
         capabilities: { tools: { listChanged: true } },
         ttlMs: 0,
         cacheScope: 'private',


### PR DESCRIPTION
Fixes #257

Makes the server's protocol self-description match what it actually implements,
so clients stop applying the strict `2026-07-28` schema to responses produced by
an SDK that does not implement that revision.

## Change

- `src/server/mcp-discovery.ts` — drop `2026-07-28` from `supportedVersions`;
  advertise `[MCP_LEGACY_PROTOCOL_VERSION, MCP_OLDEST_LEGACY_PROTOCOL_VERSION]`.
- `src/cli/commands/serve-http.ts:416` — return
  `MCP_SDK_COMPAT_PROTOCOL_VERSION` in the `Mcp-Protocol-Version` response header
  instead of echoing the client's requested version, so the header matches the
  version `initialize` actually negotiates.
- `tests/server/mcp-discovery.test.ts`, `tests/server/stdio-startup-gate.test.ts`
  updated to the advertised set.

## What this affects

- Discovery changes for the plain server and for the stdio gateway
  (`src/server/stdio-startup-gate.ts`).
- The durable project handle feature from 1.8.0 is unchanged: it is selected by
  request headers (`Mcp-Stateless`, `Mcp-Project-Handle`, or an incoming
  `2026-07-28`), not by what discovery advertises. It simply stops being
  advertised as a full 2026 runtime.
- The Codex/rmcp session route is untouched.

## Rejected alternatives

- Fixing only the response header: discovery still advertises 2026, so the client
  still applies the strict schema.
- Fixing only discovery: the response header still misreports the version.
- Emitting a synthetic `resultType`: that masks an SDK that does not implement the
  revision.
- Upgrading the SDK: wider than this fix, and no compatible 2026 release was
  found.

## Tests

- `vitest run tests/server/mcp-discovery.test.ts tests/server/stdio-startup-gate.test.ts tests/cli/serve-mode.test.ts`
  → `Test Files 3 passed (3)`, `Tests 15 passed (15)`.
- `npm test` → `Test Files 1 failed | 307 passed | 2 skipped (310)`. The only
  failing file is `tests/hooks/handler-e2e.test.ts` (`:348`, `:393`), which fails
  identically on a clean tree.
- Live against the running server, with `mcp-protocol-version: 2026-07-28` on
  every request: `server/discover` → `["2025-11-25","2024-11-05"]`; `initialize`
  header and body both `2025-11-25`; `tools/list` → `200`, 47 tools.
- Real clients: `claude mcp list` → `✔ Connected`. `codex mcp list` unchanged
  (`enabled`).