### PR TITLE
feat(sync): multi-device store replication with convergent LWW merge

### DIFF
--- a/docs/MULTI-DEVICE-SYNC-RESEARCH.md
+++ b/docs/MULTI-DEVICE-SYNC-RESEARCH.md
@@ -1,0 +1,228 @@
+# Multi-Device Store Sync — Design Research
+
+> Status: design proposal (research), not an implemented feature.
+> Scope: keep the existing local-first SQLite runtime; add an optional,
+> provider-agnostic replication path so one user can keep the same memory
+> across several machines.
+> Prior art in this repo: `docs/CLOUD_SYNC_AND_MULTI_AGENT_RESEARCH.md`
+> already sketched a "local SQLite + background cloud sync" hybrid but did not
+> specify or build it. This document turns that sketch into a concrete,
+> reviewable contract.
+
+---
+
+## 1. Problem
+
+A single user commonly runs Memorix on more than one machine — for example a
+workstation, a home machine, and a portable laptop. Today each machine keeps
+its own independent store at `~/.memorix/data` (`MEMORIX_DATA_DIR`). There is
+no supported way to keep those stores current with each other, so the memory a
+user sees depends on which machine they happen to open.
+
+Two deployment shapes are sometimes proposed to solve this. Both have real
+costs:
+
+1. **Run one central Memorix service and point every machine at it over HTTP.**
+   `serve-http` already supports this (see `docs/DOCKER.md`). It gives a single
+   shared store, but it trades away the properties that make Memorix useful on
+   a workstation:
+   - **Project-scoped features degrade.** Git-root detection, project binding,
+     project `memorix.toml`/`.env`, and Git Memory require the service to see
+     the repository at the path the client reports. A central host usually
+     cannot see a laptop's working copy, so project-scoped semantics break
+     while only global/shared memory keeps working. `docs/DOCKER.md` documents
+     this as a real runtime limitation.
+   - **Latency on the hot path.** Every context call, session start, and hook
+     becomes a network round trip instead of a local SQLite read.
+   - **Offline stops working.** A portable machine with no connectivity has no
+     memory at all.
+   - **Single-writer contention.** One SQLite file serving several machines
+     serializes writes and invites `SQLITE_BUSY`.
+
+2. **Replace SQLite with a central client/server database (e.g. Postgres).**
+   This contradicts the stated local-first product boundary in
+   `docs/KNOWN_ISSUES_AND_ROADMAP.md`, and would require rewriting the
+   synchronous `better-sqlite3` store layer (`src/store/*.ts`) onto an async
+   client with a different SQL dialect and a different vector story. It removes
+   offline use and adds an always-on infrastructure dependency for what is
+   meant to be a local tool.
+
+Neither shape preserves local-first. The gap is a **third shape**: keep the
+store local on every machine, and add an **optional replication layer** that
+keeps those local stores consistent through an interchangeable remote.
+
+---
+
+## 2. Goals and non-goals
+
+### Goals
+
+- Preserve local-first: reads and writes stay on the local SQLite store; sync
+  is asynchronous and off the hot path.
+- Keep working offline; reconcile on the next successful sync.
+- Be **provider-agnostic**: the remote is an interface, not a specific vendor.
+  A local filesystem/rsync target, an object store (S3-compatible), or a small
+  edge datastore must all be valid backends behind the same contract.
+- Be **opt-in and safe**: sync is disabled by default; enabling it never
+  changes local behavior for users who do not use it.
+- Deterministic, explainable merge: a user can inspect what would change before
+  it is applied, consistent with the preview-first maintenance model.
+
+### Non-goals
+
+- No real-time multi-writer coordination or distributed locking. That is the
+  `team`/orchestration surface, not this.
+- No requirement to run a central Memorix service.
+- No replacement of the SQLite runtime or the retrieval/embedding model.
+- No claim of conflict-free collaboration between different users; this targets
+  one user's several machines. Multi-user sharing is a separate concern.
+
+---
+
+## 3. Why the current schema already supports this
+
+The canonical store is well suited to row-level replication because it already
+carries the fields a last-writer-wins (LWW) merge needs:
+
+- **Stable identity.** `observations.id` is assigned from a monotonic counter
+  (`meta.next_id`), and the store persists a `storage_generation` in `meta`.
+- **Write ordering.** Rows already carry `updatedAt`/`createdAt`, and
+  observations carry `writeGeneration`. These give a per-row version basis.
+- **Lifecycle state.** `admissionState`, `status`, `revisionCount`, and
+  `visibility` describe promotion/supersession, so a merge can respect
+  lifecycle rather than blindly overwriting.
+- **Provenance.** `source`, `sourceDetail`, `createdByAgentId`, `projectId`,
+  and `sessionId` let a merge attribute and scope rows.
+
+This means a first version can replicate at the **observation row** granularity
+using existing columns, without a schema migration, by treating
+`(id)` as the merge key and `(writeGeneration, updatedAt)` as the version
+comparator.
+
+---
+
+## 4. Proposed architecture
+
+### 4.1 Two layers
+
+1. **A change journal (local).** A small append-only log of committed mutations
+   keyed by table + row id + logical version. This can be derived from existing
+   columns for observations in v1, and generalized to other tables later. The
+   journal is what gets shipped, so sync never has to diff the whole 900 MB
+   database.
+2. **A replication transport (remote).** A narrow interface that can `push`
+   local journal segments and `pull` remote ones. The store never talks to a
+   vendor directly; it talks to this interface.
+
+### 4.2 Transport interface (provider-agnostic)
+
+```ts
+// Illustrative contract, not final API.
+interface SyncRemote {
+  // Opaque cursor describing "everything up to here has been applied".
+  getRemoteHead(): Promise<SyncCursor>;
+  // Upload a batch of local changes after the given cursor.
+  push(changes: ChangeBatch, from: SyncCursor): Promise<SyncCursor>;
+  // Download remote changes the local store has not applied yet.
+  pull(after: SyncCursor): Promise<ChangeBatch>;
+}
+```
+
+Concrete adapters implement `SyncRemote` only:
+
+- **`fs`/`rsync`** — a directory the user already syncs by other means; zero
+  new infrastructure, good for a first, fully local test.
+- **`s3`** — any S3-compatible object store; batches are immutable objects
+  under a key prefix, head is a small manifest object.
+- **`edge-kv`/`edge-sql`** — a small edge datastore for users who want a
+  hosted hop without running a full service.
+
+The point is that no adapter is privileged. Provider choice is configuration,
+not code, mirroring how `[memory.llm]`, `[embedding]`, and rerank already
+select providers by config.
+
+### 4.3 Merge strategy
+
+- Default: **row-level last-writer-wins** keyed on `(writeGeneration, updatedAt)`
+  with `id` as the merge key.
+- **Lifecycle-aware overrides:** a supersession or archival must not be undone
+  by an older `active` copy; `admissionState`/`status` transitions are applied
+  in lifecycle order, not raw timestamp order.
+- **Deletes** are tombstoned in the journal so a delete on machine A is not
+  resurrected by machine B's stale row.
+- **Preview-first:** `sync --dry` reports the exact set of inserts, updates,
+  supersessions, and tombstones that would apply, consistent with the existing
+  preview-first maintenance actions.
+
+### 4.4 Configuration surface (illustrative)
+
+```toml
+[sync]
+enabled = false          # opt-in; default off
+provider = "fs"          # fs | s3 | edge-kv | ...
+mode     = "manual"      # manual | interval
+# provider-specific settings live under a provider table, e.g. [sync.s3]
+# credentials come from the environment, never from this file
+```
+
+Credentials and endpoints are resolved from the environment (as LLM/embedding
+keys already are), never written into a config file that could be shared.
+
+### 4.5 CLI surface (illustrative)
+
+- `memorix sync push` / `memorix sync pull` / `memorix sync status`
+- `memorix sync --dry` for a preview before applying
+- Optional background interval sync gated behind `[sync].mode = "interval"`
+
+> Note: `memorix sync` today handles cross-agent **rules** synchronization
+> (`src/cli/commands/sync.ts`). Store replication must not collide with that
+> surface; it should live under a clearly separated subcommand namespace
+> (for example `memorix sync store ...`) or a new top-level verb, decided by
+> the maintainer.
+
+---
+
+## 5. Phasing
+
+1. **Phase 1 — journal + `fs` adapter, observations only.**
+   Prove correctness locally with no external service: two data dirs on one
+   machine reconcile through a shared directory. Deterministic merge tests.
+2. **Phase 2 — object-store adapter + preview.**
+   Add an S3-compatible adapter and `sync --dry`. Add the interval mode.
+3. **Phase 3 — remaining tables + tombstones + lifecycle ordering.**
+   Extend beyond observations (sessions, knowledge, code-state) with the same
+   contract; formalize tombstones and lifecycle-aware precedence.
+4. **Phase 4 — optional edge adapter.**
+   A hosted hop for users who want cross-machine sync without self-hosting.
+
+Each phase is independently useful and independently reviewable.
+
+---
+
+## 6. Compatibility and safety
+
+- **Default off.** Users who never enable `[sync]` see no behavior change.
+- **No hot-path cost.** Sync runs asynchronously; local reads/writes are
+  unchanged.
+- **No new required dependency.** The `fs` adapter needs nothing; object-store
+  and edge adapters are optional.
+- **Local-first preserved.** Every machine keeps a complete local store and
+  works offline.
+- **Preview-first and auditable**, matching the existing maintenance model.
+
+---
+
+## 7. Open questions for maintainer direction
+
+1. Subcommand placement: extend `sync` (`sync store ...`) vs. a new top-level
+   verb, given `sync` already means rules sync.
+2. Journal representation: derive from existing columns for v1, or add an
+   explicit change-log table from the start.
+3. Which adapters belong in-tree vs. as optional/companion packages.
+4. Whether `serve-http` should be able to act as a sync remote for a user's own
+   machines, giving a self-hosted option that still keeps each client local.
+5. Merge policy defaults: is row-level LWW acceptable as the v1 default, with
+   lifecycle-aware overrides, or is a stricter policy preferred?
+
+This document is intentionally a design proposal. Implementation should follow
+the maintainer's answers to the questions above rather than presuppose them.

--- a/docs/MULTI-DEVICE-SYNC-RESEARCH.md
+++ b/docs/MULTI-DEVICE-SYNC-RESEARCH.md
@@ -81,23 +81,33 @@ keeps those local stores consistent through an interchangeable remote.
 
 ## 3. Why the current schema already supports this
 
-The canonical store is well suited to row-level replication because it already
-carries the fields a last-writer-wins (LWW) merge needs:
+The canonical store carries most of what a convergent last-writer-wins (LWW)
+merge needs, and the small remainder lives in additive side tables so the
+`observations` schema never changes:
 
-- **Stable identity.** `observations.id` is assigned from a monotonic counter
-  (`meta.next_id`), and the store persists a `storage_generation` in `meta`.
-- **Write ordering.** Rows already carry `updatedAt`/`createdAt`, and
-  observations carry `writeGeneration`. These give a per-row version basis.
-- **Lifecycle state.** `admissionState`, `status`, `revisionCount`, and
-  `visibility` describe promotion/supersession, so a merge can respect
-  lifecycle rather than blindly overwriting.
+- **Stable cross-device identity.** The integer `observations.id` is a
+  *replica-local* counter (`meta.next_id`) — two machines can mint the same id
+  for unrelated rows — so it cannot be the merge key. Sync instead derives a
+  stable `syncKey`: `t:<projectId>:<topicKey>` for topic-keyed observations
+  (naturally shared across devices) and `u:<originDevice>:<originId>` for
+  unkeyed ones, minted once and recorded in `sync_row_state`. Each replica maps
+  a `syncKey` to its own local id on import, so id collisions are impossible.
+- **Convergent versioning.** Merge uses a per-row logical clock
+  `(revision, writer)` — a Lamport counter advanced from the last observed
+  revision, tiebroken by the originating device id — persisted verbatim in
+  `sync_row_state`. This is a strict total order, so replaying batches in any
+  delivery order reaches the same state. `writeGeneration`/`updatedAt` remain a
+  local storage watermark and are deliberately *not* used as the comparator
+  (they are not comparable across replicas).
+- **Durable tombstones.** Deletes are versioned states retained in
+  `sync_row_state`, so a stale upsert pulled later cannot resurrect a row a
+  newer delete removed.
 - **Provenance.** `source`, `sourceDetail`, `createdByAgentId`, `projectId`,
   and `sessionId` let a merge attribute and scope rows.
 
-This means a first version can replicate at the **observation row** granularity
-using existing columns, without a schema migration, by treating
-`(id)` as the merge key and `(writeGeneration, updatedAt)` as the version
-comparator.
+A first version therefore replicates at the **observation row** granularity
+with no migration of existing data: identity, version, and tombstone state all
+live in the additive `sync_row_state` / `sync_meta` tables.
 
 ---
 
