### PR TITLE
docs: finalize 1.9.0 release status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,11 @@ All notable changes to this project will be documented in this file.
 ## [1.9.0] - 2026-09-07
 
 ### Added
-- **Opt-in multi-device sync candidate** -- adds a project-scoped observation
+- **Opt-in multi-device sync** -- adds a project-scoped observation
   event contract with privacy filtering, local outbox retry, conflict evidence,
   device-clone protection, bounded relay pulls, and filesystem/GitHub/S3/
-  Postgres transport boundaries. It is disabled by default and is not yet a
-  release claim until the cross-platform acceptance gate passes.
+  Postgres transport boundaries. It is disabled by default and keeps local
+  SQLite as the canonical store.
 - **Sync hardening** -- retracts records that become private or agent-targeted,
   keeps imported observations and sync state atomic, rejects immutable-key
   collisions, verifies every pulled content hash, and uses stable continuation

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -13,8 +13,8 @@ Memorix is a TypeScript project built around:
 
 ## Current Development Baseline
 
-The current release work targets the **1.8.6 release line** and package metadata
-is kept at `1.8.6` for this release commit.
+The current release line is **1.9.0** and package metadata is kept synchronized
+with the root package and MCP Registry manifest.
 
 Contributors should assume the following areas are part of the current release line:
 

--- a/docs/MULTI-DEVICE-SYNC-RESEARCH.md
+++ b/docs/MULTI-DEVICE-SYNC-RESEARCH.md
@@ -1,7 +1,7 @@
 # Multi-Device Store Sync — Plan and Acceptance Contract
 
-> Status: implemented candidate; release remains gated on full regression and
-> cross-platform acceptance in P6.
+> Status: released in 1.9.0. Background sync, broader table replication, and
+> encrypted snapshots remain future work.
 > Scope: keep the existing local-first SQLite runtime; add an optional,
 > provider-agnostic replication path so one user can keep the same memory
 > across several machines.
@@ -336,11 +336,9 @@ Each phase is independently useful and independently reviewable.
 5. Merge policy defaults: is row-level LWW acceptable as the v1 default, with
    lifecycle-aware overrides, or is a stricter policy preferred?
 
-The first implementation slice is now present behind the opt-in CLI. It covers
+The first implementation slice is released behind the opt-in CLI. It covers
 the project-scoped observation event path, filesystem/GitHub/S3/Postgres relay
 contracts, local outbox retry, clone detection, conflict evidence, and bounded
 keyset pulls. It does not enable background sync, upload private memory,
 replicate sessions/knowledge/CodeGraph tables, or claim that GitHub is a
-production database. The candidate remains release-gated until P6 is checked
-on the supported operating systems and the contributor change is reviewed in
-the upstream PR.
+production database.

--- a/docs/README.md
+++ b/docs/README.md
@@ -125,9 +125,9 @@ Historical/deep-reference documents may describe older designs. If they conflict
 
 ## Current Product Line
 
-The current product line is **1.8.9**. The multi-device sync implementation is
-an opt-in acceptance candidate; it is not enabled for existing users until its
-cross-platform release gates pass.
+The current product line is **1.9.0**. Multi-device store sync is opt-in and
+keeps local SQLite canonical; existing users do not upload anything until they
+configure a relay provider explicitly.
 The authoritative acceptance contract for the current implementation is
 [1.8.0 Release Specification](1.8.0-RELEASE-CANDIDATE-SPEC.md).
 The current baseline has:


### PR DESCRIPTION
Update the canonical docs and changelog to reflect the merged and verified 1.9.0 multi-device sync release. No runtime behavior changes.\n\nRefs #277\nRefs #278