### PR TITLE
fix(store): retry transient SQLite locks instead of degrading permanently

### DIFF
--- a/src/store/obs-store.ts
+++ b/src/store/obs-store.ts
@@ -194,27 +194,68 @@ export function resetObservationStore(): void {
   _storeDataDir = null;
 }
 
+/** SQLite error codes that mean "busy right now", not "permanently broken". */
+const TRANSIENT_SQLITE_ERROR = /SQLITE_BUSY|SQLITE_LOCKED|database is locked|database table is locked/i;
+
+function isTransientSqliteError(err: unknown): boolean {
+  const code = (err as { code?: unknown } | null)?.code;
+  if (typeof code === 'string' && TRANSIENT_SQLITE_ERROR.test(code)) return true;
+  return err instanceof Error && TRANSIENT_SQLITE_ERROR.test(err.message);
+}
+
+const INIT_RETRY_DELAYS_MS = [50, 150, 400, 1000, 2500];
+
+/**
+ * Initialize a SQLite backend, retrying transient lock contention.
+ *
+ * Another process (for example the maintenance runner, or a second agent
+ * harness) can hold a write transaction while we open the database and run
+ * migrations. That is temporary by definition, so we back off and retry
+ * instead of giving up on SQLite entirely.
+ */
+async function initSqliteWithRetry(store: ObservationStore, dataDir: string): Promise<void> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await store.init(dataDir);
+      return;
+    } catch (err) {
+      if (!isTransientSqliteError(err) || attempt >= INIT_RETRY_DELAYS_MS.length) throw err;
+      const delay = INIT_RETRY_DELAYS_MS[attempt];
+      console.error(
+        `[memorix] SQLite busy while opening store (attempt ${attempt + 1}/${INIT_RETRY_DELAYS_MS.length + 1}), retrying in ${delay}ms`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
+  }
+}
+
 /**
  * Create a fresh ObservationStore instance for a specific data directory
  * without touching the process-wide singleton. This is useful for long-lived
  * multi-project hosts (for example serve-http embedded dashboard APIs) where
  * requests may need to read different project data dirs concurrently.
+ *
+ * Only a *structural* failure — better-sqlite3 genuinely unavailable — falls
+ * back to the read-only DegradedBackend. A transient lock is retried, and a
+ * persistent runtime failure is thrown rather than silently degraded: an
+ * empty-looking store is far more dangerous than a loud error, because
+ * callers cannot distinguish it from a project with no observations yet.
  */
 export async function createObservationStore(dataDir: string): Promise<ObservationStore> {
-  // Try SQLite first (optionalDependencies — may not be installed)
+  let SqliteBackend: new () => ObservationStore;
   try {
-    const { SqliteBackend } = await import('./sqlite-store.js');
-    const store = new SqliteBackend();
+    ({ SqliteBackend } = await import('./sqlite-store.js'));
+  } catch (err) {
+    // Structural: the optional dependency is not installed. Degrading is correct.
+    console.error(`[memorix] SQLite module unavailable — degraded mode (read-only): ${err instanceof Error ? err.message : err}`);
+    const store = new DegradedBackend();
     await store.init(dataDir);
     return store;
-  } catch (err) {
-    console.error(`[memorix] SQLite backend unavailable — degraded mode (read-only): ${err instanceof Error ? err.message : err}`);
   }
 
-  // No writable JSON fallback — degraded read-only mode instead
-  // observations.json is only used as migration source, not runtime backend
-  const store = new DegradedBackend();
-  await store.init(dataDir);
+  // Runtime: the module loaded, so SQLite works. Lock contention is temporary.
+  const store = new SqliteBackend();
+  await initSqliteWithRetry(store, dataDir);
   return store;
 }
 

--- a/tests/store/obs-store-transient-lock.test.ts
+++ b/tests/store/obs-store-transient-lock.test.ts
@@ -1,0 +1,70 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { closeAllDatabases } from '../../src/store/sqlite-db.js';
+import { createObservationStore } from '../../src/store/obs-store.js';
+
+let tempDir = '';
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  closeAllDatabases();
+  if (tempDir) await rm(tempDir, { recursive: true, force: true });
+  tempDir = '';
+});
+
+/**
+ * A transient SQLITE_BUSY while opening the store must not permanently
+ * degrade the process to the read-only DegradedBackend.
+ *
+ * Degrading on lock contention is especially dangerous because DegradedBackend
+ * reads return empty rather than throwing, so callers cannot distinguish
+ * "storage is broken" from "this project has no observations yet".
+ */
+describe('createObservationStore under lock contention', () => {
+  it('retries a transient lock instead of degrading to read-only', async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'memorix-obs-lock-'));
+
+    const sqliteStore = await import('../../src/store/sqlite-store.js');
+    const realInit = sqliteStore.SqliteBackend.prototype.init;
+    let attempts = 0;
+
+    vi.spyOn(sqliteStore.SqliteBackend.prototype, 'init').mockImplementation(
+      async function (this: unknown, dataDir: string) {
+        attempts += 1;
+        if (attempts === 1) {
+          const err = new Error('database is locked') as Error & { code?: string };
+          err.code = 'SQLITE_BUSY';
+          throw err;
+        }
+        return realInit.call(this, dataDir);
+      },
+    );
+
+    const store = await createObservationStore(tempDir);
+
+    expect(attempts).toBe(2);
+    expect(store.getBackendName()).toBe('sqlite');
+
+    // The store must be genuinely writable, not merely reporting the right name.
+    await expect(
+      store.atomic(async (tx) => tx.loadIdCounter()),
+    ).resolves.toBeTypeOf('number');
+  });
+
+  it('surfaces a persistent lock as an error rather than an empty store', async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), 'memorix-obs-lock-'));
+
+    const sqliteStore = await import('../../src/store/sqlite-store.js');
+    vi.spyOn(sqliteStore.SqliteBackend.prototype, 'init').mockImplementation(async () => {
+      const err = new Error('database is locked') as Error & { code?: string };
+      err.code = 'SQLITE_BUSY';
+      throw err;
+    });
+
+    // Exhausting retries must throw. Returning an empty read-only store here
+    // would let agents conclude the project has no memory at all.
+    await expect(createObservationStore(tempDir)).rejects.toThrow(/locked/i);
+  });
+});


