### PR TITLE
fix(mcp): make piped package launches discoverable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.9.2] - 2026-09-11
+
+### Fixed
+- **Non-interactive MCP startup** -- running the package without arguments
+  through piped stdio now starts the MCP server, while a real terminal keeps
+  opening the bundled memcode agent. This makes generic npm MCP launchers and
+  registry handshake checks use the correct protocol entry point.
+- **Maintenance initialization** -- dashboard Consolidate uses its
+  request-scoped observation store, and CLI deduplication initializes the
+  project memory LLM before checking availability.
+
 ## [1.9.1] - 2026-09-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -317,6 +317,11 @@ If your agent only needs a manual MCP entry, use stdio:
 }
 ```
 
+For an npm-based MCP client or registry tester, use the complete command
+`npx -y memorix serve`. The `serve` argument matters: `memorix` without
+arguments opens the bundled memcode terminal agent when run by a human, while
+MCP clients should start the stdio server explicitly.
+
 For a manually managed Claude Code entry, add `"alwaysLoad": true` inside the `memorix` server object. This lets Claude Code expose Memorix tools during print-mode startup; `memorix doctor agents --agent claude` can detect and repair a missing setting.
 
 HTTP is not required for normal setup. Use it only when you intentionally want a shared background service, dashboard, VPS Docker deployment, or multiple clients using the same endpoint. Local development uses the Node service directly and does not require Docker:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -310,6 +310,10 @@ memorix setup --agent grok --global
 }
 ```
 
+如果是 npm 方式启动 MCP 客户端或收录平台测试器，请使用完整命令
+`npx -y memorix serve`。`serve` 参数不能省略：人类在终端里直接运行
+`memorix` 会打开内置 memcode，而 MCP 客户端应明确启动 stdio MCP 服务。
+
 如果是手动维护 Claude Code 的 MCP 配置，需要在 `memorix` server 对象里加上 `"alwaysLoad": true`。这样 Claude Code 在 print-mode 启动时就会暴露 Memorix tools；`memorix doctor agents --agent claude` 可以检查并修复缺失的设置。
 
 普通安装不需要 HTTP。只有在你明确需要共享后台服务、Dashboard、VPS Docker 部署，或多个客户端共用一个端点时才使用。本机开发直接运行 Node 服务，不需要 Docker：

--- a/docs/INTEGRATIONS.md
+++ b/docs/INTEGRATIONS.md
@@ -122,6 +122,10 @@ If an agent only needs a raw stdio MCP entry:
 
 Avoid `npx` in persistent MCP configs. Use the globally installed `memorix` binary so startup is predictable.
 
