### PR TITLE
chore(release): prepare memorix 1.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.8.4] - 2026-08-27
+
+### Fixed
+- **Stateless HTTP MCP requests (#255)** -- clients such as Claude Code that
+  send the current protocol header on every request can list and call tools
+  without echoing a custom project handle. Durable handles are still created
+  on `initialize` and remain available when a client opts into them.
+- **MCP protocol self-description (#257)** -- discovery and HTTP response
+  headers now advertise the legacy revisions implemented by the pinned SDK,
+  instead of claiming complete support for the newer 2026 revision.
+- **MCP stdio smoke contract** -- the release smoke script now checks the
+  truthful advertised revision set after the compatibility fix.
+
+### MCP Compatibility
+- The 1.8.4 line supports legacy stateful MCP, versionless stdio tool calls,
+  pre-initialize discovery, and the narrow stateless HTTP compatibility path.
+  It does not claim full 2026 result metadata, Tasks, subscriptions, or list
+  caching support.
+
 ## [1.8.3] - 2026-08-25
 
 ### Fixed

--- a/docs/1.8.0-RELEASE-CANDIDATE-SPEC.md
+++ b/docs/1.8.0-RELEASE-CANDIDATE-SPEC.md
@@ -18,7 +18,7 @@ Status: accepted implementation contract for Memorix 1.8.0.
 ## Compatibility Contract
 
 Memorix preserves the legacy 2025-era initialize contract, including stdio and
-stateful Streamable HTTP with `Mcp-Session-Id`. Memorix 1.8.3 also registers a
+stateful Streamable HTTP with `Mcp-Session-Id`. Memorix 1.8.4 also registers a
 low-level `server/discover` compatibility adapter for the 2026-07-28 request.
 Its `DiscoverResult` is complete for the required identity, versions,
 capabilities, and private zero-TTL cache hint. Versionless `tools/list` and

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -150,7 +150,7 @@ feedback projection.
 ### MCP Compatibility
 
 Legacy clients use stateful Streamable HTTP with `Mcp-Session-Id` and the
-2025-era `initialize` handshake. The 1.8.3 stdio server starts a bounded
+2025-era `initialize` handshake. The 1.8.4 stdio server starts a bounded
 newline-delimited JSON-RPC gate before project initialization: it answers the
 2026-07-28 `server/discover` request before `initialize`, then replays other
 requests, notifications, and responses in order into the pinned SDK transport.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -13,8 +13,8 @@ Memorix is a TypeScript project built around:
 
 ## Current Development Baseline
 
-The current release work targets the **1.8.3 release line** and package metadata
-is kept at `1.8.3` for this release commit.
+The current release work targets the **1.8.4 release line** and package metadata
+is kept at `1.8.4` for this release commit.
 
 Contributors should assume the following areas are part of the current release line:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -94,7 +94,7 @@ The public docs are organized by user intent:
 | 1.2 honest Lite and optional semantic CodeGraph provider contract | [1.2 Provider Quality](1.2.0-PROVIDER-QUALITY.md) |
 | 1.3 long-term memory model, source boundary, and lifecycle | [1.3 Memory Architecture](1.3-MEMORY-ARCHITECTURE.md) |
 | Active context-control work | [1.2.2 Memory Control Plane](1.2.2-MEMORY-CONTROL-PLANE.md) |
-| 1.8.3 stdio discovery startup and compatibility acceptance contract | [1.8.0 Release Specification](1.8.0-RELEASE-CANDIDATE-SPEC.md) |
+| 1.8.4 MCP compatibility acceptance contract | [1.8.0 Release Specification](1.8.0-RELEASE-CANDIDATE-SPEC.md) |
 | Historical cloud sync and multi-agent research | [CLOUD_SYNC_AND_MULTI_AGENT_RESEARCH.md](CLOUD_SYNC_AND_MULTI_AGENT_RESEARCH.md) |
 | Known issues and old roadmap notes | [KNOWN_ISSUES_AND_ROADMAP.md](KNOWN_ISSUES_AND_ROADMAP.md) |
 
@@ -122,7 +122,7 @@ Historical/deep-reference documents may describe older designs. If they conflict
 
 ## Current Product Line
 
-The current product line is **1.8.3**. The authoritative acceptance contract is
+The current product line is **1.8.4**. The authoritative acceptance contract is
 [1.8.0 Release Specification](1.8.0-RELEASE-CANDIDATE-SPEC.md).
 The current baseline has:
 
@@ -141,7 +141,7 @@ The current baseline has:
 - `~/.memorix/config.toml` and project `memorix.toml` are the user-facing configuration model
 - legacy `memorix.yml`, `.env`, and `config.json` files are still read for compatibility, but new setups should use TOML
 
-For MCP compatibility, 1.8.3 preserves legacy 2025-era initialize and
+For MCP compatibility, 1.8.4 preserves legacy 2025-era initialize and
 stateful Streamable HTTP behavior. `memorix serve` starts a bounded stdio
 startup gate: pre-initialize 2026-07-28 `server/discover` is answered with a
 complete discovery result, and other early JSON-RPC messages replay in order

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.8.3",
+      "version": "1.8.4",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memorix",
   "mcpName": "io.github.AVIDS2/memorix",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/plugins/antigravity/memorix/plugin.json
+++ b/plugins/antigravity/memorix/plugin.json
@@ -1,4 +1,4 @@
 {
   "name": "memorix",
-  "version": "1.8.3"
+  "version": "1.8.4"
 }

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
+++ b/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Local-first project memory for CodeBuddy Code and other coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/hermes/memorix/plugin.yaml
+++ b/plugins/hermes/memorix/plugin.yaml
@@ -1,5 +1,5 @@
 name: memorix
-version: "1.8.3"
+version: "1.8.4"
 description: Shared workspace memory bridge for Hermes Agent.
 author: AVIDS2
 license: Apache-2.0

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/scripts/mcp-stdio-smoke.mjs
+++ b/scripts/mcp-stdio-smoke.mjs
@@ -136,7 +136,7 @@ async function main() {
     assert.equal(discovery.error, undefined)
     assert.equal(discovery.result.resultType, 'complete')
     assert.deepEqual(discovery.result._meta['io.modelcontextprotocol/serverInfo'].name, 'memorix')
-    assert.ok(discovery.result.supportedVersions.includes('2026-07-28'))
+    assert.deepEqual(discovery.result.supportedVersions, ['2025-11-25', '2024-11-05'])
 
     const listId = 'smoke-list'
     const callId = 'smoke-call'

--- a/scripts/sync-plugin-release-manifests.mjs
+++ b/scripts/sync-plugin-release-manifests.mjs
@@ -7,29 +7,40 @@ const packageJson = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'
 const checkOnly = process.argv.includes('--check');
 
 const versionedPluginManifests = [
-  'plugins/claude/memorix/.claude-plugin/plugin.json',
-  'plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json',
-  'plugins/codex/memorix/.codex-plugin/plugin.json',
-  'plugins/copilot/memorix/plugin.json',
-  'plugins/gemini/memorix/gemini-extension.json',
-  'plugins/omp/memorix/package.json',
-  'plugins/openclaw/memorix/.codex-plugin/plugin.json',
-  'plugins/pi/memorix/package.json',
+  { path: 'plugins/antigravity/memorix/plugin.json', format: 'json' },
+  { path: 'plugins/claude/memorix/.claude-plugin/plugin.json', format: 'json' },
+  { path: 'plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json', format: 'json' },
+  { path: 'plugins/codex/memorix/.codex-plugin/plugin.json', format: 'json' },
+  { path: 'plugins/copilot/memorix/plugin.json', format: 'json' },
+  { path: 'plugins/gemini/memorix/gemini-extension.json', format: 'json' },
+  { path: 'plugins/hermes/memorix/plugin.yaml', format: 'yaml' },
+  { path: 'plugins/omp/memorix/package.json', format: 'json' },
+  { path: 'plugins/openclaw/memorix/.codex-plugin/plugin.json', format: 'json' },
+  { path: 'plugins/pi/memorix/package.json', format: 'json' },
 ];
 
 const mismatches = [];
 
-for (const relativePath of versionedPluginManifests) {
-  const manifestPath = join(root, relativePath);
+for (const entry of versionedPluginManifests) {
+  const manifestPath = join(root, entry.path);
   const raw = await readFile(manifestPath, 'utf8');
-  const manifest = JSON.parse(raw);
+  const currentVersion = entry.format === 'json'
+    ? JSON.parse(raw).version
+    : raw.match(/^version:\s*["']?([^"'\r\n]+)["']?\s*$/m)?.[1];
 
-  if (manifest.version === packageJson.version) continue;
+  if (currentVersion === packageJson.version) continue;
 
-  mismatches.push(`${relativePath}: ${String(manifest.version)} -> ${packageJson.version}`);
+  mismatches.push(`${entry.path}: ${String(currentVersion)} -> ${packageJson.version}`);
   if (!checkOnly) {
-    manifest.version = packageJson.version;
-    await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+    if (entry.format === 'json') {
+      const manifest = JSON.parse(raw);
+      manifest.version = packageJson.version;
+      await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+    } else {
+      const next = raw.replace(/^(version:\s*)(["']?)[^"'\r\n]+\2(\s*)$/m, `$1"${packageJson.version}"$3`);
+      if (next === raw) throw new Error(`Could not update version in ${entry.path}.`);
+      await writeFile(manifestPath, next, 'utf8');
+    }
   }
 }
 

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AVIDS2/memorix",
     "source": "github"
   },
-  "version": "1.8.3",
+  "version": "1.8.4",
   "websiteUrl": "https://github.com/AVIDS2/memorix#readme",
   "icons": [
     {
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "memorix",
-      "version": "1.8.3",
+      "version": "1.8.4",
       "runtimeHint": "npx",
       "packageArguments": [
         {

--- a/tests/integration/dashboard-coordination-truth.test.ts
+++ b/tests/integration/dashboard-coordination-truth.test.ts
@@ -165,10 +165,10 @@ describe('Dashboard coordination truth', () => {
     const packageLock = JSON.parse(await fs.readFile(path.join(process.cwd(), 'package-lock.json'), 'utf8'));
     const serverManifest = JSON.parse(await fs.readFile(path.join(process.cwd(), 'server.json'), 'utf8'));
 
-    expect(packageJson.version).toBe('1.8.3');
-    expect(packageLock.version).toBe('1.8.3');
-    expect(packageLock.packages[''].version).toBe('1.8.3');
-    expect(serverManifest.version).toBe('1.8.3');
+    expect(packageJson.version).toBe('1.8.4');
+    expect(packageLock.version).toBe('1.8.4');
+    expect(packageLock.packages[''].version).toBe('1.8.4');
+    expect(serverManifest.version).toBe('1.8.4');
     expect(app).toContain("teamTaskStatus: 'Task Status'");
     expect(app).toContain("teamTaskStatus: '任务状态'");
     expect(app).toContain("teamTitle: 'Coordination Status'");

--- a/tests/integration/plugin-release-metadata.test.ts
+++ b/tests/integration/plugin-release-metadata.test.ts
@@ -4,22 +4,25 @@ import { describe, expect, it } from 'vitest';
 import { getCliVersion } from '../../src/cli/version.js';
 
 const versionedPluginManifests = [
-  'plugins/claude/memorix/.claude-plugin/plugin.json',
-  'plugins/codex/memorix/.codex-plugin/plugin.json',
-  'plugins/copilot/memorix/plugin.json',
-  'plugins/gemini/memorix/gemini-extension.json',
-  'plugins/omp/memorix/package.json',
-  'plugins/openclaw/memorix/.codex-plugin/plugin.json',
-  'plugins/pi/memorix/package.json',
+  { path: 'plugins/antigravity/memorix/plugin.json', format: 'json' },
+  { path: 'plugins/claude/memorix/.claude-plugin/plugin.json', format: 'json' },
+  { path: 'plugins/codex/memorix/.codex-plugin/plugin.json', format: 'json' },
+  { path: 'plugins/copilot/memorix/plugin.json', format: 'json' },
+  { path: 'plugins/gemini/memorix/gemini-extension.json', format: 'json' },
+  { path: 'plugins/hermes/memorix/plugin.yaml', format: 'yaml' },
+  { path: 'plugins/omp/memorix/package.json', format: 'json' },
+  { path: 'plugins/openclaw/memorix/.codex-plugin/plugin.json', format: 'json' },
+  { path: 'plugins/pi/memorix/package.json', format: 'json' },
 ];
 
 describe('shipped plugin release metadata', () => {
   it('keeps every versioned plugin manifest aligned with the published CLI release', async () => {
-    for (const manifestPath of versionedPluginManifests) {
-      const manifest = JSON.parse(await readFile(path.join(process.cwd(), manifestPath), 'utf-8')) as {
-        version?: unknown;
-      };
-      expect(manifest.version, manifestPath).toBe(getCliVersion());
+    for (const entry of versionedPluginManifests) {
+      const raw = await readFile(path.join(process.cwd(), entry.path), 'utf-8');
+      const version = entry.format === 'json'
+        ? (JSON.parse(raw) as { version?: unknown }).version
+        : raw.match(/^version:\s*["']?([^"'\r\n]+)["']?\s*$/m)?.[1];
+      expect(version, entry.path).toBe(getCliVersion());
     }
   });
 });


### PR DESCRIPTION
## What changed

- Release Memorix 1.8.4 after merged fixes #256 and #258.
- Keep the stdio smoke assertion aligned with truthful MCP protocol discovery.
- Synchronize server.json and every shipped plugin manifest, including Antigravity and Hermes.
- Update current release documentation and metadata.

## Verification

- npm run lint
- npm run build
- npm test: 308 test files passed, 2 skipped; 2993 tests passed, 4 skipped
- node scripts/mcp-stdio-smoke.mjs
- node scripts/smoke-stateless-http.mjs
- Real HTTP smoke: discovery and initialize return 2025-11-25; modern-header tools/list returns HTTP 200 with 47 tools
- Legacy stateful HTTP tools/list returns HTTP 200 with 47 tools

The published 1.8.3 baseline reproduced the reported HTTP failures; the candidate fixed both #255 and #257 behavior. Full modern MCP 2026 conformance remains tracked separately in #249.