### PR TITLE
fix(maintenance): initialize stores for dashboard and CLI paths

### DIFF
--- a/src/cli/commands/memory.ts
+++ b/src/cli/commands/memory.ts
@@ -280,7 +280,8 @@ export default defineCommand({
         case 'deduplicate': {
           const query = asStringArg(args.query);
           const dryRun = !!args.dryRun || !!args['dry-run'];
-          const { isLLMEnabled } = await import('../../llm/provider.js');
+          const { initLLM, isLLMEnabled } = await import('../../llm/provider.js');
+          initLLM({ scope: 'memory', projectRoot: project.rootPath });
           if (!isLLMEnabled()) {
             emitResult(
               { project, available: false, usedLLM: false },

--- a/src/dashboard/maintenance.ts
+++ b/src/dashboard/maintenance.ts
@@ -221,6 +221,7 @@ export async function previewConsolidate(context: DashboardMaintenanceContext) {
   const clusters = await findConsolidationCandidates(
     context.projectRoot ?? context.dataDir,
     context.projectId,
+    { store: context.store },
   );
   const payload: ConsolidateTokenPayload = { clusterIds: normalizeClusters(clusters.map((cluster) => cluster.ids)) };
   return {
@@ -248,11 +249,19 @@ export async function executeConsolidate(
   const clusterIds = record.clusterIds.map((ids, index) => payloadIds(ids, `clusterIds[${index}]`));
   const normalized: ConsolidateTokenPayload = { clusterIds: normalizeClusters(clusterIds) };
   verify('consolidate', context.projectId, normalized, token);
-  const current = await findConsolidationCandidates(context.projectRoot ?? context.dataDir, context.projectId);
+  const current = await findConsolidationCandidates(
+    context.projectRoot ?? context.dataDir,
+    context.projectId,
+    { store: context.store },
+  );
   if (JSON.stringify(normalized.clusterIds) !== JSON.stringify(normalizeClusters(current.map((cluster) => cluster.ids)))) {
     throw new DashboardMaintenanceError('Memory changed after the preview. Refresh before consolidating.', 409);
   }
-  const result = await executeConsolidation(context.projectRoot ?? context.dataDir, context.projectId);
+  const result = await executeConsolidation(
+    context.projectRoot ?? context.dataDir,
+    context.projectId,
+    { store: context.store },
+  );
   return { action: 'consolidate', projectId: context.projectId, ...result };
 }
 

--- a/src/memory/consolidation.ts
+++ b/src/memory/consolidation.ts
@@ -16,7 +16,7 @@
  */
 
 import type { Observation } from '../types.js';
-import { getObservationStore } from '../store/obs-store.js';
+import { getObservationStore, type ObservationStore } from '../store/obs-store.js';
 import { isEligibleForAutomaticDelivery } from './admission.js';
 import { resolveObservationVisibility } from './visibility.js';
 
@@ -108,6 +108,14 @@ interface ConsolidationPage {
   nextCursor?: number;
 }
 
+export interface ConsolidationOptions {
+  threshold?: number;
+  limit?: number;
+  afterId?: number;
+  /** Use a request-scoped store when running inside a multi-project host. */
+  store?: ObservationStore;
+}
+
 function clampBatchSize(limit: number | undefined): number {
   if (!Number.isFinite(limit)) return MAX_BATCH_SIZE;
   return Math.min(MAX_BATCH_SIZE, Math.max(1, Math.floor(limit!)));
@@ -120,10 +128,11 @@ function clampCursor(afterId: number | undefined): number {
 
 async function loadConsolidationPage(
   projectId: string,
-  options: { limit?: number; afterId?: number },
+  options: ConsolidationOptions,
 ): Promise<ConsolidationPage> {
   const limit = clampBatchSize(options.limit);
-  const page = await getObservationStore().loadByProject(projectId, {
+  const store = options.store ?? getObservationStore();
+  const page = await store.loadByProject(projectId, {
     status: 'active',
     afterId: clampCursor(options.afterId),
     limit: limit + 1,
@@ -205,7 +214,7 @@ function findClusters(observations: Observation[], threshold: number): Consolida
 export async function findConsolidationCandidates(
   _projectDir: string,
   projectId: string,
-  opts?: { threshold?: number; limit?: number; afterId?: number },
+  opts?: ConsolidationOptions,
 ): Promise<ConsolidationCluster[]> {
   const threshold = opts?.threshold ?? DEFAULT_SIMILARITY_THRESHOLD;
   const page = await loadConsolidationPage(projectId, opts ?? {});
@@ -224,9 +233,9 @@ export async function findConsolidationCandidates(
 export async function executeConsolidation(
   _projectDir: string,
   projectId: string,
-  opts?: { threshold?: number; limit?: number; afterId?: number },
+  opts?: ConsolidationOptions,
 ): Promise<ConsolidationResult> {
-  const store = getObservationStore();
+  const store = opts?.store ?? getObservationStore();
   const page = await loadConsolidationPage(projectId, opts ?? {});
   const clusters = findClusters(page.observations, opts?.threshold ?? DEFAULT_SIMILARITY_THRESHOLD);
 

--- a/tests/cli/memory-command.test.ts
+++ b/tests/cli/memory-command.test.ts
@@ -4,6 +4,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import memoryCommand from '../../src/cli/commands/memory.js';
+import { setLLMConfig } from '../../src/llm/provider.js';
 import { closeAllDatabases } from '../../src/store/sqlite-db.js';
 import { resetObservationStore } from '../../src/store/obs-store.js';
 import { resetSessionStore } from '../../src/store/session-store.js';
@@ -98,5 +99,41 @@ describe('memory store CLI argument coercion', () => {
     expect(parsed.observation.topicKey).toBe('upgrade note');
     expect(parsed.observation.entityName).toBe('cli memory');
     expect(parsed.observation.facts).toEqual(['a', 'b', 'c']);
+  });
+
+  it('initializes the project memory LLM before checking deduplicate availability', async () => {
+    const originalKeys = {
+      apiKey: process.env.MEMORIX_LLM_API_KEY,
+      provider: process.env.MEMORIX_LLM_PROVIDER,
+      model: process.env.MEMORIX_LLM_MODEL,
+      baseUrl: process.env.MEMORIX_LLM_BASE_URL,
+    };
+    process.env.MEMORIX_LLM_API_KEY = 'test-memory-key';
+    process.env.MEMORIX_LLM_PROVIDER = 'openai';
+    process.env.MEMORIX_LLM_MODEL = 'test-memory-model';
+    process.env.MEMORIX_LLM_BASE_URL = 'http://127.0.0.1:9/v1';
+
+    try {
+      const result = await runCommand(memoryCommand, {
+        _: ['deduplicate'],
+        dryRun: true,
+        json: true,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).not.toContain('LLM not configured');
+      expect(JSON.parse(result.stdout)).toMatchObject({ project: { id: expect.any(String) } });
+    } finally {
+      setLLMConfig(null);
+      for (const [key, value] of Object.entries({
+        MEMORIX_LLM_API_KEY: originalKeys.apiKey,
+        MEMORIX_LLM_PROVIDER: originalKeys.provider,
+        MEMORIX_LLM_MODEL: originalKeys.model,
+        MEMORIX_LLM_BASE_URL: originalKeys.baseUrl,
+      })) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
   });
 });

--- a/tests/dashboard/maintenance-actions.test.ts
+++ b/tests/dashboard/maintenance-actions.test.ts
@@ -23,7 +23,7 @@ import {
   previewRetentionArchive,
 } from '../../src/dashboard/maintenance.js';
 import { setLLMConfig } from '../../src/llm/provider.js';
-import { getObservationStore, initObservationStore, resetObservationStore } from '../../src/store/obs-store.js';
+import { createObservationStore, getObservationStore, initObservationStore, resetObservationStore } from '../../src/store/obs-store.js';
 import { closeAllDatabases } from '../../src/store/sqlite-db.js';
 import type { Observation } from '../../src/types.js';
 
@@ -99,6 +99,35 @@ describe('dashboard maintenance actions', () => {
     const result = await executeConsolidate(context(), preview.payload, preview.token);
     expect(result.clustersFound).toBe(1);
     expect(result.observationsMerged).toBe(1);
+  });
+
+  it('uses the request-scoped store when the global store is unavailable', async () => {
+    const requestStore = await createObservationStore(path.join(dataDir, 'request-scoped'));
+    try {
+      await requestStore.insert(observation(1, 'Windows path separator bug', {
+        narrative: 'Use path join because string path concatenation breaks on Windows.',
+      }));
+      await requestStore.insert(observation(2, 'Windows path separator issue', {
+        narrative: 'String path concatenation breaks on Windows so use path join.',
+      }));
+
+      // This is the control-plane failure mode: the HTTP worker has its own
+      // store, but no process-wide observation singleton.
+      const requestContext = {
+        dataDir,
+        projectId: PROJECT_ID,
+        projectRoot: null,
+        store: requestStore,
+      };
+      resetObservationStore();
+      const preview = await previewConsolidate(requestContext);
+      expect(preview.summary.clusters).toBe(1);
+
+      const result = await executeConsolidate(requestContext, preview.payload, preview.token);
+      expect(result.observationsMerged).toBe(1);
+    } finally {
+      requestStore.close();
+    }
   });
 
   it('previews and archives only current retention candidates', async () => {


### PR DESCRIPTION
Fixes #285. Dashboard control-plane Consolidate now uses the request-scoped ObservationStore instead of an uninitialized process singleton. CLI memorix memory deduplicate now initializes the project-scoped memory LLM before checking availability. Added regression coverage for both paths. Verification: npm run lint; npm run build; focused maintenance/CLI/consolidation/dashboard tests 18 passed; full suite was rerun after rebuilding the optional better-sqlite3 native binding and the previously affected tests passed. No user data or config files changed.