### PR TITLE
chore: release memorix 1.8.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.8.8] - 2026-09-03
+
+### Changed
+- **Public product website metadata** -- package, MCP Registry, Agent plugin,
+  installer, README, and GitHub repository links now point to the live
+  Memorix website at `https://mem.rglens.com`. This patch does not change the
+  runtime behavior of the memory layer.
+
 ## [1.8.7] - 2026-09-02
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.8.7",
+      "version": "1.8.8",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memorix",
   "mcpName": "io.github.AVIDS2/memorix",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/plugins/antigravity/memorix/plugin.json
+++ b/plugins/antigravity/memorix/plugin.json
@@ -1,4 +1,4 @@
 {
   "name": "memorix",
-  "version": "1.8.7"
+  "version": "1.8.8"
 }

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
+++ b/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "Local-first project memory for CodeBuddy Code and other coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/hermes/memorix/plugin.yaml
+++ b/plugins/hermes/memorix/plugin.yaml
@@ -1,5 +1,5 @@
 name: memorix
-version: "1.8.7"
+version: "1.8.8"
 description: Shared workspace memory bridge for Hermes Agent.
 author: AVIDS2
 license: Apache-2.0

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.8.7",
+  "version": "1.8.8",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AVIDS2/memorix",
     "source": "github"
   },
-  "version": "1.8.7",
+  "version": "1.8.8",
   "websiteUrl": "https://mem.rglens.com",
   "icons": [
     {
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "memorix",
-      "version": "1.8.7",
+      "version": "1.8.8",
       "runtimeHint": "npx",
       "packageArguments": [
         {


### PR DESCRIPTION
## Summary\n- release the public website metadata update as memorix@1.8.8\n- keep package, MCP Registry, and all integration manifests on the same version\n- record that runtime behavior is unchanged\n\n## Verification\n- npm run prepublishOnly\n- 316 test files passed\n- 3038 tests passed\n- MCP Registry metadata check passed\n- plugin release metadata check passed