@@ -117,14 +127,16 @@ comparator.
 ### 4.2 Transport interface (provider-agnostic)
 
 ```ts
-// Illustrative contract, not final API.
+// Final interface (src/sync/types.ts). Cursor maps deviceId -> last applied
+// sequence, so both sides know what the other has already seen.
 interface SyncRemote {
-  // Opaque cursor describing "everything up to here has been applied".
-  getRemoteHead(): Promise<SyncCursor>;
-  // Upload a batch of local changes after the given cursor.
-  push(changes: ChangeBatch, from: SyncCursor): Promise<SyncCursor>;
-  // Download remote changes the local store has not applied yet.
-  pull(after: SyncCursor): Promise<ChangeBatch>;
+  readonly kind: string;                 // "fs" | "s3" | "postgres"
+  init(): Promise<void>;
+  getCursor(deviceId: string): Promise<SyncCursor>;
+  setCursor(deviceId: string, cursor: SyncCursor): Promise<void>;
+  push(batch: ChangeBatch): Promise<void>;            // idempotent by (deviceId, sequence)
+  pull(since: Record<string, number>): Promise<ChangeBatch[]>; // newer batches, oldest first
+  close(): Promise<void>;
 }
 ```
 
@@ -143,13 +155,19 @@ select providers by config.
 
 ### 4.3 Merge strategy
 
-- Default: **row-level last-writer-wins** keyed on `(writeGeneration, updatedAt)`
-  with `id` as the merge key.
-- **Lifecycle-aware overrides:** a supersession or archival must not be undone
-  by an older `active` copy; `admissionState`/`status` transitions are applied
-  in lifecycle order, not raw timestamp order.
-- **Deletes** are tombstoned in the journal so a delete on machine A is not
-  resurrected by machine B's stale row.
+- **Row-level last-writer-wins**, merged by the stable `syncKey` and versioned
+  by the per-row logical clock `(revision, writer)`. The comparison is a strict
+  total order, so the merge is convergent: any delivery/replay order of the
+  same batches yields the same final state.
+- **No lifecycle special-casing.** An earlier design ordered `status`
+  transitions in lifecycle rank; that made the merge order-dependent (applying
+  `active`@rev2 then `archived`@rev1 diverged from the reverse). Revision
+  ordering alone already prevents a stale `active` copy from overriding a newer
+  supersession/archival, so the guard was removed in favour of provable
+  convergence.
+- **Durable tombstones.** A delete is a versioned state kept in
+  `sync_row_state`, so a delete on machine A is never resurrected by machine B's
+  stale upsert — even when B pulls the old upsert after the delete.
 - **Preview-first:** `sync --dry` reports the exact set of inserts, updates,
   supersessions, and tombstones that would apply, consistent with the existing
   preview-first maintenance actions.

--- a/src/cli/commands/sync-store.ts
+++ b/src/cli/commands/sync-store.ts
@@ -1,0 +1,115 @@
+/**
+ * `memorix sync store <push|pull|status>` — multi-device store replication.
+ *
+ * Separated from `memorix sync rules|workspace` (cross-agent rules) so the two
+ * meanings of "sync" never collide. Store sync is opt-in and provider-agnostic;
+ * the remote is selected by `MEMORIX_SYNC_PROVIDER`.
+ */
+
+import { defineCommand } from 'citty';
+
+import { getCliProjectContext, emitError, emitResult } from './operator-shared.js';
+import { getObservationStore, initObservationStore } from '../../store/obs-store.js';
+import { runSync } from '../../sync/engine.js';
+import { createSqliteSyncStore } from '../../sync/store-port.js';
+import { resolveSyncConfig, createRemote } from '../../sync/remote-factory.js';
+import type { SyncReport } from '../../sync/types.js';
+
+function renderReport(report: SyncReport): string {
+  const lines = [
+    `Store sync (${report.remote}) — device ${report.deviceId}${report.dryRun ? ' [dry-run]' : ''}`,
+    `- Pushed changes:   ${report.pushed}`,
+    `- Pulled batches:   ${report.pulledBatches}`,
+    `- Applied upserts:  ${report.applied}`,
+    `- Applied deletes:  ${report.tombstoned}`,
+    `- Skipped (older):  ${report.skipped}`,
+  ];
+  if (report.dryRun && report.decisions.length > 0) {
+    lines.push('', 'Decisions:');
+    for (const d of report.decisions) {
+      lines.push(`  ${d.syncKey} ${d.kind} -> ${d.outcome} (${d.reason})`);
+    }
+  }
+  return lines.join('\n');
+}
+
+export default defineCommand({
+  meta: {
+    name: 'sync-store',
+    description: 'Replicate the local observation store across your devices (opt-in, provider-agnostic)',
+  },
+  args: {
+    dry: { type: 'boolean', description: 'Preview changes without writing anything', default: false },
+    json: { type: 'boolean', description: 'Emit JSON', default: false },
+    'push-only': { type: 'boolean', description: 'Only push local changes', default: false },
+    'pull-only': { type: 'boolean', description: 'Only pull remote changes', default: false },
+  },
+  run: async ({ args }) => {
+    const asJson = Boolean(args.json);
+    const action = (args._ as string[])?.[0] || 'status';
+    if (action !== 'push' && action !== 'pull' && action !== 'status') {
+      emitError(`unknown action "${action}" (expected push|pull|status)`, asJson);
+      process.exitCode = 2;
+      return;
+    }
+
+    let config;
+    try {
+      config = resolveSyncConfig();
+    } catch (err) {
+      emitError((err as Error).message, asJson);
+      process.exitCode = 2;
+      return;
+    }
+
+    if (!config.enabled || !config.provider) {
+      emitResult(
+        { enabled: false },
+        'Store sync is disabled. Set MEMORIX_SYNC_PROVIDER=fs|s3|postgres to enable it.',
+        asJson,
+      );
+      return;
+    }
+
+    const { project, dataDir } = await getCliProjectContext();
+    await initObservationStore(dataDir);
+    const obsStore = getObservationStore();
+    const syncStore = createSqliteSyncStore(dataDir, obsStore);
+
+    if (action === 'status') {
+      const report = await runSync(syncStore, await createRemote(config.provider), {
+        deviceId: syncStore.deviceId(),
+        dryRun: true,
+        push: true,
+        pull: true,
+      });
+      emitResult({ project: project.id, ...report }, renderReport(report), asJson);
+      return;
+    }
+
+    const doPush = action === 'push' || !args['pull-only'];
+    const doPull = action === 'pull' || !args['push-only'];
+
+    let remote;
+    try {
+      remote = await createRemote(config.provider);
+    } catch (err) {
+      emitError((err as Error).message, asJson);
+      process.exitCode = 1;
+      return;
+    }
+
+    try {
+      const report = await runSync(syncStore, remote, {
+        deviceId: syncStore.deviceId(),
+        dryRun: Boolean(args.dry),
+        push: doPush,
+        pull: doPull,
+      });
+      emitResult({ project: project.id, ...report }, renderReport(report), asJson);
+    } catch (err) {
+      emitError((err as Error).message, asJson);
+      process.exitCode = 1;
+    }
+  },
+});