### PR DESCRIPTION
Fixes #291.

## Problem

`createObservationStore` wraps two unrelated failure classes in one `try`/`catch`:

```js
try {
  const { SqliteBackend } = await import('./sqlite-store.js');  // structural: dependency missing
  const store = new SqliteBackend();
  await store.init(dataDir);                                     // runtime: can be SQLITE_BUSY
  return store;
} catch (err) {
  console.error(`[memorix] SQLite backend unavailable — degraded mode (read-only): ...`);
}
```

The file's own docs state the intent was only the first case — *"Used when better-sqlite3 is unavailable"* — but a transient `database is locked` during `init()` lands in the same handler and produces `DegradedBackend`.

`initObservationStore` then caches that in a module-level singleton, so a single lost race leaves the process read-only for its entire lifetime. There is no retry and no recovery when the lock clears.

The damage is amplified by `DegradedBackend`'s read semantics: `loadAll()` returns `[]` and `countAll()` returns `0` rather than throwing. A broken store is indistinguishable from an empty project, so an agent asking what it knows receives a confident empty answer instead of an error.

I hit this with four processes holding write handles on one database (two agent harnesses, an editor, and Memorix's own `maintenance-runner`). 52,273 observations were on disk while agents saw nothing, and `memorix doctor` reported `Status: ready` throughout.

## Change

Split the two failure classes:

- **Module import fails** → structural, still degrades to `DegradedBackend`. Unchanged behaviour.
- **`init()` fails with `SQLITE_BUSY`/`SQLITE_LOCKED`** → retried with backoff (`50, 150, 400, 1000, 2500` ms).
- **Retries exhausted** → throws, rather than silently degrading.

That last point is the important one. A hard error is visible and actionable; an empty-looking memory store is neither.

Transient detection matches both `err.code` and the message, since `better-sqlite3`, `node:sqlite`, and `bun:sqlite` surface these differently and `sqlite-db.ts` supports all three.

## Verification

New regression test, `tests/store/obs-store-transient-lock.test.ts`:

| | With fix | Without fix |
|---|---|---|
| retries a transient lock instead of degrading | pass | **fail** |
| surfaces a persistent lock as an error | pass | **fail** |

```
$ npx vitest run tests/store/obs-store-transient-lock.test.ts --no-file-parallelism --maxWorkers=1 --minWorkers=1
 ✓ tests/store/obs-store-transient-lock.test.ts (2 tests) 5680ms
   Tests  2 passed (2)
```

Reverting only `src/store/obs-store.ts` and re-running gives `2 failed`, so the test genuinely covers the change rather than passing incidentally.

The first test asserts the store is actually writable (`atomic()` succeeds), not merely that `getBackendName()` returns the right string.

Wider suite, `tests/store tests/memory tests/server`:

```
Test Files  1 failed | 63 passed (64)
     Tests  5 failed | 593 passed (598)
```

The 5 failures are all in `tests/store/cross-process-freshness.test.ts` and **pre-exist on unmodified `upstream/main`** — verified by stashing this patch and re-running that file alone (`5 failed | 1 passed`). They are untouched by this change.

`npm run lint` reports 2 errors, both in `src/media/minimax.ts` (missing `@memorix/ai` workspace package). Also pre-existing on `main`, zero in `obs-store.ts`.

## Notes

- No CONTRIBUTING.md or PR template in the repo, so this follows the existing commit-message style (`fix(scope): …`) from recent history.
- I deliberately kept the diff to `obs-store.ts`. The same pattern exists in `session-store.ts` and `mini-skill-store.ts` — the latter emits *"Install better-sqlite3 for full functionality"*, which is actively misleading when the real cause is lock contention. Happy to extend this PR to those two, or follow up separately, whichever you prefer.
- The retry schedule is a first proposal. If you'd rather have it configurable, or bounded differently for a 640 MB store, say the word and I'll adjust.
