### PR TITLE
fix(background): serialize background start to prevent duplicate control-plane spawns

### DIFF
--- a/src/cli/commands/background.ts
+++ b/src/cli/commands/background.ts
@@ -302,7 +302,16 @@ async function isPortInUse(port: number): Promise<boolean> {
 // Subcommands
 // ============================================================
 
-export async function doStart(port: number): Promise<void> {
+/**
+ * Core start logic: check-then-spawn. Not exported directly — two callers
+ * racing through this function (e.g. two agent sessions starting at boot, or
+ * a LaunchAgent/systemd unit racing a manual `background start`) can both
+ * observe "port not in use yet" and each spawn their own `serve-http`
+ * process on the same port, leaving one as an untracked orphan. Callers
+ * should go through the exported `doStart`, which serializes access with
+ * `acquireBackgroundLock` first.
+ */
+async function doStartUnlocked(port: number): Promise<void> {
   // 1. Check if already running — validate both PID existence AND HTTP health
   const state = loadState();
   if (state) {
@@ -489,6 +498,85 @@ export async function doStart(port: number): Promise<void> {
     '  Stop with:       memorix background stop',
   ].join('\n');
   process.stderr.write(footer + '\n');
+}
+
+/**
+ * `doStartUnlocked` checks-then-spawns: it probes `isPortInUse` and, if
+ * nothing answers, spawns a detached `serve-http` child. Two callers racing
+ * through that window (e.g. two agent sessions starting at boot, or a
+ * LaunchAgent/systemd unit racing a manual `background start`) can both
+ * observe "not in use yet" and each spawn their own server on the same port —
+ * one becomes an orphan that never gets tracked in `background.json`.
+ *
+ * This wrapper serializes callers with a simple exclusive-create lock file
+ * (`background.lock`) before delegating to `doStartUnlocked`, so only one
+ * caller can be inside the check-then-spawn section at a time. A stale lock
+ * (owner crashed mid-section) is reclaimed after 15s; if the lock can't be
+ * acquired at all within 5s we fall back to running unlocked rather than
+ * hanging forever — worse case is the pre-existing race, not a deadlock.
+ */
+const BACKGROUND_LOCK_STALE_MS = 15_000;
+const BACKGROUND_LOCK_ACQUIRE_TIMEOUT_MS = 5_000;
+
+function getBackgroundLockPath(): string {
+  return getMemorixDir() + '/background.lock';
+}
+
+interface BackgroundLock {
+  fd: number | null;
+  acquired: boolean;
+  path: string;
+}
+
+/**
+ * Exclusive-create a lock file so only one caller can be inside the
+ * check-then-spawn section of `doStart` at a time. A lock older than
+ * `staleMs` is assumed to belong to a crashed holder and is reclaimed.
+ * If the lock still can't be acquired within `timeoutMs`, returns
+ * `acquired: false` rather than hanging forever — the caller should fall
+ * back to running unlocked (worst case: the pre-existing race, not a deadlock).
+ */
+async function acquireBackgroundLock(
+  lockPath: string,
+  staleMs: number = BACKGROUND_LOCK_STALE_MS,
+  timeoutMs: number = BACKGROUND_LOCK_ACQUIRE_TIMEOUT_MS,
+): Promise<BackgroundLock> {
+  const lockDir = path.dirname(lockPath);
+  if (!fs.existsSync(lockDir)) fs.mkdirSync(lockDir, { recursive: true });
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const fd = fs.openSync(lockPath, 'wx');
+      fs.writeSync(fd, String(process.pid));
+      return { fd, acquired: true, path: lockPath };
+    } catch (err) {
+      if (!(err && (err as NodeJS.ErrnoException).code === 'EEXIST')) break;
+      try {
+        if (Date.now() - fs.statSync(lockPath).mtimeMs > staleMs) {
+          fs.unlinkSync(lockPath);
+          continue; // stale lock cleared — retry the open immediately
+        }
+      } catch { /* lock disappeared between stat and unlink — fine, loop will retry open */ }
+      await new Promise(r => setTimeout(r, 200));
+    }
+  }
+  return { fd: null, acquired: false, path: lockPath };
+}
+
+function releaseBackgroundLock(lock: BackgroundLock): void {
+  if (!lock.acquired) return;
+  try { if (lock.fd !== null) fs.closeSync(lock.fd); } catch { /* ok */ }
+  try { fs.unlinkSync(lock.path); } catch { /* ok */ }
+}
+
+export async function doStart(port: number): Promise<void> {
+  const lock = await acquireBackgroundLock(getBackgroundLockPath());
+  try {
+    await doStartUnlocked(port);
+  } finally {
+    releaseBackgroundLock(lock);
+  }
 }
 
 export async function doStop(): Promise<void> {
@@ -838,4 +926,7 @@ export const _testing = {
   resolveBackgroundCliEntry,
   resolveBackgroundCliEntryFrom,
   resolveBackgroundCwd,
+  acquireBackgroundLock,
+  releaseBackgroundLock,
+  getBackgroundLockPath,
 };

--- a/tests/cli/background-launcher.test.ts
+++ b/tests/cli/background-launcher.test.ts
@@ -1,5 +1,50 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import { _testing } from '../../src/cli/commands/background.js';
+
+describe('background start lock (prevents duplicate serve-http spawns)', () => {
+  let lockPath: string;
+
+  afterEach(() => {
+    if (lockPath) {
+      try { fs.unlinkSync(lockPath); } catch { /* already gone */ }
+    }
+  });
+
+  it('lets a second caller acquire the lock only after the first releases it', async () => {
+    lockPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'memorix-lock-')), 'background.lock');
+
+    const first = await _testing.acquireBackgroundLock(lockPath);
+    expect(first.acquired).toBe(true);
+    expect(fs.existsSync(lockPath)).toBe(true);
+
+    // Second caller must not acquire while the first still holds it — this is
+    // exactly the race that let two `background start` calls both pass the
+    // `isPortInUse` check and each spawn a duplicate `serve-http` process.
+    const second = await _testing.acquireBackgroundLock(lockPath, 15_000, 300);
+    expect(second.acquired).toBe(false);
+
+    _testing.releaseBackgroundLock(first);
+    expect(fs.existsSync(lockPath)).toBe(false);
+
+    const third = await _testing.acquireBackgroundLock(lockPath);
+    expect(third.acquired).toBe(true);
+    _testing.releaseBackgroundLock(third);
+  });
+
+  it('reclaims a stale lock left behind by a crashed holder', async () => {
+    lockPath = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'memorix-lock-')), 'background.lock');
+    fs.writeFileSync(lockPath, '999999'); // simulate a lock from a dead/crashed process
+    const past = Date.now() / 1000 - 60; // 60s old — well past the staleness threshold
+    fs.utimesSync(lockPath, past, past);
+
+    const lock = await _testing.acquireBackgroundLock(lockPath, 15_000, 2_000);
+    expect(lock.acquired).toBe(true);
+    _testing.releaseBackgroundLock(lock);
+  });
+});
 
 describe('Windows background launcher', () => {
   it('builds a hidden, independent PowerShell launch command with quoted paths', () => {


### PR DESCRIPTION
Fixes #259

## Problem

`doStart(port)` checks `isPortInUse(port)` and only spawns a detached `serve-http` child if nothing answers — but there's no lock around that check-then-spawn window. Two callers racing through it near-simultaneously (a LaunchAgent/systemd `RunAtLoad` firing at boot while an agent session's own startup hook also calls `background ensure`, for example) can both see "not in use yet" and each spawn their own server on the same port. Only one gets tracked in `background.json`; the other is a silent orphan.

Hit this for real on a machine after reboot — two `serve-http --port 3211` processes, one of them untracked. Full repro and detail in #259.

## Fix

- Renamed the existing check-then-spawn logic to an internal `doStartUnlocked` (**no behavior change**).
- Added `acquireBackgroundLock` / `releaseBackgroundLock`: a small exclusive-create lock file (`~/.memorix/background.lock`) that serializes callers through the critical section.
  - Stale lock (crashed holder) reclaimed after 15s.
  - If the lock can't be acquired at all within 5s, falls back to running unlocked rather than deadlocking — worst case is today's pre-existing race, never a hang.
- Exported `doStart` now wraps `doStartUnlocked` with the lock. All existing call sites (`background.ts` restart/ensure, `cli/index.ts`) are unaffected since the exported name/signature didn't change.

## Verification

- **Real concurrency repro** (throwaway port, not the production singleton): two simultaneous `background start` calls → before this change, 2 `serve-http` processes bound to the port; after, exactly 1 (the second caller logs `[OK] Control plane is already running` and backs off cleanly).
- Added 2 regression tests (`tests/cli/background-launcher.test.ts`): lock contention (second acquire blocked until first releases) and stale-lock reclaim.
- `background-launcher.test.ts`: 9/9 pass (was 7/7 before adding the 2 new tests).
- Broader `tests/cli/` suite: same pass/fail counts before and after this change (234 vs 232 passing — the +2 are the new tests; the 13 pre-existing failures are identical on `main` with and without this patch, confirmed via `git stash`).
- `tsc --noEmit`: no new errors (the 2 pre-existing errors in `src/media/minimax.ts` are present on `main` without this change too — unrelated workspace-resolution issue).

## Risk

Low. The lock only wraps `doStart`'s entry; `doStartUnlocked`'s internal logic is byte-for-byte unchanged. Failure modes of the lock itself (can't acquire, stale detection misfires) all fall back to today's existing behavior rather than introducing a new failure mode.