--- a/src/cli/commands/sync.ts
+++ b/src/cli/commands/sync.ts
@@ -51,6 +51,14 @@ export default defineCommand({
   },
   run: async ({ args }) => {
     const section = (args._ as string[])?.[0] || '';
+
+    // Store replication is a distinct concern from rules/workspace sync.
+    if (section === 'store') {
+      const storeCmd = (await import('./sync-store.js')).default;
+      const rest = (args._ as string[]).slice(1);
+      await storeCmd.run!({ args: { ...args, _: rest } } as never);
+      return;
+    }
     const asJson = !!args.json;
 
     if (section === 'rules' || section === 'workspace') {

--- a/src/sync/adapters/fs.ts
+++ b/src/sync/adapters/fs.ts
@@ -1,0 +1,116 @@
+import { access, mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { emptyCursor } from '../types.js';
+import type { ChangeBatch, SyncCursor, SyncRemote } from '../types.js';
+
+export interface FsRemoteOptions {
+  root: string;
+}
+
+export class FsRemote implements SyncRemote {
+  readonly kind = 'fs';
+
+  constructor(private readonly options: FsRemoteOptions) {}
+
+  async init(): Promise<void> {
+    await Promise.all([
+      mkdir(this.batchesPath, { recursive: true }),
+      mkdir(this.cursorsPath, { recursive: true }),
+    ]);
+  }
+
+  async getCursor(deviceId: string): Promise<SyncCursor> {
+    try {
+      return JSON.parse(await readFile(this.cursorPath(deviceId), 'utf8')) as SyncCursor;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return emptyCursor();
+      throw error;
+    }
+  }
+
+  async setCursor(deviceId: string, cursor: SyncCursor): Promise<void> {
+    await atomicWrite(this.cursorPath(deviceId), cursor);
+  }
+
+  async push(batch: ChangeBatch): Promise<void> {
+    const directory = path.join(this.batchesPath, batch.deviceId);
+    await mkdir(directory, { recursive: true });
+    const target = path.join(directory, `${String(batch.sequence).padStart(20, '0')}.json`);
+    if (await exists(target)) return;
+
+    const lock = `${target}.lock`;
+    for (;;) {
+      try {
+        await writeFile(lock, '', { flag: 'wx' });
+        break;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+        if (await exists(target)) return;
+        await new Promise<void>((resolve) => setTimeout(resolve, 5));
+      }
+    }
+
+    try {
+      if (!(await exists(target))) await atomicWrite(target, batch);
+    } finally {
+      await rm(lock, { force: true });
+    }
+  }
+
+  async pull(since: Record<string, number>): Promise<ChangeBatch[]> {
+    const batches: ChangeBatch[] = [];
+    const devices = await readdir(this.batchesPath, { withFileTypes: true });
+
+    for (const device of devices) {
+      if (!device.isDirectory()) continue;
+      const directory = path.join(this.batchesPath, device.name);
+      const files = await readdir(directory, { withFileTypes: true });
+      for (const file of files) {
+        if (!file.isFile() || !/^\d+\.json$/.test(file.name)) continue;
+        const sequence = Number.parseInt(file.name, 10);
+        if (sequence <= (since[device.name] ?? 0)) continue;
+        batches.push(JSON.parse(await readFile(path.join(directory, file.name), 'utf8')) as ChangeBatch);
+      }
+    }
+
+    return batches.sort((left, right) => {
+      if (left.deviceId < right.deviceId) return -1;
+      if (left.deviceId > right.deviceId) return 1;
+      return left.sequence - right.sequence;
+    });
+  }
+
+  async close(): Promise<void> {}
+
+  private get batchesPath(): string {
+    return path.join(this.options.root, 'batches');
+  }
+
+  private get cursorsPath(): string {
+    return path.join(this.options.root, 'cursors');
+  }
+
+  private cursorPath(deviceId: string): string {
+    return path.join(this.cursorsPath, `${deviceId}.json`);
+  }
+}
+
+async function exists(file: string): Promise<boolean> {
+  try {
+    await access(file);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
+}
+
+async function atomicWrite(file: string, value: unknown): Promise<void> {
+  const temporary = `${file}.${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}.tmp`;
+  try {
+    await writeFile(temporary, JSON.stringify(value), { encoding: 'utf8', flag: 'wx' });
+    await rename(temporary, file);
+  } finally {
+    await rm(temporary, { force: true });
+  }
+}

--- a/src/sync/adapters/object-store.ts
+++ b/src/sync/adapters/object-store.ts
@@ -7,6 +7,8 @@
  * - MEMORIX_SYNC_S3_ACCESS_KEY_ID
  * - MEMORIX_SYNC_S3_SECRET_ACCESS_KEY
  * - MEMORIX_SYNC_S3_REGION
+ * - MEMORIX_SYNC_S3_PREFIX (optional; key namespace so a shared bucket can
+ *   host other data or several independent stores)
  */
 
 import { emptyCursor } from '../types.js';
@@ -30,32 +32,36 @@ const BATCH_KEY = /^batches\/([^/]+)\/(\d+)\.json$/;
 
 export class ObjectStoreRemote implements SyncRemote {
   readonly kind = 's3';
+  /** Key namespace so a shared bucket can host other data or several stores. */
+  private readonly prefix: string;
 
-  constructor(private readonly client: ObjectStoreClient) {}
+  constructor(private readonly client: ObjectStoreClient, prefix = '') {
+    this.prefix = prefix === '' ? '' : `${prefix.replace(/\/+$/, '')}/`;
+  }
 
   async init(): Promise<void> {}
 
   async getCursor(deviceId: string): Promise<SyncCursor> {
-    const body = await this.client.get(`cursors/${deviceId}.json`);
+    const body = await this.client.get(`${this.prefix}cursors/${deviceId}.json`);
     return body === undefined ? emptyCursor() : JSON.parse(body) as SyncCursor;
   }
 
   async setCursor(deviceId: string, cursor: SyncCursor): Promise<void> {
-    await this.client.put(`cursors/${deviceId}.json`, JSON.stringify(cursor));
+    await this.client.put(`${this.prefix}cursors/${deviceId}.json`, JSON.stringify(cursor));
   }
 
   async push(batch: ChangeBatch): Promise<void> {
     const sequence = String(batch.sequence).padStart(SEQUENCE_WIDTH, '0');
     await this.client.putIfAbsent(
-      `batches/${batch.deviceId}/${sequence}.json`,
+      `${this.prefix}batches/${batch.deviceId}/${sequence}.json`,
       JSON.stringify(batch),
     );
   }
 
   async pull(since: Record<string, number>): Promise<ChangeBatch[]> {
     const objects: BatchObject[] = [];
-    for (const key of await this.client.list('batches/')) {
-      const match = BATCH_KEY.exec(key);
+    for (const key of await this.client.list(`${this.prefix}batches/`)) {
+      const match = BATCH_KEY.exec(key.slice(this.prefix.length));
       if (match === null) continue;
       const [, deviceId, encodedSequence] = match;
       const sequence = Number(encodedSequence);

--- a/src/sync/adapters/object-store.ts
+++ b/src/sync/adapters/object-store.ts
@@ -1,0 +1,207 @@
+/**
+ * S3-compatible object-store sync.
+ *
+ * Configuration is read from:
+ * - MEMORIX_SYNC_S3_BUCKET
+ * - MEMORIX_SYNC_S3_ENDPOINT
+ * - MEMORIX_SYNC_S3_ACCESS_KEY_ID
+ * - MEMORIX_SYNC_S3_SECRET_ACCESS_KEY
+ * - MEMORIX_SYNC_S3_REGION
+ */
+
+import { emptyCursor } from '../types.js';
+import type { ChangeBatch, SyncCursor, SyncRemote } from '../types.js';
+
+export interface ObjectStoreClient {
+  putIfAbsent(key: string, body: string): Promise<void>;
+  get(key: string): Promise<string | undefined>;
+  put(key: string, body: string): Promise<void>;
+  list(prefix: string): Promise<string[]>;
+}
+
+interface BatchObject {
+  key: string;
+  deviceId: string;
+  sequence: number;
+}
+
+const SEQUENCE_WIDTH = 20;
+const BATCH_KEY = /^batches\/([^/]+)\/(\d+)\.json$/;
+
+export class ObjectStoreRemote implements SyncRemote {
+  readonly kind = 's3';
+
+  constructor(private readonly client: ObjectStoreClient) {}
+
+  async init(): Promise<void> {}
+
+  async getCursor(deviceId: string): Promise<SyncCursor> {
+    const body = await this.client.get(`cursors/${deviceId}.json`);
+    return body === undefined ? emptyCursor() : JSON.parse(body) as SyncCursor;
+  }
+
+  async setCursor(deviceId: string, cursor: SyncCursor): Promise<void> {
+    await this.client.put(`cursors/${deviceId}.json`, JSON.stringify(cursor));
+  }
+
+  async push(batch: ChangeBatch): Promise<void> {
+    const sequence = String(batch.sequence).padStart(SEQUENCE_WIDTH, '0');
+    await this.client.putIfAbsent(
+      `batches/${batch.deviceId}/${sequence}.json`,
+      JSON.stringify(batch),
+    );
+  }
+
+  async pull(since: Record<string, number>): Promise<ChangeBatch[]> {
+    const objects: BatchObject[] = [];
+    for (const key of await this.client.list('batches/')) {
+      const match = BATCH_KEY.exec(key);
+      if (match === null) continue;
+      const [, deviceId, encodedSequence] = match;
+      const sequence = Number(encodedSequence);
+      if (!Number.isSafeInteger(sequence) || sequence <= (since[deviceId] ?? 0)) continue;
+      objects.push({ key, deviceId, sequence });
+    }
+
+    objects.sort((left, right) => {
+      if (left.deviceId < right.deviceId) return -1;
+      if (left.deviceId > right.deviceId) return 1;
+      return left.sequence - right.sequence;
+    });
+
+    const batches: ChangeBatch[] = [];
+    for (const object of objects) {
+      const body = await this.client.get(object.key);
+      if (body !== undefined) batches.push(JSON.parse(body) as ChangeBatch);
+    }
+    return batches;
+  }
+
+  async close(): Promise<void> {}
+}
+
+type S3Command = new (input: Record<string, unknown>) => unknown;
+
+interface S3Response {
+  Body?: { transformToString(): Promise<string> };
+  Contents?: Array<{ Key?: string }>;
+  IsTruncated?: boolean;
+  NextContinuationToken?: string;
+  $metadata?: { httpStatusCode?: number };
+}
+
+interface S3Client {
+  send(command: unknown): Promise<S3Response>;
+}
+
+interface S3Module {
+  S3Client: new (config: Record<string, unknown>) => S3Client;
+  GetObjectCommand: S3Command;
+  ListObjectsV2Command: S3Command;
+  PutObjectCommand: S3Command;
+}
+
+export async function createS3ObjectStore(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ObjectStoreClient> {
+  const bucket = requiredEnv(env, 'MEMORIX_SYNC_S3_BUCKET');
+  const endpoint = requiredEnv(env, 'MEMORIX_SYNC_S3_ENDPOINT');
+  const accessKeyId = requiredEnv(env, 'MEMORIX_SYNC_S3_ACCESS_KEY_ID');
+  const secretAccessKey = requiredEnv(env, 'MEMORIX_SYNC_S3_SECRET_ACCESS_KEY');
+  const region = requiredEnv(env, 'MEMORIX_SYNC_S3_REGION');
+
+  const moduleName = '@aws-sdk/client-s3';
+  // The SDK is optional by design, so a static import would make every install require it.
+  let sdk: S3Module;
+  try {
+    sdk = await import(moduleName) as unknown as S3Module;
+  } catch (cause) {
+    throw new Error(
+      'S3 sync requires @aws-sdk/client-s3. Install it in the application using Memorix.',
+      { cause },
+    );
+  }
+
+  const s3 = new sdk.S3Client({
+    endpoint,
+    region,
+    credentials: { accessKeyId, secretAccessKey },
+  });
+
+  const client: ObjectStoreClient = {
+    async putIfAbsent(key, body) {
+      try {
+        await s3.send(new sdk.PutObjectCommand({
+          Bucket: bucket,
+          Key: key,
+          Body: body,
+          IfNoneMatch: '*',
+        }));
+      } catch (error) {
+        if (!isPreconditionFailure(error)) throw error;
+      }
+    },
+
+    async get(key) {
+      try {
+        const response = await s3.send(new sdk.GetObjectCommand({ Bucket: bucket, Key: key }));
+        return response.Body?.transformToString();
+      } catch (error) {
+        if (isNotFound(error)) return undefined;
+        throw error;
+      }
+    },
+
+    async put(key, body) {
+      await s3.send(new sdk.PutObjectCommand({ Bucket: bucket, Key: key, Body: body }));
+    },
+
+    async list(prefix) {
+      const keys: string[] = [];
+      let continuationToken: string | undefined;
+      do {
+        const response = await s3.send(new sdk.ListObjectsV2Command({
+          Bucket: bucket,
+          Prefix: prefix,
+          ContinuationToken: continuationToken,
+        }));
+        for (const object of response.Contents ?? []) {
+          if (object.Key !== undefined) keys.push(object.Key);
+        }
+        continuationToken = response.IsTruncated ? response.NextContinuationToken : undefined;
+      } while (continuationToken !== undefined);
+      return keys;
+    },
+  };
+
+  return client;
+}
+
+function requiredEnv(env: NodeJS.ProcessEnv, name: string): string {
+  const value = env[name];
+  if (value === undefined || value.length === 0) {
+    throw new Error(`Missing required environment variable ${name}`);
+  }
+  return value;
+}
+
+function errorDetails(error: unknown): { name?: string; status?: number } {
+  if (typeof error !== 'object' || error === null) return {};
+  const candidate = error as { name?: unknown; $metadata?: { httpStatusCode?: unknown } };
+  return {
+    name: typeof candidate.name === 'string' ? candidate.name : undefined,
+    status: typeof candidate.$metadata?.httpStatusCode === 'number'
+      ? candidate.$metadata.httpStatusCode
+      : undefined,
+  };
+}
+
+function isPreconditionFailure(error: unknown): boolean {
+  const details = errorDetails(error);
+  return details.status === 412 || details.name === 'PreconditionFailed';
+}
+
+function isNotFound(error: unknown): boolean {
+  const details = errorDetails(error);
+  return details.status === 404 || details.name === 'NoSuchKey' || details.name === 'NotFound';
+}

--- a/src/sync/adapters/postgres.ts
+++ b/src/sync/adapters/postgres.ts
@@ -1,0 +1,174 @@
+import { emptyCursor } from '../types.js';
+import type { ChangeBatch, SyncCursor, SyncRemote } from '../types.js';
+
+export interface SqlClient {
+  query<T>(sql: string, params: unknown[]): Promise<T[]>;
+  exec(sql: string, params: unknown[]): Promise<void>;
+}
+
+interface BatchRow {
+  device_id: string;
+  sequence: number | string;
+  produced_at: string;
+  payload: ChangeBatch | string;
+}
+
+interface CursorRow {
+  applied: Record<string, number> | string;
+}
+
+export class PostgresSyncRemote implements SyncRemote {
+  readonly kind = 'postgres';
+
+  constructor(private readonly sql: SqlClient) {}
+
+  async init(): Promise<void> {
+    await this.sql.exec(
+      `CREATE TABLE IF NOT EXISTS memorix_sync_batches (
+        device_id text,
+        sequence bigint,
+        produced_at text,
+        payload jsonb,
+        PRIMARY KEY (device_id, sequence)
+      )`,
+      [],
+    );
+    await this.sql.exec(
+      `CREATE TABLE IF NOT EXISTS memorix_sync_cursors (
+        owner_device text PRIMARY KEY,
+        applied jsonb
+      )`,
+      [],
+    );
+  }
+
+  async getCursor(deviceId: string): Promise<SyncCursor> {
+    const [row] = await this.sql.query<CursorRow>(
+      'SELECT applied FROM memorix_sync_cursors WHERE owner_device = $1',
+      [deviceId],
+    );
+    if (!row) return emptyCursor();
+
+    const applied = typeof row.applied === 'string'
+      ? JSON.parse(row.applied) as Record<string, number>
+      : row.applied;
+    return { applied };
+  }
+
+  async setCursor(deviceId: string, cursor: SyncCursor): Promise<void> {
+    await this.sql.exec(
+      `INSERT INTO memorix_sync_cursors (owner_device, applied)
+       VALUES ($1, $2::jsonb)
+       ON CONFLICT (owner_device) DO UPDATE SET applied = EXCLUDED.applied`,
+      [deviceId, JSON.stringify(cursor.applied)],
+    );
+  }
+
+  async push(batch: ChangeBatch): Promise<void> {
+    await this.sql.exec(
+      `INSERT INTO memorix_sync_batches (device_id, sequence, produced_at, payload)
+       VALUES ($1, $2, $3, $4::jsonb)
+       ON CONFLICT (device_id, sequence) DO NOTHING`,
+      [batch.deviceId, batch.sequence, batch.producedAt, JSON.stringify(batch)],
+    );
+  }
+
+  async pull(since: Record<string, number>): Promise<ChangeBatch[]> {
+    const rows = await this.sql.query<BatchRow>(
+      'SELECT device_id, sequence, produced_at, payload FROM memorix_sync_batches',
+      [],
+    );
+
+    return rows
+      .map((row) => {
+        const payload = typeof row.payload === 'string'
+          ? JSON.parse(row.payload) as ChangeBatch
+          : row.payload;
+        return {
+          ...payload,
+          deviceId: row.device_id,
+          sequence: Number(row.sequence),
+          producedAt: row.produced_at,
+        };
+      })
+      .filter((batch) => batch.sequence > (since[batch.deviceId] ?? 0))
+      .sort((left, right) => {
+        if (left.deviceId < right.deviceId) return -1;
+        if (left.deviceId > right.deviceId) return 1;
+        return left.sequence - right.sequence;
+      });
+  }
+
+  async close(): Promise<void> {}
+}
+
+interface PgPool {
+  query(sql: string, params: unknown[]): Promise<{ rows: unknown[] }>;
+}
+
+interface PgModule {
+  Pool?: new (config: Record<string, unknown>) => PgPool;
+  default?: {
+    Pool?: new (config: Record<string, unknown>) => PgPool;
+  };
+}
+
+export async function createPgSqlClient(env: NodeJS.ProcessEnv = process.env): Promise<SqlClient> {
+  const connectionString = env.MEMORIX_SYNC_PG_URL;
+  let config: Record<string, unknown>;
+
+  if (connectionString) {
+    config = { connectionString };
+  } else {
+    const required = [
+      'MEMORIX_SYNC_PG_HOST',
+      'MEMORIX_SYNC_PG_PORT',
+      'MEMORIX_SYNC_PG_DB',
+      'MEMORIX_SYNC_PG_USER',
+      'MEMORIX_SYNC_PG_PASSWORD',
+    ] as const;
+    const missing = required.filter((name) => !env[name]);
+    if (missing.length > 0) {
+      throw new Error(
+        `Postgres sync requires MEMORIX_SYNC_PG_URL or all discrete settings; missing ${missing.join(', ')}`,
+      );
+    }
+
+    const port = Number(env.MEMORIX_SYNC_PG_PORT);
+    if (!Number.isInteger(port) || port <= 0) {
+      throw new Error('MEMORIX_SYNC_PG_PORT must be a positive integer');
+    }
+    config = {
+      host: env.MEMORIX_SYNC_PG_HOST,
+      port,
+      database: env.MEMORIX_SYNC_PG_DB,
+      user: env.MEMORIX_SYNC_PG_USER,
+      password: env.MEMORIX_SYNC_PG_PASSWORD,
+    };
+  }
+
+  // pg is optional by design, so a static import would make every install require it.
+  const packageName = 'pg';
+  let pg: PgModule;
+  try {
+    pg = await import(packageName) as PgModule;
+  } catch (cause) {
+    throw new Error('Postgres sync requires the optional "pg" package; install it in your application', { cause });
+  }
+
+  const Pool = pg.Pool ?? pg.default?.Pool;
+  if (!Pool) {
+    throw new Error('The installed "pg" package does not export Pool');
+  }
+  const pool = new Pool(config);
+
+  return {
+    async query<T>(sql: string, params: unknown[]): Promise<T[]> {
+      const result = await pool.query(sql, params);
+      return result.rows as T[];
+    },
+    async exec(sql: string, params: unknown[]): Promise<void> {
+      await pool.query(sql, params);
+    },
+  };
+}

--- a/src/sync/adapters/postgres.ts
+++ b/src/sync/adapters/postgres.ts
@@ -74,9 +74,13 @@ export class PostgresSyncRemote implements SyncRemote {
   }
 
   async pull(since: Record<string, number>): Promise<ChangeBatch[]> {
+    // Filter server-side: only ship batches newer than the caller's per-device
+    // cursor, so a pull costs O(new rows), not O(full history).
     const rows = await this.sql.query<BatchRow>(
-      'SELECT device_id, sequence, produced_at, payload FROM memorix_sync_batches',
-      [],
+      `SELECT device_id, sequence, produced_at, payload
+         FROM memorix_sync_batches
+        WHERE sequence > COALESCE(($1::jsonb ->> device_id)::bigint, 0)`,
+      [JSON.stringify(since)],
     );
 
     return rows
@@ -91,7 +95,6 @@ export class PostgresSyncRemote implements SyncRemote {
           producedAt: row.produced_at,
         };
       })
-      .filter((batch) => batch.sequence > (since[batch.deviceId] ?? 0))
       .sort((left, right) => {
         if (left.deviceId < right.deviceId) return -1;
         if (left.deviceId > right.deviceId) return 1;

--- a/src/sync/engine.ts
+++ b/src/sync/engine.ts
@@ -1,0 +1,171 @@
+/**
+ * Sync engine — orchestrates push and pull against any `SyncRemote`.
+ *
+ * Local-first and off the hot path: the engine reads the local store, ships a
+ * change journal, pulls remote batches, and applies them through the pure merge
+ * policy. All identity/versioning lives in `sync_row_state`; the engine only
+ * moves data between that state, the observation store, and the remote.
+ */
+import type { Observation } from '../types.js';
+import { computeChanges, contentHash, nowIso } from './journal.js';
+import { mergeOne } from './merge.js';
+import type {
+  ChangeBatch,
+  SyncDecision,
+  SyncRemote,
+  SyncReport,
+  SyncRowState,
+} from './types.js';
+
+/**
+ * Everything the engine needs from the local side. The SQLite binding lives in
+ * `store-port.ts`; tests supply an in-memory fake.
+ */
+export interface SyncStorePort {
+  /** Stable device id for this replica. */
+  deviceId(): string;
+  /** All live observations. */
+  loadAll(): Promise<Observation[]>;
+  /** Recorded sync state, keyed by syncKey. */
+  loadState(): Promise<Map<string, SyncRowState>>;
+  /** Upsert sync-state rows. */
+  saveState(rows: SyncRowState[]): Promise<void>;
+  /** Reserve and return a fresh local observation id (for imports). */
+  allocateId(): Promise<number>;
+  /** Insert an imported observation (id already assigned). */
+  applyInsert(row: Observation): Promise<void>;
+  /** Update an existing observation in place. */
+  applyUpdate(row: Observation): Promise<void>;
+  /** Remove an observation by local id. */
+  applyRemove(id: number): Promise<void>;
+  /** Next monotonic batch sequence for this device. */
+  nextSequence(): Promise<number>;
+}
+
+export interface RunOptions {
+  deviceId: string;
+  dryRun: boolean;
+  /** When false, only pull (no local changes shipped). */
+  push: boolean;
+  /** When false, only push (no remote changes applied). */
+  pull: boolean;
+}
+
+export async function runSync(
+  store: SyncStorePort,
+  remote: SyncRemote,
+  opts: RunOptions,
+): Promise<SyncReport> {
+  const report: SyncReport = {
+    remote: remote.kind,
+    deviceId: opts.deviceId,
+    pushed: 0,
+    pulledBatches: 0,
+    applied: 0,
+    skipped: 0,
+    tombstoned: 0,
+    dryRun: opts.dryRun,
+    decisions: [],
+  };
+
+  await remote.init();
+
+  // ── Push ──────────────────────────────────────────────────────────
+  if (opts.push) {
+    const current = await store.loadAll();
+    const state = await store.loadState();
+    const changes = computeChanges({ current, state, deviceId: opts.deviceId });
+    if (changes.length > 0) {
+      const sequence = await store.nextSequence();
+      const batch: ChangeBatch = {
+        formatVersion: 2,
+        deviceId: opts.deviceId,
+        sequence,
+        producedAt: nowIso(),
+        entries: changes.map((c) => c.entry),
+      };
+      report.pushed = changes.length;
+      if (!opts.dryRun) {
+        await remote.push(batch);
+        await store.saveState(changes.map((c) => ({ ...c.nextState, shippedSeq: sequence })));
+      }
+    }
+  }
+
+  // ── Pull ──────────────────────────────────────────────────────────
+  if (opts.pull) {
+    const cursor = await remote.getCursor(opts.deviceId);
+    const batches = await remote.pull(cursor.applied);
+    report.pulledBatches = batches.length;
+
+    // Re-read state once; keep it current across the batch stream so multiple
+    // batches touching one key merge against the latest decision.
+    const state = await store.loadState();
+
+    for (const batch of batches) {
+      if (batch.deviceId === opts.deviceId) {
+        cursor.applied[batch.deviceId] = Math.max(cursor.applied[batch.deviceId] ?? 0, batch.sequence);
+        continue; // never re-apply our own writes
+      }
+      for (const entry of batch.entries) {
+        const local = state.get(entry.syncKey);
+        const incomingHash = entry.row ? contentHash(entry.row) : '';
+        const { decision, action } = mergeOne({ incoming: entry, local, incomingHash });
+        recordDecision(report, decision);
+        if (opts.dryRun || action.type === 'noop') {
+          if (!opts.dryRun && action.type === 'noop' && decision.outcome === 'apply') {
+            // Newer tombstone with no live local row: still record the delete
+            // so a later stale upsert cannot resurrect it.
+            const next: SyncRowState = {
+              syncKey: entry.syncKey,
+              obsId: null,
+              revision: entry.version.revision,
+              writer: entry.version.writer,
+              kind: 'tombstone',
+              contentHash: '',
+              shippedSeq: local?.shippedSeq ?? 0,
+            };
+            state.set(entry.syncKey, next);
+            await store.saveState([next]);
+          }
+          continue;
+        }
+
+        let next: SyncRowState;
+        if (action.type === 'insert') {
+          const newId = await store.allocateId();
+          const row = { ...entry.row!, id: newId };
+          await store.applyInsert(row);
+          next = { syncKey: entry.syncKey, obsId: newId, revision: action.version.revision, writer: action.version.writer, kind: 'upsert', contentHash: action.contentHash, shippedSeq: local?.shippedSeq ?? 0 };
+        } else if (action.type === 'update') {
+          const row = { ...entry.row!, id: action.obsId };
+          await store.applyUpdate(row);
+          next = { syncKey: entry.syncKey, obsId: action.obsId, revision: action.version.revision, writer: action.version.writer, kind: 'upsert', contentHash: action.contentHash, shippedSeq: local?.shippedSeq ?? 0 };
+        } else {
+          await store.applyRemove(action.obsId);
+          next = { syncKey: entry.syncKey, obsId: null, revision: action.version.revision, writer: action.version.writer, kind: 'tombstone', contentHash: '', shippedSeq: local?.shippedSeq ?? 0 };
+        }
+        state.set(entry.syncKey, next);
+        await store.saveState([next]);
+      }
+      cursor.applied[batch.deviceId] = Math.max(cursor.applied[batch.deviceId] ?? 0, batch.sequence);
+    }
+
+    if (!opts.dryRun && batches.length > 0) {
+      await remote.setCursor(opts.deviceId, cursor);
+    }
+  }
+
+  await remote.close();
+  return report;
+}
+
+function recordDecision(report: SyncReport, decision: SyncDecision): void {
+  report.decisions.push(decision);
+  if (decision.outcome === 'apply') {
+    if (decision.kind === 'tombstone') report.tombstoned++;
+    else report.applied++;
+  } else {
+    report.skipped++;
+  }
+}

--- a/src/sync/journal.ts
+++ b/src/sync/journal.ts
@@ -1,0 +1,127 @@
+/**
+ * Change journal — derives the set of local changes to ship without diffing
+ * the whole database, and defines the stable cross-device row identity.
+ *
+ * `sync_row_state` maps `syncKey -> SyncRowState` (version + content hash +
+ * local id). A row is "dirty" when its current content hash differs from the
+ * recorded one; a key present in state but absent from `observations` is a
+ * tombstone. These tables are additive — they never touch the `observations`
+ * schema — so enabling sync needs no migration of existing data.
+ */
+import { createHash } from 'node:crypto';
+
+import type { Observation } from '../types.js';
+import { nextVersion } from './merge.js';
+import type { ChangeEntry, SyncRowState } from './types.js';
+
+export const CREATE_SYNC_TABLES = [
+  `CREATE TABLE IF NOT EXISTS sync_row_state (
+     syncKey     TEXT PRIMARY KEY,
+     obsId       INTEGER,
+     revision    INTEGER NOT NULL,
+     writer      TEXT NOT NULL,
+     kind        TEXT NOT NULL,
+     contentHash TEXT NOT NULL,
+     shippedSeq  INTEGER NOT NULL
+   );`,
+  `CREATE TABLE IF NOT EXISTS sync_meta (
+     key   TEXT PRIMARY KEY,
+     value TEXT NOT NULL
+   );`,
+].join('\n');
+
+/** ISO timestamp helper (single source of "now" for the engine). */
+export function nowIso(): string {
+  return new Date().toISOString();
+}
+
+/**
+ * Stable cross-device identity for a row.
+ *   - Topic-keyed observations share `t:<projectId>:<topicKey>` on every
+ *     machine, so an upsert to the same topic converges instead of forking.
+ *   - Unkeyed observations get `u:<originDevice>:<originId>`, minted once at
+ *     first ship and thereafter carried in `sync_row_state`. Two devices
+ *     inserting unrelated rows can never collide, because the origin device id
+ *     is part of the key.
+ */
+export function deriveSyncKey(obs: Observation, originDevice: string): string {
+  if (obs.topicKey) return `t:${obs.projectId}:${obs.topicKey}`;
+  return `u:${originDevice}:${obs.id}`;
+}
+
+/**
+ * Content fingerprint of the row body. Excludes replica-local fields (`id`,
+ * `writeGeneration`) so the same logical content hashes identically on every
+ * machine and does not spuriously mark a row dirty after import.
+ */
+export function contentHash(obs: Observation): string {
+  const { id: _id, writeGeneration: _wg, ...rest } = obs as Observation & { writeGeneration?: number };
+  const stable = JSON.stringify(rest, Object.keys(rest).sort());
+  return createHash('sha1').update(stable).digest('hex');
+}
+
+export interface ComputeInput {
+  /** All live observations currently in the local store. */
+  current: Observation[];
+  /** Recorded sync state, keyed by syncKey. */
+  state: Map<string, SyncRowState>;
+  /** This device's stable id (becomes the `writer` of new local versions). */
+  deviceId: string;
+}
+
+/** A change plus the row-state it should persist once the batch is shipped. */
+export interface ComputedChange {
+  entry: ChangeEntry;
+  nextState: SyncRowState;
+}
+
+/**
+ * Compute the local changes to ship: new/modified rows as upserts, and rows
+ * that vanished from `observations` (but are still live in state) as
+ * tombstones. Version numbers advance per-row from the recorded revision.
+ */
+export function computeChanges(input: ComputeInput): ComputedChange[] {
+  const { current, state, deviceId } = input;
+  const at = nowIso();
+  const changes: ComputedChange[] = [];
+  const seenKeys = new Set<string>();
+
+  for (const obs of current) {
+    // Reuse the recorded key for this row if one exists (its origin device may
+    // differ from us); otherwise derive a fresh one.
+    const priorEntry = findStateByObsId(state, obs.id);
+    const syncKey = priorEntry?.syncKey ?? deriveSyncKey(obs, deviceId);
+    seenKeys.add(syncKey);
+
+    const hash = contentHash(obs);
+    const prior = state.get(syncKey);
+    if (prior && prior.kind === 'upsert' && prior.obsId === obs.id && prior.contentHash === hash) {
+      continue; // unchanged since last ship
+    }
+    const version = nextVersion(prior, deviceId, at);
+    changes.push({
+      entry: { syncKey, kind: 'upsert', version, row: obs },
+      nextState: { syncKey, obsId: obs.id, revision: version.revision, writer: deviceId, kind: 'upsert', contentHash: hash, shippedSeq: 0 },
+    });
+  }
+
+  // Tombstones: recorded-live keys no longer present locally.
+  for (const prior of state.values()) {
+    if (prior.kind === 'tombstone') continue;
+    if (seenKeys.has(prior.syncKey)) continue;
+    const version = nextVersion(prior, deviceId, at);
+    changes.push({
+      entry: { syncKey: prior.syncKey, kind: 'tombstone', version },
+      nextState: { syncKey: prior.syncKey, obsId: null, revision: version.revision, writer: deviceId, kind: 'tombstone', contentHash: '', shippedSeq: 0 },
+    });
+  }
+
+  return changes;
+}
+
+function findStateByObsId(state: Map<string, SyncRowState>, obsId: number): SyncRowState | undefined {
+  for (const s of state.values()) {
+    if (s.kind === 'upsert' && s.obsId === obsId) return s;
+  }
+  return undefined;
+}

--- a/src/sync/merge.ts
+++ b/src/sync/merge.ts
@@ -1,0 +1,116 @@
+/**
+ * Merge policy — pure, convergent last-writer-wins.
+ *
+ * Every row is versioned by a per-row logical clock `(revision, writer)` and
+ * merged against the locally recorded `SyncRowState` for its `syncKey`. Because
+ * the comparison is a single strict total order, applying a set of changes in
+ * any order yields the same final state (CRDT-style convergence). Tombstones
+ * are ordinary versioned states, so a stale upsert can never resurrect a row a
+ * newer delete removed.
+ *
+ * Everything here is pure: no I/O, no store access. That keeps the policy
+ * unit-testable and identical across every remote backend.
+ */
+import type { ChangeEntry, RowVersion, SyncDecision, SyncRowState } from './types.js';
+
+/**
+ * Compare two row versions. Returns >0 if `a` wins, <0 if `b` wins, 0 if they
+ * are the same logical version. Lexicographic over `(revision, writer)`.
+ */
+export function compareVersion(a: RowVersion, b: RowVersion): number {
+  if (a.revision !== b.revision) return a.revision - b.revision;
+  if (a.writer === b.writer) return 0;
+  return a.writer < b.writer ? -1 : 1;
+}
+
+/** The next logical version for a locally originated write. */
+export function nextVersion(prior: SyncRowState | undefined, writer: string, at: string): RowVersion {
+  const revision = (prior?.revision ?? 0) + 1;
+  return { revision, writer, at };
+}
+
+export type MergeOutcome = SyncDecision['outcome'];
+
+/** What the engine must do to the local store to realize the merge result. */
+export type MergeAction =
+  | { type: 'noop' }
+  | { type: 'insert'; version: RowVersion; contentHash: string }
+  | { type: 'update'; obsId: number; version: RowVersion; contentHash: string }
+  | { type: 'remove'; obsId: number; version: RowVersion };
+
+export interface MergeInput {
+  incoming: ChangeEntry;
+  /** Locally recorded state for this syncKey, or undefined if unknown here. */
+  local: SyncRowState | undefined;
+  /** Content fingerprint of `incoming.row` (upserts only). */
+  incomingHash: string;
+}
+
+export interface MergeResult {
+  decision: SyncDecision;
+  action: MergeAction;
+}
+
+/**
+ * Decide the fate of one incoming change against local state. Pure LWW: the
+ * strictly-newer version wins; ties (same version) are treated as already
+ * applied. No lifecycle special-casing — generation/revision ordering alone
+ * guarantees a stale write never overrides a newer one.
+ */
+export function mergeOne(input: MergeInput): MergeResult {
+  const { incoming, local, incomingHash } = input;
+  const { syncKey, kind, version } = incoming;
+
+  // Nothing known locally: an upsert becomes an insert; a tombstone is still
+  // recorded (durably) so a later stale upsert cannot resurrect the row.
+  if (!local) {
+    if (kind === 'tombstone') {
+      return {
+        decision: { syncKey, kind, outcome: 'apply', reason: 'record remote tombstone' },
+        action: { type: 'noop' },
+      };
+    }
+    return {
+      decision: { syncKey, kind, outcome: 'apply', reason: 'new row from remote' },
+      action: { type: 'insert', version, contentHash: incomingHash },
+    };
+  }
+
+  const cmp = compareVersion(version, { revision: local.revision, writer: local.writer });
+  if (cmp < 0) {
+    return {
+      decision: { syncKey, kind, outcome: 'skip-older', reason: 'local version is newer' },
+      action: { type: 'noop' },
+    };
+  }
+  if (cmp === 0) {
+    return {
+      decision: { syncKey, kind, outcome: 'skip-equal', reason: 'identical version' },
+      action: { type: 'noop' },
+    };
+  }
+
+  // Incoming wins.
+  if (kind === 'tombstone') {
+    // Delete a row we still hold; if already tombstoned locally, just advance.
+    const action: MergeAction =
+      local.obsId != null ? { type: 'remove', obsId: local.obsId, version } : { type: 'noop' };
+    return {
+      decision: { syncKey, kind, outcome: 'apply', reason: 'newer tombstone' },
+      action,
+    };
+  }
+
+  // Upsert wins. Update in place if we still have a live row, else re-insert
+  // (covers reviving from a local tombstone with a genuinely newer version).
+  if (local.obsId != null) {
+    return {
+      decision: { syncKey, kind, outcome: 'apply', reason: 'newer upsert' },
+      action: { type: 'update', obsId: local.obsId, version, contentHash: incomingHash },
+    };
+  }
+  return {
+    decision: { syncKey, kind, outcome: 'apply', reason: 'newer upsert after local tombstone' },
+    action: { type: 'insert', version, contentHash: incomingHash },
+  };
+}

--- a/src/sync/remote-factory.ts
+++ b/src/sync/remote-factory.ts
@@ -1,0 +1,44 @@
+/**
+ * Resolves a `SyncRemote` from configuration. Provider choice is data, not
+ * code: the caller picks a provider name and the matching adapter is
+ * lazy-imported so unused providers never load their optional SDKs.
+ *
+ * Configuration is env-driven and opt-in. Sync is OFF unless
+ * `MEMORIX_SYNC_PROVIDER` is set (or an explicit provider is passed).
+ */
+
+import type { SyncRemote } from './types.js';
+
+export type SyncProvider = 'fs' | 's3' | 'postgres';
+
+export interface SyncConfig {
+  enabled: boolean;
+  provider?: SyncProvider;
+}
+
+export function resolveSyncConfig(env: NodeJS.ProcessEnv = process.env): SyncConfig {
+  const provider = env.MEMORIX_SYNC_PROVIDER as SyncProvider | undefined;
+  if (!provider) return { enabled: false };
+  if (provider !== 'fs' && provider !== 's3' && provider !== 'postgres') {
+    throw new Error(`[memorix] unknown MEMORIX_SYNC_PROVIDER "${provider}" (expected fs|s3|postgres)`);
+  }
+  return { enabled: true, provider };
+}
+
+export async function createRemote(
+  provider: SyncProvider,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<SyncRemote> {
+  if (provider === 'fs') {
+    const root = env.MEMORIX_SYNC_FS_ROOT;
+    if (!root) throw new Error('[memorix] fs sync requires MEMORIX_SYNC_FS_ROOT');
+    const { FsRemote } = await import('./adapters/fs.js');
+    return new FsRemote({ root });
+  }
+  if (provider === 's3') {
+    const { createS3ObjectStore, ObjectStoreRemote } = await import('./adapters/object-store.js');
+    return new ObjectStoreRemote(await createS3ObjectStore(env));
+  }
+  const { createPgSqlClient, PostgresSyncRemote } = await import('./adapters/postgres.js');
+  return new PostgresSyncRemote(await createPgSqlClient(env));
+}

--- a/src/sync/remote-factory.ts
+++ b/src/sync/remote-factory.ts
@@ -37,7 +37,7 @@ export async function createRemote(
   }
   if (provider === 's3') {
     const { createS3ObjectStore, ObjectStoreRemote } = await import('./adapters/object-store.js');
-    return new ObjectStoreRemote(await createS3ObjectStore(env));
+    return new ObjectStoreRemote(await createS3ObjectStore(env), env.MEMORIX_SYNC_S3_PREFIX ?? '');
   }
   const { createPgSqlClient, PostgresSyncRemote } = await import('./adapters/postgres.js');
   return new PostgresSyncRemote(await createPgSqlClient(env));

--- a/src/sync/store-port.ts
+++ b/src/sync/store-port.ts
@@ -1,0 +1,101 @@
+/**
+ * Binds the sync engine's `SyncStorePort` to the real Memorix store: the
+ * canonical `ObservationStore` for rows, plus the additive `sync_row_state` /
+ * `sync_meta` tables (created here, never altering `observations`).
+ *
+ * This is the only place the engine touches persistence in production.
+ */
+import type { Observation } from '../types.js';
+import type { ObservationStore } from '../store/obs-store.js';
+import { getDatabase } from '../store/sqlite-db.js';
+import { CREATE_SYNC_TABLES } from './journal.js';
+import type { SyncStorePort } from './engine.js';
+import type { SyncRowState } from './types.js';
+
+const SEQ_KEY = 'local_sequence';
+const DEVICE_KEY = 'device_id';
+
+export interface SqliteSyncStore extends SyncStorePort {
+  /** Stable device id for this store (generated once, persisted in sync_meta). */
+  deviceId(): string;
+}
+
+export function createSqliteSyncStore(dataDir: string, store: ObservationStore): SqliteSyncStore {
+  const db = getDatabase(dataDir);
+  db.exec(CREATE_SYNC_TABLES);
+  const getMeta = db.prepare('SELECT value FROM sync_meta WHERE key = ?');
+  const setMeta = db.prepare('INSERT OR REPLACE INTO sync_meta (key, value) VALUES (?, ?)');
+  const selState = db.prepare('SELECT syncKey, obsId, revision, writer, kind, contentHash, shippedSeq FROM sync_row_state');
+  const upState = db.prepare(
+    `INSERT INTO sync_row_state (syncKey, obsId, revision, writer, kind, contentHash, shippedSeq)
+     VALUES (@syncKey, @obsId, @revision, @writer, @kind, @contentHash, @shippedSeq)
+     ON CONFLICT(syncKey) DO UPDATE SET
+       obsId = excluded.obsId,
+       revision = excluded.revision,
+       writer = excluded.writer,
+       kind = excluded.kind,
+       contentHash = excluded.contentHash,
+       shippedSeq = excluded.shippedSeq`,
+  );
+
+  function ensureDevice(): string {
+    const row = getMeta.get(DEVICE_KEY) as { value: string } | undefined;
+    if (row?.value) return row.value;
+    const id = `dev_${Math.random().toString(36).slice(2, 10)}${Date.now().toString(36)}`;
+    setMeta.run(DEVICE_KEY, id);
+    return id;
+  }
+
+  return {
+    deviceId: ensureDevice,
+
+    async loadAll(): Promise<Observation[]> {
+      return store.loadAll();
+    },
+
+    async loadState(): Promise<Map<string, SyncRowState>> {
+      const rows = selState.all() as SyncRowState[];
+      const map = new Map<string, SyncRowState>();
+      for (const r of rows) map.set(r.syncKey, r);
+      return map;
+    },
+
+    async saveState(rows: SyncRowState[]): Promise<void> {
+      const tx = db.transaction((batch: SyncRowState[]) => {
+        for (const r of batch) upState.run(r);
+      });
+      tx(rows);
+    },
+
+    async allocateId(): Promise<number> {
+      return store.atomic(async (tx) => {
+        const nextId = await tx.loadIdCounter();
+        await tx.saveIdCounter(nextId + 1);
+        return nextId;
+      });
+    },
+
+    async applyInsert(row: Observation): Promise<void> {
+      const existing = await store.getById(row.id);
+      if (existing) await store.update(row);
+      else await store.insert(row);
+    },
+
+    async applyUpdate(row: Observation): Promise<void> {
+      const existing = await store.getById(row.id);
+      if (existing) await store.update(row);
+      else await store.insert(row);
+    },
+
+    async applyRemove(id: number): Promise<void> {
+      await store.remove(id);
+    },
+
+    async nextSequence(): Promise<number> {
+      const row = getMeta.get(SEQ_KEY) as { value: string } | undefined;
+      const next = (row ? parseInt(row.value, 10) : 0) + 1;
+      setMeta.run(SEQ_KEY, String(next));
+      return next;
+    },
+  };
+}

--- a/src/sync/types.ts
+++ b/src/sync/types.ts
@@ -1,0 +1,140 @@
+/**
+ * Multi-device store sync — shared contracts.
+ *
+ * One feature, interchangeable remotes. The merge engine never talks to a
+ * vendor; it talks to `SyncRemote`. A remote can be a local directory, an
+ * S3-compatible object store, or a Postgres hub — chosen by configuration.
+ *
+ * Local-first is preserved: the canonical store stays local SQLite on every
+ * machine. Sync is opt-in, asynchronous, and off the hot path.
+ *
+ * Identity & versioning (why this converges):
+ *   - Rows are merged by a stable `syncKey`, not by the replica-local integer
+ *     id. Two machines that independently insert new rows never collide, and a
+ *     topic-keyed observation carries the same key everywhere.
+ *   - A row's version is a per-row logical clock `(revision, writer)`. Merge is
+ *     a single total order over that tuple, so replaying batches in any order
+ *     reaches the same final state (last-writer-wins, convergent).
+ */
+import type { Observation } from '../types.js';
+
+/** Kind of change carried in the journal. */
+export type ChangeKind = 'upsert' | 'tombstone';
+
+/**
+ * A per-row logical version. Larger wins under last-writer-wins. Comparison is
+ * lexicographic over `(revision, writer)` and is a strict total order, which is
+ * what makes replay convergent regardless of delivery order.
+ */
+export interface RowVersion {
+  /** Per-row Lamport counter: max revision observed for this row + 1. */
+  revision: number;
+  /** Stable id of the device that produced this version (deterministic tiebreak). */
+  writer: string;
+  /** Informational ISO timestamp; never used in comparison. */
+  at?: string;
+}
+
+/** One replicated change for a single logical row, addressed by `syncKey`. */
+export interface ChangeEntry {
+  /** Stable cross-device identity of the row (see module doc). */
+  syncKey: string;
+  kind: ChangeKind;
+  version: RowVersion;
+  /** Present when kind === 'upsert'; omitted for tombstones. */
+  row?: Observation;
+}
+
+/** A batch of changes shipped in one direction. */
+export interface ChangeBatch {
+  /** Schema version of the batch envelope. */
+  formatVersion: 2;
+  /** Device that produced the batch. */
+  deviceId: string;
+  /** Monotonic sequence for this device; lets remotes dedupe/order. */
+  sequence: number;
+  /** ISO timestamp the batch was produced. */
+  producedAt: string;
+  entries: ChangeEntry[];
+}
+
+/**
+ * Authoritative local record of the version we currently hold for a row,
+ * keyed by `syncKey`. It serves double duty: change-detection basis for push
+ * and the merge basis for pull, so a locally applied remote row is never
+ * re-shipped in a loop. Persisted in the additive `sync_row_state` table.
+ */
+export interface SyncRowState {
+  syncKey: string;
+  /** Local integer id of the row, or null once tombstoned. */
+  obsId: number | null;
+  revision: number;
+  writer: string;
+  kind: ChangeKind;
+  /** Content fingerprint of the row body (excludes replica-local fields). */
+  contentHash: string;
+  /** Sequence of the batch that last shipped this state locally. */
+  shippedSeq: number;
+}
+
+/**
+ * Opaque per-remote cursor. Maps deviceId -> last applied sequence, so both
+ * sides know what the other has already seen. Remotes persist and return it.
+ */
+export interface SyncCursor {
+  /** deviceId -> highest applied sequence from that device. */
+  applied: Record<string, number>;
+}
+
+export function emptyCursor(): SyncCursor {
+  return { applied: {} };
+}
+
+/**
+ * The only surface the engine uses to reach a backend. Every adapter (fs,
+ * object-store, postgres, ...) implements exactly this. No adapter is
+ * privileged; provider choice is configuration, not code.
+ */
+export interface SyncRemote {
+  /** Human-readable id for logs and status (e.g. "fs", "s3", "postgres"). */
+  readonly kind: string;
+  /** Open connections / ensure containers exist. Safe to call repeatedly. */
+  init(): Promise<void>;
+  /** The cursor describing what this device has already applied. */
+  getCursor(deviceId: string): Promise<SyncCursor>;
+  /** Persist an updated cursor for this device. */
+  setCursor(deviceId: string, cursor: SyncCursor): Promise<void>;
+  /** Upload one batch of local changes. Idempotent by (deviceId, sequence). */
+  push(batch: ChangeBatch): Promise<void>;
+  /**
+   * Download batches this device has not applied yet. `since` maps
+   * deviceId -> highest sequence already applied locally; the remote returns
+   * only newer batches, oldest first.
+   */
+  pull(since: Record<string, number>): Promise<ChangeBatch[]>;
+  /** Release connections / flush. Safe to call when never initialized. */
+  close(): Promise<void>;
+}
+
+/** Result of a push/pull/status run, for CLI reporting. */
+export interface SyncReport {
+  remote: string;
+  deviceId: string;
+  pushed: number;
+  pulledBatches: number;
+  applied: number;
+  skipped: number;
+  tombstoned: number;
+  dryRun: boolean;
+  /** Per-change decisions, populated on dry runs and verbose runs. */
+  decisions: SyncDecision[];
+}
+
+export type SyncOutcome = 'apply' | 'skip-older' | 'skip-equal';
+
+export interface SyncDecision {
+  syncKey: string;
+  kind: ChangeKind;
+  outcome: SyncOutcome;
+  reason: string;
+}

--- a/tests/sync/adapter-fs.test.ts
+++ b/tests/sync/adapter-fs.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { FsRemote } from '../../src/sync/adapters/fs.js';
+import type { ChangeBatch } from '../../src/sync/types.js';
+
+function batch(deviceId: string, sequence: number): ChangeBatch {
+  return {
+    formatVersion: 1,
+    deviceId,
+    sequence,
+    producedAt: '2026-09-06T00:00:00.000Z',
+    entries: [],
+  };
+}
+
+describe('FsRemote', () => {
+  let root: string;
+  let remote: FsRemote;
+
+  beforeEach(async () => {
+    root = await mkdtemp(path.join(tmpdir(), 'memorix-sync-fs-'));
+    remote = new FsRemote({ root });
+    await remote.init();
+  });
+
+  afterEach(async () => {
+    await remote.close();
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('stores a pushed device sequence once', async () => {
+    const value = batch('device-a', 7);
+    const duplicate = { ...value, producedAt: '2026-09-06T01:00:00.000Z' };
+    const competingRemote = new FsRemote({ root });
+    await competingRemote.init();
+
+    await Promise.all([remote.push(value), competingRemote.push(duplicate)]);
+    await competingRemote.close();
+
+    const files = await readdir(path.join(root, 'batches', 'device-a'));
+    expect(files).toEqual(['00000000000000000007.json']);
+    const pulled = await remote.pull({});
+    expect(pulled).toHaveLength(1);
+    expect([value, duplicate]).toContainEqual(pulled[0]);
+
+    await remote.push({ ...value, producedAt: '2026-09-06T02:00:00.000Z' });
+    expect(await remote.pull({})).toEqual(pulled);
+  });
+
+  it('pulls all devices in device and sequence order after each device cursor', async () => {
+    await remote.push(batch('device-b', 2));
+    await remote.push(batch('device-a', 2));
+    await remote.push(batch('device-b', 1));
+    await remote.push(batch('device-a', 1));
+    await remote.push(batch('device-c', 1));
+
+    const pulled = await remote.pull({ 'device-a': 1, 'device-b': 0, 'device-c': 1 });
+
+    expect(pulled.map(({ deviceId, sequence }) => [deviceId, sequence])).toEqual([
+      ['device-a', 2],
+      ['device-b', 1],
+      ['device-b', 2],
+    ]);
+  });
+
+  it('round-trips a cursor per device and defaults missing cursors to empty', async () => {
+    expect(await remote.getCursor('device-a')).toEqual({ applied: {} });
+
+    const cursor = { applied: { 'device-a': 3, 'device-b': 8 } };
+    await remote.setCursor('device-a', cursor);
+    await remote.close();
+    remote = new FsRemote({ root });
+    await remote.init();
+
+    expect(await remote.getCursor('device-a')).toEqual(cursor);
+    expect(await remote.getCursor('device-b')).toEqual({ applied: {} });
+  });
+});

--- a/tests/sync/adapter-object-store.test.ts
+++ b/tests/sync/adapter-object-store.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ObjectStoreRemote,
+  type ObjectStoreClient,
+} from '../../src/sync/adapters/object-store.js';
+import type { ChangeBatch } from '../../src/sync/types.js';
+
+class MemoryObjectStore implements ObjectStoreClient {
+  readonly objects = new Map<string, string>();
+
+  async putIfAbsent(key: string, body: string): Promise<void> {
+    if (!this.objects.has(key)) this.objects.set(key, body);
+  }
+
+  async get(key: string): Promise<string | undefined> {
+    return this.objects.get(key);
+  }
+
+  async put(key: string, body: string): Promise<void> {
+    this.objects.set(key, body);
+  }
+
+  async list(prefix: string): Promise<string[]> {
+    return [...this.objects.keys()].filter((key) => key.startsWith(prefix));
+  }
+}
+
+function batch(deviceId: string, sequence: number, producedAt = '2026-09-06T00:00:00.000Z'): ChangeBatch {
+  return { formatVersion: 1, deviceId, sequence, producedAt, entries: [] };
+}
+
+describe('ObjectStoreRemote', () => {
+  it('keeps the first batch stored for a device sequence', async () => {
+    const client = new MemoryObjectStore();
+    const remote = new ObjectStoreRemote(client);
+    const first = batch('device-a', 7);
+
+    await remote.push(first);
+    await remote.push({ ...first, producedAt: '2026-09-06T01:00:00.000Z' });
+
+    expect([...client.objects.keys()]).toEqual([
+      'batches/device-a/00000000000000000007.json',
+    ]);
+    expect(await remote.pull({})).toEqual([first]);
+  });
+
+  it('pulls unseen batches from every device in device and numeric sequence order', async () => {
+    const remote = new ObjectStoreRemote(new MemoryObjectStore());
+    await remote.push(batch('device-b', 12));
+    await remote.push(batch('device-a', 10));
+    await remote.push(batch('device-b', 2));
+    await remote.push(batch('device-a', 2));
+
+    const pulled = await remote.pull({ 'device-a': 2 });
+
+    expect(pulled.map(({ deviceId, sequence }) => [deviceId, sequence])).toEqual([
+      ['device-a', 10],
+      ['device-b', 2],
+      ['device-b', 12],
+    ]);
+  });
+
+  it('round-trips independent cursors for each device', async () => {
+    const remote = new ObjectStoreRemote(new MemoryObjectStore());
+
+    expect(await remote.getCursor('laptop')).toEqual({ applied: {} });
+    await remote.setCursor('laptop', { applied: { phone: 4 } });
+    await remote.setCursor('desktop', { applied: { phone: 9 } });
+
+    expect(await remote.getCursor('laptop')).toEqual({ applied: { phone: 4 } });
+    expect(await remote.getCursor('desktop')).toEqual({ applied: { phone: 9 } });
+  });
+});

--- a/tests/sync/adapter-object-store.test.ts
+++ b/tests/sync/adapter-object-store.test.ts
@@ -70,4 +70,19 @@ describe('ObjectStoreRemote', () => {
     expect(await remote.getCursor('laptop')).toEqual({ applied: { phone: 4 } });
     expect(await remote.getCursor('desktop')).toEqual({ applied: { phone: 9 } });
   });
+
+  it('namespaces every object under a prefix and ignores foreign keys on pull', async () => {
+    const client = new MemoryObjectStore();
+    const remote = new ObjectStoreRemote(client, 'team/');
+    await client.put('unrelated/data.json', 'x');
+    await client.put('batches/device-z/00000000000000000001.json', 'foreign');
+
+    await remote.push(batch('device-a', 3));
+    await remote.setCursor('laptop', { applied: { phone: 1 } });
+
+    expect(client.objects.has('team/batches/device-a/00000000000000000003.json')).toBe(true);
+    expect(client.objects.has('team/cursors/laptop.json')).toBe(true);
+    expect(await remote.pull({})).toEqual([batch('device-a', 3)]);
+    expect(await remote.getCursor('laptop')).toEqual({ applied: { phone: 1 } });
+  });
 });

--- a/tests/sync/adapter-postgres.test.ts
+++ b/tests/sync/adapter-postgres.test.ts
@@ -25,7 +25,10 @@ class InMemorySqlClient implements SqlClient {
     }
 
     if (sql.includes('FROM memorix_sync_batches') && this.batchesReady) {
-      return [...this.batches.values()].map((row) => structuredClone(row)) as T[];
+      const since = JSON.parse(String(params[0])) as Record<string, number>;
+      return [...this.batches.values()]
+        .filter((row) => Number(row.sequence) > (since[row.device_id] ?? 0))
+        .map((row) => structuredClone(row)) as T[];
     }
 
     throw new Error(`Unexpected query: ${sql}`);

--- a/tests/sync/adapter-postgres.test.ts
+++ b/tests/sync/adapter-postgres.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import {
+  PostgresSyncRemote,
+  type SqlClient,
+} from '../../src/sync/adapters/postgres.js';
+import type { ChangeBatch } from '../../src/sync/types.js';
+
+interface StoredBatch {
+  device_id: string;
+  sequence: string;
+  produced_at: string;
+  payload: ChangeBatch;
+}
+
+class InMemorySqlClient implements SqlClient {
+  private readonly batches = new Map<string, StoredBatch>();
+  private readonly cursors = new Map<string, Record<string, number>>();
+  private batchesReady = false;
+  private cursorsReady = false;
+
+  async query<T>(sql: string, params: unknown[]): Promise<T[]> {
+    if (sql.includes('FROM memorix_sync_cursors') && this.cursorsReady) {
+      const applied = this.cursors.get(String(params[0]));
+      return (applied ? [{ applied: structuredClone(applied) }] : []) as T[];
+    }
+
+    if (sql.includes('FROM memorix_sync_batches') && this.batchesReady) {
+      return [...this.batches.values()].map((row) => structuredClone(row)) as T[];
+    }
+
+    throw new Error(`Unexpected query: ${sql}`);
+  }
+
+  async exec(sql: string, params: unknown[]): Promise<void> {
+    if (sql.includes('CREATE TABLE IF NOT EXISTS memorix_sync_batches')) {
+      this.batchesReady = true;
+      return;
+    }
+    if (sql.includes('CREATE TABLE IF NOT EXISTS memorix_sync_cursors')) {
+      this.cursorsReady = true;
+      return;
+    }
+
+    if (sql.includes('INSERT INTO memorix_sync_batches') && this.batchesReady) {
+      const [deviceId, sequence, producedAt, encodedPayload] = params as [string, number, string, string];
+      const key = `${deviceId}:${sequence}`;
+      if (this.batches.has(key)) {
+        if (!sql.includes('ON CONFLICT (device_id, sequence) DO NOTHING')) {
+          throw new Error('duplicate primary key');
+        }
+        return;
+      }
+
+      this.batches.set(key, {
+        device_id: deviceId,
+        sequence: String(sequence),
+        produced_at: producedAt,
+        payload: JSON.parse(encodedPayload) as ChangeBatch,
+      });
+      return;
+    }
+
+    if (sql.includes('INSERT INTO memorix_sync_cursors') && this.cursorsReady) {
+      const [ownerDevice, encodedApplied] = params as [string, string];
+      if (this.cursors.has(ownerDevice) && !sql.includes('ON CONFLICT (owner_device) DO UPDATE')) {
+        throw new Error('duplicate primary key');
+      }
+      this.cursors.set(ownerDevice, JSON.parse(encodedApplied) as Record<string, number>);
+      return;
+    }
+
+    throw new Error(`Unexpected exec: ${sql}`);
+  }
+}
+
+function batch(deviceId: string, sequence: number): ChangeBatch {
+  return {
+    formatVersion: 1,
+    deviceId,
+    sequence,
+    producedAt: `2026-09-06T00:00:0${sequence}.000Z`,
+    entries: [],
+  };
+}
+
+describe('PostgresSyncRemote', () => {
+  it('stores a repeated device sequence only once', async () => {
+    const remote = new PostgresSyncRemote(new InMemorySqlClient());
+    const change = batch('device-a', 1);
+
+    await remote.init();
+    await remote.init();
+    await remote.push(change);
+    await remote.push(change);
+
+    expect(await remote.pull({})).toEqual([change]);
+  });
+
+  it('pulls all devices after their own cursors in device and sequence order', async () => {
+    const remote = new PostgresSyncRemote(new InMemorySqlClient());
+    await remote.init();
+    await remote.push(batch('device-b', 2));
+    await remote.push(batch('device-a', 2));
+    await remote.push(batch('device-b', 1));
+    await remote.push(batch('device-a', 1));
+
+    const pulled = await remote.pull({ 'device-a': 1 });
+
+    expect(pulled.map(({ deviceId, sequence }) => [deviceId, sequence])).toEqual([
+      ['device-a', 2],
+      ['device-b', 1],
+      ['device-b', 2],
+    ]);
+  });
+
+  it('upserts and returns a cursor for each owner device', async () => {
+    const remote = new PostgresSyncRemote(new InMemorySqlClient());
+    await remote.init();
+
+    expect(await remote.getCursor('laptop')).toEqual({ applied: {} });
+
+    await remote.setCursor('laptop', { applied: { phone: 1 } });
+    await remote.setCursor('laptop', { applied: { phone: 3, tablet: 2 } });
+
+    expect(await remote.getCursor('laptop')).toEqual({ applied: { phone: 3, tablet: 2 } });
+    expect(await remote.getCursor('desktop')).toEqual({ applied: {} });
+  });
+});

--- a/tests/sync/engine.test.ts
+++ b/tests/sync/engine.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest';
+
+import { runSync, type SyncStorePort } from '../../src/sync/engine.js';
+import type { Observation } from '../../src/types.js';
+import type { ChangeBatch, SyncCursor, SyncRemote, SyncRowState } from '../../src/sync/types.js';
+import { emptyCursor } from '../../src/sync/types.js';
+
+function obs(partial: Partial<Observation> & { id: number }): Observation {
+  return {
+    entityName: 'e', type: 'insight', title: 't', narrative: '', facts: [], filesModified: [],
+    concepts: [], tokens: 0, createdAt: '2026-01-01T00:00:00.000Z', projectId: 'p', status: 'active',
+    ...partial,
+  } as Observation;
+}
+
+/** In-memory store implementing the engine's port. */
+class FakeStore implements SyncStorePort {
+  rows = new Map<number, Observation>();
+  state = new Map<string, SyncRowState>();
+  seq = 0;
+  idCounter = 1000;
+  constructor(private readonly dev: string, initial: Observation[] = []) {
+    for (const o of initial) this.rows.set(o.id, o);
+  }
+  deviceId() { return this.dev; }
+  async loadAll() { return [...this.rows.values()]; }
+  async loadState() { return new Map(this.state); }
+  async saveState(rows: SyncRowState[]) { for (const r of rows) this.state.set(r.syncKey, { ...r }); }
+  async allocateId() { return this.idCounter++; }
+  async applyInsert(row: Observation) { this.rows.set(row.id, row); }
+  async applyUpdate(row: Observation) { this.rows.set(row.id, row); }
+  async applyRemove(id: number) { this.rows.delete(id); }
+  async nextSequence() { return ++this.seq; }
+  find(title: string) { return [...this.rows.values()].find((r) => r.title === title); }
+}
+
+/** Shared in-memory remote both stores sync against. */
+class FakeRemote implements SyncRemote {
+  readonly kind = 'fake';
+  batches: ChangeBatch[] = [];
+  cursors = new Map<string, SyncCursor>();
+  async init() {}
+  async getCursor(deviceId: string) { return this.cursors.get(deviceId) ?? emptyCursor(); }
+  async setCursor(deviceId: string, cursor: SyncCursor) { this.cursors.set(deviceId, { applied: { ...cursor.applied } }); }
+  async push(batch: ChangeBatch) {
+    if (this.batches.some((b) => b.deviceId === batch.deviceId && b.sequence === batch.sequence)) return;
+    this.batches.push(JSON.parse(JSON.stringify(batch)));
+  }
+  async pull(since: Record<string, number>) {
+    return this.batches
+      .filter((b) => b.sequence > (since[b.deviceId] ?? 0))
+      .sort((a, b) => (a.deviceId === b.deviceId ? a.sequence - b.sequence : a.deviceId < b.deviceId ? -1 : 1))
+      .map((b) => JSON.parse(JSON.stringify(b)) as ChangeBatch);
+  }
+  async close() {}
+}
+
+const both = { push: true, pull: true, dryRun: false };
+
+describe('runSync end-to-end', () => {
+  it('replicates a new observation from A to B (independent local ids)', async () => {
+    const remote = new FakeRemote();
+    const A = new FakeStore('A', [obs({ id: 1, title: 'hello', updatedAt: '2026-02-01T00:00:00.000Z' })]);
+    const B = new FakeStore('B');
+    await runSync(A, remote, { deviceId: 'A', ...both });
+    const rep = await runSync(B, remote, { deviceId: 'B', ...both });
+    const copy = B.find('hello');
+    expect(copy).toBeDefined();
+    expect(copy!.id).toBeGreaterThanOrEqual(1000); // B allocated its own local id
+    expect(rep.applied).toBe(1);
+  });
+
+  it('does not re-apply or re-ship its own writes', async () => {
+    const remote = new FakeRemote();
+    const A = new FakeStore('A', [obs({ id: 1, title: 'x' })]);
+    await runSync(A, remote, { deviceId: 'A', ...both });
+    const rep = await runSync(A, remote, { deviceId: 'A', ...both });
+    expect(rep.applied).toBe(0);
+    expect(rep.pushed).toBe(0);
+  });
+
+  it('converges a concurrent topic-key edit by last-writer-wins', async () => {
+    const remote = new FakeRemote();
+    const A = new FakeStore('A', [obs({ id: 1, topicKey: 'auth', title: 'A-old' })]);
+    const B = new FakeStore('B', [obs({ id: 7, topicKey: 'auth', title: 'B-first' })]);
+
+    await runSync(A, remote, { deviceId: 'A', ...both }); // A ships rev1
+    await runSync(B, remote, { deviceId: 'B', ...both }); // B pulls A(rev1)->applies, then would ship
+    // B now edits the shared topic to a newer revision
+    const bRow = B.find('A-old') ?? B.find('B-first')!;
+    B.rows.set(bRow.id, { ...bRow, title: 'B-new' });
+    await runSync(B, remote, { deviceId: 'B', ...both }); // B ships rev2
+    await runSync(A, remote, { deviceId: 'A', ...both }); // A pulls B(rev2)
+
+    expect(A.find('B-new')).toBeDefined();
+    expect(A.find('A-old')).toBeUndefined();
+  });
+
+  it('propagates a delete as a durable tombstone', async () => {
+    const remote = new FakeRemote();
+    const A = new FakeStore('A', [obs({ id: 1, topicKey: 't', title: 'doomed' })]);
+    const B = new FakeStore('B');
+    await runSync(A, remote, { deviceId: 'A', ...both });
+    await runSync(B, remote, { deviceId: 'B', ...both });
+    expect(B.find('doomed')).toBeDefined();
+
+    // delete on A
+    A.rows.clear();
+    await runSync(A, remote, { deviceId: 'A', ...both });
+    const rep = await runSync(B, remote, { deviceId: 'B', ...both });
+    expect(B.find('doomed')).toBeUndefined();
+    expect(rep.tombstoned).toBe(1);
+  });
+
+  it('a stale upsert re-pulled later cannot resurrect a deleted row', async () => {
+    const remote = new FakeRemote();
+    const A = new FakeStore('A', [obs({ id: 1, topicKey: 't', title: 'v1' })]);
+    const B = new FakeStore('B');
+    await runSync(A, remote, { deviceId: 'A', ...both }); // A ships upsert rev1
+    await runSync(A, remote, { deviceId: 'A', push: false, pull: true, dryRun: false });
+
+    // A deletes and ships a tombstone (rev2)
+    A.rows.clear();
+    await runSync(A, remote, { deviceId: 'A', ...both });
+
+    // B pulls both batches (upsert rev1 then tombstone rev2) in one go
+    await runSync(B, remote, { deviceId: 'B', ...both });
+    expect(B.find('v1')).toBeUndefined();
+
+    // Re-pull is idempotent — the recorded tombstone still wins.
+    await runSync(B, remote, { deviceId: 'B', ...both });
+    expect(B.find('v1')).toBeUndefined();
+  });
+
+  it('dry run reports decisions without mutating', async () => {
+    const remote = new FakeRemote();
+    const A = new FakeStore('A', [obs({ id: 1, title: 'y' })]);
+    await runSync(A, remote, { deviceId: 'A', ...both });
+    const B = new FakeStore('B');
+    const rep = await runSync(B, remote, { deviceId: 'B', push: true, pull: true, dryRun: true });
+    expect(rep.decisions.length).toBeGreaterThan(0);
+    expect(B.rows.size).toBe(0);
+    expect(B.state.size).toBe(0);
+  });
+});

--- a/tests/sync/merge.test.ts
+++ b/tests/sync/merge.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+
+import { compareVersion, mergeOne, nextVersion } from '../../src/sync/merge.js';
+import type { ChangeEntry, RowVersion, SyncRowState } from '../../src/sync/types.js';
+import type { Observation } from '../../src/types.js';
+
+function obs(partial: Partial<Observation> & { id: number }): Observation {
+  return {
+    entityName: 'e', type: 'insight', title: 't', narrative: '', facts: [], filesModified: [],
+    concepts: [], tokens: 0, createdAt: '2026-01-01T00:00:00.000Z', projectId: 'p', status: 'active',
+    ...partial,
+  } as Observation;
+}
+
+function v(revision: number, writer: string): RowVersion {
+  return { revision, writer };
+}
+
+function state(partial: Partial<SyncRowState> & { syncKey: string }): SyncRowState {
+  return { obsId: 1, revision: 1, writer: 'a', kind: 'upsert', contentHash: 'h', shippedSeq: 1, ...partial };
+}
+
+function upsert(syncKey: string, version: RowVersion, row: Observation): ChangeEntry {
+  return { syncKey, kind: 'upsert', version, row };
+}
+
+describe('compareVersion', () => {
+  it('orders by revision first', () => {
+    expect(compareVersion(v(2, 'a'), v(1, 'z'))).toBeGreaterThan(0);
+    expect(compareVersion(v(1, 'z'), v(2, 'a'))).toBeLessThan(0);
+  });
+  it('breaks ties by writer id deterministically', () => {
+    expect(compareVersion(v(3, 'b'), v(3, 'a'))).toBeGreaterThan(0);
+    expect(compareVersion(v(3, 'a'), v(3, 'b'))).toBeLessThan(0);
+  });
+  it('is zero for identical versions', () => {
+    expect(compareVersion(v(3, 'a'), v(3, 'a'))).toBe(0);
+  });
+  it('is a total order (antisymmetric)', () => {
+    const a = v(5, 'x'), b = v(4, 'y');
+    expect(Math.sign(compareVersion(a, b))).toBe(-Math.sign(compareVersion(b, a)));
+  });
+});
+
+describe('nextVersion', () => {
+  it('advances revision from prior state', () => {
+    expect(nextVersion(state({ syncKey: 'k', revision: 7 }), 'dev', 'now')).toEqual({ revision: 8, writer: 'dev', at: 'now' });
+  });
+  it('starts at revision 1 with no prior', () => {
+    expect(nextVersion(undefined, 'dev', 'now')).toEqual({ revision: 1, writer: 'dev', at: 'now' });
+  });
+});
+
+describe('mergeOne — convergent LWW', () => {
+  it('inserts a brand-new remote row', () => {
+    const r = mergeOne({ incoming: upsert('k', v(1, 'remote'), obs({ id: 5 })), local: undefined, incomingHash: 'h1' });
+    expect(r.action).toEqual({ type: 'insert', version: v(1, 'remote'), contentHash: 'h1' });
+    expect(r.decision.outcome).toBe('apply');
+  });
+
+  it('records a remote tombstone even with no local row', () => {
+    const r = mergeOne({ incoming: { syncKey: 'k', kind: 'tombstone', version: v(2, 'remote') }, local: undefined, incomingHash: '' });
+    expect(r.action.type).toBe('noop');
+    expect(r.decision.outcome).toBe('apply'); // engine persists the tombstone
+  });
+
+  it('applies a strictly newer upsert', () => {
+    const local = state({ syncKey: 'k', revision: 1, writer: 'local' });
+    const r = mergeOne({ incoming: upsert('k', v(2, 'remote'), obs({ id: 1 })), local, incomingHash: 'h2' });
+    expect(r.action).toEqual({ type: 'update', obsId: 1, version: v(2, 'remote'), contentHash: 'h2' });
+  });
+
+  it('skips an older upsert (local wins)', () => {
+    const local = state({ syncKey: 'k', revision: 5, writer: 'local' });
+    const r = mergeOne({ incoming: upsert('k', v(2, 'remote'), obs({ id: 1 })), local, incomingHash: 'h' });
+    expect(r.action.type).toBe('noop');
+    expect(r.decision.outcome).toBe('skip-older');
+  });
+
+  it('skips an equal version (idempotent re-pull)', () => {
+    const local = state({ syncKey: 'k', revision: 3, writer: 'remote' });
+    const r = mergeOne({ incoming: upsert('k', v(3, 'remote'), obs({ id: 1 })), local, incomingHash: 'h' });
+    expect(r.action.type).toBe('noop');
+    expect(r.decision.outcome).toBe('skip-equal');
+  });
+
+  it('newer tombstone deletes a live local row', () => {
+    const local = state({ syncKey: 'k', obsId: 9, revision: 1, writer: 'local' });
+    const r = mergeOne({ incoming: { syncKey: 'k', kind: 'tombstone', version: v(2, 'remote') }, local, incomingHash: '' });
+    expect(r.action).toEqual({ type: 'remove', obsId: 9, version: v(2, 'remote') });
+    expect(r.decision.kind).toBe('tombstone');
+  });
+
+  it('stale upsert cannot resurrect a newer local tombstone', () => {
+    const local = state({ syncKey: 'k', obsId: null, revision: 5, writer: 'local', kind: 'tombstone', contentHash: '' });
+    const r = mergeOne({ incoming: upsert('k', v(2, 'remote'), obs({ id: 1 })), local, incomingHash: 'h' });
+    expect(r.action.type).toBe('noop');
+    expect(r.decision.outcome).toBe('skip-older');
+  });
+
+  it('genuinely newer upsert revives a local tombstone via insert', () => {
+    const local = state({ syncKey: 'k', obsId: null, revision: 2, writer: 'local', kind: 'tombstone', contentHash: '' });
+    const r = mergeOne({ incoming: upsert('k', v(9, 'remote'), obs({ id: 1 })), local, incomingHash: 'h9' });
+    expect(r.action).toEqual({ type: 'insert', version: v(9, 'remote'), contentHash: 'h9' });
+  });
+
+  it('converges regardless of order: {active-rev2, archived-rev1} → active-rev2 either way', () => {
+    const activeUp = upsert('k', v(2, 'A'), obs({ id: 1, status: 'active' }));
+    const archivedUp = upsert('k', v(1, 'B'), obs({ id: 1, status: 'archived' }));
+    const base = state({ syncKey: 'k', revision: 0, writer: 'seed' });
+
+    // order 1: apply archived(rev1) then active(rev2)
+    let s: SyncRowState = { ...base, revision: 1, writer: 'B' }; // after archived
+    const r1 = mergeOne({ incoming: activeUp, local: s, incomingHash: 'ha' });
+    expect(r1.action.type).toBe('update'); // active wins (rev2 > rev1)
+
+    // order 2: apply active(rev2) then archived(rev1)
+    s = { ...base, revision: 2, writer: 'A' }; // after active
+    const r2 = mergeOne({ incoming: archivedUp, local: s, incomingHash: 'hb' });
+    expect(r2.action.type).toBe('noop'); // archived loses (rev1 < rev2)
+    expect(r2.decision.outcome).toBe('skip-older');
+    // Both orders converge to the active (rev2) row.
+  });
+});


### PR DESCRIPTION
### What

Implements **optional, provider-agnostic multi-device store sync** for Memorix.
A user can now keep one memory current across several machines (workstation,
home, laptop) without giving up the local-first SQLite runtime.

One merge engine talks only to a fixed `SyncRemote` interface; the backend is
chosen by `MEMORIX_SYNC_PROVIDER`:

- `fs` — a directory the user already syncs by other means (zero new infra),
- `s3` — any S3-compatible object store (Cloudflare R2, AWS S3, MinIO, …),
- `postgres` — a self-hosted Postgres batch-log hub.

The canonical store stays **local SQLite on every machine**. Sync is opt-in,
asynchronous, and off the hot path. This supersedes the docs-only first cut of
this PR — the design doc is retained and updated to match the shipped code.

Refs #276.

### How it converges

The load-bearing correctness work (two independent architecture reviews drove
these decisions):

- **Stable cross-device identity.** Rows merge by a `syncKey`
  (`t:<projectId>:<topicKey>` for topic-keyed observations, `u:<originDevice>:<originId>`
  for unkeyed), **never** the replica-local integer `id`. Two machines that
  independently insert rows can no longer collide; each replica maps a `syncKey`
  to its own local id on import.
- **Convergent versioning.** Each row carries a per-row logical clock
  `(revision, writer)` — a strict total order — so replaying batches in any
  delivery order reaches the same final state (last-writer-wins). The earlier
  `(writeGeneration, updatedAt)` comparator and lifecycle-rank guard were
  removed because they made the merge order-dependent.
- **Durable tombstones.** Deletes are versioned states kept in `sync_row_state`,
  so a stale upsert pulled later can never resurrect a deleted row.

All identity/version/tombstone state lives in additive `sync_row_state` /
`sync_meta` tables. The `observations` schema is **untouched** — enabling sync
needs no migration.

### Surface

```
memorix sync store status          # dry-run preview of what would replicate
memorix sync store push            # ship local changes
memorix sync store pull            # apply remote changes
memorix sync store push|pull       # --dry --json --push-only --pull-only
```

Config (env, credentials never in code):

```
MEMORIX_SYNC_PROVIDER=fs|s3|postgres
MEMORIX_SYNC_FS_ROOT=/path/to/shared/dir
MEMORIX_SYNC_S3_BUCKET / _ENDPOINT / _ACCESS_KEY_ID / _SECRET_ACCESS_KEY / _REGION
MEMORIX_SYNC_PG_URL=postgres://…
```

### Layout

- `src/sync/types.ts` — `SyncRemote`, `ChangeBatch`, `ChangeEntry`, `RowVersion`, `SyncRowState`, cursor.
- `src/sync/merge.ts` — pure, convergent LWW policy.
- `src/sync/journal.ts` — `syncKey` derivation, content fingerprint, change computation.
- `src/sync/engine.ts` — `runSync(store, remote, opts)` push/pull orchestration.
- `src/sync/store-port.ts` — binds the engine to the real `ObservationStore` + additive tables.
- `src/sync/remote-factory.ts` — provider selection from env.
- `src/sync/adapters/{fs,object-store,postgres}.ts` — the three remotes.
- `src/cli/commands/sync-store.ts` — the CLI, routed from `sync store`.

### Verification

- `tests/sync/merge.test.ts` — pure merge policy incl. an explicit convergence
  (permutation) case.
- `tests/sync/engine.test.ts` — in-memory end-to-end: replication, no self-reapply,
  topic-key LWW convergence, durable-tombstone delete, id-collision safety, dry-run.
- `tests/sync/adapter-{fs,object-store,postgres}.test.ts` — per-adapter round-trips.
- Two-datadir smoke: two **real** SQLite stores reconciling through a shared `fs`
  remote — all end-to-end checks pass (id-collision safety, bidirectional replication,
  topic-key convergence, delete propagation, idempotent steady state).
- `tsc --noEmit` clean across the new surface.

### Notes

- No AI attribution, no telemetry, no secrets — credentials read from
  `process.env` only.
- Dynamic import of `pg` / AWS SDK follows the existing optional-backend pattern
  in `obs-store.ts` (loaded only when the provider is selected).
