### PR TITLE
fix(codegraph): skip Python virtualenvs by their pyvenv.cfg marker

### DIFF
--- a/src/codegraph/lite-provider.ts
+++ b/src/codegraph/lite-provider.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import { readdirSync, readFileSync, statSync, type Dirent } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync, type Dirent } from 'node:fs';
 import { join, relative } from 'node:path';
 import type { CodeEdge, CodeFile, CodeStateSnapshot, CodeSymbol } from './types.js';
 import { collectCodeStateSnapshot } from './code-state.js';
@@ -210,6 +210,14 @@ function resolveMaxFileBytes(value: number | undefined): number {
   return Math.max(1, Math.floor(value!));
 }
 
+function isPythonVirtualenvDir(dir: string): boolean {
+  // PEP 405 virtualenvs place a `pyvenv.cfg` at their root regardless of the
+  // directory name (`.venv`, `.venv-leann`, `env`, uv/poetry envs, ...). Their
+  // `site-packages` trees are large and generated; descending into one can stall
+  // `codegraph refresh`, so skip virtualenvs by this marker rather than by name.
+  return existsSync(join(dir, 'pyvenv.cfg'));
+}
+
 function walk(root: string, exclude: string[], maxFiles: number): string[] {
   const out: string[] = [];
   const visit = (dir: string) => {
@@ -228,6 +236,7 @@ function walk(root: string, exclude: string[], maxFiles: number): string[] {
       if (entry.isDirectory()) {
         if (entry.name === '.git' || entry.name === '.worktrees' || entry.name === '.tmp' || entry.name === 'node_modules') continue;
         if (rel === '.claude/worktrees' || rel.startsWith('.claude/worktrees/')) continue;
+        if (isPythonVirtualenvDir(abs)) continue;
         visit(abs);
         if (out.length >= maxFiles) return;
         continue;

--- a/tests/codegraph/lite-provider.test.ts
+++ b/tests/codegraph/lite-provider.test.ts
@@ -339,6 +339,27 @@ describe('CodeGraph Lite provider', () => {
     expect(store.getFile('org/repo', 'src/worker.ts')).toBeNull();
   });
 
+  it('skips Python virtualenv directories detected by their pyvenv.cfg marker', async () => {
+    const dir = makeRoot();
+    mkdirSync(join(dir, 'src'), { recursive: true });
+    writeFileSync(join(dir, 'src', 'app.py'), 'def real_app_symbol():\n    return 1\n');
+
+    // A PEP 405 virtualenv with a non-default name: `isCodeGraphExcludedPath`
+    // does not match `.venv-leann`, but the `pyvenv.cfg` marker must.
+    const venv = join(dir, '.venv-leann', 'lib', 'python3.13', 'site-packages');
+    mkdirSync(venv, { recursive: true });
+    writeFileSync(join(dir, '.venv-leann', 'pyvenv.cfg'), 'home = /usr/bin\nversion = 3.13.0\n');
+    writeFileSync(join(venv, 'vendored.py'), 'def vendored_site_packages_symbol():\n    return 2\n');
+
+    const store = new CodeGraphStore();
+    await store.init(dir);
+    const result = await refreshProjectLite(store, { projectId: 'org/repo', projectRoot: dir });
+
+    expect(result.scannedFiles).toBe(1);
+    expect(store.findSymbols('org/repo', 'real_app_symbol')).toHaveLength(1);
+    expect(store.findSymbols('org/repo', 'vendored_site_packages_symbol')).toHaveLength(0);
+  });
+
   it('continues indexing when a discovered file cannot be read', async () => {
     vi.resetModules();
     vi.doMock('node:fs', () => ({
@@ -358,6 +379,7 @@ describe('CodeGraph Lite provider', () => {
         return 'export function stable() {}\n';
       }),
       statSync: vi.fn(() => ({ mtimeMs: 42, size: 28 })),
+      existsSync: vi.fn(() => false),
     }));
 
     const { indexProjectLite: mockedIndexProjectLite } = await import('../../src/codegraph/lite-provider.js');


### PR DESCRIPTION
## What

`memorix codegraph refresh` hangs indefinitely on projects that keep a Python virtualenv under a non-default name (e.g. `.venv-leann`). This fixes that by skipping virtualenvs via their PEP 405 `pyvenv.cfg` marker instead of by directory name.

Fixes #286.

## Why

`DEFAULT_CODEGRAPH_EXCLUDES` only lists `.venv/**` and `venv/**`, and `matchesPattern()` cannot express a `.venv*` wildcard, so `.venv-leann/…` is never excluded. `walk()` then descends into `site-packages`, collects up to `maxFiles` large generated files, and the per-file symbol scan plus persistence never completes within the timeout. Because refresh cascades, `context --refresh auto/always`, `resume`, and the MCP `context_pack` tool hang too.

## How

`walk()` now skips a directory when it contains a `pyvenv.cfg` file. That marker is written at the root of every virtualenv created by `venv`/`uv`/`virtualenv`/`poetry`, regardless of the directory name, and never appears in a real source tree — so no legitimate source directory is skipped. This is name-agnostic and also covers `.venv`/`venv` (kept in `DEFAULT_CODEGRAPH_EXCLUDES` for the config-only paths that filter without walking).

## Testing

- New regression test in `tests/codegraph/lite-provider.test.ts`: a `.venv-leann` tree containing a `pyvenv.cfg` and a `.py` file is not indexed, while a sibling source `.py` is. It fails on `main` (venv symbol gets indexed) and passes with this change.
- End-to-end: built the CLI from this branch and ran `codegraph refresh` against a real 34,647-file `.venv-leann` (torch/mlx/pymupdf). Before: rc=124 hang. After: rc=0 in ~2s, indexing only the real source file.
- `tests/codegraph/lite-provider.test.ts` passes (13/13).
