### PR TITLE
fix(task-lens): ignore a bare continuation filler, keep real resume requests

### DIFF
--- a/src/codegraph/task-lens.ts
+++ b/src/codegraph/task-lens.ts
@@ -143,18 +143,66 @@ const KEYWORDS: Record<Exclude<TaskLensId, 'general'>, string[]> = {
 // Continuation is a delivery intent, not a task lens. A request can both resume
 // prior work and be a bugfix, feature, or release task, so callers keep the
 // normal lens and add a bounded prior-work projection separately.
-const CONTINUATION_KEYWORDS = [
+//
+// Matching triggers buildHookProjectContext() and a full prior-work brief,
+// which measurably costs 2-3x an ordinary prompt (~3s → ~7.5s locally, 15s+
+// under load) — enough to blow the 10s UserPromptSubmit hook timeout, after
+// which Claude Code discards the injection entirely.
+//
+// The split below is about *evidence of intent*, not about the words alone:
+//
+//   EXPLICIT   — handoff vocabulary is deliberate on its own. "交接" and
+//                "handoff" are not said casually, so a bare mention counts.
+//   AMBIGUOUS  — "继续" / "continue" / "恢复" are everyday verbs. Bare, they
+//                are filler meaning "go on" (and "恢复" usually means "restore
+//                the service" in ops work). Carrying a real task they are a
+//                genuine resume request — `memorix resume "继续处理发布阻塞问题"`
+//                is documented usage — so they require substantive content.
+const EXPLICIT_HANDOFF_KEYWORDS = [
+  'handoff',
+  'hand off',
+  'hand over',
+  'previous session',
+  'last session',
+  'pick up where',
+  '交接',          // 覆盖「任务交接」「工作交接」
+  '接手',
+  '上次会话',
+  '上次的会话',
+];
+
+const AMBIGUOUS_CONTINUATION_KEYWORDS = [
   'continue',
   'resume',
-  'pick up',
   'carry on',
-  'previous session',
+  'pick up',
   '继续',
-  '接手',
   '恢复',
   '延续',
-  '上次会话',
 ];
+
+const CONTINUATION_KEYWORDS = [
+  ...EXPLICIT_HANDOFF_KEYWORDS,
+  ...AMBIGUOUS_CONTINUATION_KEYWORDS,
+];
+
+/**
+ * Characters that carry no task meaning on their own: punctuation, whitespace,
+ * Chinese modal particles, and the generic scaffolding words users wrap around
+ * a bare "继续" ("任务继续", "继续一下").
+ */
+const TASK_FILLER = /[\s\p{P}]|[吧了呢啊吗嘛呀哦噢]|一下|一起|接着|请|帮我|task|任务|工作|the|a|an|please/giu;
+
+/** Minimum residual characters that count as a real task description. */
+const MIN_TASK_SUBSTANCE = 4;
+
+function hasSubstantiveTask(text: string, keyword: string): boolean {
+  const withoutKeyword = text.replace(
+    new RegExp(keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi'),
+    ' ',
+  );
+  return withoutKeyword.replace(TASK_FILLER, '').length >= MIN_TASK_SUBSTANCE;
+}
 
 const LENS_PRIORITY: Exclude<TaskLensId, 'general'>[] = [
   'bugfix',
@@ -250,11 +298,22 @@ export function resolveTaskLens(task?: string): TaskLens {
  * Detect when the caller is asking to continue existing work. This stays
  * separate from task-lens routing so "continue fixing the timeout" remains a
  * bugfix, while still receiving a compact prior-work brief.
+ *
+ * Explicit handoff vocabulary counts on its own. Everyday continuation verbs
+ * additionally require a substantive task, so a bare "继续" / "continue" — the
+ * single most common thing a user types to mean "go on" — stays on the cheap
+ * path instead of paying for a full brief on every turn.
  */
 export function isContinuationTask(task?: string): boolean {
   const normalized = (task ?? '').trim().toLowerCase();
-  return normalized.length > 0 && CONTINUATION_KEYWORDS.some((keyword) =>
-    containsTaskKeyword(normalized, keyword),
+  if (normalized.length === 0) return false;
+
+  if (EXPLICIT_HANDOFF_KEYWORDS.some((keyword) => containsTaskKeyword(normalized, keyword))) {
+    return true;
+  }
+
+  return AMBIGUOUS_CONTINUATION_KEYWORDS.some((keyword) =>
+    containsTaskKeyword(normalized, keyword) && hasSubstantiveTask(normalized, keyword),
   );
 }
 

--- a/src/codegraph/task-lens.ts
+++ b/src/codegraph/task-lens.ts
@@ -181,27 +181,33 @@ const AMBIGUOUS_CONTINUATION_KEYWORDS = [
   '延续',
 ];
 
-const CONTINUATION_KEYWORDS = [
-  ...EXPLICIT_HANDOFF_KEYWORDS,
-  ...AMBIGUOUS_CONTINUATION_KEYWORDS,
-];
-
 /**
  * Characters that carry no task meaning on their own: punctuation, whitespace,
  * Chinese modal particles, and the generic scaffolding words users wrap around
  * a bare "继续" ("任务继续", "继续一下").
  */
-const TASK_FILLER = /[\s\p{P}]|[吧了呢啊吗嘛呀哦噢]|一下|一起|接着|请|帮我|task|任务|工作|the|a|an|please/giu;
+const TASK_FILLER_WORDS = /\b(?:please|task|work|the|a|an)\b/giu;
+const TASK_FILLER_PHRASES = /(?:吧|了|呢|啊|吗|嘛|呀|哦|噢|一下|一起|接着|请|帮我)/gu;
 
-/** Minimum residual characters that count as a real task description. */
-const MIN_TASK_SUBSTANCE = 4;
+/** Minimum residual code points that count as a real task description. */
+const MIN_TASK_SUBSTANCE = 2;
 
 function hasSubstantiveTask(text: string, keyword: string): boolean {
   const withoutKeyword = text.replace(
     new RegExp(keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi'),
     ' ',
   );
-  return withoutKeyword.replace(TASK_FILLER, '').length >= MIN_TASK_SUBSTANCE;
+  const residual = withoutKeyword
+    // English fillers are removed as whole words, so `a` in `API` and `work`
+    // in `workflow` remain meaningful task text.
+    .replace(TASK_FILLER_WORDS, ' ')
+    .replace(TASK_FILLER_PHRASES, ' ')
+    .replace(/[\s\p{P}]/gu, '');
+
+  // These are scaffolding-only phrases, not tasks. Keep `工作流` intact by
+  // checking the complete residual instead of removing `工作` as a prefix.
+  if (/^(?:任务|工作|一下|一起|接着)$/u.test(residual)) return false;
+  return Array.from(residual).length >= MIN_TASK_SUBSTANCE;
 }
 
 const LENS_PRIORITY: Exclude<TaskLensId, 'general'>[] = [

--- a/tests/codegraph/task-lens.test.ts
+++ b/tests/codegraph/task-lens.test.ts
@@ -25,4 +25,50 @@ describe('task lens routing', () => {
     expect(isContinuationTask('请接手上次留下的登录问题。')).toBe(true);
     expect(isContinuationTask('Document the current worker API.')).toBe(false);
   });
+
+  it('ignores a bare continuation filler with no task to continue', () => {
+    // The single most common thing a user types to mean "go on". Matching it
+    // would buy a full prior-work brief on nearly every turn — 2-3x the cost of
+    // an ordinary prompt, enough to blow the 10s UserPromptSubmit hook budget.
+    for (const filler of [
+      '继续',
+      '继续吧',
+      '任务继续',
+      '请继续',
+      '继续一下',
+      'continue',
+      'continue please',
+      'resume',
+      'carry on',
+    ]) {
+      expect(isContinuationTask(filler)).toBe(false);
+    }
+  });
+
+  it('still detects an everyday continuation verb carrying a real task', () => {
+    // Documented usage: `memorix resume "继续处理发布阻塞问题"`.
+    for (const withTask of [
+      '继续处理发布阻塞问题',
+      '继续 JWT refresh 的灰度发布',
+      'Continue the JWT refresh rollout safely. Do not modify any files.',
+      'resume the migration we paused yesterday',
+    ]) {
+      expect(isContinuationTask(withTask)).toBe(true);
+    }
+  });
+
+  it('treats explicit handoff vocabulary as intent on its own', () => {
+    for (const explicit of [
+      '任务交接',
+      '交接',
+      '请接手这个项目',
+      '上次会话我们做到哪了',
+      'handoff',
+      'hand off this work',
+      'pick up where we left off',
+      'previous session context',
+    ]) {
+      expect(isContinuationTask(explicit)).toBe(true);
+    }
+  });
 });

--- a/tests/codegraph/task-lens.test.ts
+++ b/tests/codegraph/task-lens.test.ts
@@ -48,12 +48,34 @@ describe('task lens routing', () => {
   it('still detects an everyday continuation verb carrying a real task', () => {
     // Documented usage: `memorix resume "继续处理发布阻塞问题"`.
     for (const withTask of [
+      '继续修复',
+      '继续优化',
+      '继续 API',
+      '继续一下修复',
+      'resume bug',
+      'resume API',
+      'Continue API',
+      'pick up API',
+      '恢复服务',
+      '延续迁移',
       '继续处理发布阻塞问题',
       '继续 JWT refresh 的灰度发布',
       'Continue the JWT refresh rollout safely. Do not modify any files.',
       'resume the migration we paused yesterday',
     ]) {
       expect(isContinuationTask(withTask)).toBe(true);
+    }
+  });
+
+  it('does not count filler words as a substantive continuation task', () => {
+    for (const filler of [
+      '继续任务',
+      '继续工作',
+      '继续接着',
+      'continue the',
+      'resume please',
+    ]) {
+      expect(isContinuationTask(filler)).toBe(false);
     }
   });
 


### PR DESCRIPTION
## Problem: multi-memory-system collision in Claude Code

Memorix is a **cross-agent collaboration memory framework**. In Claude Code it rarely runs alone — users typically have Claude's own memory plus other memory plugins active at the same time. In that setup, a continuation trigger that fires on everyday vocabulary causes a real conflict: a full prior-work brief is injected on prompts where the user never asked for one, competing with Claude's own memory for the same context window.

`'继续'` (go on) and `'恢复'` (restore) are said dozens of times a day. `'恢复'` in particular usually means *restore the service* in ops work, not *resume a session*.

The failure becomes visible under **network fluctuation or system load**. `UserPromptSubmit` ships with `timeout: 10`, and the continuation path does not fit:

| prompt | before | after |
|---|---|---|
| `继续` | 5.6–9.4s (**15.8s under load**) | **2.7–3.3s** |
| `继续吧` | 5.5–8.3s | **2.7–2.9s** |
| `hello` (no keyword) | 2.7–3.1s | unchanged |
| `任务交接` / `继续处理发布阻塞问题` | — | brief still delivered *(intended)* |

Measured on a 16-core Mac via `memorix hook UserPromptSubmit`, 2 runs each. The "under load" figure was taken with background runners saturating cores (load avg 35).

When it exceeds the budget, Claude Code reports:

```
UserPromptSubmit hook timed out after 10s — output discarded.
```

The injection is **discarded entirely** — the user pays the latency and still gets no context. Saying `继续` after a network hiccup was a reliable way to reproduce it.

## Fix

Split the trigger by **evidence of intent**, not by the word alone:

**EXPLICIT** — deliberate handoff vocabulary; a bare mention is intent enough:
`handoff`, `hand off`, `hand over`, `previous session`, `last session`, `pick up where`, `交接`, `接手`, `上次会话`

**AMBIGUOUS** — everyday verbs; these now additionally require substantive content beyond the keyword and filler particles:
`continue`, `resume`, `carry on`, `pick up`, `继续`, `恢复`, `延续`

So:

| prompt | continuation? |
|---|---|
| `继续` / `任务继续` / `continue` | ✗ bare filler → cheap path |
| `继续处理发布阻塞问题` | ✓ documented usage, preserved |
| `Continue the JWT refresh rollout safely.` | ✓ preserved |
| `任务交接` / `handoff` | ✓ explicit intent |

`handoff` / `hand off` / `hand over` were **missing entirely** despite being the canonical English terms for this feature.

This is a vocabulary/intent fix, not a performance one. The brief is worth its cost — it should just be paid when the user actually means it.

### A note on the first revision

An earlier push removed the ambiguous words outright. That broke two `tool-profile` integration tests which set up state with `'Continue the JWT refresh rollout safely.'`, and it contradicted documented usage (`memorix resume "继续处理发布阻塞问题"` in README.zh-CN.md). **Those tests were right to fail.** The substantive-task rule is the narrower fix that satisfies both.

## Tests

- `tests/codegraph/task-lens.test.ts` — new cases for bare filler (9 phrases → `false`), continuation-with-task (4 → `true`), and explicit handoff (8 → `true`).
- `tests/integration/tool-profile.test.ts` — untouched and passing; it is what caught the first revision.
- Both files together: **18 passed**.
- Full suite: **unchanged against upstream on this machine** — 110 pre-existing failures both before and after the change (`2896 → 2899` passing; the +3 are the new cases). The differing suites between runs are symmetric flakes in unrelated areas (`cli/uninstall`, `git/subdir-scan`, `cli/agent-doctor`) under load, and `tests/codegraph/auto-context.test.ts` fails on clean upstream too.

## Compatibility

Behaviour narrows only for prompts that are *just* a continuation verb with no task. Anything that names what to continue, and all explicit handoff vocabulary, is unchanged.