+For npm-based MCP clients or registry testers, the complete package command is
+`npx -y memorix serve`. Do not omit `serve`: bare `memorix` is the interactive
+memcode entry in a human terminal.
+
 For HTTP mode:
 
 ```bash

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -170,6 +170,11 @@ Generic stdio MCP config:
 
 Avoid `npx` in persistent MCP configs. Use the globally installed `memorix` binary so startup is predictable.
 
+When an npm-based MCP client or registry tester must launch the package
+directly, use `npx -y memorix serve`. The explicit `serve` argument selects
+the stdio MCP server; a human running bare `memorix` in a terminal gets the
+bundled memcode agent instead.
+
 ### Option C: memcode terminal agent
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "memorix",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "memorix",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/ai",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "memorix",
   "mcpName": "io.github.AVIDS2/memorix",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Local-first shared memory layer for AI coding agents across MCP clients, Git history, reasoning context, and project sessions.",
   "type": "module",
   "sideEffects": false,

--- a/plugins/antigravity/memorix/plugin.json
+++ b/plugins/antigravity/memorix/plugin.json
@@ -1,4 +1,4 @@
 {
   "name": "memorix",
-  "version": "1.9.1"
+  "version": "1.9.2"
 }

--- a/plugins/claude/memorix/.claude-plugin/plugin.json
+++ b/plugins/claude/memorix/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "memorix",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Shared workspace memory for Claude Code and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
+++ b/plugins/codebuddy/memorix/.codebuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Local-first project memory for CodeBuddy Code and other coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/codex/memorix/.codex-plugin/plugin.json
+++ b/plugins/codex/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Shared workspace memory for Codex and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/copilot/memorix/plugin.json
+++ b/plugins/copilot/memorix/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Shared local workspace memory for GitHub Copilot CLI and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/gemini/memorix/gemini-extension.json
+++ b/plugins/gemini/memorix/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "mcpServers": {
     "memorix": {
       "command": "memorix",

--- a/plugins/hermes/memorix/plugin.yaml
+++ b/plugins/hermes/memorix/plugin.yaml
@@ -1,5 +1,5 @@
 name: memorix
-version: "1.9.1"
+version: "1.9.2"
 description: Shared workspace memory bridge for Hermes Agent.
 author: AVIDS2
 license: Apache-2.0

--- a/plugins/omp/memorix/package.json
+++ b/plugins/omp/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-omp-package",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Memorix shared workspace memory package for Oh-my-Pi.",
   "license": "Apache-2.0",
   "keywords": [

--- a/plugins/openclaw/memorix/.codex-plugin/plugin.json
+++ b/plugins/openclaw/memorix/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Shared workspace memory for OpenClaw and other AI coding agents.",
   "author": {
     "name": "AVIDS2",

--- a/plugins/pi/memorix/package.json
+++ b/plugins/pi/memorix/package.json
@@ -1,6 +1,6 @@
 {
   "name": "memorix-pi-package",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Memorix shared workspace memory package for Pi coding agent.",
   "license": "Apache-2.0",
   "keywords": [

--- a/server.json
+++ b/server.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/AVIDS2/memorix",
     "source": "github"
   },
-  "version": "1.9.1",
+  "version": "1.9.2",
   "websiteUrl": "https://mem.rglens.com",
   "icons": [
     {
@@ -22,7 +22,7 @@
     {
       "registryType": "npm",
       "identifier": "memorix",
-      "version": "1.9.1",
+      "version": "1.9.2",
       "runtimeHint": "npx",
       "packageArguments": [
         {

--- a/src/cli/default-mode.ts
+++ b/src/cli/default-mode.ts
@@ -1,0 +1,15 @@
+export interface CliInteractivity {
+  stdinIsTTY?: boolean;
+  stdoutIsTTY?: boolean;
+}
+
+/**
+ * MCP hosts start package commands with piped stdio, while a human terminal
+ * has TTYs on both streams. Keep the friendly memcode default for humans and
+ * make the package safe for registry probes and generic MCP launchers.
+ */
+export function shouldDefaultToMcp(options: CliInteractivity = {}): boolean {
+  const stdinIsTTY = options.stdinIsTTY ?? process.stdin.isTTY;
+  const stdoutIsTTY = options.stdoutIsTTY ?? process.stdout.isTTY;
+  return stdinIsTTY !== true || stdoutIsTTY !== true;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -20,6 +20,7 @@ import { importBundledMemcode } from './memcode-bootstrap.js';
 import { installCliPipeErrorGuard } from './pipe-errors.js';
 import { normalizeCliInvocation } from './invocation.js';
 import { printCliGuideForHelp, renderCliGuide } from './command-guide.js';
+import { shouldDefaultToMcp } from './default-mode.js';
 
 installCliPipeErrorGuard();
 
@@ -327,8 +328,16 @@ const main = defineCommand({
       'background', 'bg', 'bs', 'doctor', 'repair', 'dashboard', 'cleanup', 'purge', 'uninstall', 'orchestrate'];
     if (firstArg && knownSubs.includes(firstArg)) return;
 
-    // No subcommand provided — enter memcode TUI (native coding agent)
+    // No subcommand provided — keep the interactive memcode default for a
+    // human terminal, but make piped package launches an MCP server. Generic
+    // MCP directories and clients commonly execute `npx memorix` without
+    // reading server.json's package arguments.
     if (!firstArg) {
+      if (shouldDefaultToMcp()) {
+        const serve = await import('./commands/serve.js');
+        await serve.default.run?.({ args: {}, rawArgs: [], cmd: serve.default } as any);
+        return;
+      }
       try {
         const { runCli } = await importBundledMemcode();
         await runCli(process.argv.slice(2));

--- a/tests/cli/default-mode.test.ts
+++ b/tests/cli/default-mode.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { shouldDefaultToMcp } from '../../src/cli/default-mode.js';
+
+describe('CLI default mode', () => {
+  it('keeps bare memorix interactive for a real terminal', () => {
+    expect(shouldDefaultToMcp({ stdinIsTTY: true, stdoutIsTTY: true })).toBe(false);
+  });
+
+  it('selects stdio MCP for piped or automated launches', () => {
+    expect(shouldDefaultToMcp({ stdinIsTTY: false, stdoutIsTTY: false })).toBe(true);
+    expect(shouldDefaultToMcp({ stdinIsTTY: undefined, stdoutIsTTY: undefined })).toBe(true);
+    expect(shouldDefaultToMcp({ stdinIsTTY: true, stdoutIsTTY: false })).toBe(true);
+  });
+});


### PR DESCRIPTION
What changed: bare memorix still opens memcode in a real interactive terminal. When stdin or stdout is not a TTY, the package now defaults to the stdio MCP server, covering generic MCP clients and registry handshake workers that invoke npx -y memorix without reading server.json. The canonical npm MCP command npx -y memorix serve is documented. Version 1.9.2, server.json, and all versioned plugin manifests are synchronized. The maintenance fixes from #289 remain included. Why: MCPVault's real handshake used npx -y memorix, which entered memcode and failed at initialize. Verification: npm run prepublishOnly; 327 test files passed; 3105 tests passed and 4 skipped; npm pack dry-run; real child-process MCP initialize smoke passed with no arguments; no user configuration changes.