### PR TITLE
fix(doctor): report storage failures instead of showing an empty store

### DIFF
--- a/src/cli/commands/doctor.ts
+++ b/src/cli/commands/doctor.ts
@@ -283,6 +283,7 @@ export default defineCommand({
       let activeCount = 0;
       let ranCount = 0;
       let backendName = 'unknown';
+      let storeError: string | undefined;
       try {
         const { initObservationStore, getObservationStore } = await import('../../store/obs-store.js');
         await initObservationStore(dataDir);
@@ -295,12 +296,21 @@ export default defineCommand({
         obsCount = projectObservations.length;
         activeCount = projectObservations.filter((o: any) => (o.status ?? 'active') === 'active').length;
         ranCount = projectObservations.filter((o: any) => /^Ran:\s/i.test(o.title ?? '')).length;
-      } catch { /* ignore */ }
+      } catch (err) {
+        // The store could not be opened at all. Without this the counters stay
+        // at zero and the branch below reports "0 total" as a healthy result,
+        // which is indistinguishable from a project that has no observations.
+        storeError = err instanceof Error ? err.message : String(err);
+      }
 
-      if (backendName === 'degraded') {
-        lines.push(warn('Observations: SQLite unavailable — degraded (read-only, no data)'));
+      if (storeError) {
+        lines.push(fail(`Observations: storage unavailable — ${storeError}`));
+        issues.push(`Observation store could not be opened: ${storeError}`);
+      } else if (backendName === 'degraded') {
+        lines.push(fail('Observations: SQLite unavailable — degraded (read-only, no data)'));
         issues.push('SQLite backend unavailable — observations cannot be read or written.');
       } else {
+        lines.push(ok('Backend: sqlite (read-write)'));
         lines.push(ok(`Observations: ${obsCount} total, ${activeCount} active`));
         if (ranCount > 0) {
           const pct = Math.round(ranCount / obsCount * 100);

--- a/tests/cli/doctor-storage-status.test.ts
+++ b/tests/cli/doctor-storage-status.test.ts
@@ -1,0 +1,92 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import os from 'node:os';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const detectProjectMock = vi.fn();
+const initObservationStoreMock = vi.fn();
+const getObservationStoreMock = vi.fn();
+
+let tempDir: string | undefined;
+
+vi.mock('../../src/project/detector.js', () => ({
+  detectProjectWithDiagnostics: detectProjectMock,
+}));
+
+vi.mock('../../src/store/obs-store.js', () => ({
+  initObservationStore: initObservationStoreMock,
+  getObservationStore: getObservationStoreMock,
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+  if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+  tempDir = undefined;
+});
+
+function captureJson(): { lines: string[] } {
+  const lines: string[] = [];
+  vi.spyOn(console, 'log').mockImplementation((value?: unknown) => {
+    lines.push(String(value));
+  });
+  return { lines };
+}
+
+async function runDoctor(): Promise<Record<string, unknown>> {
+  const { lines } = captureJson();
+  const doctor = (await import('../../src/cli/commands/doctor.js')).default;
+  await doctor.run?.({ args: { json: true } } as never);
+  const payload = lines.find((l) => l.trimStart().startsWith('{'));
+  return payload ? JSON.parse(payload) : {};
+}
+
+/**
+ * `doctor` must never present an unreadable store as an empty one.
+ *
+ * Reporting "0 observations" with an [OK] marker is indistinguishable from a
+ * project that genuinely has no memories yet, so an operator has no signal
+ * that persistence is broken.
+ */
+describe('doctor storage status', () => {
+  it('reports a failure when the observation store cannot be opened', async () => {
+    tempDir = mkdtempSync(join(os.tmpdir(), 'memorix-doctor-'));
+    detectProjectMock.mockReturnValue({
+      project: {
+        id: 'local/probe',
+        name: 'probe',
+        rootPath: tempDir,
+        dataDir: tempDir,
+        gitRemote: '',
+      },
+    });
+    initObservationStoreMock.mockRejectedValue(new Error('database is locked'));
+
+    const report = await runDoctor();
+    const issues = (report.issues ?? []) as string[];
+
+    expect(issues.some((i) => /could not be opened|database is locked/i.test(i))).toBe(true);
+  });
+
+  it('reports a failure when the store falls back to the degraded backend', async () => {
+    tempDir = mkdtempSync(join(os.tmpdir(), 'memorix-doctor-'));
+    detectProjectMock.mockReturnValue({
+      project: {
+        id: 'local/probe',
+        name: 'probe',
+        rootPath: tempDir,
+        dataDir: tempDir,
+        gitRemote: '',
+      },
+    });
+    initObservationStoreMock.mockResolvedValue(undefined);
+    getObservationStoreMock.mockReturnValue({
+      getBackendName: () => 'degraded',
+      loadAll: async () => [],
+    });
+
+    const report = await runDoctor();
+    const issues = (report.issues ?? []) as string[];
+
+    expect(issues.some((i) => /SQLite backend unavailable/i.test(i))).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #292.

## Problem

The Data Status block in `doctor` wraps store access in a bare swallow:

```js
let backendName = 'unknown';
try {
  const { initObservationStore, getObservationStore } = await import('../../store/obs-store.js');
  await initObservationStore(dataDir);
  const store = getObservationStore();
  backendName = store.getBackendName();
  // …counts…
} catch { /* ignore */ }

if (backendName === 'degraded') {
  lines.push(warn('Observations: SQLite unavailable — degraded (read-only, no data)'));
  issues.push('SQLite backend unavailable — observations cannot be read or written.');
} else {
  lines.push(ok(`Observations: ${obsCount} total, ${activeCount} active`));
}
```

The degraded branch is correct and already present. The gap is the `catch`: if `initObservationStore` **throws**, `backendName` stays `'unknown'`, the degraded check does not match, and execution falls into the healthy branch with the counters still at their initial `0`. Output:

```
[OK] Observations: 0 total, 0 active
```

Which is exactly what a brand-new project looks like.

I hit this with a 640 MB store holding 52,273 observations that could not be opened due to lock contention (#291). `doctor` reported `Status: ready` and zero observations, so there was no indication that persistence was broken. Agents ran for days against what looked like an empty project.

## Change

Three small adjustments, all in the same block:

1. **Capture the init error** instead of discarding it, and report it as `[ERROR]` plus an `issues[]` entry. This is the actual bug — the path that produced a false healthy result.
2. **Raise the existing degraded line from `[WARN]` to `[ERROR]`.** In degraded mode `insert`/`update`/`atomic` all throw; nothing can be persisted. That is a failure, not a warning.
3. **Always state the active backend.** A healthy run now shows `[OK] Backend: sqlite (read-write)` rather than leaving it implicit, so the degraded/failed cases are visibly different rather than merely differently-worded.

No behaviour changes outside `doctor`'s reporting.

## Verification

New test `tests/cli/doctor-storage-status.test.ts`:

```
✓ reports a failure when the observation store cannot be opened
✓ reports a failure when the store falls back to the degraded backend
  Tests  2 passed (2)
```

Reverting only `src/cli/commands/doctor.ts` and re-running:

```
  Tests  1 failed | 1 passed (2)
```

The init-failure test fails without the patch — that is the regression this PR fixes. The degraded-backend test passes either way, since that branch already existed; it is included to keep the behaviour pinned.

The test asserts against `report.issues` from `--json` rather than matching console text, so it does not pin log wording.

`npm run lint` reports 2 errors, both in `src/media/minimax.ts` (missing `@memorix/ai` workspace package). Pre-existing on `main`, zero in `doctor.ts`.

## Notes

- Complements #293 (which fixes the *cause* of degradation for the lock case). This PR is the detection half and applies regardless of why the store failed.
- The two `(o: any)` annotations visible in the diff context are pre-existing upstream code that I moved verbatim while widening the `try` block's error handling. I left them untouched to keep the diff reviewable rather than mixing in a typing cleanup — happy to address separately if you'd like.
