### PR TITLE
docs: add Community section with the Omarchy bar widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,14 @@ npm test
 npm run build
 ```
 
+## Community
+
+Desktop and shell integrations built on Memorix:
+
+- [omarchy-memorix](https://github.com/mbot11/omarchy-memorix) — a native [Omarchy](https://omarchy.org) shell bar widget: pool stats, live global search, per-project breakdown, recent memories, and a workbench launcher. Read-only over `~/.memorix/data`; no daemons, no telemetry.
+
+Built something on top of Memorix? Open a PR to list it here.
+
 <h2 id="acknowledgements"><picture><source media="(prefers-color-scheme: dark)" srcset="assets/tags/light/section-acknowledgements.svg"><img src="assets/tags/section-acknowledgements.svg" alt="Acknowledgements" height="32" /></picture></h2>
 
 Memorix draws from the MCP ecosystem and prior memory projects such as mcp-memory-service, MemCP, claude-mem, and Mem0. memcode is based on the Pi coding-agent codebase and adapts its terminal-agent model for the Memorix ecosystem.


### PR DESCRIPTION
## What

Adds a small **Community** section to the README (just before Acknowledgements) listing desktop/shell integrations built on Memorix, starting with:

**[omarchy-memorix](https://github.com/mbot11/omarchy-memorix)** — a native [Omarchy](https://omarchy.org) shell bar widget: pool stats, live global search, per-project breakdown, recent memories, and a workbench launcher.

## Notes

- Read-only over `~/.memorix/data/memorix.db` (WAL-safe), no daemons, no telemetry
- MIT licensed; ships as a standard Omarchy shell plugin (`omarchy plugin add ... --enable`)
- Includes an invitation line so other community integrations have a home

Docs-only change — no runtime code touched.